### PR TITLE
Fix SQL export corrupting newlines for PostgreSQL/SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add syntax highlighting to Import SQL file preview
 
 ### Fixed
+- Fix SQL export corrupting newline/tab/backslash characters for PostgreSQL and SQLite (MySQL-style backslash escaping was incorrectly applied to all database types)
+- Fix PostgreSQL SQL export failing to import when types/sequences already exist (`DROP IF EXISTS` now always emitted for dependent types and sequences)
 - Fix PostgreSQL SQL export missing `CREATE TYPE` definitions for enum columns, causing import errors
 - Fix PostgreSQL DDL tab not showing enum type definitions used by table columns
 

--- a/TablePro/Core/Database/SQLEscaping.swift
+++ b/TablePro/Core/Database/SQLEscaping.swift
@@ -12,37 +12,51 @@ import Foundation
 enum SQLEscaping {
     /// Escape a string value for use in SQL string literals (VALUES, WHERE clauses, etc.)
     ///
-    /// Handles the following special characters:
-    /// - Backslashes (must be escaped first to avoid double-escaping)
-    /// - Single quotes (SQL standard: doubled)
-    /// - Control characters: null, backspace, tab, newline, form feed, carriage return
-    /// - MySQL EOF marker (\x1A) which can cause parsing issues
+    /// MySQL/MariaDB: Uses backslash escape sequences for control characters (`\n`, `\t`, etc.)
+    /// PostgreSQL/SQLite: Uses standard SQL escaping (only single quotes doubled).
+    /// Newlines, tabs, and backslashes are valid as-is in standard SQL string literals.
     ///
     /// Example:
     /// ```swift
-    /// let safe = SQLEscaping.escapeStringLiteral("O'Brien\\test")
+    /// let safe = SQLEscaping.escapeStringLiteral("O'Brien\\test", databaseType: .mysql)
     /// // Result: "O''Brien\\\\test"
-    /// let sql = "INSERT INTO users (name) VALUES ('\(safe)')"
+    /// let safe2 = SQLEscaping.escapeStringLiteral("O'Brien\\test", databaseType: .postgresql)
+    /// // Result: "O''Brien\\test"
     /// ```
     ///
-    /// - Parameter str: The raw string to escape
+    /// - Parameters:
+    ///   - str: The raw string to escape
+    ///   - databaseType: The target database type (defaults to `.mysql` for backward compatibility)
     /// - Returns: The escaped string safe for use in SQL string literals
-    static func escapeStringLiteral(_ str: String) -> String {
-        var result = str
-        // IMPORTANT: Escape backslashes FIRST to avoid double-escaping
-        result = result.replacingOccurrences(of: "\\", with: "\\\\")
-        // Single quote: SQL standard escaping (double the quote)
-        result = result.replacingOccurrences(of: "'", with: "''")
-        // Common control characters
-        result = result.replacingOccurrences(of: "\n", with: "\\n")
-        result = result.replacingOccurrences(of: "\r", with: "\\r")
-        result = result.replacingOccurrences(of: "\t", with: "\\t")
-        result = result.replacingOccurrences(of: "\0", with: "\\0")
-        // Additional control characters that can cause issues
-        result = result.replacingOccurrences(of: "\u{08}", with: "\\b")  // Backspace
-        result = result.replacingOccurrences(of: "\u{0C}", with: "\\f")  // Form feed
-        result = result.replacingOccurrences(of: "\u{1A}", with: "\\Z")  // MySQL EOF marker (Ctrl+Z)
-        return result
+    static func escapeStringLiteral(_ str: String, databaseType: DatabaseType = .mysql) -> String {
+        switch databaseType {
+        case .mysql, .mariadb:
+            // MySQL/MariaDB: backslash escaping is active by default
+            var result = str
+            // IMPORTANT: Escape backslashes FIRST to avoid double-escaping
+            result = result.replacingOccurrences(of: "\\", with: "\\\\")
+            // Single quote: SQL standard escaping (double the quote)
+            result = result.replacingOccurrences(of: "'", with: "''")
+            // Common control characters
+            result = result.replacingOccurrences(of: "\n", with: "\\n")
+            result = result.replacingOccurrences(of: "\r", with: "\\r")
+            result = result.replacingOccurrences(of: "\t", with: "\\t")
+            result = result.replacingOccurrences(of: "\0", with: "\\0")
+            // Additional control characters that can cause issues
+            result = result.replacingOccurrences(of: "\u{08}", with: "\\b")  // Backspace
+            result = result.replacingOccurrences(of: "\u{0C}", with: "\\f")  // Form feed
+            result = result.replacingOccurrences(of: "\u{1A}", with: "\\Z")  // MySQL EOF marker (Ctrl+Z)
+            return result
+
+        case .postgresql, .sqlite:
+            // Standard SQL: only single quotes need doubling
+            // Newlines, tabs, backslashes are valid as-is in string literals
+            var result = str
+            result = result.replacingOccurrences(of: "'", with: "''")
+            // Strip null bytes (PostgreSQL rejects them in text)
+            result = result.replacingOccurrences(of: "\0", with: "")
+            return result
+        }
     }
 
     /// Escape wildcards in LIKE patterns while preserving intentional wildcards

--- a/TablePro/Core/Services/CreateTableService.swift
+++ b/TablePro/Core/Services/CreateTableService.swift
@@ -547,7 +547,7 @@ struct CreateTableService {
     /// Escape characters that can break SQL strings
     /// Delegates to shared SQLEscaping utility for consistent escaping across the codebase
     private func escapeSQLString(_ str: String) -> String {
-        SQLEscaping.escapeStringLiteral(str)
+        SQLEscaping.escapeStringLiteral(str, databaseType: databaseType)
     }
 }
 

--- a/TablePro/Core/Services/ExportService.swift
+++ b/TablePro/Core/Services/ExportService.swift
@@ -779,19 +779,26 @@ final class ExportService: ObservableObject {
             try fileHandle.write(contentsOf: "-- Generated: \(dateFormatter.string(from: Date()))\n".toUTF8Data())
             try fileHandle.write(contentsOf: "-- Database Type: \(databaseType.rawValue)\n\n".toUTF8Data())
 
-            // Collect and emit dependent enum type definitions (PostgreSQL)
+            // Collect and emit dependent sequences and enum types (PostgreSQL)
+            var emittedSequenceNames: Set<String> = []
             var emittedTypeNames: Set<String> = []
-            let anyTableHasDrop = tables.contains { $0.sqlOptions.includeDrop }
-
             for table in tables where table.sqlOptions.includeStructure {
+                let sequences = try await driver.fetchDependentSequences(forTable: table.name)
+                for seq in sequences where !emittedSequenceNames.contains(seq.name) {
+                    emittedSequenceNames.insert(seq.name)
+                    let quotedName = "\"\(seq.name.replacingOccurrences(of: "\"", with: "\"\""))\""
+                    // Always DROP dependent sequences — they must be recreated for CREATE TABLE to succeed
+                    try fileHandle.write(contentsOf: "DROP SEQUENCE IF EXISTS \(quotedName) CASCADE;\n".toUTF8Data())
+                    try fileHandle.write(contentsOf: "\(seq.ddl)\n\n".toUTF8Data())
+                }
+
                 let enumTypes = try await driver.fetchDependentTypes(forTable: table.name)
                 for enumType in enumTypes where !emittedTypeNames.contains(enumType.name) {
                     emittedTypeNames.insert(enumType.name)
                     let quotedName = "\"\(enumType.name.replacingOccurrences(of: "\"", with: "\"\""))\""
-                    if anyTableHasDrop {
-                        try fileHandle.write(contentsOf: "DROP TYPE IF EXISTS \(quotedName) CASCADE;\n".toUTF8Data())
-                    }
-                    let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0))'" }
+                    // Always DROP dependent types — they must be recreated for CREATE TABLE to succeed
+                    try fileHandle.write(contentsOf: "DROP TYPE IF EXISTS \(quotedName) CASCADE;\n".toUTF8Data())
+                    let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0, databaseType: databaseType))'" }
                     try fileHandle.write(contentsOf: "CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n\n".toUTF8Data())
                 }
             }
