### PR TITLE
feat: add custom About window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Custom About window with version info and links (Website, GitHub, Documentation)
+
 ## [0.9.2] - 2026-02-28
 
 ### Fixed

--- a/TablePro/OpenTableApp.swift
+++ b/TablePro/OpenTableApp.swift
@@ -123,8 +123,11 @@ struct AppMenuCommands: Commands {
     }
 
     var body: some Commands {
-        // Check for Updates menu item (after "About TablePro")
-        CommandGroup(after: .appInfo) {
+        // Custom About window + Check for Updates
+        CommandGroup(replacing: .appInfo) {
+            Button(String(localized: "About TablePro")) {
+                AboutWindowController.shared.showAboutPanel()
+            }
             CheckForUpdatesView(updaterBridge: updaterBridge)
         }
 

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -539,6 +539,9 @@
         }
       }
     },
+    "© 2026 Ngo Quoc Dat.\n%@" : {
+
+    },
     "<1ms" : {
       "localizations" : {
         "vi" : {
@@ -799,6 +802,9 @@
         }
       }
     },
+    "About TablePro" : {
+
+    },
     "Accent Color:" : {
       "localizations" : {
         "vi" : {
@@ -1048,6 +1054,9 @@
           }
         }
       }
+    },
+    "All rights reserved." : {
+
     },
     "ALL SCHEMAS" : {
 
@@ -3017,6 +3026,9 @@
           }
         }
       }
+    },
+    "Documentation" : {
+
     },
     "Don't Allow" : {
       "localizations" : {
@@ -8621,6 +8633,16 @@
         }
       }
     },
+    "Version %@ (Build %@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %1$@ (Build %2$@)"
+          }
+        }
+      }
+    },
     "View" : {
       "localizations" : {
         "vi" : {
@@ -8653,6 +8675,9 @@
           }
         }
       }
+    },
+    "Website" : {
+
     },
     "Welcome to TablePro" : {
       "localizations" : {

--- a/TablePro/Views/About/AboutView.swift
+++ b/TablePro/Views/About/AboutView.swift
@@ -1,0 +1,82 @@
+//
+//  AboutView.swift
+//  TablePro
+//
+//  Custom About window view with app info and links.
+//
+
+import AppKit
+import SwiftUI
+
+struct AboutView: View {
+    @State private var hoveredLink: String?
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.md) {
+            Spacer()
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+
+            VStack(spacing: DesignConstants.Spacing.xxs) {
+                Text("TablePro")
+                    .font(
+                        .system(
+                            size: DesignConstants.IconSize.extraLarge, weight: .semibold,
+                            design: .rounded))
+
+                Text("Version \(Bundle.main.appVersion) (Build \(Bundle.main.buildNumber))")
+                    .font(.system(size: DesignConstants.FontSize.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("© 2026 Ngo Quoc Dat.\n\(String(localized: "All rights reserved."))")
+                .font(.system(size: DesignConstants.FontSize.small))
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: DesignConstants.Spacing.lg) {
+                linkButton(
+                    title: String(localized: "Website"),
+                    icon: "globe",
+                    url: "https://tablepro.app"
+                )
+                linkButton(
+                    title: "GitHub",
+                    icon: "chevron.left.forwardslash.chevron.right",
+                    url: "https://github.com/datlechin/TablePro"
+                )
+                linkButton(
+                    title: String(localized: "Documentation"),
+                    icon: "book",
+                    url: "https://docs.tablepro.app"
+                )
+            }
+
+            Spacer()
+        }
+        .frame(width: 300, height: 320)
+    }
+
+    private func linkButton(title: String, icon: String, url: String) -> some View {
+        Button {
+            if let link = URL(string: url) {
+                NSWorkspace.shared.open(link)
+            }
+        } label: {
+            VStack(spacing: DesignConstants.Spacing.xxxs) {
+                Image(systemName: icon)
+                    .font(.system(size: DesignConstants.FontSize.body))
+                Text(title)
+                    .font(.system(size: DesignConstants.FontSize.small))
+                    .underline(hoveredLink == title)
+            }
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered in
+            hoveredLink = isHovered ? title : nil
+        }
+    }
+}

--- a/TablePro/Views/About/AboutWindowController.swift
+++ b/TablePro/Views/About/AboutWindowController.swift
@@ -1,0 +1,44 @@
+//
+//  AboutWindowController.swift
+//  TablePro
+//
+//  Singleton controller for the custom About window.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class AboutWindowController {
+    static let shared = AboutWindowController()
+    private var panel: NSPanel?
+
+    private init() {}
+
+    func showAboutPanel() {
+        if let existingPanel = panel {
+            existingPanel.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.identifier = NSUserInterfaceItemIdentifier("about")
+        panel.title = String(localized: "About TablePro")
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovableByWindowBackground = true
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.fullScreenNone]
+        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden = true
+        panel.contentView = NSHostingView(rootView: AboutView())
+        panel.center()
+        panel.makeKeyAndOrderFront(nil)
+        self.panel = panel
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the default macOS About panel with a custom About window showing app icon, name, version/build, copyright, and link buttons (Website, GitHub, Documentation)
- Uses NSPanel singleton pattern (non-resizable, no minimize/zoom, reuses on re-open)
- Links open in default browser via `NSWorkspace.shared.open()`

## Test plan

- [ ] Open "TablePro" menu → click "About TablePro" → verify custom window appears
- [ ] Verify: app icon, name, version/build, copyright are correct
- [ ] Verify: all 3 link buttons open correct URLs in browser
- [ ] Verify: Escape key closes the window
- [ ] Verify: re-opening reuses the same window (no duplicates)
- [ ] Verify: "Check for Updates..." still appears below About