### PR TITLE
Add database-specific type picker popover for Structure view

### DIFF
--- a/TablePro/Models/TableCreationModels.swift
+++ b/TablePro/Models/TableCreationModels.swift
@@ -294,37 +294,50 @@ enum DataTypeCategory: String, CaseIterable {
     func types(for dbType: DatabaseType) -> [String] {
         switch self {
         case .numeric:
-            var types = ["INT", "BIGINT", "SMALLINT", "DECIMAL", "FLOAT", "DOUBLE"]
-            if dbType == .mysql || dbType == .mariadb {
-                types.append(contentsOf: ["TINYINT", "MEDIUMINT"])
+            switch dbType {
+            case .mysql, .mariadb:
+                return ["TINYINT", "SMALLINT", "MEDIUMINT", "INT", "BIGINT", "DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "BIT"]
+            case .postgresql:
+                return ["SMALLINT", "INTEGER", "BIGINT", "DECIMAL", "NUMERIC", "REAL", "DOUBLE PRECISION", "SMALLSERIAL", "SERIAL", "BIGSERIAL"]
+            case .sqlite:
+                return ["INTEGER", "REAL", "NUMERIC"]
             }
-            if dbType == .postgresql {
-                types.append(contentsOf: ["SERIAL", "BIGSERIAL"])
-            }
-            return types
         case .string:
-            var types = ["VARCHAR", "CHAR", "TEXT"]
-            if dbType == .mysql || dbType == .mariadb {
-                types.append(contentsOf: ["MEDIUMTEXT", "LONGTEXT", "TINYTEXT"])
+            switch dbType {
+            case .mysql, .mariadb:
+                return ["CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"]
+            case .postgresql:
+                return ["CHAR", "VARCHAR", "TEXT"]
+            case .sqlite:
+                return ["TEXT"]
             }
-            return types
         case .dateTime:
-            var types = ["DATE", "TIME", "DATETIME", "TIMESTAMP"]
-            if dbType == .mysql || dbType == .mariadb {
-                types.append("YEAR")
+            switch dbType {
+            case .mysql, .mariadb:
+                return ["DATE", "TIME", "DATETIME", "TIMESTAMP", "YEAR"]
+            case .postgresql:
+                return ["DATE", "TIME", "TIMESTAMP", "TIMESTAMPTZ", "INTERVAL"]
+            case .sqlite:
+                return ["DATE", "DATETIME"]
             }
-            return types
         case .binary:
-            return ["BLOB", "BINARY", "VARBINARY"]
+            switch dbType {
+            case .mysql, .mariadb:
+                return ["BINARY", "VARBINARY", "TINYBLOB", "BLOB", "MEDIUMBLOB", "LONGBLOB"]
+            case .postgresql:
+                return ["BYTEA"]
+            case .sqlite:
+                return ["BLOB"]
+            }
         case .other:
-            var types = ["BOOLEAN", "JSON"]
-            if dbType == .postgresql {
-                types.append(contentsOf: ["JSONB", "UUID"])
+            switch dbType {
+            case .mysql, .mariadb:
+                return ["BOOLEAN", "ENUM", "SET", "JSON"]
+            case .postgresql:
+                return ["BOOLEAN", "UUID", "JSON", "JSONB", "ARRAY", "HSTORE", "INET", "CIDR", "MACADDR", "TSVECTOR", "TSQUERY"]
+            case .sqlite:
+                return ["BOOLEAN"]
             }
-            if dbType == .mysql || dbType == .mariadb {
-                types.append(contentsOf: ["ENUM", "SET"])
-            }
-            return types
         }
     }
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -5456,6 +5456,9 @@
         }
       }
     },
+    "Search or type..." : {
+
+    },
     "Search..." : {
       "localizations" : {
         "vi" : {

--- a/TablePro/Views/Results/DataGridView+TypePicker.swift
+++ b/TablePro/Views/Results/DataGridView+TypePicker.swift
@@ -1,0 +1,43 @@
+//
+//  DataGridView+TypePicker.swift
+//  TablePro
+//
+//  Extension for database-specific type picker popover in structure view.
+//
+
+import AppKit
+
+extension TableViewCoordinator {
+    func showTypePickerPopover(
+        tableView: NSTableView,
+        row: Int,
+        column: Int,
+        columnIndex: Int
+    ) {
+        guard let cellView = tableView.view(atColumn: column, row: row, makeIfNecessary: false),
+              let rowData = rowProvider.row(at: row) else { return }
+
+        let currentValue = rowData.value(at: columnIndex) ?? ""
+        let dbType = databaseType ?? .mysql
+
+        TypePickerPopoverController.shared.show(
+            relativeTo: cellView.bounds,
+            of: cellView,
+            databaseType: dbType,
+            currentValue: currentValue
+        ) { [weak self] newValue in
+            guard let self else { return }
+            guard let rowData = self.rowProvider.row(at: row) else { return }
+            let oldValue = rowData.value(at: columnIndex)
+            guard oldValue != newValue else { return }
+
+            self.rowProvider.updateValue(newValue, at: row, columnIndex: columnIndex)
+            self.onCellEdit?(row, columnIndex, newValue)
+
+            tableView.reloadData(
+                forRowIndexes: IndexSet(integer: row),
+                columnIndexes: IndexSet(integer: column)
+            )
+        }
+    }
+}

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -43,6 +43,8 @@ struct DataGridView: NSViewRepresentable {
     var onFilterColumn: ((String) -> Void)?
     var getVisualState: ((Int) -> RowVisualState)?
     var dropdownColumns: Set<Int>? // Column indices that should use YES/NO dropdowns
+    var typePickerColumns: Set<Int>?
+    var databaseType: DatabaseType?
 
     @Binding var selectedRowIndices: Set<Int>
     @Binding var sortState: SortState
@@ -182,6 +184,8 @@ struct DataGridView: NSViewRepresentable {
         coordinator.onFilterColumn = onFilterColumn
         coordinator.getVisualState = getVisualState
         coordinator.dropdownColumns = dropdownColumns
+        coordinator.typePickerColumns = typePickerColumns
+        coordinator.databaseType = databaseType
 
         coordinator.rebuildVisualStateCache()
 
@@ -430,6 +434,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var onFilterColumn: ((String) -> Void)?
     var getVisualState: ((Int) -> RowVisualState)?
     var dropdownColumns: Set<Int>?
+    var typePickerColumns: Set<Int>?
+    var databaseType: DatabaseType?
 
     /// Check if undo is available
     func canUndo() -> Bool {
@@ -698,6 +704,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }()
 
         let isDropdown = dropdownColumns?.contains(columnIndex) == true
+        let isTypePicker = typePickerColumns?.contains(columnIndex) == true
 
         return cellFactory?.makeDataCell(
             tableView: tableView,
@@ -709,7 +716,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             isEditable: isEditable && !state.isDeleted,
             isLargeDataset: isLargeDataset,
             isFocused: isFocused,
-            isDropdown: isDropdown,
+            isDropdown: isDropdown || isTypePicker,
             delegate: self
         )
     }
@@ -777,6 +784,12 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
         // Dropdown columns already handled by single click
         if let dropdownCols = dropdownColumns, dropdownCols.contains(columnIndex) {
+            return
+        }
+
+        // Type picker columns use database-specific type popover
+        if let typePickerCols = typePickerColumns, typePickerCols.contains(columnIndex) {
+            showTypePickerPopover(tableView: sender, row: row, column: column, columnIndex: columnIndex)
             return
         }
 
@@ -852,6 +865,9 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                 if ct.isDateType || ct.isJsonType || ct.isEnumType || ct.isSetType { return false }
             }
             if let dropdownCols = dropdownColumns, dropdownCols.contains(columnIndex) {
+                return false
+            }
+            if let typePickerCols = typePickerColumns, typePickerCols.contains(columnIndex) {
                 return false
             }
         }

--- a/TablePro/Views/Structure/StructureRowProvider.swift
+++ b/TablePro/Views/Structure/StructureRowProvider.swift
@@ -104,6 +104,16 @@ final class StructureRowProvider {
         }
     }
 
+    /// Column indices that should use the type picker popover
+    var typePickerColumns: Set<Int> {
+        switch tab {
+        case .columns:
+            return [1] // Type (index 1)
+        case .indexes, .foreignKeys, .ddl:
+            return []
+        }
+    }
+
     var totalRowCount: Int {
         rows.count
     }

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -169,6 +169,8 @@ struct TableStructureView: View {
                 structureChangeManager.getVisualState(for: row, tab: selectedTab)
             },
             dropdownColumns: provider.dropdownColumns,
+            typePickerColumns: provider.typePickerColumns,
+            databaseType: getDatabaseType(),
             selectedRowIndices: $selectedRows,
             sortState: $sortState,
             editingCell: $editingCell,

--- a/TablePro/Views/Structure/TypePickerPopoverController.swift
+++ b/TablePro/Views/Structure/TypePickerPopoverController.swift
@@ -1,0 +1,220 @@
+//
+//  TypePickerPopoverController.swift
+//  TablePro
+//
+//  Searchable type picker popover for structure view column type editing.
+//
+
+import AppKit
+import Combine
+import SwiftUI
+
+// MARK: - SwiftUI State
+
+private final class TypePickerState: ObservableObject {
+    @Published var searchText: String = ""
+
+    let databaseType: DatabaseType
+    let currentValue: String
+    var onCommit: ((String) -> Void)?
+    var dismiss: (() -> Void)?
+
+    init(
+        databaseType: DatabaseType,
+        currentValue: String,
+        onCommit: ((String) -> Void)?
+    ) {
+        self.databaseType = databaseType
+        self.currentValue = currentValue
+        self.onCommit = onCommit
+    }
+}
+
+// MARK: - SwiftUI Content View
+
+private struct TypePickerContentView: View {
+    @ObservedObject var state: TypePickerState
+
+    private static let rowHeight: CGFloat = 22
+    private static let sectionHeaderHeight: CGFloat = 28
+    private static let searchAreaHeight: CGFloat = 44
+    private static let maxTotalHeight: CGFloat = 360
+
+    private var visibleCategories: [DataTypeCategory] {
+        DataTypeCategory.allCases.filter { !filteredTypes(for: $0).isEmpty }
+    }
+
+    private func filteredTypes(for category: DataTypeCategory) -> [String] {
+        let types = category.types(for: state.databaseType)
+        if state.searchText.isEmpty {
+            return types
+        }
+        let query = state.searchText.lowercased()
+        return types.filter { $0.lowercased().contains(query) }
+    }
+
+    private var totalFilteredCount: Int {
+        visibleCategories.reduce(0) { $0 + filteredTypes(for: $1).count }
+    }
+
+    private var listHeight: CGFloat {
+        let contentHeight = CGFloat(totalFilteredCount) * Self.rowHeight
+            + CGFloat(visibleCategories.count) * Self.sectionHeaderHeight
+            + 8
+        return min(contentHeight, Self.maxTotalHeight - Self.searchAreaHeight)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Search or type...", text: $state.searchText)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 13))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 8)
+                .onSubmit { commitFreeform() }
+
+            Divider()
+
+            List {
+                ForEach(visibleCategories, id: \.self) { category in
+                    Section(header: Text(category.rawValue)) {
+                        ForEach(filteredTypes(for: category), id: \.self) { type in
+                            typeRow(type)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                                .onTapGesture { commitType(type) }
+                                .listRowInsets(EdgeInsets(
+                                    top: 2, leading: 6, bottom: 2, trailing: 6
+                                ))
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .environment(\.defaultMinListRowHeight, Self.rowHeight)
+            .frame(height: listHeight)
+        }
+        .frame(width: 280)
+    }
+
+    @ViewBuilder
+    private func typeRow(_ type: String) -> some View {
+        if type.caseInsensitiveCompare(state.currentValue) == .orderedSame {
+            Text(type)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.accentColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        } else {
+            Text(type)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    private func commitFreeform() {
+        let text = state.searchText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        state.onCommit?(text)
+        state.dismiss?()
+    }
+
+    private func commitType(_ type: String) {
+        state.onCommit?(type)
+        state.dismiss?()
+    }
+}
+
+// MARK: - Controller
+
+/// Manages showing a searchable type picker popover for structure view column type editing
+@MainActor
+final class TypePickerPopoverController: NSObject, NSPopoverDelegate {
+    static let shared = TypePickerPopoverController()
+
+    private var popover: NSPopover?
+    private var state: TypePickerState?
+    private var keyMonitor: Any?
+
+    func show(
+        relativeTo bounds: NSRect,
+        of view: NSView,
+        databaseType: DatabaseType,
+        currentValue: String,
+        onCommit: @escaping (String) -> Void
+    ) {
+        popover?.close()
+
+        // Create state and SwiftUI content
+        let popoverState = TypePickerState(
+            databaseType: databaseType,
+            currentValue: currentValue,
+            onCommit: onCommit
+        )
+        self.state = popoverState
+
+        let contentView = TypePickerContentView(state: popoverState)
+        let hostingController = NSHostingController(rootView: contentView)
+
+        // Calculate height to fit content
+        let searchAreaHeight: CGFloat = 44
+        let maxTotalHeight: CGFloat = 360
+        let rowHeight: CGFloat = 22
+        let sectionHeaderHeight: CGFloat = 28
+
+        var totalRows = 0
+        var sectionCount = 0
+        for category in DataTypeCategory.allCases {
+            let types = category.types(for: databaseType)
+            if !types.isEmpty {
+                totalRows += types.count
+                sectionCount += 1
+            }
+        }
+        let listHeight = min(
+            CGFloat(totalRows) * rowHeight + CGFloat(sectionCount) * sectionHeaderHeight + 8,
+            maxTotalHeight - searchAreaHeight
+        )
+        let totalHeight = searchAreaHeight + listHeight
+
+        let pop = NSPopover()
+        pop.contentViewController = hostingController
+        pop.contentSize = NSSize(width: 280, height: totalHeight)
+        pop.behavior = .semitransient
+        pop.delegate = self
+        pop.show(relativeTo: bounds, of: view, preferredEdge: .maxY)
+
+        popover = pop
+
+        popoverState.dismiss = { [weak self] in
+            self?.popover?.close()
+        }
+
+        // Handle Escape to cancel
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.popover != nil else { return event }
+            if event.keyCode == 53 { // Escape
+                self.popover?.close()
+                return nil
+            }
+            return event
+        }
+    }
+
+    // MARK: - NSPopoverDelegate
+
+    func popoverDidClose(_ notification: Notification) {
+        cleanup()
+    }
+
+    private func cleanup() {
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyMonitor = nil
+        }
+        state = nil
+        popover = nil
+    }
+}


### PR DESCRIPTION
## Summary

- Add searchable type picker popover for the Type column in Structure view, grouped by category (Numeric, String, Date & Time, Binary, Other)
- Support freeform input for parametric types like `VARCHAR(255)`
- Integrate the type picker into DataGridView for consistent type selection

## Files Changed

- `TablePro/Models/TableCreationModels.swift` — Updated type models
- `TablePro/Views/Structure/TypePickerPopoverController.swift` — New popover controller (220 lines)
- `TablePro/Views/Results/DataGridView+TypePicker.swift` — DataGridView type picker extension (43 lines)
- `TablePro/Views/Results/DataGridView.swift` — Integration hooks
- `TablePro/Views/Structure/StructureRowProvider.swift` — Row provider updates
- `TablePro/Views/Structure/TableStructureView.swift` — View integration
- `TablePro/Resources/Localizable.xcstrings` — Localization updates

## Test plan

- [ ] Open Structure view for any table
- [ ] Click the Type column — verify searchable popover appears with grouped categories
- [ ] Search for a type (e.g., "var") — verify filtered results
- [ ] Type a parametric type like `VARCHAR(255)` — verify freeform input works
- [ ] Verify the selected type is applied correctly to the column