@@ -932,7 +939,7 @@ final class ExportService: ObservableObject {
             let values = row.map { value -> String in
                 guard let val = value else { return "NULL" }
                 // Use proper SQL escaping to prevent injection (handles backslashes, quotes, etc.)
-                let escaped = SQLEscaping.escapeStringLiteral(val)
+                let escaped = SQLEscaping.escapeStringLiteral(val, databaseType: databaseType)
                 return "'\(escaped)'"
             }.joined(separator: ", ")
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarSave.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarSave.swift
@@ -70,7 +70,7 @@ extension MainContentCoordinator {
                 if isSidebarSQLFunction(newValue) {
                     value = newValue.trimmingCharacters(in: .whitespaces)
                 } else {
-                    value = "'\(SQLEscaping.escapeStringLiteral(newValue))'"
+                    value = "'\(SQLEscaping.escapeStringLiteral(newValue, databaseType: dbType))'"
                 }
             } else {
                 value = "NULL"
@@ -79,7 +79,7 @@ extension MainContentCoordinator {
         }.joined(separator: ", ")
 
         let quotedPK = dbType.quoteIdentifier(pkColumn)
-        let quotedPKValue = "'\(SQLEscaping.escapeStringLiteral(pkValue))'"
+        let quotedPKValue = "'\(SQLEscaping.escapeStringLiteral(pkValue, databaseType: dbType))'"
         let whereClause = "\(quotedPK) = \(quotedPKValue)"
         let limitClause = (dbType == .mysql || dbType == .mariadb) ? " LIMIT 1" : ""
 

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -706,15 +706,19 @@ struct TableStructureView: View {
             case .foreignKeys:
                 foreignKeys = try await driver.fetchForeignKeys(table: tableName)
             case .ddl:
+                let sequences = try await driver.fetchDependentSequences(forTable: tableName)
                 let enumTypes = try await driver.fetchDependentTypes(forTable: tableName)
                 let baseDDL = try await driver.fetchTableDDL(table: tableName)
-                if enumTypes.isEmpty {
+                if sequences.isEmpty && enumTypes.isEmpty {
                     ddlStatement = baseDDL
                 } else {
                     var preamble = ""
+                    for seq in sequences {
+                        preamble += seq.ddl + "\n\n"
+                    }
                     for enumType in enumTypes {
                         let quotedName = "\"\(enumType.name.replacingOccurrences(of: "\"", with: "\"\""))\""
-                        let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0))'" }
+                        let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0, databaseType: .postgresql))'" }
                         preamble += "CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n"
                     }
                     ddlStatement = preamble + "\n" + baseDDL

