### PR TITLE
fix: keyboard shortcuts not working after connecting from welcome screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Toolbar briefly showing "MySQL" and missing version (e.g., "MongoDB" instead of "MongoDB 8.2.5") when opening a new tab
+- Keyboard shortcuts not working (beep sound) after connecting from welcome screen until a second tab is opened
 
 ## [0.10.0] - 2026-03-01
 

--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -105,6 +105,11 @@ struct ContentView: View {
                 if let connectionId = ourConnectionId ?? newSessionId {
                     currentSession = DatabaseManager.shared.activeSessions[connectionId]
                     columnVisibility = currentSession != nil ? .all : .detailOnly
+                    if let session = currentSession {
+                        AppState.shared.isConnected = true
+                        AppState.shared.isReadOnly = session.connection.isReadOnly
+                        AppState.shared.isMongoDB = session.connection.type == .mongodb
+                    }
                 } else {
                     currentSession = nil
                     columnVisibility = .detailOnly
@@ -134,6 +139,9 @@ struct ContentView: View {
                     return
                 }
                 currentSession = newSession
+                AppState.shared.isConnected = true
+                AppState.shared.isReadOnly = newSession.connection.isReadOnly
+                AppState.shared.isMongoDB = newSession.connection.type == .mongodb
             }
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
                 // Sync AppState flags from this window's session when it becomes focused


### PR DESCRIPTION
## Summary
- Keyboard shortcuts produced a beep and were non-functional after connecting to a database from the welcome screen, until a second tab was opened
- Root cause: `AppState.shared.isConnected` was only set to `true` inside the `didBecomeKeyNotification` handler, which fires before the session is ready (during the "Connecting..." phase), leaving all menu items disabled
- Fix: sync `AppState` flags in both `$currentSessionId` and `$activeSessions` handlers when the session becomes available

## Test plan
- [ ] Connect to a database from the welcome screen
- [ ] Verify keyboard shortcuts (Cmd+T, Cmd+K, Cmd+R, etc.) work immediately without needing to open a second tab
- [ ] Verify multi-window scenarios still update AppState correctly when switching between windows