### PR TITLE
refactor: Embed onboarding into welcome window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- AI feature highlight row on onboarding features page
+
 ## [0.5.0] - 2026-02-19
 
 ### Changed

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -28,6 +28,7 @@ final class AppSettingsStorage {
         static let keyboard = "com.TablePro.settings.keyboard"
         static let ai = "com.TablePro.settings.ai"
         static let lastConnectionId = "com.TablePro.settings.lastConnectionId"
+        static let hasCompletedOnboarding = "com.TablePro.settings.hasCompletedOnboarding"
     }
 
     private init() {}
@@ -130,6 +131,18 @@ final class AppSettingsStorage {
         } else {
             defaults.removeObject(forKey: Keys.lastConnectionId)
         }
+    }
+
+    // MARK: - Onboarding
+
+    /// Check if user has completed onboarding
+    func hasCompletedOnboarding() -> Bool {
+        defaults.bool(forKey: Keys.hasCompletedOnboarding)
+    }
+
+    /// Mark onboarding as completed
+    func setOnboardingCompleted() {
+        defaults.set(true, forKey: Keys.hasCompletedOnboarding)
     }
 
     // MARK: - Reset

--- a/TablePro/OpenTableApp.swift
+++ b/TablePro/OpenTableApp.swift
@@ -140,7 +140,8 @@ struct TableProApp: App {
     }
 
     var body: some Scene {
-        // Welcome Window - opens on launch
+        // Welcome Window - opens on launch (must be first Window scene so SwiftUI
+        // restores it by default when clicking the dock icon)
         Window("Welcome to TablePro", id: "welcome") {
             WelcomeWindowView()
                 .tint(accentTint)

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -764,6 +764,16 @@
         }
       }
     },
+    "A fast, lightweight native macOS database client" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ứng dụng quản lý cơ sở dữ liệu gốc macOS nhanh và nhẹ"
+          }
+        }
+      }
+    },
     "Accent Color:" : {
       "localizations" : {
         "vi" : {
@@ -1878,6 +1888,16 @@
         }
       }
     },
+    "Continue" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        }
+      }
+    },
     "Conversation History" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2048,6 +2068,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạo"
+          }
+        }
+      }
+    },
+    "Create a connection to get started with\nyour databases." : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo kết nối để bắt đầu sử dụng\ncơ sở dữ liệu của bạn."
           }
         }
       }
@@ -3687,6 +3717,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhận trợ giúp viết truy vấn, giải thích schema hoặc sửa lỗi."
+          }
+        }
+      }
+    },
+    "Get Started" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bắt đầu"
           }
         }
       }
@@ -6570,6 +6610,16 @@
         }
       }
     },
+    "Skip" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bỏ qua"
+          }
+        }
+      }
+    },
     "Software Update" : {
       "localizations" : {
         "vi" : {
@@ -7715,6 +7765,16 @@
         }
       }
     },
+    "What you can do" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn có thể làm gì"
+          }
+        }
+      }
+    },
     "When enabled, clicking a new table replaces the current clean table tab instead of opening a new tab" : {
       "localizations" : {
         "vi" : {
@@ -7804,6 +7864,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bạn có thay đổi chưa lưu trong cấu trúc bảng. Làm mới sẽ hủy các thay đổi này."
+          }
+        }
+      }
+    },
+    "You're all set!" : {
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn đã sẵn sàng!"
           }
         }
       }

