### PR TITLE
Add TSV copy support to structure datagrid

### DIFF
--- a/OpenTable/Views/Results/TableRowViewWithMenu.swift
+++ b/OpenTable/Views/Results/TableRowViewWithMenu.swift
@@ -136,10 +136,13 @@ final class TableRowViewWithMenu: NSTableRowView {
 
     @objc private func copySelectedOrCurrentRow() {
         guard let coordinator = coordinator else { return }
-        if !coordinator.selectedRowIndices.isEmpty {
-            coordinator.copyRows(at: coordinator.selectedRowIndices)
+        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
+            ? coordinator.selectedRowIndices
+            : [rowIndex]
+        if let callback = coordinator.onCopyRows {
+            callback(indices)
         } else {
-            coordinator.copyRows(at: [rowIndex])
+            coordinator.copyRows(at: indices)
         }
     }
 

--- a/OpenTable/Views/Structure/TableStructureView.swift
+++ b/OpenTable/Views/Structure/TableStructureView.swift
@@ -357,25 +357,44 @@ struct TableStructureView: View {
             break
         }
 
-        // Store in pasteboard as JSON string using CUSTOM TYPE
+        // Store in pasteboard with both custom JSON type (internal paste) and TSV (external paste)
         guard !copiedItems.isEmpty else { return }
+
+        // Build JSON string for custom pasteboard type
+        var jsonString: String?
+        if let columns = copiedItems as? [EditableColumnDefinition],
+           let encoded = try? JSONEncoder().encode(columns) {
+            jsonString = String(data: encoded, encoding: .utf8)
+        } else if let indexes = copiedItems as? [EditableIndexDefinition],
+                  let encoded = try? JSONEncoder().encode(indexes) {
+            jsonString = String(data: encoded, encoding: .utf8)
+        } else if let fks = copiedItems as? [EditableForeignKeyDefinition],
+                  let encoded = try? JSONEncoder().encode(fks) {
+            jsonString = String(data: encoded, encoding: .utf8)
+        }
+
+        // Build TSV string for external paste
+        let provider = StructureRowProvider(changeManager: structureChangeManager, tab: selectedTab)
+        var lines: [String] = []
+        for row in rowIndices.sorted() {
+            guard let rowData = provider.row(at: row) else { continue }
+            let line = rowData.values.map { $0 ?? "NULL" }.joined(separator: "\t")
+            lines.append(line)
+        }
+        let tsvString = lines.joined(separator: "\n")
+
+        // Write both types on a single pasteboard item
+        let item = NSPasteboardItem()
+        if let json = jsonString {
+            item.setString(json, forType: Self.structurePasteboardType)
+        }
+        if !tsvString.isEmpty {
+            item.setString(tsvString, forType: .string)
+        }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-
-        if let columns = copiedItems as? [EditableColumnDefinition],
-           let encoded = try? JSONEncoder().encode(columns),
-           let jsonString = String(data: encoded, encoding: .utf8) {
-            pasteboard.setString(jsonString, forType: Self.structurePasteboardType)
-        } else if let indexes = copiedItems as? [EditableIndexDefinition],
-                  let encoded = try? JSONEncoder().encode(indexes),
-                  let jsonString = String(data: encoded, encoding: .utf8) {
-            pasteboard.setString(jsonString, forType: Self.structurePasteboardType)
-        } else if let fks = copiedItems as? [EditableForeignKeyDefinition],
-                  let encoded = try? JSONEncoder().encode(fks),
-                  let jsonString = String(data: encoded, encoding: .utf8) {
-            pasteboard.setString(jsonString, forType: Self.structurePasteboardType)
-        }
+        pasteboard.writeObjects([item])
     }
 
     private func handlePaste() {


### PR DESCRIPTION
## Summary
- Write both custom JSON type (for internal paste/duplicate) and plain-text TSV (for external paste into text editors/spreadsheets) when copying rows in the structure view
- Use `NSPasteboardItem` to hold both representations on a single clipboard item, ensuring they coexist correctly
- Route context menu "Copy" through the `onCopyRows` callback when available, so both Cmd+C and right-click → Copy produce identical output

## Test plan
- [ ] Open a table's Structure tab (Columns, Indexes, or Foreign Keys)
- [ ] Select one or more rows
- [ ] **Cmd+C** → paste into a text editor → verify TSV output
- [ ] **Right-click → Copy** → paste into a text editor → verify same TSV output
- [ ] **Cmd+C** then **Cmd+V** in structure view → verify internal paste still works (new row with duplicated data)
- [ ] Verify the regular data grid's Copy still works unchanged