### PR TITLE
fix: only pass sslrootcert to libpq when SSL mode requires verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New row (Cmd+I) and duplicated row not appearing in datagrid until manual refresh
 - PostgreSQL SSH tunnel connections failing with "no encryption" due to SSL config not being preserved
+- PostgreSQL SSL `sslrootcert` passed unconditionally to libpq, causing certificate verification failure even in `Required` mode
 
 ## [0.9.2] - 2026-02-28
 

--- a/TablePro/Core/Database/LibPQConnection.swift
+++ b/TablePro/Core/Database/LibPQConnection.swift
@@ -215,7 +215,7 @@ final class LibPQConnection: @unchecked Sendable {
                     connStr += " sslmode='verify-full'"
                 }
 
-                if !self.sslConfig.caCertificatePath.isEmpty {
+                if self.sslConfig.verifiesCertificate, !self.sslConfig.caCertificatePath.isEmpty {
                     connStr += " sslrootcert='\(escapeConnParam(self.sslConfig.caCertificatePath))'"
                 }
                 if !self.sslConfig.clientCertificatePath.isEmpty {


### PR DESCRIPTION
## Summary

- Only pass `sslrootcert` to libpq when SSL mode is `verify-ca` or `verify-full`, using the existing `verifiesCertificate` computed property
- In PostgreSQL 12+, `sslmode=require` + `sslrootcert` present causes libpq to behave like `verify-ca`, triggering certificate verification even when the user only wants encryption
- This fixes connections failing with "could not read root certificate file" when a stale CA cert path is configured but the user selects `Required` (encrypt-only) mode

## Test plan

- [ ] `Required` mode with stale/invalid CA cert path → should connect successfully (encrypt without verification)
- [ ] `Verify CA` mode with valid CA cert → should still verify correctly
- [ ] `Verify Full` mode with valid CA cert → should still verify correctly
- [ ] `Disabled` mode → no SSL params passed (unchanged)
- [ ] `Preferred` mode → `sslmode=prefer` without `sslrootcert` (fixed)