### PR TITLE
fix: eliminate center toolbar flicker on new tab window

### DIFF
--- a/TablePro/Models/ConnectionToolbarState.swift
+++ b/TablePro/Models/ConnectionToolbarState.swift
@@ -191,6 +191,8 @@ final class ConnectionToolbarState: ObservableObject {
     /// Replication lag in seconds (for replicated databases)
     @Published var replicationLagSeconds: Int?
 
+    var hasCompletedSetup = false
+
     // MARK: - Computed Properties
 
     /// Formatted database version with type

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -96,6 +96,7 @@ struct MainContentView: View {
             toolbarSt.connectionState = .connected
             toolbarSt.databaseVersion = driver.serverVersion
         }
+        toolbarSt.hasCompletedSetup = true
 
         // Initialize single tab based on payload
         if let payload, !payload.isConnectionOnly {
@@ -301,7 +302,10 @@ struct MainContentView: View {
                         coordinator.runQuery()
                     }
                 }
-                toolbarState.connectionState = mapSessionStatus(session.status)
+                let mappedState = mapSessionStatus(session.status)
+                if mappedState != toolbarState.connectionState {
+                    toolbarState.connectionState = mappedState
+                }
             }
 
             .onChange(of: selectedTables) { _, newTables in
@@ -409,9 +413,6 @@ struct MainContentView: View {
     private func initializeAndRestoreTabs() async {
         guard !hasInitialized else { return }
         hasInitialized = true
-        // Sync toolbar setup (fast, no I/O)
-        coordinator.initializeToolbar()
-        // Schema load runs in background — doesn't block data query
         Task { await coordinator.loadSchemaIfNeeded() }
 
         // If payload provided a specific tab (not connection-only), execute its query immediately

--- a/TablePro/Views/Toolbar/OpenTableToolbarView.swift
+++ b/TablePro/Views/Toolbar/OpenTableToolbarView.swift
@@ -43,7 +43,7 @@ struct ToolbarPrincipalContent: View {
             )
         }
         .animation(.spring(), value: state.tagId)
-        .animation(.easeInOut, value: state.connectionState)
+        .animation(state.hasCompletedSetup ? .easeInOut : nil, value: state.connectionState)
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove redundant `coordinator.initializeToolbar()` call from `.task {}` — init already pre-populates toolbar state synchronously, so the async call was causing duplicate `@Published` writes after first render
- Guard `onReceive($activeSessions)` with equality check to skip redundant `connectionState` writes that fire `objectWillChange` unnecessarily
- Suppress animation during initial toolbar setup via `hasCompletedSetup` flag, so the `.easeInOut` transition doesn't visually animate the initial state population

## Test plan

- [ ] Open app, connect to a database, open new tab window (Cmd+T) — center toolbar should appear instantly without flicker
- [ ] Disconnect and reconnect — toolbar status animation should still work normally
- [ ] Execute a query — execution indicator should still animate
- [ ] Open a table via double-click — new window toolbar should appear without flicker