### PR TITLE
fix: new row and duplicated row not appearing in datagrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- New row (Cmd+I) and duplicated row not appearing in datagrid until manual refresh
 - PostgreSQL SSH tunnel connections failing with "no encryption" due to SSL config not being preserved
 
 ## [0.9.2] - 2026-02-28

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
@@ -27,6 +27,7 @@ extension MainContentCoordinator {
         selectedRowIndices = [result.rowIndex]
         editingCell = CellPosition(row: result.rowIndex, column: 0)
         tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func deleteSelectedRows(indices: Set<Int>, selectedRowIndices: inout Set<Int>) {
@@ -48,6 +49,7 @@ extension MainContentCoordinator {
         }
 
         tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func duplicateSelectedRow(index: Int, selectedRowIndices: inout Set<Int>, editingCell: inout CellPosition?) {
@@ -68,6 +70,7 @@ extension MainContentCoordinator {
         selectedRowIndices = [result.rowIndex]
         editingCell = CellPosition(row: result.rowIndex, column: 0)
         tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func undoInsertRow(at rowIndex: Int, selectedRowIndices: inout Set<Int>) {
@@ -79,6 +82,7 @@ extension MainContentCoordinator {
             resultRows: &tabManager.tabs[tabIndex].resultRows,
             selectedIndices: selectedRowIndices
         )
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func undoLastChange(selectedRowIndices: inout Set<Int>) {
@@ -92,6 +96,7 @@ extension MainContentCoordinator {
         }
 
         tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func redoLastChange() {
@@ -105,6 +110,7 @@ extension MainContentCoordinator {
         )
 
         tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.tabs[tabIndex].resultVersion += 1
     }
 
     func copySelectedRowsToClipboard(indices: Set<Int>) {

--- a/TableProTests/Core/Services/RowOperationsManagerTests.swift
+++ b/TableProTests/Core/Services/RowOperationsManagerTests.swift
@@ -1,0 +1,285 @@
+//
+//  RowOperationsManagerTests.swift
+//  TableProTests
+//
+//  Tests for RowOperationsManager row operations: add, duplicate, delete, undo/redo.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("Row Operations Manager")
+struct RowOperationsManagerTests {
+    // MARK: - Test Helpers
+
+    private func makeManager() -> (RowOperationsManager, DataChangeManager) {
+        let changeManager = DataChangeManager()
+        changeManager.configureForTable(
+            tableName: "users",
+            columns: ["id", "name", "email"],
+            primaryKeyColumn: "id",
+            databaseType: .mysql
+        )
+        let manager = RowOperationsManager(changeManager: changeManager)
+        return (manager, changeManager)
+    }
+
+    // MARK: - addNewRow Tests
+
+    @Test("addNewRow appends row to resultRows")
+    func addNewRowAppendsRow() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 3)
+        let originalCount = rows.count
+
+        _ = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+
+        #expect(rows.count == originalCount + 1)
+    }
+
+    @Test("addNewRow returns correct row index")
+    func addNewRowReturnsCorrectIndex() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 5)
+
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        #expect(result?.rowIndex == 5)
+    }
+
+    @Test("addNewRow uses DEFAULT marker for columns with defaults")
+    func addNewRowUsesDefaultMarker() {
+        let (manager, _) = makeManager()
+        var rows: [QueryResultRow] = []
+        let defaults: [String: String?] = [
+            "id": "auto_increment",
+            "name": nil,
+            "email": "user@example.com"
+        ]
+
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: defaults,
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        #expect(result?.values[0] == "__DEFAULT__")
+        #expect(result?.values[2] == "__DEFAULT__")
+    }
+
+    @Test("addNewRow uses nil for columns without defaults")
+    func addNewRowUsesNilForNoDefaults() {
+        let (manager, _) = makeManager()
+        var rows: [QueryResultRow] = []
+        let defaults: [String: String?] = [
+            "id": "auto_increment"
+        ]
+
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: defaults,
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        #expect(result?.values[1] == nil)
+        #expect(result?.values[2] == nil)
+    }
+
+    @Test("addNewRow records insertion in change manager")
+    func addNewRowRecordsInsertion() {
+        let (manager, changeManager) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 2)
+
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        #expect(changeManager.hasChanges)
+        #expect(changeManager.isRowInserted(result!.rowIndex))
+    }
+
+    @Test("addNewRow increments change manager reload version")
+    func addNewRowIncrementsReloadVersion() {
+        let (manager, changeManager) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 2)
+        let versionBefore = changeManager.reloadVersion
+
+        _ = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+
+        #expect(changeManager.reloadVersion > versionBefore)
+    }
+
+    @Test("multiple addNewRow calls append sequential rows")
+    func multipleAddNewRowAppendsSequentially() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 2)
+
+        let r1 = manager.addNewRow(columns: ["id", "name", "email"], columnDefaults: [:], resultRows: &rows)
+        let r2 = manager.addNewRow(columns: ["id", "name", "email"], columnDefaults: [:], resultRows: &rows)
+        let r3 = manager.addNewRow(columns: ["id", "name", "email"], columnDefaults: [:], resultRows: &rows)
+
+        #expect(rows.count == 5)
+        #expect(r1?.rowIndex == 2)
+        #expect(r2?.rowIndex == 3)
+        #expect(r3?.rowIndex == 4)
+    }
+
+    // MARK: - duplicateRow Tests
+
+    @Test("duplicateRow copies source row values")
+    func duplicateRowCopiesValues() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 3)
+        let sourceValues = rows[1].values
+
+        let result = manager.duplicateRow(
+            sourceRowIndex: 1,
+            columns: ["id", "name", "email"],
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        // Non-PK columns should match source
+        #expect(result?.values[1] == sourceValues[1])
+        #expect(result?.values[2] == sourceValues[2])
+    }
+
+    @Test("duplicateRow sets primary key to DEFAULT")
+    func duplicateRowSetsPkToDefault() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 3)
+
+        let result = manager.duplicateRow(
+            sourceRowIndex: 0,
+            columns: ["id", "name", "email"],
+            resultRows: &rows
+        )
+
+        #expect(result != nil)
+        #expect(result?.values[0] == "__DEFAULT__")
+    }
+
+    @Test("duplicateRow returns nil for invalid source index")
+    func duplicateRowReturnsNilForInvalidIndex() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 3)
+
+        let result = manager.duplicateRow(
+            sourceRowIndex: 10,
+            columns: ["id", "name", "email"],
+            resultRows: &rows
+        )
+
+        #expect(result == nil)
+    }
+
+    // MARK: - deleteSelectedRows Tests
+
+    @Test("deleteSelectedRows marks existing rows as deleted")
+    func deleteSelectedRowsMarksExistingAsDeleted() {
+        let (manager, changeManager) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 5)
+
+        _ = manager.deleteSelectedRows(
+            selectedIndices: [1, 3],
+            resultRows: &rows
+        )
+
+        #expect(changeManager.hasChanges)
+        #expect(changeManager.isRowDeleted(1))
+        #expect(changeManager.isRowDeleted(3))
+    }
+
+    @Test("deleteSelectedRows removes inserted rows from resultRows")
+    func deleteSelectedRowsRemovesInsertedRows() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 3)
+
+        // Insert a new row first
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+        #expect(rows.count == 4)
+
+        // Delete the inserted row
+        _ = manager.deleteSelectedRows(
+            selectedIndices: [result!.rowIndex],
+            resultRows: &rows
+        )
+
+        #expect(rows.count == 3)
+    }
+
+    @Test("deleteSelectedRows returns correct next selection")
+    func deleteSelectedRowsReturnsNextSelection() {
+        let (manager, _) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 5)
+
+        // Insert a row, then delete it — next selection should be valid
+        _ = manager.addNewRow(columns: ["id", "name", "email"], columnDefaults: [:], resultRows: &rows)
+        #expect(rows.count == 6)
+
+        let nextRow = manager.deleteSelectedRows(
+            selectedIndices: [5],
+            resultRows: &rows
+        )
+
+        // After removing the last row, should select the new last row
+        #expect(nextRow >= 0)
+        #expect(nextRow < rows.count)
+    }
+
+    // MARK: - Integration Tests
+
+    @Test("addNewRow then edit cell preserves insertion state")
+    func addNewRowThenEditPreservesInsertion() {
+        let (manager, changeManager) = makeManager()
+        var rows = TestFixtures.makeQueryResultRows(count: 2)
+
+        // Add a new row
+        let result = manager.addNewRow(
+            columns: ["id", "name", "email"],
+            columnDefaults: [:],
+            resultRows: &rows
+        )
+        #expect(result != nil)
+        let newIndex = result!.rowIndex
+
+        // Edit a cell in the new row
+        changeManager.recordCellChange(
+            rowIndex: newIndex,
+            columnIndex: 1,
+            columnName: "name",
+            oldValue: nil,
+            newValue: "Alice"
+        )
+
+        // Both the insertion and the cell edit should be tracked
+        #expect(changeManager.hasChanges)
+        #expect(changeManager.isRowInserted(newIndex))
+        // The row should still exist in resultRows
+        #expect(rows.count == 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Cmd+I (insert row), duplicate row, and undo/redo operations mutate `tab.resultRows` but did not increment `tab.resultVersion`, causing `TableTabContentView` to return a stale cached `InMemoryRowProvider` with the old row count
- The DataGridView never detected a row count change, so new rows were never rendered (though the status bar total did increase since it reads `tab.resultRows.count` directly)
- Added `resultVersion += 1` to all 6 coordinator methods that mutate row count: `addNewRow`, `deleteSelectedRows`, `duplicateSelectedRow`, `undoInsertRow`, `undoLastChange`, `redoLastChange`
- Added 14 tests for `RowOperationsManager` covering add, duplicate, delete, and integration scenarios

## Test plan
- [ ] Open a table, press Cmd+I — new row with green background appears at the bottom
- [ ] Duplicate a row (right-click > Duplicate) — duplicated row appears with green background
- [ ] Undo insert (Cmd+Z) — row disappears from the grid
- [ ] Redo insert (Cmd+Shift+Z) — row reappears
- [ ] Delete an inserted row — row is removed from the grid
- [ ] All 14 new `RowOperationsManagerTests` pass