### PR TITLE
feat: enable sidebar editing for single-table SELECT query tabs

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -36,7 +36,7 @@ extension MainContentView {
     var isSidebarEditable: Bool {
         guard !coordinator.connection.isReadOnly,
               let tab = coordinator.tabManager.selectedTab,
-              tab.tabType == .table,
+              tab.tabType == .table || tab.tableName != nil,
               !selectedRowIndices.isEmpty else {
             return false
         }

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -778,8 +778,7 @@ struct MainContentView: View {
     // MARK: - Sidebar Edit Handling
 
     private func updateSidebarEditState() {
-        guard isSidebarEditable,
-              let tab = coordinator.tabManager.selectedTab,
+        guard let tab = coordinator.tabManager.selectedTab,
               !selectedRowIndices.isEmpty
         else {
             rightPanelState.editState.fields = []
@@ -800,6 +799,11 @@ struct MainContentView: View {
             columns: tab.resultColumns,
             columnTypes: tab.columnTypes
         )
+
+        guard isSidebarEditable else {
+            rightPanelState.editState.onFieldChanged = nil
+            return
+        }
 
         let capturedCoordinator = coordinator
         let capturedEditState = rightPanelState.editState


### PR DESCRIPTION
## Summary
- Allow the Details sidebar to edit fields in query tabs when the SQL is a simple `SELECT ... FROM table`
- Relax `isSidebarEditable` guard from `tab.tabType == .table` to also accept query tabs where `tab.tableName != nil` (set by `extractTableName()`)
- Show read-only field values for complex queries (JOINs, CTEs, aggregations) where `extractTableName()` returns nil

## Test plan
- [ ] Execute `SELECT * FROM users` in a query tab, select a row — Details pane shows editable fields, changes save correctly
- [ ] Execute a JOIN query in a query tab, select a row — Details pane shows read-only fields
- [ ] Table tab, select a row — editable fields (unchanged behavior)
- [ ] Read-only connection — read-only fields