### PR TITLE
fix: toolbar showing wrong database engine name when opening new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Toolbar briefly showing "MySQL" and missing version (e.g., "MongoDB" instead of "MongoDB 8.2.5") when opening a new tab
+
 ## [0.10.0] - 2026-03-01
 
 ### Added

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -84,7 +84,18 @@ struct MainContentView: View {
         let tabMgr = QueryTabManager()
         let changeMgr = DataChangeManager()
         let filterMgr = FilterStateManager()
-        let toolbarSt = ConnectionToolbarState()
+        let toolbarSt = ConnectionToolbarState(connection: connection)
+
+        // Eagerly populate version + state from existing session to avoid flash
+        if let session = DatabaseManager.shared.session(for: connection.id) {
+            toolbarSt.updateConnectionState(from: session.status)
+            if let driver = session.driver {
+                toolbarSt.databaseVersion = driver.serverVersion
+            }
+        } else if let driver = DatabaseManager.shared.driver(for: connection.id) {
+            toolbarSt.connectionState = .connected
+            toolbarSt.databaseVersion = driver.serverVersion
+        }
 
         // Initialize single tab based on payload
         if let payload, !payload.isConnectionOnly {


### PR DESCRIPTION
## Summary

- Fix toolbar briefly flashing "MySQL" (default) instead of the correct database engine when opening a new tab
- Fix toolbar showing engine name without version (e.g., "MongoDB" instead of "MongoDB 8.2.5") during tab initialization

## Root cause

`ConnectionToolbarState()` was created with an empty `init()` that defaulted `databaseType` to `.mysql` and `databaseVersion` to `nil`. The correct values were only populated later in an async `.task` block via `initializeToolbar()`, causing a visible flash on the first render frame.

## Fix

Initialize `ConnectionToolbarState` with the `connection` object and eagerly read the server version from the existing `DatabaseManager` session — both available synchronously in `MainContentView.init()`.

## Test plan

- [ ] Connect to a PostgreSQL/SQLite/MongoDB database
- [ ] Open a new table tab (double-click or Cmd+click)
- [ ] Verify toolbar immediately shows correct engine name and version (no "MySQL" flash)