### PR TITLE
feat: improve filter panel UI/UX

### DIFF
--- a/TablePro/Models/FilterState.swift
+++ b/TablePro/Models/FilterState.swift
@@ -27,6 +27,7 @@ final class FilterStateManager: ObservableObject {
     @Published var appliedFilters: [TableFilter] = []
     @Published var focusedFilterId: UUID?
     @Published var quickSearchText: String = ""
+    @Published var shouldFocusQuickSearch: Bool = false
     @Published var filterLogicMode: FilterLogicMode = .and  // AND or OR logic
 
     /// Settings storage reference
@@ -170,8 +171,12 @@ final class FilterStateManager: ObservableObject {
 
     /// Toggle filter panel visibility
     func toggle() {
+        let willOpen = !isVisible
         withAnimation(.easeInOut(duration: 0.2)) {
             isVisible.toggle()
+        }
+        if willOpen {
+            shouldFocusQuickSearch = true
         }
     }
 
@@ -180,6 +185,7 @@ final class FilterStateManager: ObservableObject {
         withAnimation(.easeInOut(duration: 0.2)) {
             isVisible = true
         }
+        shouldFocusQuickSearch = true
     }
 
     /// Close panel

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -2,13 +2,13 @@
 //  FilterPanelView.swift
 //  TablePro
 //
-//  Bottom filter panel for table data filtering.
+//  Filter panel for table data filtering.
 //  Child views extracted to separate files for maintainability.
 //
 
 import SwiftUI
 
-/// Bottom filter panel for table data filtering
+/// Filter panel for table data filtering
 struct FilterPanelView: View {
     @ObservedObject var filterState: FilterStateManager
     let columns: [String]
@@ -32,24 +32,19 @@ struct FilterPanelView: View {
             Divider()
                 .foregroundStyle(Color(nsColor: .separatorColor))
 
-            // Quick Search field (when no filters or alongside filters)
-            if filterState.hasActiveQuickSearch || filterState.filters.isEmpty {
-                QuickSearchField(
-                    searchText: $filterState.quickSearchText,
-                    hasActiveSearch: filterState.hasActiveQuickSearch,
-                    onSubmit: { onQuickSearch?(filterState.quickSearchText) },
-                    onClear: { filterState.clearQuickSearch() }
-                )
-                Divider()
-                    .foregroundStyle(Color(nsColor: .separatorColor))
-            }
+            // Quick Search field (always visible)
+            QuickSearchField(
+                searchText: $filterState.quickSearchText,
+                hasActiveSearch: filterState.hasActiveQuickSearch,
+                shouldFocus: $filterState.shouldFocusQuickSearch,
+                onSubmit: { onQuickSearch?(filterState.quickSearchText) },
+                onClear: { filterState.clearQuickSearch() }
+            )
+            Divider()
+                .foregroundStyle(Color(nsColor: .separatorColor))
 
-            // Filter rows
-            if filterState.filters.isEmpty {
-                if !filterState.hasActiveQuickSearch {
-                    emptyState
-                }
-            } else {
+            // Filter rows (only when filters exist)
+            if !filterState.filters.isEmpty {
                 filterList
             }
 
@@ -171,34 +166,6 @@ struct FilterPanelView: View {
         .onAppear {
             loadPresets()
         }
-    }
-
-    // MARK: - Empty State
-
-    private var emptyState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "line.3.horizontal.decrease.circle")
-                .font(.system(size: DesignConstants.IconSize.huge))
-                .foregroundStyle(.tertiary)
-
-            Text("No filters active")
-                .font(.system(size: DesignConstants.FontSize.body, weight: .medium))
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 8) {
-                Button("Add Filter") {
-                    filterState.addFilter(columns: columns, primaryKeyColumn: primaryKeyColumn)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                Text("or use Quick Search above")
-                    .font(.system(size: DesignConstants.FontSize.small))
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
     }
 
     // MARK: - Filter List

--- a/TablePro/Views/Filter/QuickSearchField.swift
+++ b/TablePro/Views/Filter/QuickSearchField.swift
@@ -12,8 +12,11 @@ import SwiftUI
 struct QuickSearchField: View {
     @Binding var searchText: String
     let hasActiveSearch: Bool
+    @Binding var shouldFocus: Bool
     let onSubmit: () -> Void
     let onClear: () -> Void
+
+    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         HStack(spacing: 8) {
@@ -24,6 +27,7 @@ struct QuickSearchField: View {
             TextField("Quick search across all columns...", text: $searchText)
                 .textFieldStyle(.plain)
                 .font(.system(size: DesignConstants.FontSize.medium))
+                .focused($isTextFieldFocused)
                 .onSubmit {
                     if !searchText.isEmpty {
                         onSubmit()
@@ -43,5 +47,11 @@ struct QuickSearchField: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(Color(nsColor: .textBackgroundColor))
+        .onChange(of: shouldFocus) { _, newValue in
+            if newValue {
+                isTextFieldFocused = true
+                shouldFocus = false
+            }
+        }
     }
 }

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -217,6 +217,7 @@ struct MainEditorContentView: View {
         VStack(spacing: 0) {
             if tab.showStructure, let tableName = tab.tableName {
                 TableStructureView(tableName: tableName, connection: connection)
+                    .id(tableName)
                     .frame(maxHeight: .infinity)
             } else if tab.resultColumns.isEmpty && tab.errorMessage == nil && tab.lastExecutedAt != nil && !tab.isExecuting {
                 QuerySuccessView(
@@ -224,22 +225,22 @@ struct MainEditorContentView: View {
                     executionTime: tab.executionTime
                 )
             } else {
-                dataGridView(tab: tab)
-            }
+                // Filter panel (collapsible, above data grid)
+                if filterStateManager.isVisible && tab.tabType == .table {
+                    FilterPanelView(
+                        filterState: filterStateManager,
+                        columns: tab.resultColumns,
+                        primaryKeyColumn: changeManager.primaryKeyColumn,
+                        databaseType: connection.type,
+                        onApply: onApplyFilters,
+                        onUnset: onClearFilters,
+                        onQuickSearch: onQuickSearch
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    Divider()
+                }
 
-            // Filter panel (collapsible, at bottom)
-            if filterStateManager.isVisible && tab.tabType == .table {
-                Divider()
-                FilterPanelView(
-                    filterState: filterStateManager,
-                    columns: tab.resultColumns,
-                    primaryKeyColumn: changeManager.primaryKeyColumn,
-                    databaseType: connection.type,
-                    onApply: onApplyFilters,
-                    onUnset: onClearFilters,
-                    onQuickSearch: onQuickSearch
-                )
-                .transition(.move(edge: .bottom).combined(with: .opacity))
+                dataGridView(tab: tab)
             }
 
             statusBar(tab: tab)

--- a/TablePro/Views/Main/Child/TableTabContentView.swift
+++ b/TablePro/Views/Main/Child/TableTabContentView.swift
@@ -47,8 +47,24 @@ struct TableTabContentView: View {
             // Show structure view or data view based on toggle
             if showStructure, let tableName = tab.tableName {
                 TableStructureView(tableName: tableName, connection: connection)
+                    .id(tableName)
                     .frame(maxHeight: .infinity)
             } else {
+                // Filter panel (collapsible, above data grid)
+                if filterStateManager.isVisible && tab.tabType == .table {
+                    FilterPanelView(
+                        filterState: filterStateManager,
+                        columns: tab.resultColumns,
+                        primaryKeyColumn: changeManager.primaryKeyColumn,
+                        databaseType: connection.type,
+                        onApply: onApplyFilters,
+                        onUnset: onClearFilters,
+                        onQuickSearch: onQuickSearch
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    Divider()
+                }
+
                 DataGridView(
                     rowProvider: InMemoryRowProvider(
                         rows: sortedRows,
@@ -70,21 +86,6 @@ struct TableTabContentView: View {
                     editingCell: $editingCell
                 )
                 .frame(maxHeight: .infinity, alignment: .top)
-            }
-
-            // Filter panel (collapsible, at bottom)
-            if filterStateManager.isVisible && tab.tabType == .table {
-                Divider()
-                FilterPanelView(
-                    filterState: filterStateManager,
-                    columns: tab.resultColumns,
-                    primaryKeyColumn: changeManager.primaryKeyColumn,
-                    databaseType: connection.type,
-                    onApply: onApplyFilters,
-                    onUnset: onClearFilters,
-                    onQuickSearch: onQuickSearch
-                )
-                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
             // Status bar


### PR DESCRIPTION
## Summary

- **Move filter panel above data grid** — Filter panel now appears above the data grid (pushing it down) instead of at the bottom overlapping/pushing the status bar. Applied to both `TableTabContentView` and `MainEditorContentView`.
- **Remove empty state** — Removed the wasteful "No filters active" empty state with large icon, text, and buttons that took excessive vertical space.
- **Always show quick search** — Quick search field is now always visible when the filter panel is open, not just when no filters exist or a search is active.
- **Auto-focus quick search on Cmd+F** — When opening the filter panel with Cmd+F, the quick search field is automatically focused and ready for typing.

## Test plan

- [ ] Open a table tab → press `Cmd+F` → filter panel appears **above** the data grid, quick search field is focused
- [ ] Press `Cmd+F` again → filter panel closes
- [ ] Press `Cmd+F` → type search text → `Enter` → search applies
- [ ] Add filters via + button → filters appear below quick search, no "No filters active" empty state
- [ ] Quick search is always visible alongside filters
- [ ] Open editor tab with table results → filter panel also appears above data grid