### PR TITLE
fix: improve native tab bar appearance and dark mode handling

### DIFF
--- a/OpenTable/Views/Editor/NativeTabBarView.swift
+++ b/OpenTable/Views/Editor/NativeTabBarView.swift
@@ -325,7 +325,9 @@ final class NativeTabBarView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            self.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        }
         // Re-render tab items to update colors
         for snapshot in tabSnapshots {
             tabViews[snapshot.id]?.update(

--- a/OpenTable/Views/Editor/NativeTabItemView.swift
+++ b/OpenTable/Views/Editor/NativeTabItemView.swift
@@ -21,6 +21,7 @@ final class NativeTabItemView: NSView {
     private var tabType: TabType
     private var isSelected: Bool = false
     private var isHovered: Bool = false
+    private var isWindowKey: Bool = true
 
     // MARK: - Callbacks
 
@@ -191,6 +192,43 @@ final class NativeTabItemView: NSView {
         statusIconLeadingConstraint?.isActive = true
     }
 
+    // MARK: - Window Key State
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        NotificationCenter.default.removeObserver(
+            self, name: NSWindow.didBecomeKeyNotification, object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self, name: NSWindow.didResignKeyNotification, object: nil
+        )
+
+        guard let window = window else { return }
+        isWindowKey = window.isKeyWindow
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowKeyStateChanged),
+            name: NSWindow.didBecomeKeyNotification, object: window
+        )
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowKeyStateChanged),
+            name: NSWindow.didResignKeyNotification, object: window
+        )
+
+        updateAppearance()
+    }
+
+    @objc private func windowKeyStateChanged(_ notification: Notification) {
+        isWindowKey = window?.isKeyWindow ?? true
+        updateAppearance()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
+    }
+
     // MARK: - Drag Source
 
     private func setupDragSource() {
@@ -239,18 +277,15 @@ final class NativeTabItemView: NSView {
         closeButton.isHidden = !isHovered || isPinned
 
         // Background
-        if isSelected {
-            layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
-            layer?.borderColor = NSColor.separatorColor.cgColor
-            layer?.borderWidth = 0.5
-        } else if isHovered {
-            layer?.backgroundColor = NSColor.controlBackgroundColor.withAlphaComponent(0.5).cgColor
-            layer?.borderColor = nil
-            layer?.borderWidth = 0
-        } else {
-            layer?.backgroundColor = nil
-            layer?.borderColor = nil
-            layer?.borderWidth = 0
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            if self.isSelected {
+                self.layer?.backgroundColor = NSColor.controlAccentColor
+                    .withAlphaComponent(0.15).cgColor
+            } else if self.isHovered {
+                self.layer?.backgroundColor = NSColor.quaternaryLabelColor.cgColor
+            } else {
+                self.layer?.backgroundColor = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **Dark mode color fix**: Wrap background color assignments in `performAsCurrentDrawingAppearance` so colors resolve correctly during light/dark appearance transitions
- **Window key state tracking**: Tab items now observe `didBecomeKey`/`didResignKey` notifications and refresh appearance when the window gains or loses focus
- **Cleaner tab selection style**: Replace border-based selected tab highlight with accent-tinted background (`controlAccentColor` at 15% opacity), and use `quaternaryLabelColor` for hover state

## Test plan
- [ ] Switch between light and dark mode — tab bar background and tab items should update colors correctly without stale colors
- [ ] Click away from the app window and back — tab selection appearance should update
- [ ] Hover over tabs — should show subtle hover highlight
- [ ] Selected tab should show accent-tinted background without borders