### PR TITLE
fix: Use native Section(isExpanded:) for sidebar table list

### DIFF
--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -245,8 +245,9 @@ struct SidebarView: View {
                 }
             } header: {
                 Text("Tables")
+                    .help("Right-click to show all tables")
                     .contextMenu {
-                        Button("Show All Tables") {
+                        Button(String(localized: "Show All Tables")) {
                             onShowAllTables?()
                         }
                     }


### PR DESCRIPTION
## Summary
- Replace custom chevron `onTapGesture` with native `Section(isExpanded:)` API for the sidebar table list
- Provides smooth expand/collapse animation matching Xcode's sidebar behavior
- Native disclosure chevron with proper hit target and system-standard section header styling
- Move `onShowAllTables` action to right-click context menu on the section header

## Test plan
- [ ] Verify the sidebar "Tables" section expands/collapses with smooth animation
- [ ] Verify the disclosure chevron has a proper clickable area
- [ ] Verify the section header matches native macOS sidebar styling
- [ ] Verify right-click on "Tables" header shows "Show All Tables" context menu
- [ ] Verify table selection and context menus still work correctly