### PR TITLE
feat: add context menu with New Connection option on welcome window

### DIFF
--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -197,6 +197,15 @@ struct WelcomeWindowView: View {
             }
         }
         .frame(minWidth: 350)
+        .contentShape(Rectangle())
+        .contextMenu { newConnectionContextMenu }
+    }
+
+    @ViewBuilder
+    private var newConnectionContextMenu: some View {
+        Button(action: { openWindow(id: "connection-form") }) {
+            Label("New Connection...", systemImage: "plus")
+        }
     }
 
     // MARK: - Connection List


### PR DESCRIPTION
## Summary
- Add right-click context menu to the welcome window connection list area
- Context menu contains a "New Connection..." option that opens the connection form window

## Test plan
- [ ] Right-click on the welcome window connection list area
- [ ] Verify "New Connection..." option appears in context menu
- [ ] Click the option and confirm the connection form window opens

<img width="695" height="443" alt="Screenshot 2026-03-02 at 12 45 20" src="https://github.com/user-attachments/assets/408eb889-067f-4e73-81d7-b7fc17f68697" />

