### PR TITLE
feat: support SSH tunnel URL import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Import database connections from SSH tunnel URLs (e.g., `mysql+ssh://`, `postgresql+ssh://`)
+
 ### Fixed
 
 - Toolbar briefly showing "MySQL" and missing version (e.g., "MongoDB" instead of "MongoDB 8.2.5") when opening a new tab

--- a/TablePro/Core/Utilities/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/ConnectionURLParser.swift
@@ -14,8 +14,16 @@ struct ParsedConnectionURL {
     let password: String
     let sslMode: SSLMode?
     let authSource: String?
+    let sshHost: String?
+    let sshPort: Int?
+    let sshUsername: String?
+    let usePrivateKey: Bool?
+    let connectionName: String?
 
     var suggestedName: String {
+        if let connectionName, !connectionName.isEmpty {
+            return connectionName
+        }
         let typeName = type.rawValue
         if !database.isEmpty {
             return "\(typeName) \(host)/\(database)"
@@ -58,7 +66,13 @@ struct ConnectionURLParser {
             return .failure(.invalidURL)
         }
 
-        let scheme = trimmed[trimmed.startIndex..<schemeEnd.lowerBound].lowercased()
+        var scheme = trimmed[trimmed.startIndex..<schemeEnd.lowerBound].lowercased()
+
+        var isSSH = false
+        if scheme.hasSuffix("+ssh") {
+            isSSH = true
+            scheme = String(scheme.dropLast(4))
+        }
 
         let dbType: DatabaseType
         switch scheme {
@@ -86,8 +100,17 @@ struct ConnectionURLParser {
                 username: "",
                 password: "",
                 sslMode: nil,
-                authSource: nil
+                authSource: nil,
+                sshHost: nil,
+                sshPort: nil,
+                sshUsername: nil,
+                usePrivateKey: nil,
+                connectionName: nil
             ))
+        }
+
+        if isSSH {
+            return parseSSHURL(trimmed, schemeEnd: schemeEnd, dbType: dbType)
         }
 
         let httpURL = "http://" + String(trimmed[schemeEnd.upperBound...])
@@ -133,7 +156,149 @@ struct ConnectionURLParser {
             username: username,
             password: password,
             sslMode: sslMode,
-            authSource: authSource
+            authSource: authSource,
+            sshHost: nil,
+            sshPort: nil,
+            sshUsername: nil,
+            usePrivateKey: nil,
+            connectionName: nil
+        ))
+    }
+
+    // SSH URL format: scheme+ssh://ssh_user@ssh_host:ssh_port/db_user:db_pass@db_host:db_port/db_name?params
+    // URLComponents can't handle two user@host segments, so we parse manually.
+    private static func parseSSHURL(
+        _ urlString: String,
+        schemeEnd: Range<String.Index>,
+        dbType: DatabaseType
+    ) -> Result<ParsedConnectionURL, ConnectionURLParseError> {
+        let afterScheme = String(urlString[schemeEnd.upperBound...])
+
+        var mainPart = afterScheme
+        var queryString: String?
+        if let questionIndex = afterScheme.firstIndex(of: "?") {
+            mainPart = String(afterScheme[afterScheme.startIndex..<questionIndex])
+            queryString = String(afterScheme[afterScheme.index(after: questionIndex)...])
+        }
+
+        guard let firstSlash = mainPart.firstIndex(of: "/") else {
+            return .failure(.invalidURL)
+        }
+
+        let sshPart = String(mainPart[mainPart.startIndex..<firstSlash])
+        let dbPart = String(mainPart[mainPart.index(after: firstSlash)...])
+
+        var sshUsername: String?
+        var sshHostPort: String
+        if let atIndex = sshPart.firstIndex(of: "@") {
+            sshUsername = String(sshPart[sshPart.startIndex..<atIndex])
+            sshHostPort = String(sshPart[sshPart.index(after: atIndex)...])
+        } else {
+            sshHostPort = sshPart
+        }
+
+        guard !sshHostPort.isEmpty else {
+            return .failure(.missingHost)
+        }
+
+        var sshHost: String
+        var sshPort: Int?
+        if let colonIndex = sshHostPort.firstIndex(of: ":") {
+            sshHost = String(sshHostPort[sshHostPort.startIndex..<colonIndex])
+            sshPort = Int(sshHostPort[sshHostPort.index(after: colonIndex)...])
+        } else {
+            sshHost = sshHostPort
+        }
+
+        var dbUsername = ""
+        var dbPassword = ""
+        var dbHostPort = ""
+        var database = ""
+
+        if let atIndex = dbPart.lastIndex(of: "@") {
+            let credentials = String(dbPart[dbPart.startIndex..<atIndex])
+            let afterAt = String(dbPart[dbPart.index(after: atIndex)...])
+
+            if let colonIndex = credentials.firstIndex(of: ":") {
+                dbUsername = String(credentials[credentials.startIndex..<colonIndex])
+                dbPassword = String(credentials[credentials.index(after: colonIndex)...])
+            } else {
+                dbUsername = credentials
+            }
+
+            if let slashIndex = afterAt.firstIndex(of: "/") {
+                dbHostPort = String(afterAt[afterAt.startIndex..<slashIndex])
+                database = String(afterAt[afterAt.index(after: slashIndex)...])
+            } else {
+                dbHostPort = afterAt
+            }
+        } else {
+            if let slashIndex = dbPart.firstIndex(of: "/") {
+                dbHostPort = String(dbPart[dbPart.startIndex..<slashIndex])
+                database = String(dbPart[dbPart.index(after: slashIndex)...])
+            } else {
+                dbHostPort = dbPart
+            }
+        }
+
+        var host: String
+        var port: Int?
+        if let colonIndex = dbHostPort.lastIndex(of: ":") {
+            host = String(dbHostPort[dbHostPort.startIndex..<colonIndex])
+            port = Int(dbHostPort[dbHostPort.index(after: colonIndex)...])
+        } else {
+            host = dbHostPort
+        }
+
+        if host.isEmpty {
+            host = "127.0.0.1"
+        }
+
+        var connectionName: String?
+        var usePrivateKey: Bool?
+        var sslMode: SSLMode?
+        var authSource: String?
+
+        if let queryString {
+            let params = queryString.split(separator: "&", omittingEmptySubsequences: true)
+            for param in params {
+                let parts = param.split(separator: "=", maxSplits: 1)
+                guard let key = parts.first else { continue }
+                let value = parts.count > 1 ? String(parts[1]) : nil
+
+                switch String(key) {
+                case "name":
+                    connectionName = value?
+                        .replacingOccurrences(of: "+", with: " ")
+                        .removingPercentEncoding ?? value
+                case "usePrivateKey":
+                    usePrivateKey = value?.lowercased() == "true"
+                case "sslmode":
+                    if let value {
+                        sslMode = parseSSLMode(value)
+                    }
+                case "authSource", "authsource":
+                    authSource = value
+                default:
+                    break
+                }
+            }
+        }
+
+        return .success(ParsedConnectionURL(
+            type: dbType,
+            host: host,
+            port: port,
+            database: database,
+            username: dbUsername,
+            password: dbPassword,
+            sslMode: sslMode,
+            authSource: authSource,
+            sshHost: sshHost,
+            sshPort: sshPort,
+            sshUsername: sshUsername,
+            usePrivateKey: usePrivateKey,
+            connectionName: connectionName
         ))
     }
 

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -817,7 +817,18 @@ struct ConnectionFormView: View {
             username = parsed.username
             password = parsed.password
             sslMode = parsed.sslMode ?? .disabled
-            if name.isEmpty {
+            if let sshHostValue = parsed.sshHost {
+                sshEnabled = true
+                sshHost = sshHostValue
+                sshPort = parsed.sshPort.map(String.init) ?? "22"
+                sshUsername = parsed.sshUsername ?? ""
+                if parsed.usePrivateKey == true {
+                    sshAuthMethod = .privateKey
+                }
+            }
+            if let connectionName = parsed.connectionName, !connectionName.isEmpty {
+                name = connectionName
+            } else if name.isEmpty {
                 name = parsed.suggestedName
             }
         case .failure(let error):

--- a/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
@@ -312,4 +312,118 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.sslMode == .required)
     }
