### PR TITLE
fix: Cmd+A randomly opens a table and new window tab loses sidebar selection

### DIFF
--- a/TablePro/Views/Main/TableSelectionAction.swift
+++ b/TablePro/Views/Main/TableSelectionAction.swift
@@ -1,0 +1,52 @@
+//
+//  TableSelectionAction.swift
+//  TablePro
+//
+//  Pure logic for deciding whether a sidebar selection change should trigger
+//  navigation. Extracted so it can be unit-tested without any SwiftUI state.
+//
+
+import Foundation
+
+/// Describes what should happen when the sidebar selection set changes.
+enum TableSelectionAction: Equatable {
+    /// Selection changed but no single table was added — skip navigation.
+    /// Covers: Cmd+A (multi-select), Shift+click range, deselection.
+    case noNavigation
+    /// Exactly one table was added — navigate to it.
+    case navigate(tableName: String, isView: Bool)
+
+    /// Pure function — determines the action from old/new selection sets.
+    static func resolve(
+        oldTables: Set<TableInfo>,
+        newTables: Set<TableInfo>
+    ) -> TableSelectionAction {
+        let added = newTables.subtracting(oldTables)
+        guard added.count == 1, let table = added.first else {
+            return .noNavigation
+        }
+        return .navigate(tableName: table.name, isView: table.type == .view)
+    }
+}
+
+/// Determines which table (if any) to select when the table list loads in a new window.
+enum SidebarSyncAction: Equatable {
+    case noSync
+    case select(tableName: String)
+
+    /// Called when `tables` array changes. Returns which table to sync to, if any.
+    static func resolveOnTablesLoad(
+        newTables: [TableInfo],
+        selectedTables: Set<TableInfo>,
+        currentTabTableName: String?
+    ) -> SidebarSyncAction {
+        // Only sync when tables just loaded and sidebar has no selection
+        guard !newTables.isEmpty, selectedTables.isEmpty,
+              let tabTableName = currentTabTableName,
+              newTables.contains(where: { $0.name == tabTableName })
+        else {
+            return .noSync
+        }
+        return .select(tableName: tabTableName)
+    }
+}

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -313,6 +313,17 @@ struct MainContentView: View {
                     syncSidebarToCurrentTab()
                 }
             }
