### PR TITLE
feat: add ENUM/SET column editor with searchable dropdown popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Escape single quotes in PostgreSQL `pg_enum` lookup and SQLite `sqlite_master` queries to prevent SQL injection
+- ENUM column nullable detection now uses actual schema metadata instead of heuristic rawType check
 - PostgreSQL primary key modification now queries the actual constraint name from `pg_constraint` instead of assuming the `{table}_pkey` naming convention, supporting tables with custom constraint names
 - Align Xcode `SWIFT_VERSION` build setting from 5.0 to 5.9 to match `.swiftformat` target version
 

--- a/TablePro/Core/Database/MariaDBConnection.swift
+++ b/TablePro/Core/Database/MariaDBConnection.swift
@@ -9,6 +9,11 @@
 import CMariaDB
 import Foundation
 
+// MySQL/MariaDB field flag constants
+private let mysqlBinaryFlag: UInt = 0x0080   // 128
+private let mysqlEnumFlag: UInt = 0x0100     // 256
+private let mysqlSetFlag: UInt = 0x0800      // 2048
+
 // MARK: - Error Types
 
 /// MySQL/MariaDB error with server error code and message
@@ -79,11 +84,11 @@ struct MariaDBColumnInfo {
 private func mysqlTypeToString(_ type: UInt32, length: UInt, flags: UInt) -> String {
     // ENUM/SET fields may be reported as STRING (254) or VAR_STRING (253)
     // in result sets — check flags first
-    if (flags & 256) != 0 { return "ENUM" }   // ENUM_FLAG = 0x100
-    if (flags & 2_048) != 0 { return "SET" }   // SET_FLAG = 0x800
+    if (flags & mysqlEnumFlag) != 0 { return "ENUM" }
+    if (flags & mysqlSetFlag) != 0 { return "SET" }
 
     // Check if this is a text-based field (not binary)
-    let isBinary = (flags & 128) != 0  // BINARY_FLAG = 128
+    let isBinary = (flags & mysqlBinaryFlag) != 0
 
     switch type {
     case 0: return "DECIMAL"
@@ -476,8 +481,8 @@ final class MariaDBConnection: @unchecked Sendable {
                 // Extract column type — correct ENUM/SET codes from flags
                 let fieldFlags = UInt(field.flags)
                 var fieldType = field.type.rawValue
-                if (fieldFlags & 256) != 0 { fieldType = 247 }   // ENUM_FLAG
-                if (fieldFlags & 2_048) != 0 { fieldType = 248 }  // SET_FLAG
+                if (fieldFlags & mysqlEnumFlag) != 0 { fieldType = 247 }
+                if (fieldFlags & mysqlSetFlag) != 0 { fieldType = 248 }
                 columnTypes.append(fieldType)
                 // Extract raw type name
                 columnTypeNames.append(mysqlTypeToString(
@@ -760,8 +765,8 @@ final class MariaDBConnection: @unchecked Sendable {
                 }
                 let fieldFlags = UInt(field.flags)
                 var fieldType = field.type.rawValue
-                if (fieldFlags & 256) != 0 { fieldType = 247 }   // ENUM_FLAG
-                if (fieldFlags & 2_048) != 0 { fieldType = 248 }  // SET_FLAG
+                if (fieldFlags & mysqlEnumFlag) != 0 { fieldType = 247 }
+                if (fieldFlags & mysqlSetFlag) != 0 { fieldType = 248 }
                 columnTypes.append(fieldType)
                 columnTypeNames.append(mysqlTypeToString(
                     fieldType,

--- a/TablePro/Core/Database/PostgreSQLDriver.swift
+++ b/TablePro/Core/Database/PostgreSQLDriver.swift
@@ -260,11 +260,12 @@ final class PostgreSQLDriver: DatabaseDriver {
 
     /// Fetch allowed values for a PostgreSQL user-defined enum type
     func fetchEnumValues(typeName: String) async throws -> [String] {
+        let safeTypeName = typeName.replacingOccurrences(of: "'", with: "''")
         let query = """
             SELECT e.enumlabel
             FROM pg_enum e
             JOIN pg_type t ON e.enumtypid = t.oid
-            WHERE t.typname = '\(typeName)'
+            WHERE t.typname = '\(safeTypeName)'
             ORDER BY e.enumsortorder
         """
         let result = try await execute(query: query)

--- a/TablePro/Core/Database/SQLiteDriver.swift
+++ b/TablePro/Core/Database/SQLiteDriver.swift
@@ -424,7 +424,8 @@ final class SQLiteDriver: DatabaseDriver {
 
     /// Fetch the CREATE TABLE SQL from sqlite_master
     private func fetchCreateTableSQL(table: String) async throws -> String? {
-        let query = "SELECT sql FROM sqlite_master WHERE type='table' AND name='\(table)'"
+        let safeTable = table.replacingOccurrences(of: "'", with: "''")
+        let query = "SELECT sql FROM sqlite_master WHERE type='table' AND name='\(safeTable)'"
         let result = try await execute(query: query)
         return result.rows.first?.first ?? nil
     }
@@ -453,26 +454,8 @@ final class SQLiteDriver: DatabaseDriver {
         let valuesRange = match.range(at: 1)
         let valuesString = nsString.substring(with: valuesRange)
 
-        // Parse 'val1','val2','val3'
-        var values: [String] = []
-        var current = ""
-        var inQuote = false
-
-        for char in valuesString {
-            if char == "'" {
-                inQuote.toggle()
-            } else if char == "," && !inQuote {
-                values.append(current.trimmingCharacters(in: .whitespaces))
-                current = ""
-            } else if inQuote {
-                current.append(char)
-            }
-        }
-        if !current.isEmpty {
-            values.append(current.trimmingCharacters(in: .whitespaces))
-        }
-
-        return values.isEmpty ? nil : values
+        // Reuse shared parser by wrapping in ENUM(...) format
+        return ColumnType.parseEnumValues(from: "ENUM(\(valuesString))")
     }
 
     func fetchTableDDL(table: String) async throws -> String {

--- a/TablePro/Models/QueryTab.swift
+++ b/TablePro/Models/QueryTab.swift
@@ -220,6 +220,7 @@ struct QueryTab: Identifiable, Equatable {
     var columnDefaults: [String: String?]  // Column name -> default value from schema
     var columnForeignKeys: [String: ForeignKeyInfo]  // Column name -> FK info (for FK lookup)
     var columnEnumValues: [String: [String]]  // Column name -> allowed enum/set values
+    var columnNullable: [String: Bool]  // Column name -> is nullable
     var resultRows: [QueryResultRow]
     var executionTime: TimeInterval?
     var rowsAffected: Int  // Number of rows affected by non-SELECT queries
@@ -276,6 +277,7 @@ struct QueryTab: Identifiable, Equatable {
         self.columnDefaults = [:]
         self.columnForeignKeys = [:]
         self.columnEnumValues = [:]
+        self.columnNullable = [:]
         self.resultRows = []
         self.executionTime = nil
         self.rowsAffected = 0
@@ -311,6 +313,7 @@ struct QueryTab: Identifiable, Equatable {
         self.columnDefaults = [:]
         self.columnForeignKeys = [:]
         self.columnEnumValues = [:]
+        self.columnNullable = [:]
         self.resultRows = []
         self.executionTime = nil
         self.rowsAffected = 0
@@ -571,6 +574,7 @@ final class QueryTabManager: ObservableObject {
         newTab.columnTypes = tab.columnTypes
         newTab.columnForeignKeys = tab.columnForeignKeys
         newTab.columnEnumValues = tab.columnEnumValues
+        newTab.columnNullable = tab.columnNullable
         newTab.resultRows = tab.resultRows
 
         if let index = tabs.firstIndex(of: tab) {

--- a/TablePro/Models/RowProvider.swift
+++ b/TablePro/Models/RowProvider.swift
@@ -68,6 +68,7 @@ final class InMemoryRowProvider: RowProvider {
     private(set) var columnTypes: [ColumnType]
     private(set) var columnForeignKeys: [String: ForeignKeyInfo]
     private(set) var columnEnumValues: [String: [String]]
+    private(set) var columnNullable: [String: Bool]
 
     var totalRowCount: Int {
         sourceRows.count
@@ -79,13 +80,15 @@ final class InMemoryRowProvider: RowProvider {
         columnDefaults: [String: String?] = [:],
         columnTypes: [ColumnType]? = nil,
         columnForeignKeys: [String: ForeignKeyInfo] = [:],
-        columnEnumValues: [String: [String]] = [:]
+        columnEnumValues: [String: [String]] = [:],
+        columnNullable: [String: Bool] = [:]
     ) {
         self.columns = columns
         self.columnDefaults = columnDefaults
         self.columnTypes = columnTypes ?? Array(repeating: ColumnType.text(rawType: nil), count: columns.count)
         self.columnForeignKeys = columnForeignKeys
         self.columnEnumValues = columnEnumValues
+        self.columnNullable = columnNullable
         self.sourceRows = rows
     }
 

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -276,7 +276,8 @@ struct MainEditorContentView: View {
                 columnDefaults: tab.columnDefaults,
                 columnTypes: tab.columnTypes,
                 columnForeignKeys: tab.columnForeignKeys,
-                columnEnumValues: tab.columnEnumValues
+                columnEnumValues: tab.columnEnumValues,
+                columnNullable: tab.columnNullable
             ),
             changeManager: AnyChangeManager(dataManager: changeManager),
             isEditable: tab.isEditable && !tab.isView && !connection.isReadOnly,

--- a/TablePro/Views/Main/Child/TableTabContentView.swift
+++ b/TablePro/Views/Main/Child/TableTabContentView.swift
@@ -71,7 +71,8 @@ struct TableTabContentView: View {
                         columns: tab.resultColumns,
                         columnDefaults: tab.columnDefaults,
                         columnTypes: tab.columnTypes,
-                        columnEnumValues: tab.columnEnumValues
+                        columnEnumValues: tab.columnEnumValues,
+                        columnNullable: tab.columnNullable
                     ),
                     changeManager: AnyChangeManager(dataManager: changeManager),
                     isEditable: tab.isEditable && !tab.isView,

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -335,6 +335,7 @@ final class MainContentCoordinator: ObservableObject {
                 var primaryKeyColumn: String?
 
                 var columnEnumValues: [String: [String]] = [:]
+                var columnNullable: [String: Bool] = [:]
 
                 if isEditable, let tableName = tableName {
                     if let driver = DatabaseManager.shared.activeDriver {
@@ -347,6 +348,7 @@ final class MainContentCoordinator: ObservableObject {
 
                         for col in columnInfo {
                             columnDefaults[col.name] = col.defaultValue
+                            columnNullable[col.name] = col.isNullable
                         }
 
                         // Build FK lookup map (column name -> FK info)
@@ -383,6 +385,7 @@ final class MainContentCoordinator: ObservableObject {
                 let safeColumnDefaults = columnDefaults.mapValues { $0.map { String($0) } }
                 let safeColumnForeignKeys = columnForeignKeys
                 let safeColumnEnumValues = columnEnumValues
+                let safeColumnNullable = columnNullable
                 let safeTableName = tableName.map { String($0) }
                 let safeTotalRowCount = totalRowCount
                 let safePrimaryKeyColumn = primaryKeyColumn.map { String($0) }
@@ -413,6 +416,7 @@ final class MainContentCoordinator: ObservableObject {
                         updatedTab.columnDefaults = safeColumnDefaults
                         updatedTab.columnForeignKeys = safeColumnForeignKeys
                         updatedTab.columnEnumValues = safeColumnEnumValues
+                        updatedTab.columnNullable = safeColumnNullable
                         updatedTab.resultRows = safeRows
                         updatedTab.resultVersion += 1
                         updatedTab.executionTime = safeExecutionTime

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -789,16 +789,13 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     }
 
     private func showEnumPopover(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
-        guard let rowData = rowProvider.row(at: row) else { return }
-        let currentValue = rowData.value(at: columnIndex)
+        guard let cellView = tableView.view(atColumn: column, row: row, makeIfNecessary: false),
+              let rowData = rowProvider.row(at: row) else { return }
         let columnName = rowProvider.columns[columnIndex]
-
-        guard let cellView = tableView.view(atColumn: column, row: row, makeIfNecessary: false) else { return }
         guard let allowedValues = rowProvider.columnEnumValues[columnName] else { return }
 
-        // Determine nullable from column info
-        let columnType = rowProvider.columnTypes[columnIndex]
-        let isNullable = currentValue == nil || columnType.rawType?.uppercased().contains("NOT NULL") != true
+        let currentValue = rowData.value(at: columnIndex)
+        let isNullable = rowProvider.columnNullable[columnName] ?? true
 
         EnumPopoverController.shared.show(
             relativeTo: cellView.bounds,
@@ -807,35 +804,17 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             allowedValues: allowedValues,
             isNullable: isNullable
         ) { [weak self] newValue in
-            guard let self = self else { return }
-            guard let rowData = self.rowProvider.row(at: row) else { return }
-            let oldValue = rowData.value(at: columnIndex)
-            guard oldValue != newValue else { return }
-
-            let columnName = self.rowProvider.columns[columnIndex]
-            self.changeManager.recordCellChange(
-                rowIndex: row,
-                columnIndex: columnIndex,
-                columnName: columnName,
-                oldValue: oldValue,
-                newValue: newValue,
-                originalRow: rowData.values
-            )
-
-            self.rowProvider.updateValue(newValue, at: row, columnIndex: columnIndex)
-            self.onCellEdit?(row, columnIndex, newValue)
-
-            tableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integer: column))
+            self?.commitPopoverEdit(tableView: tableView, row: row, column: column, columnIndex: columnIndex, newValue: newValue)
         }
     }
 
     private func showSetPopover(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
-        guard let rowData = rowProvider.row(at: row) else { return }
-        let currentValue = rowData.value(at: columnIndex)
+        guard let cellView = tableView.view(atColumn: column, row: row, makeIfNecessary: false),
+              let rowData = rowProvider.row(at: row) else { return }
         let columnName = rowProvider.columns[columnIndex]
-
-        guard let cellView = tableView.view(atColumn: column, row: row, makeIfNecessary: false) else { return }
         guard let allowedValues = rowProvider.columnEnumValues[columnName] else { return }
+
+        let currentValue = rowData.value(at: columnIndex)
 
         SetPopoverController.shared.show(
             relativeTo: cellView.bounds,
@@ -843,26 +822,29 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             currentValue: currentValue,
             allowedValues: allowedValues
         ) { [weak self] newValue in
-            guard let self = self else { return }
-            guard let rowData = self.rowProvider.row(at: row) else { return }
-            let oldValue = rowData.value(at: columnIndex)
-            guard oldValue != newValue else { return }
-
-            let columnName = self.rowProvider.columns[columnIndex]
-            self.changeManager.recordCellChange(
-                rowIndex: row,
-                columnIndex: columnIndex,
-                columnName: columnName,
-                oldValue: oldValue,
-                newValue: newValue,
-                originalRow: rowData.values
-            )
-
-            self.rowProvider.updateValue(newValue, at: row, columnIndex: columnIndex)
-            self.onCellEdit?(row, columnIndex, newValue)
-
-            tableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integer: column))
+            self?.commitPopoverEdit(tableView: tableView, row: row, column: column, columnIndex: columnIndex, newValue: newValue)
         }
+    }
+
+    private func commitPopoverEdit(tableView: NSTableView, row: Int, column: Int, columnIndex: Int, newValue: String?) {
+        guard let rowData = rowProvider.row(at: row) else { return }
+        let oldValue = rowData.value(at: columnIndex)
+        guard oldValue != newValue else { return }
+
+        let columnName = rowProvider.columns[columnIndex]
+        changeManager.recordCellChange(
+            rowIndex: row,
+            columnIndex: columnIndex,
+            columnName: columnName,
+            oldValue: oldValue,
+            newValue: newValue,
+            originalRow: rowData.values
+        )
+
+        rowProvider.updateValue(newValue, at: row, columnIndex: columnIndex)
+        onCellEdit?(row, columnIndex, newValue)
+
+        tableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integer: column))
     }
 
     func control(_ control: NSControl, textShouldEndEditing fieldEditor: NSText) -> Bool {


### PR DESCRIPTION
## Summary

- Add popover-based editors for ENUM and SET columns across MySQL/MariaDB, PostgreSQL, and SQLite
- Fix MySQL/MariaDB ENUM/SET detection: the C API reports ENUM fields as STRING (254) / VAR_STRING (253) — now checks `ENUM_FLAG` (0x100) and `SET_FLAG` (0x800) in field flags
- Preserve original casing of ENUM/SET values from `SHOW FULL COLUMNS`
- SwiftUI content hosted in NSPopover shell for both editors

### ENUM Editor
- Searchable single-select dropdown popover
- NULL option shown at top for nullable columns (italic, secondary color)
- Current value highlighted with accent color
- Single-click commits immediately and closes popover

### SET Editor
- Multi-select checkbox popover with OK/Cancel buttons
- Pre-checks currently selected values (parsed from comma-separated cell value)

### Database Support
| Database | Source |
|----------|--------|
| MySQL/MariaDB | Native ENUM/SET types via field flags + `SHOW FULL COLUMNS` value parsing |
| PostgreSQL | User-defined enum types via `udt_name` + `pg_enum` catalog |
| SQLite | `CHECK(col IN ('a','b','c'))` constraint parsing from `CREATE TABLE` SQL |

### Security & Code Quality
- SQL injection prevention: escape single quotes in `pg_enum` and `sqlite_master` queries
- Correct nullable detection via schema metadata (`columnNullable` dict) instead of rawType heuristic
- Named constants for MySQL field flags (`mysqlEnumFlag`, `mysqlSetFlag`, `mysqlBinaryFlag`)
- Shared `commitPopoverEdit` helper eliminates duplicate popover callback code
- SQLite CHECK parser consolidated to reuse `ColumnType.parseEnumValues()`

### Files Changed
- **New**: `EnumPopoverController.swift` (SwiftUI), `SetPopoverController.swift` (SwiftUI)
- **Modified**: `ColumnType.swift`, `MariaDBConnection.swift`, `MySQLDriver.swift`, `PostgreSQLDriver.swift`, `SQLiteDriver.swift`, `MainContentCoordinator.swift`, `DataGridView.swift`, `QueryTab.swift`, `RowProvider.swift`, view wiring files

## Test plan
- [ ] MySQL: double-click ENUM column → searchable dropdown, single-click commits
- [ ] MySQL: double-click SET column → checkbox popover, OK commits comma-separated values
- [ ] Nullable ENUM: NULL option shown at top for nullable columns only
- [ ] Non-nullable ENUM: no NULL option shown
- [ ] PostgreSQL: user-defined enum type shows correct values from `pg_enum`
- [ ] SQLite: CHECK constraint pseudo-enum detected and shows dropdown
- [ ] Fallback: complex query results (no enum values) → inline text editing
- [ ] Keyboard: Escape cancels popover
- [ ] Popover sizes to fit content (no empty space)