### PR TITLE
refactor: use individual ToolbarItem entries for native macOS overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored toolbar to use individual `ToolbarItem` entries with `Label` for native macOS overflow behavior, and moved History/Export/Import to `.secondaryAction` overflow menu
 - Redesigned right sidebar detail pane with compact field layout and type-aware editors
 
 ## [0.10.0] - 2026-03-01

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3619,6 +3619,7 @@
       }
     },
     "Export data" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -4395,6 +4396,7 @@
       }
     },
     "Import data" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -4621,7 +4623,6 @@
       }
     },
     "Inspector" : {
-      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -5325,6 +5326,7 @@
       }
     },
     "New query tab" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -5981,6 +5983,7 @@
       }
     },
     "Open database" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -6806,6 +6809,7 @@
       }
     },
     "Refresh data" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -7962,6 +7966,7 @@
       }
     },
     "Switch connection" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -8465,6 +8470,7 @@
       }
     },
     "Toggle filters" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -8515,6 +8521,7 @@
       }
     },
     "Toggle inspector" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -8545,6 +8552,7 @@
       }
     },
     "Toggle query history" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {

--- a/TablePro/Theme/ToolbarDesignTokens.swift
+++ b/TablePro/Theme/ToolbarDesignTokens.swift
@@ -58,44 +58,9 @@ enum ToolbarDesignTokens {
         static let verticalPadding = DesignConstants.Spacing.xxs
     }
 
-    // MARK: - Spacing (Balanced for readability)
-
-    enum Spacing {
-        /// Spacing between icon and text within a component (5pt)
-        static let iconTextSpacing: CGFloat = 5
-
-        /// Spacing between sections - balanced readability (10pt)
-        static let betweenSections: CGFloat = 10
-
-        /// Divider height - minimal like Xcode
-        static let dividerHeight = DesignConstants.Spacing.sm
-
-        /// Icon size (default database/cylinder icon)
-        static let iconSize: CGFloat = 13
-
-        /// Tag padding from toolbar edge
-        static let tagPadding = DesignConstants.Spacing.xs
-    }
-
-    // MARK: - Animations
-
-    enum Animation {
-        /// Hover transition duration - references base constant
-        static let hover = DesignConstants.AnimationDuration.normal
-
-        /// Spring response for bouncy animations
-        static let springResponse: Double = 0.4
-
-        /// Spring damping fraction
-        static let springDamping: Double = 0.7
-    }
-
     // MARK: - Colors (Xcode-inspired minimal)
 
     enum Colors {
-        /// Divider color - very subtle like Xcode
-        static let divider = Color(nsColor: .tertiaryLabelColor)
-
         /// Secondary text color - references base constant
         static let secondaryText = DesignConstants.Colors.secondaryText
 

--- a/TablePro/Views/Toolbar/ConnectionStatusView.swift
+++ b/TablePro/Views/Toolbar/ConnectionStatusView.swift
@@ -20,14 +20,13 @@ struct ConnectionStatusView: View {
     var isReadOnly: Bool = false
 
     var body: some View {
-        HStack(spacing: ToolbarDesignTokens.Spacing.betweenSections) {
+        HStack(spacing: 10) {
             // Database type icon + version
             databaseInfoSection
 
             // Vertical separator
             Divider()
-                .frame(height: ToolbarDesignTokens.Spacing.dividerHeight)
-                .background(ToolbarDesignTokens.Colors.divider)
+                .frame(height: DesignConstants.Spacing.sm)
 
             // Database name (clickable to switch databases)
             if !databaseName.isEmpty {
@@ -75,7 +74,7 @@ struct ConnectionStatusView: View {
     private var databaseNameLabel: some View {
         HStack(spacing: 4) {
             Image(systemName: "cylinder")
-                .font(.system(size: ToolbarDesignTokens.Spacing.iconSize))
+                .font(.system(size: 13))
                 .foregroundStyle(ToolbarDesignTokens.Colors.secondaryText)
                 .overlay(alignment: .bottomTrailing) {
                     if isReadOnly {

--- a/TablePro/Views/Toolbar/ExecutionIndicatorView.swift
+++ b/TablePro/Views/Toolbar/ExecutionIndicatorView.swift
@@ -14,7 +14,7 @@ struct ExecutionIndicatorView: View {
     let lastDuration: TimeInterval?
 
     var body: some View {
-        HStack(spacing: ToolbarDesignTokens.Spacing.iconTextSpacing) {
+        HStack(spacing: 5) {
             if isExecuting {
                 ProgressView()
                     .controlSize(.small)
@@ -37,8 +37,8 @@ struct ExecutionIndicatorView: View {
                     .help("Run a query to see execution time")
             }
         }
-        .padding(.trailing, ToolbarDesignTokens.Spacing.tagPadding)
-        .animation(.easeInOut(duration: ToolbarDesignTokens.Animation.hover), value: isExecuting)
+        .padding(.trailing, DesignConstants.Spacing.xs)
+        .animation(.easeInOut(duration: DesignConstants.AnimationDuration.normal), value: isExecuting)
     }
 
     // MARK: - Helpers

--- a/TablePro/Views/Toolbar/OpenTableToolbarView.swift
+++ b/TablePro/Views/Toolbar/OpenTableToolbarView.swift
@@ -19,18 +19,13 @@ struct ToolbarPrincipalContent: View {
     @ObservedObject var state: ConnectionToolbarState
 
     var body: some View {
-        HStack(spacing: ToolbarDesignTokens.Spacing.betweenSections) {
-            // Tag badge (if tag is assigned)
+        HStack(spacing: 10) {
             if let tagId = state.tagId,
                let tag = TagStorage.shared.tag(for: tagId)
             {
                 TagBadgeView(tag: tag)
-
-                Divider()
-                    .frame(height: ToolbarDesignTokens.Spacing.dividerHeight)
             }
 
-            // Main connection status display
             ConnectionStatusView(
                 databaseType: state.databaseType,
                 databaseVersion: state.databaseVersion,
@@ -42,20 +37,12 @@ struct ToolbarPrincipalContent: View {
                 isReadOnly: state.isReadOnly
             )
 
-            Divider()
-                .frame(height: ToolbarDesignTokens.Spacing.dividerHeight)
-
-            // Execution indicator (spinner or duration)
             ExecutionIndicatorView(
                 isExecuting: state.isExecuting,
                 lastDuration: state.lastQueryDuration
             )
         }
-        .animation(
-            .spring(
-                response: ToolbarDesignTokens.Animation.springResponse,
-                dampingFraction: ToolbarDesignTokens.Animation.springDamping), value: state.tagId
-        )
+        .animation(.spring(), value: state.tagId)
         .animation(.easeInOut, value: state.connectionState)
     }
 }
@@ -71,8 +58,8 @@ struct TableProToolbar: ViewModifier {
         content
             .toolbar {
                 // MARK: - Navigation (Left)
-                // Separate items so macOS can overflow them individually with labels
-                ToolbarItemGroup(placement: .navigation) {
+
+                ToolbarItem(placement: .navigation) {
                     Button {
                         showConnectionSwitcher.toggle()
                     } label: {
@@ -84,7 +71,9 @@ struct TableProToolbar: ViewModifier {
                             showConnectionSwitcher = false
                         }
                     }
+                }
 
+                ToolbarItem(placement: .navigation) {
                     Button {
                         actions?.openDatabaseSwitcher()
                     } label: {
@@ -93,12 +82,9 @@ struct TableProToolbar: ViewModifier {
                     .help("Open Database (⌘K)")
                     .disabled(
                         state.connectionState != .connected || state.databaseType == .sqlite)
+                }
 
-                    Button(state.databaseType == .mongodb ? "MQL" : "SQL") {
-                        actions?.newTab()
-                    }
-                    .help("New Query Tab (⌘T)")
-
+                ToolbarItem(placement: .navigation) {
                     Button {
                         NotificationCenter.default.post(name: .refreshData, object: nil)
                     } label: {
@@ -106,7 +92,36 @@ struct TableProToolbar: ViewModifier {
                     }
                     .help("Refresh (⌘R)")
                     .disabled(state.connectionState != .connected)
+                }
 
+                // MARK: - Principal (Center)
+
+                ToolbarItem(placement: .principal) {
+                    ToolbarPrincipalContent(state: state)
+                }
+
+                // MARK: - Primary Action (Right)
+
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        actions?.newTab()
+                    } label: {
+                        Label("New Tab", systemImage: "plus.rectangle")
+                    }
+                    .help("New Query Tab (⌘T)")
+                }
+
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        actions?.toggleFilterPanel()
+                    } label: {
+                        Label("Filters", systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                    .help("Toggle Filters (⌘F)")
+                    .disabled(state.connectionState != .connected || !state.isTableTab)
+                }
+
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         actions?.previewSQL()
                     } label: {
@@ -116,28 +131,20 @@ struct TableProToolbar: ViewModifier {
                     }
                     .help(state.databaseType == .mongodb ? "Preview MQL (⌘⇧P)" : "Preview SQL (⌘⇧P)")
                     .disabled(!state.hasPendingChanges || state.connectionState != .connected)
-                    .popover(isPresented: $state.showSQLReviewPopover) {
-                        SQLReviewPopover(statements: state.previewStatements, databaseType: state.databaseType)
-                    }
                 }
 
-                // MARK: - Principal (Center)
-                // Main connection information display with execution indicator
-                ToolbarItem(placement: .principal) {
-                    ToolbarPrincipalContent(state: state)
-                }
-
-                // MARK: - Primary Action (Right)
-                // Separate items so macOS can overflow them individually with labels
-                ToolbarItemGroup(placement: .primaryAction) {
+                ToolbarItem(placement: .primaryAction) {
                     Button {
-                        actions?.toggleFilterPanel()
+                        actions?.toggleRightSidebar()
                     } label: {
-                        Label("Filters", systemImage: "line.3.horizontal.decrease.circle")
+                        Label("Inspector", systemImage: "sidebar.trailing")
                     }
-                    .help("Toggle Filters (⌘F)")
-                    .disabled(state.connectionState != .connected || !state.isTableTab)
+                    .help("Toggle Inspector (⌘⌥B)")
+                }
 
+                // MARK: - Secondary Action (Overflow)
+
+                ToolbarItemGroup(placement: .secondaryAction) {
                     Button {
                         actions?.toggleHistoryPanel()
                     } label: {
@@ -162,14 +169,10 @@ struct TableProToolbar: ViewModifier {
                         .help("Import Data (⌘⇧I)")
                         .disabled(state.connectionState != .connected || state.isReadOnly)
                     }
-
-                    Button {
-                        actions?.toggleRightSidebar()
-                    } label: {
-                        Label("Inspector", systemImage: "sidebar.trailing")
-                    }
-                    .help("Toggle Inspector (⌘⌥B)")
                 }
+            }
+            .popover(isPresented: $state.showSQLReviewPopover) {
+                SQLReviewPopover(statements: state.previewStatements, databaseType: state.databaseType)
             }
             .onReceive(NotificationCenter.default.publisher(for: .openConnectionSwitcher)) { _ in
                 showConnectionSwitcher = true

--- a/TablePro/Views/Toolbar/TagBadgeView.swift
+++ b/TablePro/Views/Toolbar/TagBadgeView.swift
@@ -29,7 +29,7 @@ struct TagBadgeView: View {
                 Capsule()
                     .fill(tag.color.color.opacity(ToolbarDesignTokens.Tag.backgroundOpacity))
             )
-            .padding(.leading, ToolbarDesignTokens.Spacing.tagPadding)
+            .padding(.leading, DesignConstants.Spacing.xs)
             .help("Tag: \(tag.name)")
             .accessibilityLabel("Tag: \(tag.name)")
     }


### PR DESCRIPTION
## Summary

- Replace `ToolbarItemGroup` blocks with individual `ToolbarItem` entries using `Label` so macOS can overflow toolbar buttons individually instead of as one blob
- Move History, Export, and Import to `.secondaryAction` placement (always in overflow menu)
- New Tab button now uses `Label("New Tab", systemImage: "plus.rectangle")` instead of text-only "SQL"/"MQL"
- Remove `Spacing`, `Animation` enums and `Colors.divider` from `ToolbarDesignTokens`, inlining values or using `DesignConstants` directly
- Simplify `ToolbarPrincipalContent`: remove dividers between tag/status/execution, use default `.spring()` animation

## Test plan

- [ ] Verify all toolbar buttons visible at full window width with correct icons
- [ ] Resize window narrow: primary action items overflow individually into `>>` menu with text labels
- [ ] History, Export, Import appear in the overflow `...` menu by default
- [ ] All buttons function: connection switcher popover, database switcher, refresh, new tab, filters, preview SQL popover, inspector toggle, history, export, import
- [ ] MongoDB connection hides Import item in overflow menu
- [ ] Preview SQL popover still works when Preview SQL button is in overflow