### PR TITLE
fix: use correct language label and syntax highlighting for MongoDB AI chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolbar briefly showing "MySQL" and missing version (e.g., "MongoDB" instead of "MongoDB 8.2.5") when opening a new tab
 - Keyboard shortcuts not working (beep sound) after connecting from welcome screen until a second tab is opened
 - Toolbar overflow menu showing only one item and missing all other buttons when window is narrow
+- AI chat showing "SQL" language label and missing syntax highlighting for MongoDB code blocks
 
 ### Changed
 

--- a/TablePro/Core/AI/AIPromptTemplates.swift
+++ b/TablePro/Core/AI/AIPromptTemplates.swift
@@ -9,18 +9,28 @@ import Foundation
 
 /// Centralized prompt templates for AI-powered editor features
 enum AIPromptTemplates {
-    /// Build a prompt asking AI to explain a SQL query
-    static func explainQuery(_ query: String) -> String {
-        "Explain this SQL query:\n\n```sql\n\(query)\n```"
+    /// Build a prompt asking AI to explain a query
+    static func explainQuery(_ query: String, databaseType: DatabaseType = .mysql) -> String {
+        let (typeName, lang) = queryInfo(for: databaseType)
+        return "Explain this \(typeName):\n\n```\(lang)\n\(query)\n```"
     }
 
-    /// Build a prompt asking AI to optimize a SQL query
-    static func optimizeQuery(_ query: String) -> String {
-        "Optimize this SQL query for better performance:\n\n```sql\n\(query)\n```"
+    /// Build a prompt asking AI to optimize a query
+    static func optimizeQuery(_ query: String, databaseType: DatabaseType = .mysql) -> String {
+        let (typeName, lang) = queryInfo(for: databaseType)
+        return "Optimize this \(typeName) for better performance:\n\n```\(lang)\n\(query)\n```"
     }
 
     /// Build a prompt asking AI to fix a query that produced an error
-    static func fixError(query: String, error: String) -> String {
-        "This SQL query failed with an error. Please fix it.\n\nQuery:\n```sql\n\(query)\n```\n\nError: \(error)"
+    static func fixError(query: String, error: String, databaseType: DatabaseType = .mysql) -> String {
+        let (typeName, lang) = queryInfo(for: databaseType)
+        return "This \(typeName) failed with an error. Please fix it.\n\nQuery:\n```\(lang)\n\(query)\n```\n\nError: \(error)"
+    }
+
+    private static func queryInfo(for databaseType: DatabaseType) -> (typeName: String, language: String) {
+        if databaseType == .mongodb {
+            return ("MongoDB query", "javascript")
+        }
+        return ("SQL query", "sql")
     }
 }

--- a/TablePro/Core/AI/AISchemaContext.swift
+++ b/TablePro/Core/AI/AISchemaContext.swift
@@ -54,7 +54,8 @@ struct AISchemaContext {
         if settings.includeCurrentQuery,
            let query = currentQuery,
            !query.isEmpty {
-            parts.append("\n## Current Query\n```sql\n\(query)\n```")
+            let lang = databaseType == .mongodb ? "javascript" : "sql"
+            parts.append("\n## Current Query\n```\(lang)\n\(query)\n```")
         }
 
         if settings.includeQueryResults,
@@ -63,14 +64,23 @@ struct AISchemaContext {
             parts.append("\n## Recent Query Results\n\(results)")
         }
 
-        parts.append(
-            "\nProvide SQL queries appropriate for"
-            + " \(databaseType.rawValue) syntax when applicable."
-        )
-        parts.append(
-            "When writing SQL, use the correct identifier quoting"
-            + " for \(databaseType.rawValue)."
-        )
+        if databaseType == .mongodb {
+            parts.append(
+                "\nProvide MongoDB shell queries using `javascript` fenced code blocks."
+            )
+            parts.append(
+                "Use MongoDB shell syntax (db.collection.find(), etc.), not SQL."
+            )
+        } else {
+            parts.append(
+                "\nProvide SQL queries appropriate for"
+                + " \(databaseType.rawValue) syntax when applicable."
+            )
+            parts.append(
+                "When writing SQL, use the correct identifier quoting"
+                + " for \(databaseType.rawValue)."
+            )
+        }
 
         return parts.joined(separator: "\n")
     }

--- a/TablePro/Views/AIChat/AIChatCodeBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatCodeBlockView.swift
@@ -55,7 +55,7 @@ struct AIChatCodeBlockView: View {
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
 
-            if isSQL {
+            if isInsertable {
                 Button {
                     NotificationCenter.default.post(
                         name: .insertQueryFromAI,
@@ -77,6 +77,10 @@ struct AIChatCodeBlockView: View {
                 Text(highlightedSQL(code))
                     .textSelection(.enabled)
                     .padding(10)
+            } else if isMongoDB {
+                Text(highlightedJavaScript(code))
+                    .textSelection(.enabled)
+                    .padding(10)
             } else {
                 Text(code)
                     .font(.system(size: 12, design: .monospaced))
@@ -90,6 +94,16 @@ struct AIChatCodeBlockView: View {
         guard let language else { return false }
         let sqlLanguages = ["sql", "mysql", "postgresql", "postgres", "sqlite"]
         return sqlLanguages.contains(language.lowercased())
+    }
+
+    private var isMongoDB: Bool {
+        guard let language else { return false }
+        let mongoLanguages = ["javascript", "js", "mongodb", "mongo"]
+        return mongoLanguages.contains(language.lowercased())
+    }
+
+    private var isInsertable: Bool {
+        isSQL || isMongoDB
     }
 
     // MARK: - Static SQL Regex Patterns (compiled once)
@@ -186,6 +200,117 @@ struct AIChatCodeBlockView: View {
         for match in SQLPatterns.keyword.matches(in: code, range: fullRange) {
             guard !isProtected(match.range) else { continue }
             applyColor(match.range, color: .systemBlue)
+        }
+
+        return result
+    }
+
+    // MARK: - Static JavaScript Regex Patterns (compiled once)
+
+    private enum JSPatterns {
+        // swiftlint:disable force_try
+        static let singleLineComment = try! NSRegularExpression(pattern: "//[^\r\n]*")
+        static let multiLineComment = try! NSRegularExpression(pattern: "/\\*[\\s\\S]*?\\*/")
+        static let doubleQuoteString = try! NSRegularExpression(pattern: "\"(?:[^\"\\\\]|\\\\.)*\"")
+        static let singleQuoteString = try! NSRegularExpression(pattern: "'(?:[^'\\\\]|\\\\.)*'")
+        static let number = try! NSRegularExpression(pattern: "\\b\\d+(\\.\\d+)?\\b")
+        static let boolNull = try! NSRegularExpression(
+            pattern: "\\b(true|false|null|undefined|NaN|Infinity)\\b"
+        )
+        static let keyword: NSRegularExpression = {
+            let keywords = [
+                "var", "let", "const", "function", "return", "if", "else", "for", "while",
+                "do", "switch", "case", "break", "continue", "new", "this", "typeof",
+                "instanceof", "in", "of", "try", "catch", "throw", "finally", "async", "await"
+            ]
+            let pattern = "\\b(" + keywords.joined(separator: "|") + ")\\b"
+            return try! NSRegularExpression(pattern: pattern)
+        }()
+        static let method: NSRegularExpression = {
+            let methods = [
+                "find", "findOne", "insertOne", "insertMany", "updateOne", "updateMany",
+                "deleteOne", "deleteMany", "aggregate", "countDocuments", "distinct",
+                "createIndex", "dropIndex", "explain", "limit", "skip", "sort", "project",
+                "match", "group", "unwind", "lookup", "replaceOne", "bulkWrite"
+            ]
+            let pattern = "\\.(" + methods.joined(separator: "|") + ")\\b"
+            return try! NSRegularExpression(pattern: pattern)
+        }()
+        static let property = try! NSRegularExpression(pattern: "\\b(db)\\b")
+        // swiftlint:enable force_try
+    }
+
+    private func highlightedJavaScript(_ code: String) -> AttributedString {
+        var result = AttributedString(code)
+        result.font = .system(size: 12, design: .monospaced)
+
+        var protectedRanges: [Range<AttributedString.Index>] = []
+
+        func applyColor(_ nsRange: NSRange, color: NSColor, protect: Bool = false) {
+            guard let stringRange = Range(nsRange, in: code),
+                  let attrStart = AttributedString.Index(stringRange.lowerBound, within: result),
+                  let attrEnd = AttributedString.Index(stringRange.upperBound, within: result) else {
+                return
+            }
+            let range = attrStart..<attrEnd
+            result[range].foregroundColor = Color(nsColor: color)
+            if protect {
+                protectedRanges.append(range)
+            }
+        }
+
+        func isProtected(_ nsRange: NSRange) -> Bool {
+            guard let stringRange = Range(nsRange, in: code),
+                  let attrStart = AttributedString.Index(stringRange.lowerBound, within: result),
+                  let attrEnd = AttributedString.Index(stringRange.upperBound, within: result) else {
+                return false
+            }
+            let range = attrStart..<attrEnd
+            return protectedRanges.contains { $0.overlaps(range) }
+        }
+
+        let nsCode = code as NSString
+        let fullRange = NSRange(location: 0, length: nsCode.length)
+
+        for match in JSPatterns.singleLineComment.matches(in: code, range: fullRange) {
+            applyColor(match.range, color: .systemGreen, protect: true)
+        }
+
+        for match in JSPatterns.multiLineComment.matches(in: code, range: fullRange) {
+            applyColor(match.range, color: .systemGreen, protect: true)
+        }
+
+        for match in JSPatterns.doubleQuoteString.matches(in: code, range: fullRange) {
+            applyColor(match.range, color: .systemRed, protect: true)
+        }
+
+        for match in JSPatterns.singleQuoteString.matches(in: code, range: fullRange) {
+            applyColor(match.range, color: .systemRed, protect: true)
+        }
+
+        for match in JSPatterns.number.matches(in: code, range: fullRange) {
+            guard !isProtected(match.range) else { continue }
+            applyColor(match.range, color: .systemPurple)
+        }
+
+        for match in JSPatterns.boolNull.matches(in: code, range: fullRange) {
+            guard !isProtected(match.range) else { continue }
+            applyColor(match.range, color: .systemOrange)
+        }
+
+        for match in JSPatterns.keyword.matches(in: code, range: fullRange) {
+            guard !isProtected(match.range) else { continue }
+            applyColor(match.range, color: .systemPink)
+        }
+
+        for match in JSPatterns.method.matches(in: code, range: fullRange) {
+            guard !isProtected(match.range) else { continue }
+            applyColor(match.range, color: .systemBlue)
+        }
+
+        for match in JSPatterns.property.matches(in: code, range: fullRange) {
+            guard !isProtected(match.range) else { continue }
+            applyColor(match.range, color: .systemTeal)
         }
 
         return result

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -23,6 +23,14 @@ struct AIChatPanelView: View {
         settingsManager.ai.providers.contains(where: { $0.isEnabled })
     }
 
+    private var queryLanguage: String {
+        connection.type == .mongodb ? "javascript" : "sql"
+    }
+
+    private var queryTypeName: String {
+        connection.type == .mongodb ? "MongoDB query" : "SQL query"
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -67,7 +75,7 @@ struct AIChatPanelView: View {
                   let error = userInfo["error"] as? String else { return }
             viewModel.startNewConversation()
             updateContext()
-            let prompt = "Fix this SQL query error:\n\nQuery:\n```sql\n\(query)\n```\n\nError: \(error)"
+            let prompt = "Fix this \(queryTypeName) error:\n\nQuery:\n```\(queryLanguage)\n\(query)\n```\n\nError: \(error)"
             viewModel.sendWithContext(prompt: prompt, feature: .fixError)
         }
         .onReceive(NotificationCenter.default.publisher(for: .aiExplainSelection)) { notification in
@@ -75,7 +83,7 @@ struct AIChatPanelView: View {
             guard !selectedText.isEmpty else { return }
             viewModel.startNewConversation()
             updateContext()
-            let prompt = "Explain this SQL:\n```sql\n\(selectedText)\n```"
+            let prompt = "Explain this \(queryTypeName):\n```\(queryLanguage)\n\(selectedText)\n```"
             viewModel.sendWithContext(prompt: prompt, feature: .explainQuery)
         }
         .onReceive(NotificationCenter.default.publisher(for: .aiOptimizeSelection)) { notification in
@@ -83,7 +91,7 @@ struct AIChatPanelView: View {
             guard !selectedText.isEmpty else { return }
             viewModel.startNewConversation()
             updateContext()
-            let prompt = "Optimize this SQL query:\n```sql\n\(selectedText)\n```"
+            let prompt = "Optimize this \(queryTypeName):\n```\(queryLanguage)\n\(selectedText)\n```"
             viewModel.sendWithContext(prompt: prompt, feature: .optimizeQuery)
         }
         .alert(


### PR DESCRIPTION
## Summary
- AI system prompt now instructs the model to use `javascript` fenced code blocks and MongoDB shell syntax when connected to MongoDB (instead of SQL)
- AI chat code blocks for MongoDB queries now show "JAVASCRIPT" language label instead of "SQL", and the Insert button works for MongoDB code blocks
- Added JavaScript/MongoDB syntax highlighting (comments, strings, numbers, keywords, MongoDB methods like `.find()`, `.aggregate()`, `db` object)
- Updated `AIPromptTemplates` with a `databaseType` parameter for database-aware prompt generation

## Test plan
- [ ] Connect to a MongoDB database and open AI chat
- [ ] Ask the AI to write a query — verify code blocks show "JAVASCRIPT" label, not "SQL"
- [ ] Verify MongoDB code blocks have syntax highlighting (colored keywords, strings, methods)
- [ ] Verify the "Insert" button appears on MongoDB code blocks and inserts into the editor
- [ ] Connect to a MySQL/PostgreSQL/SQLite database and verify AI chat still works as before with "SQL" labels