### PR TITLE
feat: add release notes link to Sparkle update window

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -598,6 +598,7 @@ jobs:
                       <sparkle:version>${BUILD_NUMBER}</sparkle:version>
                       <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
                       <sparkle:minimumSystemVersion>${MIN_OS}</sparkle:minimumSystemVersion>
+                      <sparkle:releaseNotesLink>https://github.com/datlechin/TablePro/releases/tag/v${VERSION}</sparkle:releaseNotesLink>
                       <enclosure url="${DOWNLOAD_PREFIX}/TablePro-${VERSION}-arm64.zip" length="${ARM64_LENGTH}" type="application/octet-stream" sparkle:edSignature="${ARM64_ED_SIG}" sparkle:architectures="arm64"/>
                   </item>
                   <item>
@@ -606,6 +607,7 @@ jobs:
                       <sparkle:version>${BUILD_NUMBER}</sparkle:version>
                       <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
                       <sparkle:minimumSystemVersion>${MIN_OS}</sparkle:minimumSystemVersion>
+                      <sparkle:releaseNotesLink>https://github.com/datlechin/TablePro/releases/tag/v${VERSION}</sparkle:releaseNotesLink>
                       <enclosure url="${DOWNLOAD_PREFIX}/TablePro-${VERSION}-x86_64.zip" length="${X86_64_LENGTH}" type="application/octet-stream" sparkle:edSignature="${X86_64_ED_SIG}" sparkle:architectures="x86_64"/>
                   </item>
               </channel>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Custom About window with version info and links (Website, GitHub, Documentation)
+- Release notes in Sparkle update window
 
 ### Fixed
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,7 @@
             <sparkle:version>20</sparkle:version>
             <sparkle:shortVersionString>0.9.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink>https://github.com/datlechin/TablePro/releases/tag/v0.9.3</sparkle:releaseNotesLink>
             <enclosure url="https://github.com/datlechin/TablePro/releases/download/v0.9.3/TablePro-0.9.3-arm64.zip" length="21594856" type="application/octet-stream" sparkle:edSignature="+i8FKtzE/ke7Tbjh/gbY4fBKfShSC8wbmS5mmVCR+1d6eVHjdk7J0pqawB75Hg6c8XY4yVw+D3fFEOG8DYoUBQ==" sparkle:architectures="arm64"/>
         </item>
         <item>
@@ -16,6 +17,7 @@
             <sparkle:version>20</sparkle:version>
             <sparkle:shortVersionString>0.9.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink>https://github.com/datlechin/TablePro/releases/tag/v0.9.3</sparkle:releaseNotesLink>
             <enclosure url="https://github.com/datlechin/TablePro/releases/download/v0.9.3/TablePro-0.9.3-x86_64.zip" length="22077259" type="application/octet-stream" sparkle:edSignature="wt59yu3zcluOy/rqtrH72bibC+t37Han7vqY25O+IqZevrdL7c+VOsKTnUCEfPyAfQAfWzY/1GIHK3Wx/K6/Aw==" sparkle:architectures="x86_64"/>
         </item>
     </channel>


### PR DESCRIPTION
## Summary
- Add `<sparkle:releaseNotesLink>` to appcast items, pointing to the GitHub release page
- Sparkle's update dialog will now show release notes in a WebView when an update is available
- Updated both the CI appcast generation and the existing `appcast.xml`

## Test plan
- [ ] Trigger a Sparkle update check and verify release notes appear in the update window