--- a/TablePro/Views/OnboardingContentView.swift
+++ b/TablePro/Views/OnboardingContentView.swift
@@ -1,0 +1,231 @@
+//
+//  OnboardingContentView.swift
+//  TablePro
+//
+//  First-launch onboarding walkthrough with welcome branding,
+//  feature highlights, and get started page.
+//
+
+import SwiftUI
+
+struct OnboardingContentView: View {
+    @State private var currentPage = 0
+    @State private var navigatingForward = true
+
+    var onComplete: () -> Void
+
+    private var pageTransition: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: navigatingForward ? .trailing : .leading).combined(with: .opacity),
+            removal: .move(edge: navigatingForward ? .leading : .trailing).combined(with: .opacity)
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main content area
+            ZStack {
+                switch currentPage {
+                case 0:
+                    welcomePage
+                        .transition(pageTransition)
+                case 1:
+                    featuresPage
+                        .transition(pageTransition)
+                default:
+                    getStartedPage
+                        .transition(pageTransition)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .gesture(
+                DragGesture(minimumDistance: 30)
+                    .onEnded { value in
+                        let horizontal = value.translation.width
+                        if horizontal < -30, currentPage < 2 {
+                            goToPage(currentPage + 1)
+                        } else if horizontal > 30, currentPage > 0 {
+                            goToPage(currentPage - 1)
+                        }
+                    }
+            )
+
+            // Bottom navigation bar
+            navigationBar
+        }
+        .onKeyPress(.leftArrow) {
+            guard currentPage > 0 else { return .ignored }
+            goToPage(currentPage - 1)
+            return .handled
+        }
+        .onKeyPress(.rightArrow) {
+            guard currentPage < 2 else { return .ignored }
+            goToPage(currentPage + 1)
+            return .handled
+        }
+    }
+
+    private func goToPage(_ page: Int) {
+        navigatingForward = page > currentPage
+        withAnimation(.easeInOut(duration: 0.35)) {
+            currentPage = page
+        }
+    }
+
+    // MARK: - Welcome Page
+
+    private var welcomePage: some View {
+        VStack(spacing: DesignConstants.Spacing.md) {
+            ZStack {
+                Circle()
+                    .fill(Color.orange.opacity(0.30))
+                    .frame(width: 100, height: 100)
+                    .blur(radius: 25)
+
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 80, height: 80)
+            }
+
+            Text("Welcome to TablePro")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+
+            Text("A fast, lightweight native macOS database client")
+                .font(.system(size: DesignConstants.FontSize.body))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Features Page
+
+    private var featuresPage: some View {
+        VStack(spacing: DesignConstants.Spacing.xl) {
+            Text("What you can do")
+                .font(.system(size: DesignConstants.FontSize.title2, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 16) {
+                featureRow(
+                    icon: "cylinder.split.1x2",
+                    title: "MySQL, PostgreSQL & SQLite",
+                    description: "Connect to popular databases with full feature support"
+                )
+                featureRow(
+                    icon: "chevron.left.forwardslash.chevron.right",
+                    title: "Smart SQL Editor",
+                    description: "Syntax highlighting, autocomplete, and multi-tab editing"
+                )
+                featureRow(
+                    icon: "tablecells",
+                    title: "Interactive Data Grid",
+                    description: "Browse, edit, and manage your data with ease"
+                )
+                featureRow(
+                    icon: "lock.shield",
+                    title: "Secure Connections",
+                    description: "SSH tunneling and SSL/TLS encryption support"
+                )
+                featureRow(
+                    icon: "brain",
+                    title: "AI-Powered Assistant",
+                    description: "Get intelligent SQL suggestions and query assistance"
+                )
+            }
+            .padding(.horizontal, 40)
+            .frame(maxWidth: 420)
+        }
+    }
+
+    private func featureRow(icon: String, title: String, description: String) -> some View {
+        HStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: DesignConstants.IconSize.extraLarge))
+                .foregroundStyle(.tint)
+                .frame(width: 40)
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.xxxs) {
+                Text(title)
+                    .font(.system(size: DesignConstants.FontSize.body, weight: .medium))
+                Text(description)
+                    .font(.system(size: DesignConstants.FontSize.small))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Get Started Page
+
+    private var getStartedPage: some View {
+        VStack(spacing: DesignConstants.Spacing.md) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+
+            Text("You're all set!")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+
+            Text("Create a connection to get started with\nyour databases.")
+                .font(.system(size: DesignConstants.FontSize.body))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    // MARK: - Navigation Bar
+
+    private var navigationBar: some View {
+        HStack {
+            Button("Skip") {
+                completeOnboarding()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .opacity(currentPage == 2 ? 0 : 1)
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                ForEach(0..<3, id: \.self) { i in
+                    Circle()
+                        .fill(i == currentPage ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(i == currentPage ? 1.2 : 1.0)
+                        .onTapGesture { goToPage(i) }
+                }
+            }
+            .animation(.spring(response: 0.3), value: currentPage)
+
+            Spacer()
+
+            Group {
+                if currentPage < 2 {
+                    Button("Continue") {
+                        goToPage(currentPage + 1)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                } else {
+                    Button("Get Started") {
+                        completeOnboarding()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.35), value: currentPage)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.xl)
+        .padding(.bottom, DesignConstants.Spacing.lg)
+    }
+
+    // MARK: - Actions
+
+    private func completeOnboarding() {
+        AppSettingsStorage.shared.setOnboardingCompleted()
+        onComplete()
+    }
+}
+
+#Preview("Onboarding") {
+    OnboardingContentView(onComplete: {})
+}

--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -26,6 +26,7 @@ struct WelcomeWindowView: View {
     @State private var showDeleteConfirmation = false
     @State private var hoveredConnectionId: UUID?
     @State private var selectedConnectionId: UUID?  // For keyboard navigation
+    @State private var showOnboarding = !AppSettingsStorage.shared.hasCompletedOnboarding()
 
     @Environment(\.openWindow) private var openWindow
 
@@ -41,14 +42,18 @@ struct WelcomeWindowView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            // Left panel - Branding
-            leftPanel
-
-            Divider()
-
-            // Right panel - Connections
-            rightPanel
+        ZStack {
+            if showOnboarding {
+                OnboardingContentView {
+                    withAnimation(.easeInOut(duration: 0.45)) {
+                        showOnboarding = false
+                    }
+                }
+                .transition(.move(edge: .leading))
+            } else {
+                welcomeContent
+                    .transition(.move(edge: .trailing))
+            }
         }
         .ignoresSafeArea()
         .frame(minWidth: 650, minHeight: 400)
@@ -73,6 +78,19 @@ struct WelcomeWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .connectionUpdated)) { _ in
             loadConnections()
         }
+    }
+
+    private var welcomeContent: some View {
+        HStack(spacing: 0) {
+            // Left panel - Branding
+            leftPanel
+
+            Divider()
+
+            // Right panel - Connections
+            rightPanel
+        }
+        .transition(.opacity)
     }
 
     // MARK: - Left Panel


### PR DESCRIPTION
## Summary
- Merges onboarding into the welcome window as conditional SwiftUI content, replacing the separate onboarding window scene and AppKit timing hacks (`orderOut`, `DispatchQueue.asyncAfter`, `windowDidBecomeKey` guards)
- Renames `OnboardingWindowView` → `OnboardingContentView` with an `onComplete` callback; `WelcomeWindowView` conditionally renders onboarding or connection list with a crossfade transition
- Adds AI-Powered Assistant feature row to onboarding and polished animations (slide+opacity page transitions, spring-animated dots, scale transition on Get Started button)

## Test plan
- [ ] `defaults delete com.TablePro com.TablePro.settings.hasCompletedOnboarding` → launch → welcome window shows onboarding (single window, no flicker)
- [ ] Navigate all 3 pages with smooth slide + opacity animations; features page shows 5 rows including AI
- [ ] "Get Started" or "Skip" → crossfades to connection list in the same window
- [ ] Relaunch → welcome window shows connection list directly (no onboarding)
- [ ] Build succeeds with zero errors