### PR TITLE
fix: prevent native + button from restoring all saved tabs

### DIFF
--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -390,6 +390,13 @@ struct MainContentView: View {
             return
         }
 
+        // If other windows already exist for this connection, this is a "new tab"
+        // from the native macOS "+" button — just add a single empty query tab.
+        if NativeTabRegistry.shared.hasWindows(for: connection.id) {
+            tabManager.addTab(databaseName: connection.database)
+            return
+        }
+
         // No payload — restore tabs from storage (first window on connection)
         let result = await coordinator.tabPersistence.restoreTabs()
         if !result.tabs.isEmpty {


### PR DESCRIPTION
## Summary

- Fix the native macOS "+" tab bar button spawning too many tabs by restoring all saved tabs instead of creating a single empty query tab
- When the "+" button is clicked, `payload` is `nil` — the same as initial app launch — so the code couldn't distinguish between the two cases
- Now checks `NativeTabRegistry.shared.hasWindows(for:)` before the restoration path: if windows already exist for the connection, it's a "new tab" request, not a first launch

Closes #91

## Test plan

- [ ] Connect to a database — tabs should restore normally on launch
- [ ] Click the native "+" tab bar button — should create exactly 1 new empty query tab
- [ ] Click the toolbar "SQL" button — should still create 1 new query tab (unchanged path)
- [ ] Press Cmd+T — should still create 1 new query tab (unchanged path)
- [ ] Close app, reopen — all tabs should restore correctly