--- a/TableProTests/Core/Database/SQLEscapingTests.swift
+++ b/TableProTests/Core/Database/SQLEscapingTests.swift
@@ -108,6 +108,76 @@ struct SQLEscapingTests {
 
     // MARK: - escapeLikeWildcards Tests
 
+    // MARK: - PostgreSQL/SQLite escapeStringLiteral Tests
+
+    @Test("PostgreSQL: plain string unchanged")
+    func testPostgreSQLPlainStringUnchanged() {
+        let result = SQLEscaping.escapeStringLiteral("Hello World", databaseType: .postgresql)
+        #expect(result == "Hello World")
+    }
+
+    @Test("PostgreSQL: single quotes doubled")
+    func testPostgreSQLSingleQuotesDoubled() {
+        let result = SQLEscaping.escapeStringLiteral("O'Brien", databaseType: .postgresql)
+        #expect(result == "O''Brien")
+    }
+
+    @Test("PostgreSQL: newlines preserved")
+    func testPostgreSQLNewlinesPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("Line1\nLine2", databaseType: .postgresql)
+        #expect(result == "Line1\nLine2")
+    }
+
+    @Test("PostgreSQL: carriage returns preserved")
+    func testPostgreSQLCarriageReturnsPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("Text\rMore", databaseType: .postgresql)
+        #expect(result == "Text\rMore")
+    }
+
+    @Test("PostgreSQL: tabs preserved")
+    func testPostgreSQLTabsPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("Col1\tCol2", databaseType: .postgresql)
+        #expect(result == "Col1\tCol2")
+    }
+
+    @Test("PostgreSQL: backslashes preserved")
+    func testPostgreSQLBackslashesPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("C:\\Users\\Test", databaseType: .postgresql)
+        #expect(result == "C:\\Users\\Test")
+    }
+
+    @Test("PostgreSQL: null bytes stripped")
+    func testPostgreSQLNullBytesStripped() {
+        let result = SQLEscaping.escapeStringLiteral("Text\0End", databaseType: .postgresql)
+        #expect(result == "TextEnd")
+    }
+
+    @Test("PostgreSQL: combined special characters")
+    func testPostgreSQLCombinedSpecialCharacters() {
+        let result = SQLEscaping.escapeStringLiteral("O'Brien\\test\nline2\t\0end", databaseType: .postgresql)
+        #expect(result == "O''Brien\\test\nline2\tend")
+    }
+
+    @Test("SQLite: newlines preserved")
+    func testSQLiteNewlinesPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("Line1\nLine2", databaseType: .sqlite)
+        #expect(result == "Line1\nLine2")
+    }
+
+    @Test("SQLite: backslashes preserved")
+    func testSQLiteBackslashesPreserved() {
+        let result = SQLEscaping.escapeStringLiteral("path\\to\\file", databaseType: .sqlite)
+        #expect(result == "path\\to\\file")
+    }
+
+    @Test("SQLite: single quotes doubled")
+    func testSQLiteSingleQuotesDoubled() {
+        let result = SQLEscaping.escapeStringLiteral("it's", databaseType: .sqlite)
+        #expect(result == "it''s")
+    }
+
+    // MARK: - escapeLikeWildcards Tests
+
     @Test("LIKE plain string unchanged")
     func testLikePlainStringUnchanged() {
         let input = "test"


### PR DESCRIPTION
## Summary

- **Fix MySQL-style backslash escaping applied to all database types** — `SQLEscaping.escapeStringLiteral()` now accepts a `databaseType` parameter. PostgreSQL/SQLite use standard SQL escaping (only quote doubling + null byte stripping), preserving actual newlines, tabs, and backslashes in exported data.
- **Fix `CREATE TYPE`/`CREATE SEQUENCE` failing on re-import** — `DROP IF EXISTS` is now always emitted for dependent types and sequences, regardless of the "Include DROP" table option.
- All existing call sites updated: `ExportService`, `MainContentCoordinator+SidebarSave`, `CreateTableService`

## Test plan

- [x] Build succeeds
- [x] All 31 `SQLEscapingTests` pass (13 existing MySQL + 11 new PostgreSQL/SQLite + 7 LIKE)
- [ ] PostgreSQL export: verify actual newlines in SQL file (not `\n` literals)
- [ ] MySQL export: verify `\n` escape sequences preserved (existing behavior)
- [ ] Re-import PostgreSQL export: no "type already exists" errors