### PR TITLE
feat: add dock menu with welcome window and connections list

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -46,8 +46,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
                 item.target = self
                 item.representedObject = connection.id
-                item.image = NSImage(named: connection.type.iconName)
-                item.image?.size = NSSize(width: 16, height: 16)
+                if let original = NSImage(named: connection.type.iconName) {
+                    let resized = NSImage(size: NSSize(width: 16, height: 16), flipped: false) { rect in
+                        original.draw(in: rect)
+                        return true
+                    }
+                    item.image = resized
+                }
                 submenu.addItem(item)
             }
 
@@ -81,6 +86,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     window.close()
                 }
             } catch {
+                print("[AppDelegate] Dock connection failed for '\(connection.name)': \(error.localizedDescription)")
+
                 // Connection failed - close main window, reopen welcome
                 for window in NSApp.windows where self.isMainWindow(window) {
                     window.close()


### PR DESCRIPTION
## Summary
- Add right-click dock icon context menu via `applicationDockMenu(_:)`
- "Show Welcome Window" option to quickly reopen the welcome screen
- "Open Connection" submenu listing all saved connections with database type icons, enabling quick connect directly from the dock

## Test plan
- [ ] Right-click the app icon in the dock and verify the context menu appears
- [ ] Click "Show Welcome Window" and verify the welcome window opens
- [ ] Verify "Open Connection" submenu lists all saved connections with correct icons
- [ ] Click a connection from the submenu and verify it connects and opens the main window
- [ ] Verify failed connections close the main window and reopen welcome
- [ ] Verify the menu updates when connections are added/removed (menu is rebuilt each time)