+
+    // MARK: - SSH Tunnel URLs
+
+    @Test("Full mysql+ssh URL")
+    func testFullMySQLSSHURL() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root@123.123.123.123:1234/database_user:database_password@127.0.0.1/database_name?name=FlashPanel&usePrivateKey=true&env=production")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .mysql)
+        #expect(parsed.host == "127.0.0.1")
+        #expect(parsed.port == nil)
+        #expect(parsed.database == "database_name")
+        #expect(parsed.username == "database_user")
+        #expect(parsed.password == "database_password")
+        #expect(parsed.sshHost == "123.123.123.123")
+        #expect(parsed.sshPort == 1234)
+        #expect(parsed.sshUsername == "root")
+        #expect(parsed.usePrivateKey == true)
+        #expect(parsed.connectionName == "FlashPanel")
+    }
+
+    @Test("PostgreSQL SSH URL")
+    func testPostgreSQLSSHURL() {
+        let result = ConnectionURLParser.parse("postgresql+ssh://deploy@db.example.com:22/admin:secret@10.0.0.5/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.host == "10.0.0.5")
+        #expect(parsed.database == "mydb")
+        #expect(parsed.username == "admin")
+        #expect(parsed.password == "secret")
+        #expect(parsed.sshHost == "db.example.com")
+        #expect(parsed.sshPort == 22)
+        #expect(parsed.sshUsername == "deploy")
+    }
+
+    @Test("Postgres SSH scheme alias")
+    func testPostgresSSHAlias() {
+        let result = ConnectionURLParser.parse("postgres+ssh://user@host:22/dbuser:pass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.sshHost == "host")
+    }
+
+    @Test("MariaDB SSH URL")
+    func testMariaDBSSHURL() {
+        let result = ConnectionURLParser.parse("mariadb+ssh://admin@192.168.1.1:2222/root:pass@127.0.0.1/production")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .mariadb)
+        #expect(parsed.sshHost == "192.168.1.1")
+        #expect(parsed.sshPort == 2222)
+        #expect(parsed.sshUsername == "admin")
+        #expect(parsed.host == "127.0.0.1")
+        #expect(parsed.database == "production")
+    }
+
+    @Test("SSH URL without SSH port")
+    func testSSHURLWithoutSSHPort() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root@myserver/dbuser:pass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sshHost == "myserver")
+        #expect(parsed.sshPort == nil)
+        #expect(parsed.sshUsername == "root")
+    }
+
+    @Test("SSH URL with connection name")
+    func testSSHURLWithConnectionName() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root@host:22/user:pass@localhost/db?name=My+Server")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.connectionName == "My Server")
+        #expect(parsed.suggestedName == "My Server")
+    }
+
+    @Test("SSH URL with usePrivateKey")
+    func testSSHURLWithUsePrivateKey() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root@host:22/user:pass@localhost/db?usePrivateKey=true")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.usePrivateKey == true)
+    }
+
+    @Test("Non-SSH URL has nil SSH fields")
+    func testNonSSHURLHasNilSSHFields() {
+        let result = ConnectionURLParser.parse("mysql://root:pass@localhost:3306/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sshHost == nil)
+        #expect(parsed.sshPort == nil)
+        #expect(parsed.sshUsername == nil)
+        #expect(parsed.usePrivateKey == nil)
+        #expect(parsed.connectionName == nil)
+    }
+
+    @Test("Case-insensitive SSH scheme")
+    func testCaseInsensitiveSSHScheme() {
+        let result = ConnectionURLParser.parse("MYSQL+SSH://root@host:22/user:pass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .mysql)
+        #expect(parsed.sshHost == "host")
+    }
 }

--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -80,10 +80,17 @@ If you have a database connection string (commonly provided by hosting platforms
 | MariaDB | `mariadb://user:pass@host:3306/dbname` |
 | SQLite | `sqlite:///path/to/database.db` |
 | MongoDB | `mongodb://user:pass@host:27017/dbname` |
+| MySQL (SSH) | `mysql+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
+| PostgreSQL (SSH) | `postgresql+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
+| MariaDB (SSH) | `mariadb+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
 
 <Tip>
 Connection URLs with special characters in the password (like `@`, `#`, or `%`) should use percent-encoding. For example, `p@ssword` becomes `p%40ssword`.
 </Tip>
+
+<Note>
+SSH tunnel URLs use the format `scheme+ssh://ssh_user@ssh_host:ssh_port/db_user:db_password@db_host/db_name`. Query parameters `name` (connection name) and `usePrivateKey=true` (use key-based auth) are also supported.
+</Note>
 
 ### Connection Form Fields
 

--- a/docs/databases/ssh-tunneling.mdx
+++ b/docs/databases/ssh-tunneling.mdx
@@ -259,6 +259,42 @@ chmod 644 ~/.ssh/id_*.pub
 chmod 644 ~/.ssh/config
 ```
 
+## Import from URL
+
+You can import SSH tunnel connections from a URL instead of filling in each field manually. TablePro supports `+ssh` URL schemes that encode both SSH and database credentials in a single string.
+
+**Format:**
+
+```
+scheme+ssh://ssh_user@ssh_host:ssh_port/db_user:db_password@db_host/db_name?name=MyConnection&usePrivateKey=true
+```
+
+**Supported schemes:** `mysql+ssh`, `postgresql+ssh`, `postgres+ssh`, `mariadb+ssh`
+
+**Example:**
+
+```
+mysql+ssh://root@123.123.123.123:1234/database_user:database_password@127.0.0.1/database_name?name=FlashPanel&usePrivateKey=true
+```
+
+This fills in:
+- **SSH Host**: `123.123.123.123`, **SSH Port**: `1234`, **SSH User**: `root`
+- **Database Host**: `127.0.0.1`, **Database User**: `database_user`, **Database**: `database_name`
+- **Connection Name**: `FlashPanel`, **Auth Method**: Private Key
+
+**Query parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Sets the connection name |
+| `usePrivateKey` | Set to `true` to select Private Key authentication |
+
+To import, open **New Connection**, click **Import from URL**, and paste the URL.
+
+<Tip>
+This format is compatible with TablePlus SSH connection URLs, so you can paste URLs directly when migrating.
+</Tip>
+
 ## Troubleshooting
 
 ### Connection Refused

--- a/docs/vi/databases/overview.mdx
+++ b/docs/vi/databases/overview.mdx
@@ -80,10 +80,17 @@ Nếu bạn có chuỗi kết nối cơ sở dữ liệu (thường được cun
 | MariaDB | `mariadb://user:pass@host:3306/dbname` |
 | SQLite | `sqlite:///path/to/database.db` |
 | MongoDB | `mongodb://user:pass@host:27017/dbname` |
+| MySQL (SSH) | `mysql+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
+| PostgreSQL (SSH) | `postgresql+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
+| MariaDB (SSH) | `mariadb+ssh://ssh_user@ssh_host:22/db_user:pass@db_host/dbname` |
 
 <Tip>
 URL kết nối có ký tự đặc biệt trong mật khẩu (như `@`, `#` hoặc `%`) cần sử dụng percent-encoding. Ví dụ: `p@ssword` trở thành `p%40ssword`.
 </Tip>
+
+<Note>
+URL SSH tunnel sử dụng định dạng `scheme+ssh://ssh_user@ssh_host:ssh_port/db_user:db_password@db_host/db_name`. Tham số query `name` (tên kết nối) và `usePrivateKey=true` (sử dụng xác thực key) cũng được hỗ trợ.
+</Note>
 
 ### Các trường Biểu mẫu Kết nối
 

--- a/docs/vi/databases/ssh-tunneling.mdx
+++ b/docs/vi/databases/ssh-tunneling.mdx
@@ -259,6 +259,42 @@ chmod 644 ~/.ssh/id_*.pub
 chmod 644 ~/.ssh/config
 ```
 
+## Nhập từ URL
+
+Bạn có thể nhập kết nối SSH tunnel từ URL thay vì điền từng trường thủ công. TablePro hỗ trợ scheme URL `+ssh` mã hóa cả thông tin SSH và database trong một chuỗi duy nhất.
+
+**Định dạng:**
+
+```
+scheme+ssh://ssh_user@ssh_host:ssh_port/db_user:db_password@db_host/db_name?name=MyConnection&usePrivateKey=true
+```
+
+**Các scheme được hỗ trợ:** `mysql+ssh`, `postgresql+ssh`, `postgres+ssh`, `mariadb+ssh`
+
+**Ví dụ:**
+
+```
+mysql+ssh://root@123.123.123.123:1234/database_user:database_password@127.0.0.1/database_name?name=FlashPanel&usePrivateKey=true
+```
+
+Kết quả điền:
+- **SSH Host**: `123.123.123.123`, **SSH Port**: `1234`, **SSH User**: `root`
+- **Database Host**: `127.0.0.1`, **Database User**: `database_user`, **Database**: `database_name`
+- **Tên kết nối**: `FlashPanel`, **Phương thức xác thực**: Private Key
+
+**Tham số query:**
+
+| Tham số | Mô tả |
+|-----------|-------------|
+| `name` | Đặt tên kết nối |
+| `usePrivateKey` | Đặt `true` để chọn xác thực Private Key |
+
+Để nhập, mở **New Connection**, nhấp **Import from URL**, và dán URL.
+
+<Tip>
+Định dạng này tương thích với URL kết nối SSH của TablePlus, vì vậy bạn có thể dán URL trực tiếp khi di chuyển.
+</Tip>
+
 ## Khắc Phục Sự Cố
 
 ### Từ Chối Kết Nối


### PR DESCRIPTION
## Summary

- Parse `+ssh` URL schemes (`mysql+ssh://`, `postgresql+ssh://`, `postgres+ssh://`, `mariadb+ssh://`) that encode both SSH tunnel and database credentials in a single connection string
- Auto-fill SSH form fields (host, port, username, auth method) when importing an SSH tunnel URL
- Support `name` and `usePrivateKey` query parameters for connection name and key-based auth

Closes #133

## Changes

- **`ConnectionURLParser.swift`**: Added 5 SSH fields to `ParsedConnectionURL` struct, `+ssh` scheme detection, and a custom `parseSSHURL()` method (URLComponents can't handle two `user@host` segments)
- **`ConnectionFormView.swift`**: Populate SSH form fields from parsed URL, prefer `connectionName` over `suggestedName`
- **`ConnectionURLParserTests.swift`**: 9 new tests covering all SSH URL variants, edge cases, and backward compatibility
- **Docs**: Updated connection management and SSH tunneling pages (EN + VI) with SSH URL formats and import instructions
- **CHANGELOG.md**: Added entry under `[Unreleased]`

## Test plan

- [x] Build succeeds
- [x] All 37 `ConnectionURLParserTests` pass (28 existing + 9 new)
- [x] SwiftLint passes with 0 violations
- [ ] Manual: paste `mysql+ssh://root@123.123.123.123:1234/database_user:database_password@127.0.0.1/database_name?name=FlashPanel&usePrivateKey=true` into Import from URL dialog — should auto-fill all SSH + DB fields
- [ ] Manual: paste standard `mysql://root:pass@localhost/db` — unchanged behavior, SSH fields stay disabled