### PR TITLE
Replace generic SwiftUI colors with native macOS system colors

### DIFF
--- a/TablePro/Models/ConnectionToolbarState.swift
+++ b/TablePro/Models/ConnectionToolbarState.swift
@@ -6,6 +6,7 @@
 //  Centralizes all toolbar-related state in a single, composable object.
 //
 
+import AppKit
 import Combine
 import SwiftUI
 
@@ -31,10 +32,10 @@ enum ConnectionEnvironment: String, CaseIterable {
     /// Badge background color
     var backgroundColor: Color {
         switch self {
-        case .local: return Color.gray.opacity(0.3)
-        case .ssh: return Color.orange.opacity(0.3)
-        case .production: return Color.red.opacity(0.3)
-        case .staging: return Color.blue.opacity(0.3)
+        case .local: return Color(nsColor: .systemGray).opacity(0.3)
+        case .ssh: return Color(nsColor: .systemOrange).opacity(0.3)
+        case .production: return Color(nsColor: .systemRed).opacity(0.3)
+        case .staging: return Color(nsColor: .systemBlue).opacity(0.3)
         }
     }
 
@@ -42,9 +43,9 @@ enum ConnectionEnvironment: String, CaseIterable {
     var foregroundColor: Color {
         switch self {
         case .local: return .secondary
-        case .ssh: return .orange
-        case .production: return .red
-        case .staging: return .blue
+        case .ssh: return Color(nsColor: .systemOrange)
+        case .production: return Color(nsColor: .systemRed)
+        case .staging: return Color(nsColor: .systemBlue)
         }
     }
 }
@@ -62,11 +63,11 @@ enum ToolbarConnectionState: Equatable {
     /// Status indicator color
     var indicatorColor: Color {
         switch self {
-        case .disconnected: return .gray
-        case .connecting: return .orange
-        case .connected: return .green
-        case .executing: return .blue
-        case .error: return .red
+        case .disconnected: return Color(nsColor: .systemGray)
+        case .connecting: return Color(nsColor: .systemOrange)
+        case .connected: return Color(nsColor: .systemGreen)
+        case .executing: return Color(nsColor: .systemBlue)
+        case .error: return Color(nsColor: .systemRed)
         }
     }
 
@@ -126,7 +127,7 @@ final class ConnectionToolbarState: ObservableObject {
     @Published var databaseName: String = ""
 
     /// Custom display color for the connection (uses database type color if not set)
-    @Published var displayColor: Color = .orange
+    @Published var displayColor: Color = .init(nsColor: .systemOrange)
 
     /// Current connection state
     @Published var connectionState: ToolbarConnectionState = .disconnected

--- a/TablePro/Models/DatabaseConnection.swift
+++ b/TablePro/Models/DatabaseConnection.swift
@@ -5,6 +5,7 @@
 //  Created by Ngo Quoc Dat on 16/12/25.
 //
 
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -182,14 +183,14 @@ enum ConnectionColor: String, CaseIterable, Identifiable, Codable {
     var color: Color {
         switch self {
         case .none: return .clear
-        case .red: return .red
-        case .orange: return .orange
-        case .yellow: return .yellow
-        case .green: return .green
-        case .blue: return .blue
-        case .purple: return .purple
-        case .pink: return .pink
-        case .gray: return .gray
+        case .red: return Color(nsColor: .systemRed)
+        case .orange: return Color(nsColor: .systemOrange)
+        case .yellow: return Color(nsColor: .systemYellow)
+        case .green: return Color(nsColor: .systemGreen)
+        case .blue: return Color(nsColor: .systemBlue)
+        case .purple: return Color(nsColor: .systemPurple)
+        case .pink: return Color(nsColor: .systemPink)
+        case .gray: return Color(nsColor: .systemGray)
         }
     }
 

--- a/TablePro/Theme/DesignConstants.swift
+++ b/TablePro/Theme/DesignConstants.swift
@@ -127,8 +127,8 @@ enum DesignConstants {
         static let sectionBackground = Color(nsColor: .controlBackgroundColor)
         static let cardBackground = Color(nsColor: .windowBackgroundColor)
         static let alternateRow = Color(nsColor: .controlBackgroundColor).opacity(0.5)
-        static let hoverBackground = Color.accentColor.opacity(0.05)
-        static let selectedBackground = Color.accentColor.opacity(0.1)
+        static let hoverBackground = Color(nsColor: .controlAccentColor).opacity(0.05)
+        static let selectedBackground = Color(nsColor: .selectedContentBackgroundColor)
 
         // Borders
         static let border = Color(nsColor: .separatorColor)
@@ -140,16 +140,16 @@ enum DesignConstants {
         static let tertiaryText = Color(nsColor: .tertiaryLabelColor)
 
         // Semantic
-        static let success = Color.green
-        static let warning = Color.orange
-        static let error = Color.red
-        static let info = Color.blue
+        static let success = Color(nsColor: .systemGreen)
+        static let warning = Color(nsColor: .systemOrange)
+        static let error = Color(nsColor: .systemRed)
+        static let info = Color(nsColor: .systemBlue)
 
         // Badges
-        static let badgeBackground = Color.secondary.opacity(0.15)
-        static let primaryKeyBadge = Color.blue.opacity(0.15)
-        static let autoIncrementBadge = Color.purple.opacity(0.15)
-        static let nullBadge = Color.secondary.opacity(0.1)
+        static let badgeBackground = Color(nsColor: .quaternaryLabelColor)
+        static let primaryKeyBadge = Color(nsColor: .systemBlue).opacity(0.15)
+        static let autoIncrementBadge = Color(nsColor: .systemPurple).opacity(0.15)
+        static let nullBadge = Color(nsColor: .quaternaryLabelColor)
     }
 
     // MARK: - Corner Radius
@@ -189,11 +189,11 @@ enum DesignConstants {
     enum Shadow {
         /// Card shadow (subtle elevation)
         static let card: (color: Color, radius: CGFloat, x: CGFloat, y: CGFloat) =
-            (Color.black.opacity(0.1), 4, 0, 2)
+            (Color(nsColor: .shadowColor).opacity(0.15), 4, 0, 2)
 
         /// Panel shadow (stronger elevation)
         static let panel: (color: Color, radius: CGFloat, x: CGFloat, y: CGFloat) =
-            (Color.black.opacity(0.15), 8, -2, 0)
+            (Color(nsColor: .shadowColor).opacity(0.2), 8, -2, 0)
     }
 
     // MARK: - Column Widths (for table editors)

--- a/TablePro/Theme/Theme.swift
+++ b/TablePro/Theme/Theme.swift
@@ -5,6 +5,7 @@
 //  Created by Ngo Quoc Dat on 16/12/25.
 //
 
+import AppKit
 import SwiftUI
 
 /// App-wide theme colors and styles
@@ -13,10 +14,10 @@ enum Theme {
 
     static let primaryColor = Color("AccentColor")
 
-    static let mysqlColor = Color.orange
-    static let postgresqlColor = Color.blue
-    static let sqliteColor = Color.green
-    static let mariadbColor = Color.cyan
+    static let mysqlColor = Color(nsColor: .systemOrange)
+    static let postgresqlColor = Color(nsColor: .systemBlue)
+    static let sqliteColor = Color(nsColor: .systemGreen)
+    static let mariadbColor = Color(nsColor: .systemCyan)
 
     // MARK: - Semantic Colors
 
@@ -52,7 +53,7 @@ enum Theme {
         Color(nsColor: .alternatingContentBackgroundColors[1])
     }
 
-    static let nullValue = Color.secondary.opacity(0.5)
+    static let nullValue = Color(nsColor: .tertiaryLabelColor)
     static let boolTrue = Color(nsColor: .systemGreen)
     static let boolFalse = Color(nsColor: .systemRed)
 
@@ -77,7 +78,7 @@ extension View {
     func cardStyle() -> some View {
         self
             .background(Theme.secondaryBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium))
     }
 
     /// Apply toolbar button styling

--- a/TablePro/Theme/ToolbarDesignTokens.swift
+++ b/TablePro/Theme/ToolbarDesignTokens.swift
@@ -94,7 +94,7 @@ enum ToolbarDesignTokens {
 
     enum Colors {
         /// Divider color - very subtle like Xcode
-        static let divider = DesignConstants.Colors.secondaryText.opacity(0.15)
+        static let divider = Color(nsColor: .tertiaryLabelColor)
 
         /// Secondary text color - references base constant
         static let secondaryText = DesignConstants.Colors.secondaryText

--- a/TablePro/Views/AIChat/AIChatCodeBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatCodeBlockView.swift
@@ -5,6 +5,7 @@
 //  Code block view with copy and insert-to-editor actions.
 //
 
+import AppKit
 import SwiftUI
 
 /// Displays a code block from AI response with action buttons
@@ -32,7 +33,7 @@ struct AIChatCodeBlockView: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Color(nsColor: .separatorColor).opacity(0.3))
+                    .background(Color(nsColor: .separatorColor))
                     .clipShape(RoundedRectangle(cornerRadius: 4))
             }
 
@@ -204,11 +205,11 @@ private struct CodeBlockGroupBoxStyle: GroupBoxStyle {
 
             configuration.content
         }
-        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.4), lineWidth: 1)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
         )
     }
 }

--- a/TablePro/Views/AIChat/AIChatMessageView.swift
+++ b/TablePro/Views/AIChat/AIChatMessageView.swift
@@ -5,6 +5,7 @@
 //  Individual chat message view with native macOS inspector styling.
 //
 
+import AppKit
 import MarkdownUI
 import SwiftUI
 
@@ -70,7 +71,7 @@ struct AIChatMessageView: View {
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "exclamationmark.circle")
-                            .foregroundStyle(.red)
+                            .foregroundStyle(Color(nsColor: .systemRed))
                         Text("Generation failed.")
                             .foregroundStyle(.secondary)
                         Text("Retry")
@@ -153,8 +154,8 @@ extension MarkdownUI.Theme {
         }
         .blockquote { configuration in
             HStack(spacing: 0) {
-                RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Color.secondary.opacity(0.5))
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(nsColor: .tertiaryLabelColor))
                     .frame(width: 3)
                 configuration.label
                     .markdownTextStyle {
@@ -183,7 +184,7 @@ private struct TypingIndicatorView: View {
         HStack(spacing: 5) {
             ForEach(0..<3, id: \.self) { index in
                 Circle()
-                    .fill(Color.secondary.opacity(0.6))
+                    .fill(Color(nsColor: .tertiaryLabelColor))
                     .frame(width: 6, height: 6)
                     .offset(y: animating ? -3 : 0)
                     .animation(

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -6,6 +6,7 @@
 //  Features: Rich metadata, recent databases, refresh, create database, preview panel.
 //
 
+import AppKit
 import SwiftUI
 
 struct DatabaseSwitcherSheet: View {
@@ -204,7 +205,7 @@ struct DatabaseSwitcherSheet: View {
             Image(systemName: database.icon)
                 .font(.system(size: 14))
                 .foregroundStyle(
-                    isSelected ? .white : (database.isSystemDatabase ? .orange : .blue))
+                    isSelected ? .white : (database.isSystemDatabase ? Color(nsColor: .systemOrange) : Color(nsColor: .systemBlue)))
 
             // Name
             Text(database.name)
@@ -221,11 +222,11 @@ struct DatabaseSwitcherSheet: View {
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(
-                        Capsule()
+                        RoundedRectangle(cornerRadius: 4)
                             .fill(
                                 isSelected
                                     ? Color.white.opacity(0.15)
-                                    : Color(nsColor: .separatorColor).opacity(0.5))
+                                    : Color(nsColor: .quaternaryLabelColor))
                     )
             }
         }

--- a/TablePro/Views/Editor/ColumnEditorRow.swift
+++ b/TablePro/Views/Editor/ColumnEditorRow.swift
@@ -6,6 +6,7 @@
 //  Shows key properties: name, type, length, nullable, default.
 //
 
+import AppKit
 import SwiftUI
 
 struct ColumnEditorRow: View {
@@ -37,7 +38,7 @@ struct ColumnEditorRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 4)
                     .padding(.vertical, 2)
-                    .background(Color.secondary.opacity(0.1))
+                    .background(Color(nsColor: .quaternaryLabelColor))
                     .cornerRadius(3)
             }
 
@@ -45,10 +46,10 @@ struct ColumnEditorRow: View {
             if column.autoIncrement {
                 Text("AUTO")
                     .font(.system(size: DesignConstants.FontSize.caption))
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(Color(nsColor: .systemBlue))
                     .padding(.horizontal, 4)
                     .padding(.vertical, 2)
-                    .background(Color.blue.opacity(0.1))
+                    .background(Color(nsColor: .systemBlue).opacity(0.1))
                     .cornerRadius(3)
             }
 

--- a/TablePro/Views/Editor/EditorTabBar.swift
+++ b/TablePro/Views/Editor/EditorTabBar.swift
@@ -5,6 +5,7 @@
 //  Pure SwiftUI tab bar replacement for NativeTabBar/NativeTabBarView.
 //
 
+import AppKit
 import SwiftUI
 
 /// SwiftUI tab bar for query/table tabs
@@ -113,7 +114,7 @@ private struct EditorTabItem: View {
             if tab.isPinned {
                 Image(systemName: "pin.fill")
                     .font(.system(size: 9))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(Color(nsColor: .systemOrange))
             }
 
             // Status icon or spinner
@@ -125,7 +126,7 @@ private struct EditorTabItem: View {
                 Image(systemName: tab.isView ? "eye" : tab.tabType == .table ? "tablecells" : "doc.text")
                     .font(.system(size: 11))
                     .foregroundStyle(
-                        tab.tabType == .table ? (tab.isView ? Color.purple : Color.blue) : Color.secondary
+                        tab.tabType == .table ? (tab.isView ? Color(nsColor: .systemPurple) : Color(nsColor: .systemBlue)) : Color.secondary
                     )
             }
 
@@ -165,7 +166,7 @@ private struct EditorTabItem: View {
 
     private var tabBackground: Color {
         if isSelected {
-            Color.accentColor.opacity(0.15)
+            Color(nsColor: .controlAccentColor).opacity(0.15)
         } else if isHovered {
             Color(nsColor: .quaternaryLabelColor)
         } else {

--- a/TablePro/Views/Filter/FilterRowView.swift
+++ b/TablePro/Views/Filter/FilterRowView.swift
@@ -6,6 +6,7 @@
 //  Extracted from FilterPanelView for better maintainability.
 //
 
+import AppKit
 import SwiftUI
 
 /// Single filter row view with native macOS styling
@@ -34,7 +35,7 @@ struct FilterRowView: View {
     /// Dynamic background color based on state
     private var backgroundFillColor: Color {
         if isFocused {
-            return Color.accentColor.opacity(0.06)
+            return Color(nsColor: .controlAccentColor).opacity(0.08)
         } else if isHovered {
             return Color(nsColor: .controlBackgroundColor)
         } else {
@@ -45,7 +46,7 @@ struct FilterRowView: View {
     /// Dynamic border color based on state
     private var borderColor: Color {
         if isFocused {
-            return Color.accentColor.opacity(0.3)
+            return Color(nsColor: .controlAccentColor).opacity(0.3)
         } else if isHovered {
             return Color(nsColor: .separatorColor).opacity(0.5)
         } else {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -6,6 +6,7 @@
 //  Extracted from MainContentView for better separation.
 //
 
+import AppKit
 import CodeEditSourceEditor
 import SwiftUI
 
@@ -492,7 +493,7 @@ struct MainEditorContentView: View {
                         .padding(.vertical, 2)
                         .background(
                             RoundedRectangle(cornerRadius: 4)
-                                .fill(Color.secondary.opacity(0.1))
+                                .fill(Color(nsColor: .quaternaryLabelColor))
                         )
                     Text("Open SQL Editor")
                         .font(.callout)
@@ -516,7 +517,7 @@ struct MainEditorContentView: View {
                         .padding(.vertical, 2)
                         .background(
                             RoundedRectangle(cornerRadius: 4)
-                                .fill(Color.secondary.opacity(0.1))
+                                .fill(Color(nsColor: .quaternaryLabelColor))
                         )
                     Text("Switch Database")
                         .font(.callout)

--- a/TablePro/Views/OnboardingContentView.swift
+++ b/TablePro/Views/OnboardingContentView.swift
@@ -6,6 +6,7 @@
 //  feature highlights, and get started page.
 //
 
+import AppKit
 import SwiftUI
 
 struct OnboardingContentView: View {
@@ -78,7 +79,7 @@ struct OnboardingContentView: View {
         VStack(spacing: DesignConstants.Spacing.md) {
             ZStack {
                 Circle()
-                    .fill(Color.orange.opacity(0.30))
+                    .fill(Color(nsColor: .systemOrange).opacity(0.30))
                     .frame(width: 100, height: 100)
                     .blur(radius: 25)
 
@@ -130,7 +131,7 @@ struct OnboardingContentView: View {
                     description: "Get intelligent SQL suggestions and query assistance"
                 )
             }
-            .padding(.horizontal, 40)
+            .padding(.horizontal, 20)
             .frame(maxWidth: 420)
         }
     }
@@ -186,7 +187,7 @@ struct OnboardingContentView: View {
             HStack(spacing: 8) {
                 ForEach(0..<3, id: \.self) { i in
                     Circle()
-                        .fill(i == currentPage ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .fill(i == currentPage ? Color.accentColor : Color(nsColor: .tertiaryLabelColor))
                         .frame(width: 8, height: 8)
                         .scaleEffect(i == currentPage ? 1.2 : 1.0)
                         .onTapGesture { goToPage(i) }

--- a/TablePro/Views/Settings/KeyboardSettingsView.swift
+++ b/TablePro/Views/Settings/KeyboardSettingsView.swift
@@ -5,6 +5,7 @@
 //  Settings view for customizing keyboard shortcuts.
 //
 
+import AppKit
 import SwiftUI
 
 /// Settings view for keyboard shortcut customization
@@ -34,7 +35,7 @@ struct KeyboardSettingsView: View {
                 }
             }
             .padding(8)
-            .background(.quaternary.opacity(0.5))
+            .background(.quaternary)
             .clipShape(RoundedRectangle(cornerRadius: 8))
             .padding(.horizontal, 20)
             .padding(.top, 16)

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -6,6 +6,7 @@
 //  Shown from the toolbar connection button.
 //
 
+import AppKit
 import SwiftUI
 
 /// Popover content for quick connection switching
@@ -232,7 +233,7 @@ struct ConnectionSwitcherPopover: View {
 
                 Text(connectionSubtitle(connection))
                     .font(.system(size: 11))
-                    .foregroundStyle(isHighlighted ? .white.opacity(0.7) : .secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 
@@ -244,27 +245,23 @@ struct ConnectionSwitcherPopover: View {
                     .controlSize(.small)
             } else if isActive {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(isHighlighted ? .white : .green)
+                    .foregroundStyle(isHighlighted ? .white : Color(nsColor: .systemGreen))
                     .font(.system(size: 14))
             } else if isConnected {
                 Circle()
-                    .fill(isHighlighted ? Color.white : .green)
+                    .fill(isHighlighted ? Color.white : Color(nsColor: .systemGreen))
                     .frame(width: 6, height: 6)
             }
 
             // Database type badge
             Text(connection.type.rawValue.uppercased())
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
-                .foregroundStyle(isHighlighted ? .white.opacity(0.7) : .secondary)
+                .foregroundStyle(.secondary)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 2)
                 .background(
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(
-                            isHighlighted
-                                ? Color.white.opacity(0.15)
-                                : Color.secondary.opacity(0.12)
-                        )
+                        .fill(Color(nsColor: .separatorColor))
                 )
         }
         .padding(.vertical, 2)

--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -104,7 +104,7 @@ struct WelcomeWindowView: View {
                 // Logo with glow
                 ZStack {
                     Circle()
-                        .fill(Color.orange.opacity(0.30))
+                        .fill(Color(nsColor: .systemOrange).opacity(0.30))
                         .frame(width: 100, height: 100)
                         .blur(radius: 25)
 
@@ -163,7 +163,7 @@ struct WelcomeWindowView: View {
                         .frame(width: DesignConstants.IconSize.extraLarge, height: DesignConstants.IconSize.extraLarge)
                         .background(
                             RoundedRectangle(cornerRadius: 6)
-                                .fill(Color.primary.opacity(0.06))
+                                .fill(Color(nsColor: .quaternaryLabelColor))
                         )
                 }
                 .buttonStyle(.plain)
@@ -182,7 +182,7 @@ struct WelcomeWindowView: View {
                 .padding(.vertical, 6)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.primary.opacity(0.04))
+                        .fill(Color(nsColor: .quaternaryLabelColor))
                 )
             }
             .padding(.horizontal, DesignConstants.Spacing.md)
@@ -393,7 +393,7 @@ private struct ConnectionRow: View {
                             .foregroundStyle(tag.color.color)
                             .padding(.horizontal, DesignConstants.Spacing.xxs)
                             .padding(.vertical, DesignConstants.Spacing.xxxs)
-                            .background(Capsule().fill(tag.color.color.opacity(0.15)))
+                            .background(RoundedRectangle(cornerRadius: 4).fill(tag.color.color.opacity(0.15)))
                     }
                 }
 
@@ -487,7 +487,7 @@ private struct WelcomeButtonStyle: ButtonStyle {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.primary.opacity(configuration.isPressed ? 0.08 : 0.04))
+                    .fill(Color(nsColor: configuration.isPressed ? .controlBackgroundColor : .quaternaryLabelColor))
             )
     }
 }
@@ -506,7 +506,7 @@ private struct KeyboardHint: View {
                 .padding(.vertical, DesignConstants.Spacing.xxxs)
                 .background(
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(Color.primary.opacity(0.06))
+                        .fill(Color(nsColor: .quaternaryLabelColor))
                 )
             Text(label)
         }
@@ -519,13 +519,13 @@ private extension ConnectionEnvironment {
     var badgeColor: Color {
         switch self {
         case .local:
-            return .green
+            return Color(nsColor: .systemGreen)
         case .ssh:
-            return .blue
+            return Color(nsColor: .systemBlue)
         case .staging:
-            return .orange
+            return Color(nsColor: .systemOrange)
         case .production:
-            return .red
+            return Color(nsColor: .systemRed)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace `Color.red/green/blue/orange` → `Color(nsColor: .systemRed/.systemGreen/.systemBlue/.systemOrange)` across 16 files for proper dark mode, vibrancy, and accessibility adaptation
- Replace `Color.secondary.opacity(0.x)` → semantic `NSColor` equivalents (`quaternaryLabelColor`, `tertiaryLabelColor`, `separatorColor`)
- Replace `Color.black.opacity()` shadows → `Color(nsColor: .shadowColor)` for dark mode adaptive shadows
- Replace iOS-style `Capsule()` badges → `RoundedRectangle(cornerRadius: 4)` for macOS convention
- Drop redundant `.opacity()` on already-semantic NSColors

Fixes all 82 issues tracked in `NATIVE_STYLING.md`.

## Test plan

- [ ] Verify light mode appearance across all affected views (Welcome, Toolbar, Database Switcher, Filter, AI Chat, Editor, Onboarding, Settings)
- [ ] Verify dark mode appearance — colors should adapt properly
- [ ] Verify increased contrast accessibility setting — system colors should respond
- [ ] Verify custom accent color — controlAccentColor-based tints should follow
- [ ] Check badge shapes render as rounded rects instead of capsules