### PR TITLE
fix: support macOS 13.5+ (Ventura) — downgrade all macOS 14+ APIs

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -25,8 +25,6 @@ struct ContentView: View {
 
     @Environment(\.openWindow)
     private var openWindow
-    @Environment(\.dismissWindow)
-    private var dismissWindow
     @EnvironmentObject private var appState: AppState
 
     private let storage = ConnectionStorage.shared
@@ -93,7 +91,7 @@ struct ContentView: View {
                 }
             }
             // Right sidebar toggle is handled by MainContentView (has the binding)
-            .onChange(of: dbManager.currentSessionId) { _, newSessionId in
+            .onChange(of: dbManager.currentSessionId) { newSessionId in
                 Task { @MainActor in
                     withAnimation {
                         columnVisibility = newSessionId == nil ? .detailOnly : .all
@@ -103,7 +101,7 @@ struct ContentView: View {
                     // When all sessions are closed, return to Welcome window
                     if newSessionId == nil {
                         openWindow(id: "welcome")
-                        dismissWindow(id: "main")
+                        NSApplication.shared.closeWindows(withId: "main")
                     }
                 }
             }

--- a/TablePro/Extensions/NSApplication+WindowManagement.swift
+++ b/TablePro/Extensions/NSApplication+WindowManagement.swift
@@ -1,0 +1,18 @@
+//
+//  NSApplication+WindowManagement.swift
+//  TablePro
+//
+//  macOS 13-compatible window management helpers.
+//
+
+import AppKit
+
+extension NSApplication {
+    /// Close all windows whose identifier contains the given ID.
+    /// This is a macOS 13-compatible replacement for SwiftUI's `dismissWindow(id:)` (macOS 14+).
+    func closeWindows(withId id: String) {
+        for window in windows where window.identifier?.rawValue.contains(id) == true {
+            window.close()
+        }
+    }
+}

--- a/TablePro/Views/Components/KeyEventHandler.swift
+++ b/TablePro/Views/Components/KeyEventHandler.swift
@@ -1,0 +1,78 @@
+//
+//  KeyEventHandler.swift
+//  TablePro
+//
+//  macOS 13-compatible replacement for SwiftUI's onKeyPress (macOS 14+).
+//  Uses NSViewRepresentable with a local event monitor.
+//
+
+import AppKit
+import SwiftUI
+
+/// Key codes used by KeyEventHandler
+enum KeyEventCode {
+    case `return`
+    case upArrow
+    case downArrow
+    case other(UInt16)
+}
+
+/// macOS 13-compatible key event handler using a local NSEvent monitor.
+/// Usage: `.background(KeyEventHandler { keyCode in ... })`
+struct KeyEventHandler: NSViewRepresentable {
+    let handler: (KeyEventCode) -> Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = KeyEventNSView()
+        view.handler = handler
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? KeyEventNSView)?.handler = handler
+    }
+}
+
+private class KeyEventNSView: NSView {
+    var handler: ((KeyEventCode) -> Bool)?
+
+    override var acceptsFirstResponder: Bool { false }
+
+    private var monitor: Any?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil && monitor == nil {
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self, self.window?.isKeyWindow == true else { return event }
+
+                let code: KeyEventCode
+                switch event.keyCode {
+                case 36: code = .return
+                case 126: code = .upArrow
+                case 125: code = .downArrow
+                default: code = .other(event.keyCode)
+                }
+
+                if self.handler?(code) == true {
+                    return nil // consumed
+                }
+                return event
+            }
+        }
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil, let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+
+    deinit {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+}

--- a/TablePro/Views/Components/PaginationControlsView.swift
+++ b/TablePro/Views/Components/PaginationControlsView.swift
@@ -44,10 +44,10 @@ struct PaginationControlsView: View {
             limitText = "\(pagination.pageSize)"
             offsetText = "\(pagination.currentOffset)"
         }
-        .onChange(of: pagination.pageSize) { _, newValue in
+        .onChange(of: pagination.pageSize) { newValue in
             limitText = "\(newValue)"
         }
-        .onChange(of: pagination.currentOffset) { _, newValue in
+        .onChange(of: pagination.currentOffset) { newValue in
             offsetText = "\(newValue)"
         }
     }

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -10,7 +10,6 @@ import UniformTypeIdentifiers
 
 /// Form for creating or editing a database connection
 struct ConnectionFormView: View {
-    @Environment(\.dismissWindow) private var dismissWindow
     @Environment(\.openWindow) private var openWindow
 
     // Connection ID: nil = new connection, UUID = edit existing
@@ -96,7 +95,7 @@ struct ConnectionFormView: View {
             loadConnectionData()
             loadSSHConfig()
         }
-        .onChange(of: type) { _, newType in
+        .onChange(of: type) { newType in
             port = String(newType.defaultPort)
         }
     }
@@ -265,7 +264,7 @@ struct ConnectionFormView: View {
                                 }
                                 .labelsHidden()
                                 .fixedSize()
-                                .onChange(of: selectedSSHConfigHost) { _, newValue in
+                                .onChange(of: selectedSSHConfigHost) { newValue in
                                     applySSHConfigEntry(newValue)
                                 }
 
@@ -386,7 +385,7 @@ struct ConnectionFormView: View {
 
                 // Cancel
                 Button("Cancel") {
-                    dismissWindow(id: "connection-form")
+                    NSApplication.shared.closeWindows(withId: "connection-form")
                 }
 
                 // Save
@@ -402,7 +401,7 @@ struct ConnectionFormView: View {
         }
         .background(Color(nsColor: .windowBackgroundColor))
         .onExitCommand {
-            dismissWindow(id: "connection-form")
+            NSApplication.shared.closeWindows(withId: "connection-form")
         }
     }
 
@@ -526,14 +525,14 @@ struct ConnectionFormView: View {
             savedConnections.append(connectionToSave)
             storage.saveConnections(savedConnections)
             // Close and connect to database
-            dismissWindow(id: "connection-form")
+            NSApplication.shared.closeWindows(withId: "connection-form")
             connectToDatabase(connectionToSave)
         } else {
             if let index = savedConnections.firstIndex(where: { $0.id == connectionToSave.id }) {
                 savedConnections[index] = connectionToSave
                 storage.saveConnections(savedConnections)
             }
-            dismissWindow(id: "connection-form")
+            NSApplication.shared.closeWindows(withId: "connection-form")
             NotificationCenter.default.post(name: .connectionUpdated, object: nil)
         }
     }
@@ -543,13 +542,13 @@ struct ConnectionFormView: View {
         var savedConnections = storage.loadConnections()
         savedConnections.removeAll { $0.id == id }
         storage.saveConnections(savedConnections)
-        dismissWindow(id: "connection-form")
+        NSApplication.shared.closeWindows(withId: "connection-form")
         NotificationCenter.default.post(name: .connectionUpdated, object: nil)
     }
 
     private func connectToDatabase(_ connection: DatabaseConnection) {
         openWindow(id: "main")
-        dismissWindow(id: "welcome")
+        NSApplication.shared.closeWindows(withId: "welcome")
 
         Task {
             do {

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
@@ -121,7 +121,7 @@ struct CreateDatabaseSheet: View {
                 dismiss()
             }
         }
-        .onChange(of: charset) { _, newCharset in
+        .onChange(of: charset) { newCharset in
             // Update collation when charset changes
             if let firstCollation = collations[newCharset]?.first {
                 collation = firstCollation

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -85,18 +85,23 @@ struct DatabaseSwitcherSheet: View {
             // SwiftUI handles sheet priority automatically - no nested sheets take precedence
             dismiss()
         }
-        .onKeyPress(.return) {
-            openSelectedDatabase()
-            return .handled
-        }
-        .onKeyPress(.upArrow) {
-            moveSelection(up: true)
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            moveSelection(up: false)
-            return .handled
-        }
+        .background(
+            KeyEventHandler { keyCode in
+                switch keyCode {
+                case .return:
+                    openSelectedDatabase()
+                    return true
+                case .upArrow:
+                    moveSelection(up: true)
+                    return true
+                case .downArrow:
+                    moveSelection(up: false)
+                    return true
+                default:
+                    return false
+                }
+            }
+        )
     }
 
     // MARK: - Toolbar
@@ -187,7 +192,7 @@ struct DatabaseSwitcherSheet: View {
             }
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
-            .onChange(of: viewModel.selectedDatabase) { _, newValue in
+            .onChange(of: viewModel.selectedDatabase) { newValue in
                 if let item = newValue {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         proxy.scrollTo(item, anchor: .center)

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -33,7 +33,7 @@ struct SQLEditorView: View {
             coordinators: [coordinator],
             completionDelegate: completionAdapter
         )
-        .onChange(of: editorState.cursorPositions) { _, newValue in
+        .onChange(of: editorState.cursorPositions) { newValue in
             guard let positions = newValue else { return }
             // Skip cursor propagation when the editor doesn't have focus
             // (e.g., find panel match highlighting). Propagating triggers
@@ -51,7 +51,7 @@ struct SQLEditorView: View {
         // so programmatic changes on the SAME tab (clear, format) won't appear
         // without this. Tab switches don't need it — .id(tab.id) recreates the
         // entire SourceEditor with the correct text.
-        .onChange(of: text) { _, newValue in
+        .onChange(of: text) { newValue in
             if let controller = coordinator.controller,
                controller.textView.string != newValue {
                 let fullRange = NSRange(location: 0, length: (controller.textView.string as NSString).length)

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -191,7 +191,7 @@ struct FilterPanelView: View {
                 .padding(.vertical, 4)
             }
             .frame(maxHeight: min(CGFloat(filterState.filters.count) * 40 + 8, 160))
-            .onChange(of: filterState.focusedFilterId) { _, newFocusedId in
+            .onChange(of: filterState.focusedFilterId) { newFocusedId in
                 if let focusedId = newFocusedId {
                     withAnimation(.easeInOut(duration: 0.25)) {
                         proxy.scrollTo(focusedId, anchor: .bottom)

--- a/TablePro/Views/Filter/FilterSettingsPopover.swift
+++ b/TablePro/Views/Filter/FilterSettingsPopover.swift
@@ -38,7 +38,7 @@ struct FilterSettingsPopover: View {
         }
         .formStyle(.grouped)
         .frame(width: 280)
-        .onChange(of: settings) { _, newValue in
+        .onChange(of: settings) { newValue in
             FilterSettingsStorage.shared.saveSettings(newValue)
         }
     }

--- a/TablePro/Views/Filter/QuickSearchField.swift
+++ b/TablePro/Views/Filter/QuickSearchField.swift
@@ -47,7 +47,7 @@ struct QuickSearchField: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(Color(nsColor: .textBackgroundColor))
-        .onChange(of: shouldFocus) { _, newValue in
+        .onChange(of: shouldFocus) { newValue in
             if newValue {
                 isTextFieldFocused = true
                 shouldFocus = false

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -208,7 +208,7 @@ struct ImportDialog: View {
                     }
                     .pickerStyle(.menu)
                     .frame(width: 120)
-                    .onChange(of: selectedEncoding) { _, newEncoding in
+                    .onChange(of: selectedEncoding) { newEncoding in
                         config.encoding = newEncoding.encoding
                         // Cancel previous task to avoid race conditions
                         loadFileTask?.cancel()

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -88,7 +88,7 @@ struct MainEditorContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: appState.isHistoryPanelVisible)
-        .onChange(of: tabManager.tabs.count) {
+        .onChange(of: tabManager.tabs.count) { _ in
             // Clean up sort cache for closed tabs
             let openTabIds = Set(tabManager.tabs.map(\.id))
             sortCache = sortCache.filter { openTabIds.contains($0.key) }

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -34,6 +34,8 @@ struct MainContentView: View {
     // MARK: - Local State
 
     @State var selectedRowIndices: Set<Int> = []
+    @State private var previousSelectedTabId: UUID?
+    @State private var previousSelectedTables: Set<TableInfo> = []
     @State private var editingCell: CellPosition?
     @State private var notificationHandler: MainContentNotificationHandler?
     @StateObject private var sidebarEditState = MultiRowEditState()
@@ -89,37 +91,39 @@ struct MainContentView: View {
         mainContentView
             .openTableToolbar(state: toolbarState)
             .task { await initializeAndRestoreTabs() }
-            .onChange(of: tabManager.selectedTabId) { oldTabId, newTabId in
-                handleTabSelectionChange(from: oldTabId, to: newTabId)
+            .onChange(of: tabManager.selectedTabId) { newTabId in
+                handleTabSelectionChange(from: previousSelectedTabId, to: newTabId)
+                previousSelectedTabId = newTabId
             }
-            .onChange(of: tabManager.tabs) { _, newTabs in
+            .onChange(of: tabManager.tabs) { newTabs in
                 handleTabsChange(newTabs)
             }
-            .onChange(of: currentTab?.resultColumns) { _, newColumns in
+            .onChange(of: currentTab?.resultColumns) { newColumns in
                 handleColumnsChange(newColumns: newColumns)
             }
-            .onChange(of: DatabaseManager.shared.currentSession?.isConnected) { _, isConnected in
+            .onChange(of: DatabaseManager.shared.currentSession?.isConnected) { isConnected in
                 handleConnectionChange(isConnected)
             }
-            .onChange(of: DatabaseManager.shared.currentSession?.status) { _, newStatus in
+            .onChange(of: DatabaseManager.shared.currentSession?.status) { newStatus in
                 handleSessionStatusChange(newStatus)
             }
-            .onChange(of: currentTab?.isExecuting) { _, isExecuting in
+            .onChange(of: currentTab?.isExecuting) { isExecuting in
                 toolbarState.isExecuting = isExecuting ?? false
             }
-            .onChange(of: currentTab?.executionTime) { _, executionTime in
+            .onChange(of: currentTab?.executionTime) { executionTime in
                 if let time = executionTime {
                     toolbarState.lastQueryDuration = time
                 }
             }
-            .onChange(of: selectedTables) { oldTables, newTables in
-                handleTableSelectionChange(from: oldTables, to: newTables)
+            .onChange(of: selectedTables) { newTables in
+                handleTableSelectionChange(from: previousSelectedTables, to: newTables)
+                previousSelectedTables = newTables
             }
-            .onChange(of: selectedRowIndices) { _, newIndices in
+            .onChange(of: selectedRowIndices) { newIndices in
                 AppState.shared.hasRowSelection = !newIndices.isEmpty
                 updateSidebarEditState()
             }
-            .onChange(of: currentTab?.resultRows) { _, _ in
+            .onChange(of: currentTab?.resultRows) { _ in
                 updateSidebarEditState()
             }
             .onAppear { setupNotificationHandler() }

--- a/TablePro/Views/RightSidebar/RightSidebarView.swift
+++ b/TablePro/Views/RightSidebar/RightSidebarView.swift
@@ -266,28 +266,29 @@ struct RightSidebarView: View {
 
 // MARK: - Preview
 
-#Preview {
-    @Previewable @StateObject var editState = MultiRowEditState()
-    return RightSidebarView(
-        tableName: "users",
-        tableMetadata: TableMetadata(
+struct RightSidebarView_Previews: PreviewProvider {
+    static var previews: some View {
+        RightSidebarView(
             tableName: "users",
-            dataSize: 16_384,
-            indexSize: 8_192,
-            totalSize: 24_576,
-            avgRowLength: 128,
-            rowCount: 1_250,
-            comment: "User accounts",
-            engine: "InnoDB",
-            collation: "utf8mb4_unicode_ci",
-            createTime: Date(),
-            updateTime: nil
-        ),
-        selectedRowData: nil,
-        isEditable: false,
-        isRowDeleted: false,
-        onSave: {},
-        editState: editState
-    )
-    .frame(width: 280, height: 400)
+            tableMetadata: TableMetadata(
+                tableName: "users",
+                dataSize: 16_384,
+                indexSize: 8_192,
+                totalSize: 24_576,
+                avgRowLength: 128,
+                rowCount: 1_250,
+                comment: "User accounts",
+                engine: "InnoDB",
+                collation: "utf8mb4_unicode_ci",
+                createTime: Date(),
+                updateTime: nil
+            ),
+            selectedRowData: nil,
+            isEditable: false,
+            isRowDeleted: false,
+            onSave: {},
+            editState: MultiRowEditState()
+        )
+        .frame(width: 280, height: 400)
+    }
 }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -30,6 +30,9 @@ struct SidebarView: View {
     /// Prevents selection callback during programmatic updates (e.g., refresh)
     @State private var isRestoringSelection = false
 
+    /// Tracks previous selection for onChange diff
+    @State private var previousSelectedTables: Set<TableInfo> = []
+
     /// Whether the tables section is expanded
     @State private var isTablesExpanded = true
 
@@ -54,14 +57,15 @@ struct SidebarView: View {
             content
         }
         .frame(minWidth: 280)
-        .onChange(of: selectedTables) { oldTables, newTables in
+        .onChange(of: selectedTables) { newTables in
             guard !isRestoringSelection else { return }
-            let added = newTables.subtracting(oldTables)
+            let added = newTables.subtracting(previousSelectedTables)
             if let table = added.first {
                 Task { @MainActor in
                     onTablePro?(table.name)
                 }
             }
+            previousSelectedTables = newTables
         }
         .onReceive(NotificationCenter.default.publisher(for: .databaseDidConnect)) { _ in
             Task { @MainActor in
@@ -220,28 +224,43 @@ struct SidebarView: View {
 
     private var tableList: some View {
         List(selection: $selectedTables) {
-            Section(isExpanded: $isTablesExpanded) {
-                ForEach(filteredTables) { table in
-                    TableRow(
-                        table: table,
-                        isActive: activeTableName == table.name,
-                        isPendingTruncate: pendingTruncates.contains(table.name),
-                        isPendingDelete: pendingDeletes.contains(table.name)
-                    )
-                    .tag(table)
-                    .contextMenu {
-                        tableContextMenu(clickedTable: table)
+            Section {
+                if isTablesExpanded {
+                    ForEach(filteredTables) { table in
+                        TableRow(
+                            table: table,
+                            isActive: activeTableName == table.name,
+                            isPendingTruncate: pendingTruncates.contains(table.name),
+                            isPendingDelete: pendingDeletes.contains(table.name)
+                        )
+                        .tag(table)
+                        .contextMenu {
+                            tableContextMenu(clickedTable: table)
+                        }
                     }
                 }
             } header: {
-                Button(action: {
-                    onShowAllTables?()
-                }) {
-                    Text("Tables")
-                        .contentShape(Rectangle())
+                HStack {
+                    Button(action: {
+                        onShowAllTables?()
+                    }) {
+                        Text("Tables")
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Click to show all tables with metadata")
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(isTablesExpanded ? 90 : 0))
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .padding(.trailing, 12)
+                        .onTapGesture {
+                            withAnimation { isTablesExpanded.toggle() }
+                        }
                 }
-                .buttonStyle(.plain)
-                .help("Click to show all tables with metadata")
             }
         }
         .listStyle(.sidebar)

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -57,11 +57,11 @@ struct TableStructureView: View {
             contentArea
         }
         .task(loadInitialData)
-        .onChange(of: selectedTab, onSelectedTabChanged)
-        .onChange(of: columns, onColumnsChanged)
-        .onChange(of: indexes, onIndexesChanged)
-        .onChange(of: foreignKeys, onForeignKeysChanged)
-        .onChange(of: selectedRows) { _, newSelection in
+        .onChange(of: selectedTab) { newValue in onSelectedTabChanged(newValue) }
+        .onChange(of: columns) { _ in onColumnsChanged() }
+        .onChange(of: indexes) { _ in onIndexesChanged() }
+        .onChange(of: foreignKeys) { _ in onForeignKeysChanged() }
+        .onChange(of: selectedRows) { newSelection in
             AppState.shared.hasRowSelection = !newSelection.isEmpty
         }
         .onAppear {
@@ -723,7 +723,7 @@ struct TableStructureView: View {
 
     // MARK: - Lifecycle Callbacks
 
-    private func onSelectedTabChanged(_ old: StructureTab, _ new: StructureTab) {
+    private func onSelectedTabChanged(_ new: StructureTab) {
         // Update AppState when switching to/from DDL tab
         AppState.shared.isCurrentTabEditable = (new != .ddl)
 
@@ -732,17 +732,17 @@ struct TableStructureView: View {
         }
     }
 
-    private func onColumnsChanged(_ old: [ColumnInfo], _ new: [ColumnInfo]) {
+    private func onColumnsChanged() {
         guard !isReloadingAfterSave else { return }
         loadSchemaForEditing()
     }
 
-    private func onIndexesChanged(_ old: [IndexInfo], _ new: [IndexInfo]) {
+    private func onIndexesChanged() {
         guard !isReloadingAfterSave else { return }
         loadSchemaForEditing()
     }
 
-    private func onForeignKeysChanged(_ old: [ForeignKeyInfo], _ new: [ForeignKeyInfo]) {
+    private func onForeignKeysChanged() {
         guard !isReloadingAfterSave else { return }
         loadSchemaForEditing()
     }

--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -26,7 +26,6 @@ struct WelcomeWindowView: View {
     @State private var selectedConnectionId: UUID?  // For keyboard navigation
 
     @Environment(\.openWindow) private var openWindow
-    @Environment(\.dismissWindow) private var dismissWindow
 
     private var filteredConnections: [DatabaseConnection] {
         if searchText.isEmpty {
@@ -219,16 +218,17 @@ struct WelcomeWindowView: View {
         }
         .listStyle(.inset)
         .scrollContentBackground(.hidden)
-        .alternatingRowBackgrounds(.disabled)
         .environment(\.defaultMinListRowHeight, 44)
-        .onKeyPress(.return) {
-            // Return key connects to selected row
-            if let id = selectedConnectionId,
-               let connection = connections.first(where: { $0.id == id }) {
-                connectToDatabase(connection)
+        .background(
+            KeyEventHandler { keyCode in
+                guard case .return = keyCode else { return false }
+                if let id = selectedConnectionId,
+                   let connection = connections.first(where: { $0.id == id }) {
+                    connectToDatabase(connection)
+                }
+                return true
             }
-            return .handled
-        }
+        )
     }
 
     // MARK: - Empty State
@@ -275,7 +275,7 @@ struct WelcomeWindowView: View {
     private func connectToDatabase(_ connection: DatabaseConnection) {
         // Open main window immediately - no delay
         openWindow(id: "main")
-        dismissWindow(id: "welcome")
+        NSApplication.shared.closeWindows(withId: "welcome")
 
         // Connect in background - main window shows loading state
         Task {


### PR DESCRIPTION
## Summary
- Downgrade all macOS 14+ APIs to support the declared deployment target of macOS 13.5 (Ventura)
- Migrate ~22 `onChange(of:)` call sites across 15 files from the two-parameter (macOS 14+) form to the single-parameter (macOS 13) form
- Replace `dismissWindow` (macOS 14+) with `NSApplication.closeWindows(withId:)` helper in 3 files (7 call sites)
- Replace `onKeyPress` (macOS 14+) with `KeyEventHandler` NSEvent-based local monitor in 2 files (4 call sites)
- Replace `@Previewable` (macOS 14+) with `PreviewProvider` struct
- Replace `Section(isExpanded:)` (macOS 14+) with manual chevron toggle
- Remove `alternatingRowBackgrounds` (macOS 14+, cosmetic only)
- Update docs (EN + VI) to reflect macOS 13.5+ system requirement

## New files
- `TablePro/Extensions/NSApplication+WindowManagement.swift` — macOS 13-compatible `closeWindows(withId:)` helper
- `TablePro/Views/Components/KeyEventHandler.swift` — macOS 13-compatible key event handler via `NSEvent.addLocalMonitorForEvents`

## Test plan
- [ ] Build succeeds with zero "only available in macOS 14" errors
- [ ] Full connection flow: launch → connect → browse → query → disconnect
- [ ] Tab switching preserves query text (previous-value tracking works)
- [ ] Table selection opens correct tab (previous-value diff works)
- [ ] Window management: welcome ↔ main ↔ connection-form transitions
- [ ] Keyboard navigation in database switcher (Return/Up/Down)
- [ ] Keyboard navigation in welcome window (Return to connect)
- [ ] Sidebar "Tables" section collapse/expand via chevron
- [ ] Filter panel, pagination, import dialog all function correctly