+            .onChange(of: tables) { _, newTables in
+                let syncAction = SidebarSyncAction.resolveOnTablesLoad(
+                    newTables: newTables,
+                    selectedTables: selectedTables,
+                    currentTabTableName: tabManager.selectedTab?.tableName
+                )
+                if case let .select(tableName) = syncAction,
+                   let match = newTables.first(where: { $0.name == tableName }) {
+                    selectedTables = [match]
+                }
+            }
             .onChange(of: selectedRowIndices) { _, newIndices in
                 AppState.shared.hasRowSelection = !newIndices.isEmpty
                 scheduleInspectorUpdate()
@@ -652,30 +663,29 @@ struct MainContentView: View {
     private func handleTableSelectionChange(
         from oldTables: Set<TableInfo>, to newTables: Set<TableInfo>
     ) {
-        guard let table = newTables.subtracting(oldTables).first else {
+        let action = TableSelectionAction.resolve(oldTables: oldTables, newTables: newTables)
+
+        guard case let .navigate(tableName, isView) = action else {
             AppState.shared.hasTableSelection = !newTables.isEmpty
             return
         }
 
         let result = SidebarNavigationResult.resolve(
-            clickedTableName: table.name,
+            clickedTableName: tableName,
             currentTabTableName: tabManager.selectedTab?.tableName,
             hasExistingTabs: !tabManager.tabs.isEmpty
         )
 
         switch result {
         case .skip:
-            // Programmatic sync — selection already reflects the active tab.
             AppState.shared.hasTableSelection = !newTables.isEmpty
             return
         case .openInPlace:
             selectedRowIndices = []
-            coordinator.openTableTab(table.name, isView: table.type == .view)
+            coordinator.openTableTab(tableName, isView: isView)
         case .revertAndOpenNewWindow:
-            // Revert sidebar SYNCHRONOUSLY so SwiftUI coalesces [B]→[A] into one
-            // render pass — the source window never visually flashes the new table.
             syncSidebarToCurrentTab()
-            coordinator.openTableTab(table.name, isView: table.type == .view)
+            coordinator.openTableTab(tableName, isView: isView)
         }
 
         AppState.shared.hasTableSelection = !newTables.isEmpty

--- a/TableProTests/Views/Main/SidebarSyncTests.swift
+++ b/TableProTests/Views/Main/SidebarSyncTests.swift
@@ -1,0 +1,76 @@
+//
+//  SidebarSyncTests.swift
+//  TableProTests
+//
+//  Tests for SidebarSyncAction — decides whether to sync the sidebar selection
+//  when the table list loads in a new window.
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+@Suite("SidebarSyncAction")
+struct SidebarSyncTests {
+
+    @Test("Tables load, selection empty, current tab has table name — sync")
+    func syncsWhenTablesLoadAndSelectionEmpty() {
+        let tables = [
+            TestFixtures.makeTableInfo(name: "users"),
+            TestFixtures.makeTableInfo(name: "orders")
+        ]
+        let result = SidebarSyncAction.resolveOnTablesLoad(
+            newTables: tables,
+            selectedTables: [],
+            currentTabTableName: "orders"
+        )
+        #expect(result == .select(tableName: "orders"))
+    }
+
+    @Test("Tables load, selection empty, current tab has no table name — no sync")
+    func noSyncWhenCurrentTabHasNoTableName() {
+        let tables = [TestFixtures.makeTableInfo(name: "users")]
+        let result = SidebarSyncAction.resolveOnTablesLoad(
+            newTables: tables,
+            selectedTables: [],
+            currentTabTableName: nil
+        )
+        #expect(result == .noSync)
+    }
+
+    @Test("Tables load, selection already populated — no sync")
+    func noSyncWhenSelectionAlreadyPopulated() {
+        let tables = [
+            TestFixtures.makeTableInfo(name: "users"),
+            TestFixtures.makeTableInfo(name: "orders")
+        ]
+        let selected: Set<TableInfo> = [TestFixtures.makeTableInfo(name: "users")]
+        let result = SidebarSyncAction.resolveOnTablesLoad(
+            newTables: tables,
+            selectedTables: selected,
+            currentTabTableName: "orders"
+        )
+        #expect(result == .noSync)
+    }
+
+    @Test("Tables load empty — no sync")
+    func noSyncWhenTablesEmpty() {
+        let result = SidebarSyncAction.resolveOnTablesLoad(
+            newTables: [],
+            selectedTables: [],
+            currentTabTableName: "users"
+        )
+        #expect(result == .noSync)
+    }
+
+    @Test("Tables load, selection empty, table name not in tables — no sync")
+    func noSyncWhenTableNameNotInTables() {
+        let tables = [TestFixtures.makeTableInfo(name: "users")]
+        let result = SidebarSyncAction.resolveOnTablesLoad(
+            newTables: tables,
+            selectedTables: [],
+            currentTabTableName: "nonexistent"
+        )
+        #expect(result == .noSync)
+    }
+}

--- a/TableProTests/Views/Main/TableSelectionChangeTests.swift
+++ b/TableProTests/Views/Main/TableSelectionChangeTests.swift
@@ -1,0 +1,107 @@
+//
+//  TableSelectionChangeTests.swift
+//  TableProTests
+//
+//  Tests for TableSelectionAction — the pure decision logic that determines
+//  whether a sidebar selection change should trigger table navigation.
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+@Suite("TableSelectionAction")
+struct TableSelectionChangeTests {
+
+    // MARK: - Single click (exactly one table added)
+
+    @Test("Single click adds one table — navigate to it")
+    func singleClickNavigates() {
+        let old: Set<TableInfo> = []
+        let new: Set<TableInfo> = [TestFixtures.makeTableInfo(name: "orders")]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .navigate(tableName: "orders", isView: false))
+    }
+
+    @Test("Single click on a view — navigate with isView true")
+    func singleClickOnView() {
+        let old: Set<TableInfo> = []
+        let view = TableInfo(name: "my_view", type: .view, rowCount: nil)
+        let new: Set<TableInfo> = [view]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .navigate(tableName: "my_view", isView: true))
+    }
+
+    @Test("Cmd+click adds exactly one more table — navigate to it")
+    func cmdClickAddsOneMore() {
+        let existing = TestFixtures.makeTableInfo(name: "users")
+        let added = TestFixtures.makeTableInfo(name: "orders")
+        let old: Set<TableInfo> = [existing]
+        let new: Set<TableInfo> = [existing, added]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .navigate(tableName: "orders", isView: false))
+    }
+
+    // MARK: - Multi-selection (Cmd+A, Shift+click)
+
+    @Test("Cmd+A adds many tables — no navigation")
+    func cmdANoNavigation() {
+        let old: Set<TableInfo> = []
+        let new: Set<TableInfo> = [
+            TestFixtures.makeTableInfo(name: "users"),
+            TestFixtures.makeTableInfo(name: "orders"),
+            TestFixtures.makeTableInfo(name: "products")
+        ]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .noNavigation)
+    }
+
+    @Test("Shift+click adds multiple tables — no navigation")
+    func shiftClickNoNavigation() {
+        let existing = TestFixtures.makeTableInfo(name: "users")
+        let old: Set<TableInfo> = [existing]
+        let new: Set<TableInfo> = [
+            existing,
+            TestFixtures.makeTableInfo(name: "orders"),
+            TestFixtures.makeTableInfo(name: "products")
+        ]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .noNavigation)
+    }
+
+    // MARK: - Deselection
+
+    @Test("Deselect tables (none added) — no navigation")
+    func deselectNoNavigation() {
+        let old: Set<TableInfo> = [
+            TestFixtures.makeTableInfo(name: "users"),
+            TestFixtures.makeTableInfo(name: "orders")
+        ]
+        let new: Set<TableInfo> = [TestFixtures.makeTableInfo(name: "users")]
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .noNavigation)
+    }
+
+    @Test("Deselect all — no navigation")
+    func deselectAllNoNavigation() {
+        let old: Set<TableInfo> = [TestFixtures.makeTableInfo(name: "users")]
+        let new: Set<TableInfo> = []
+        let action = TableSelectionAction.resolve(oldTables: old, newTables: new)
+        #expect(action == .noNavigation)
+    }
+
+    // MARK: - No change
+
+    @Test("No change (same set) — no navigation")
+    func noChangeNoNavigation() {
+        let tables: Set<TableInfo> = [TestFixtures.makeTableInfo(name: "users")]
+        let action = TableSelectionAction.resolve(oldTables: tables, newTables: tables)
+        #expect(action == .noNavigation)
+    }
+
+    @Test("Empty to empty — no navigation")
+    func emptyToEmptyNoNavigation() {
+        let action = TableSelectionAction.resolve(oldTables: [], newTables: [])
+        #expect(action == .noNavigation)
+    }
+}


### PR DESCRIPTION
## Summary
- **Cmd+A bug**: `handleTableSelectionChange` used `newTables.subtracting(oldTables).first` which picks a random item from a Set when multiple tables are added at once. Now uses `TableSelectionAction.resolve()` which only navigates when exactly one table was added (single click/Cmd+click).
- **New window tab bug**: When a table opens in a new native window tab, the sidebar starts with empty selection. Added `onChange(of: tables)` handler using `SidebarSyncAction.resolveOnTablesLoad()` to sync sidebar to the current tab when the table list first loads.

## Test plan
- [x] 9 tests for `TableSelectionAction.resolve()` (single click, view, Cmd+click, Cmd+A, Shift+click, deselect, no change)
- [x] 5 tests for `SidebarSyncAction.resolveOnTablesLoad()` (sync on load, no sync when no tab name/already populated/empty/missing table)
- [x] 37 existing sidebar tests pass (no regression)
- [ ] Manual: Cmd+A in sidebar selects all tables without opening any
- [ ] Manual: Click a table opens it in a new tab with sidebar selection
- [ ] Manual: Opening table in new native window tab shows correct sidebar selection