### PR TITLE
fix: preserve SSL config for PostgreSQL SSH tunnel connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Custom About window with version info and links (Website, GitHub, Documentation)
 
+### Fixed
+
+- PostgreSQL SSH tunnel connections failing with "no encryption" due to SSL config not being preserved
+
 ## [0.9.2] - 2026-02-28
 
 ### Fixed

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -357,7 +357,8 @@ final class DatabaseManager: ObservableObject {
             database: connection.database,
             username: connection.username,
             type: connection.type,
-            sshConfig: SSHConfiguration()  // Disable SSH for actual driver
+            sshConfig: SSHConfiguration(),
+            sslConfig: connection.sslConfig
         )
     }
 


### PR DESCRIPTION
## Summary

- Fix PostgreSQL SSH tunnel connections failing with `FATAL: no pg_hba.conf entry for host ... no encryption`
- `buildEffectiveConnection` was omitting `sslConfig` when creating the tunneled connection, causing SSL mode to default to `.disabled`
- Now passes through the original `connection.sslConfig` so SSL settings are preserved through the SSH tunnel

## Test plan

- [ ] Connect to a PostgreSQL database via SSH tunnel with SSL enabled
- [ ] Verify the connection succeeds without "no encryption" error
- [ ] Verify direct (non-SSH) PostgreSQL connections still work correctly