### PR TITLE
feat: add Show Structure to sidebar context menu

### DIFF
--- a/TablePro/OpenTableApp.swift
+++ b/TablePro/OpenTableApp.swift
@@ -436,6 +436,9 @@ extension Notification.Name {
     // Table creation notifications
     static let createTable = Notification.Name("createTable")
 
+    // Table structure notifications
+    static let showTableStructure = Notification.Name("showTableStructure")
+
     // Export notifications
     static let exportTables = Notification.Name("exportTables")
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1142,7 +1142,7 @@ final class MainContentCoordinator: ObservableObject {
 
     // MARK: - Table Tab Opening
 
-    func openTableTab(_ tableName: String) {
+    func openTableTab(_ tableName: String, showStructure: Bool = false) {
         let needsQuery = tabManager.TableProTabSmart(
             tableName: tableName,
             hasUnsavedChanges: changeManager.hasChanges,
@@ -1152,6 +1152,11 @@ final class MainContentCoordinator: ObservableObject {
         // Initialize pagination for new table tab
         if needsQuery, let tabIndex = tabManager.selectedTabIndex {
             tabManager.tabs[tabIndex].pagination.reset()
+        }
+
+        // Toggle structure view if requested
+        if showStructure, let tabIndex = tabManager.selectedTabIndex {
+            tabManager.tabs[tabIndex].showStructure = true
         }
 
         if needsQuery {

--- a/TablePro/Views/Main/MainContentNotificationHandler.swift
+++ b/TablePro/Views/Main/MainContentNotificationHandler.swift
@@ -369,6 +369,15 @@ final class MainContentNotificationHandler: ObservableObject {
             }
             .store(in: &cancellables)
 
+        NotificationCenter.default.publisher(for: .showTableStructure)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                if let tableName = notification.object as? String {
+                    self?.coordinator?.openTableTab(tableName, showStructure: true)
+                }
+            }
+            .store(in: &cancellables)
+
         NotificationCenter.default.publisher(for: .exportTables)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -266,6 +266,16 @@ struct SidebarView: View {
 
         Divider()
 
+        Button("Show Structure") {
+            if let tableName = clickedTable?.name {
+                NotificationCenter.default.post(
+                    name: .showTableStructure,
+                    object: tableName
+                )
+            }
+        }
+        .disabled(clickedTable == nil)
+
         Button("Copy Name") {
             let names: [String]
             if selectedTables.isEmpty, let table = clickedTable {


### PR DESCRIPTION
## Summary

- Add **"Show Structure"** option to the sidebar table right-click context menu
- Clicking it opens the table tab directly in structure view
- Adds `.showTableStructure` notification, handled by `MainContentNotificationHandler`
- Extends `openTableTab()` with a `showStructure` parameter

## Test plan

- [ ] Right-click a table in the sidebar → "Show Structure" appears in the context menu
- [ ] Click "Show Structure" → table opens in structure view (columns, indexes, foreign keys, DDL)
- [ ] Right-click with no table selected → "Show Structure" is disabled