### PR TITLE
fix: MongoDB database switch, dotted collection names, and shell parser

### DIFF
--- a/TablePro/Core/Database/MongoDBDriver.swift
+++ b/TablePro/Core/Database/MongoDBDriver.swift
@@ -13,7 +13,7 @@ import OSLog
 /// Parses mongo shell syntax (db.collection.find/insert/update/delete)
 /// and dispatches to MongoDBConnection for execution.
 final class MongoDBDriver: DatabaseDriver {
-    let connection: DatabaseConnection
+    private(set) var connection: DatabaseConnection
     private(set) var status: ConnectionStatus = .disconnected
 
     private var mongoConnection: MongoDBConnection?
@@ -22,6 +22,10 @@ final class MongoDBDriver: DatabaseDriver {
 
     init(connection: DatabaseConnection) {
         self.connection = connection
+    }
+
+    func switchDatabase(to database: String) {
+        connection.database = database
     }
 
     // MARK: - Server Version
@@ -408,7 +412,8 @@ final class MongoDBDriver: DatabaseDriver {
                     opts.append("\"name\": \"\(name)\"")
 
                     let optsJson = "{\(opts.joined(separator: ", "))}"
-                    sections.append("db.\(table).createIndex(\(keyJson), \(optsJson))")
+                    let escapedTable = table.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+                    sections.append("db[\"\(escapedTable)\"].createIndex(\(keyJson), \(optsJson))")
                 }
             }
         } catch {

--- a/TablePro/Core/MongoDB/MongoDBStatementGenerator.swift
+++ b/TablePro/Core/MongoDB/MongoDBStatementGenerator.swift
@@ -15,6 +15,11 @@ struct MongoDBStatementGenerator {
     let collectionName: String
     let columns: [String]
 
+    /// Collection accessor using bracket notation for safety with dotted names
+    private var collectionAccessor: String {
+        "db[\"\(escapeJsonString(collectionName))\"]"
+    }
+
     /// Index of "_id" field in the columns array (used as primary key equivalent)
     var idColumnIndex: Int? {
         columns.firstIndex(of: "_id")
@@ -97,7 +102,7 @@ struct MongoDBStatementGenerator {
         guard !doc.isEmpty else { return nil }
 
         let docJson = serializeDocument(doc)
-        let shell = "db.\(collectionName).insertOne(\(docJson))"
+        let shell = "\(collectionAccessor).insertOne(\(docJson))"
         return ParameterizedStatement(sql: shell, parameters: [])
     }
 
@@ -134,7 +139,7 @@ struct MongoDBStatementGenerator {
         guard docs.count > 1 else { return nil }
 
         let docsArray = "[\(docs.joined(separator: ", "))]"
-        let shell = "db.\(collectionName).insertMany(\(docsArray))"
+        let shell = "\(collectionAccessor).insertMany(\(docsArray))"
         return ParameterizedStatement(sql: shell, parameters: [])
     }
 
@@ -179,7 +184,7 @@ struct MongoDBStatementGenerator {
         }
 
         let updateJson = "{\(updateParts.joined(separator: ", "))}"
-        let shell = "db.\(collectionName).updateOne(\(filterJson), \(updateJson))"
+        let shell = "\(collectionAccessor).updateOne(\(filterJson), \(updateJson))"
         return ParameterizedStatement(sql: shell, parameters: [])
     }
 
@@ -206,7 +211,7 @@ struct MongoDBStatementGenerator {
         }
 
         let inList = idValues.joined(separator: ", ")
-        let shell = "db.\(collectionName).deleteMany({\"_id\": {\"$in\": [\(inList)]}})"
+        let shell = "\(collectionAccessor).deleteMany({\"_id\": {\"$in\": [\(inList)]}})"
         return ParameterizedStatement(sql: shell, parameters: [])
     }
 
@@ -220,7 +225,7 @@ struct MongoDBStatementGenerator {
            idIndex < originalRow.count,
            let idValue = originalRow[idIndex] {
             let filterJson = buildIdFilter(idValue)
-            let shell = "db.\(collectionName).deleteOne(\(filterJson))"
+            let shell = "\(collectionAccessor).deleteOne(\(filterJson))"
             return ParameterizedStatement(sql: shell, parameters: [])
         }
 
@@ -236,7 +241,7 @@ struct MongoDBStatementGenerator {
         guard !filter.isEmpty else { return nil }
 
         let filterJson = serializeDocument(filter)
-        let shell = "db.\(collectionName).deleteOne(\(filterJson))"
+        let shell = "\(collectionAccessor).deleteOne(\(filterJson))"
         return ParameterizedStatement(sql: shell, parameters: [])
     }
 

--- a/TablePro/Core/MongoDB/MongoShellParser.swift
+++ b/TablePro/Core/MongoDB/MongoShellParser.swift
@@ -100,6 +100,11 @@ struct MongoShellParser {
             return .runCommand(command: arg)
         }
 
+        // db["collection"].method(args) bracket notation
+        if trimmed.hasPrefix("db[") {
+            return try parseBracketExpression(trimmed)
+        }
+
         // db.collection.method(args) pattern
         guard trimmed.hasPrefix("db.") else {
             throw MongoShellParseError.invalidSyntax("Query must start with 'db.' or be a JSON command")
@@ -110,21 +115,131 @@ struct MongoShellParser {
 
     // MARK: - Private Parsing
 
+    /// Parse db["collection"].method(args) bracket notation.
+    /// Supports both double and single quotes around the collection name.
+    private static func parseBracketExpression(_ input: String) throws -> MongoOperation {
+        // input starts with db[
+        let afterBracket = String(input.dropFirst(3)) // drop "db["
+
+        // Determine quote character (" or ')
+        guard let quoteChar = afterBracket.first, quoteChar == "\"" || quoteChar == "'" else {
+            throw MongoShellParseError.invalidSyntax("Expected quoted collection name in db[...]")
+        }
+
+        // Find closing quote (handle escaped quotes)
+        var collectionName = ""
+        var i = afterBracket.index(after: afterBracket.startIndex)
+        var escapeNext = false
+        while i < afterBracket.endIndex {
+            let ch = afterBracket[i]
+            if escapeNext {
+                collectionName.append(ch)
+                escapeNext = false
+                i = afterBracket.index(after: i)
+                continue
+            }
+            if ch == "\\" {
+                escapeNext = true
+                i = afterBracket.index(after: i)
+                continue
+            }
+            if ch == quoteChar {
+                break
+            }
+            collectionName.append(ch)
+            i = afterBracket.index(after: i)
+        }
+
+        guard i < afterBracket.endIndex else {
+            throw MongoShellParseError.invalidSyntax("Unterminated string in db[...]")
+        }
+
+        // Move past closing quote and expect "]"
+        i = afterBracket.index(after: i)
+        guard i < afterBracket.endIndex, afterBracket[i] == "]" else {
+            throw MongoShellParseError.invalidSyntax("Expected ']' after collection name in db[...]")
+        }
+        i = afterBracket.index(after: i)
+
+        let remaining = String(afterBracket[i...]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // No method chain — treat as find all
+        if remaining.isEmpty {
+            return .find(collection: collectionName, filter: "{}", options: MongoFindOptions())
+        }
+
+        // Expect ".method(args)" after db["collection"]
+        guard remaining.hasPrefix(".") else {
+            throw MongoShellParseError.invalidSyntax("Expected '.method()' after db[\"...\"]")
+        }
+
+        let methodChain = String(remaining.dropFirst())
+        return try parseMethodChain(collection: collectionName, chain: methodChain)
+    }
+
     private static func parseDbExpression(_ input: String) throws -> MongoOperation {
         // Remove "db." prefix
         let afterDb = String(input.dropFirst(3))
 
-        // Find the collection name (everything before the first ".")
-        guard let dotIndex = afterDb.firstIndex(of: ".") else {
-            // Just "db.collectionName" -- treat as find all
+        guard let firstParen = afterDb.firstIndex(of: "(") else {
+            // No parentheses at all — "db.collectionName" or "db.system.version" — treat as find all
             let collection = afterDb.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !collection.isEmpty else {
+                throw MongoShellParseError.invalidSyntax("Missing collection name after 'db.'")
+            }
             return .find(collection: collection, filter: "{}", options: MongoFindOptions())
         }
 
-        let collection = String(afterDb[afterDb.startIndex..<dotIndex])
-        let remainder = String(afterDb[afterDb.index(after: dotIndex)...])
+        // Find the last "." before the first "(". Everything before it is the collection name,
+        // and everything from it onward is the method chain.
+        // This correctly handles dotted collection names like "system.version".
+        let beforeParen = afterDb[afterDb.startIndex..<firstParen]
+        guard let lastDot = beforeParen.lastIndex(of: ".") else {
+            // No dot before paren — db-level method call like db.getCollectionNames()
+            return try parseDbLevelMethod(afterDb)
+        }
+
+        let collection = String(afterDb[afterDb.startIndex..<lastDot])
+        let remainder = String(afterDb[afterDb.index(after: lastDot)...])
 
         return try parseMethodChain(collection: collection, chain: remainder)
+    }
+
+    /// Parse a db-level method call like db.getCollectionNames(), db.stats(), etc.
+    /// Input is the string after "db." — e.g. "getCollectionNames()" or "createCollection(\"test\")"
+    private static func parseDbLevelMethod(_ input: String) throws -> MongoOperation {
+        guard let parenIndex = input.firstIndex(of: "(") else {
+            throw MongoShellParseError.invalidSyntax("Expected method call with parentheses")
+        }
+
+        let methodName = String(input[input.startIndex..<parenIndex])
+        let argAndRest = try extractParenthesizedArgAndRemainder(from: input, startingAt: parenIndex)
+        let arg = argAndRest.arg
+
+        switch methodName {
+        case "getCollectionNames", "listCollections":
+            return .listCollections
+
+        case "createCollection":
+            let name = arg.trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            guard !name.isEmpty else {
+                throw MongoShellParseError.missingArgument("createCollection requires a collection name")
+            }
+            return .runCommand(command: "{ \"create\": \"\(name)\" }")
+
+        case "dropDatabase":
+            return .runCommand(command: "{ \"dropDatabase\": 1 }")
+
+        case "version":
+            return .runCommand(command: "{ \"buildInfo\": 1 }")
+
+        case "stats":
+            return .runCommand(command: "{ \"dbStats\": 1 }")
+
+        default:
+            throw MongoShellParseError.unsupportedMethod(methodName)
+        }
     }
 
     private static func parseMethodChain(collection: String, chain: String) throws -> MongoOperation {

--- a/TablePro/Core/Services/ExportService.swift
+++ b/TablePro/Core/Services/ExportService.swift
@@ -1159,7 +1159,8 @@ final class ExportService: ObservableObject {
             }
             if foundHeader {
                 var processedLine = line
-                let ddlAccessor = "db.\(collection)"
+                let escapedForDDL = collection.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+                let ddlAccessor = "db[\"\(escapedForDDL)\"]"
                 if processedLine.hasPrefix(ddlAccessor) {
                     processedLine = collectionAccessor + processedLine.dropFirst(ddlAccessor.count)
                 }

--- a/TablePro/Models/QueryTab.swift
+++ b/TablePro/Models/QueryTab.swift
@@ -565,7 +565,8 @@ final class QueryTabManager: ObservableObject {
         let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
         let query: String
         if databaseType == .mongodb {
-            query = "db.\(tableName).find({}).limit(\(pageSize))"
+            let escaped = tableName.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+            query = "db[\"\(escaped)\"].find({}).limit(\(pageSize))"
         } else {
             let quotedName = databaseType.quoteIdentifier(tableName)
             query = "SELECT * FROM \(quotedName) LIMIT \(pageSize);"
@@ -599,7 +600,8 @@ final class QueryTabManager: ObservableObject {
         let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
         let query: String
         if databaseType == .mongodb {
-            query = "db.\(tableName).find({}).limit(\(pageSize))"
+            let escaped = tableName.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+            query = "db[\"\(escaped)\"].find({}).limit(\(pageSize))"
         } else {
             let quotedName = databaseType.quoteIdentifier(tableName)
             query = "SELECT * FROM \(quotedName) LIMIT \(pageSize);"

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -7,7 +7,6 @@
 //
 
 import Combine
-import os
 import SwiftUI
 
 // MARK: - TableFetcher Protocol
@@ -34,7 +33,9 @@ struct LiveTableFetcher: TableFetcher {
                 return cached
             }
         }
-        guard let driver = await DatabaseManager.shared.driver(for: connectionId) else { return [] }
+        guard let driver = await DatabaseManager.shared.driver(for: connectionId) else {
+            return []
+        }
         return try await driver.fetchTables()
     }
 }
@@ -43,8 +44,6 @@ struct LiveTableFetcher: TableFetcher {
 
 @MainActor
 final class SidebarViewModel: ObservableObject {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SidebarViewModel")
-
     // MARK: - Published State
 
     @Published var isLoading = false
@@ -82,6 +81,7 @@ final class SidebarViewModel: ObservableObject {
     private let tableFetcher: TableFetcher
     private var cancellables = Set<AnyCancellable>()
     private var hasSetupNotifications = false
+    private var loadTask: Task<Void, Never>?
 
     // MARK: - Convenience Accessors
 
@@ -167,7 +167,7 @@ final class SidebarViewModel: ObservableObject {
         .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in
             Task { @MainActor in
-                self?.loadTables()
+                self?.forceLoadTables()
             }
         }
         .store(in: &cancellables)
@@ -201,9 +201,16 @@ final class SidebarViewModel: ObservableObject {
         guard !isLoading else { return }
         isLoading = true
         errorMessage = nil
-        Task {
+        loadTask = Task {
             await loadTablesAsync()
         }
+    }
+
+    func forceLoadTables() {
+        loadTask?.cancel()
+        loadTask = nil
+        isLoading = false
+        loadTables()
     }
 
     private func loadTablesAsync() async {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -272,7 +272,16 @@ extension MainContentCoordinator {
                     runQuery()
                 }
             } else if connection.type == .mongodb {
-                // MongoDB: just update the database name — driver reads it for every operation
+                // MongoDB: update the driver's connection so fetchTables/execute use the new database
+                if let mongoDriver = driver as? MongoDBDriver {
+                    mongoDriver.switchDatabase(to: database)
+                }
+
+                // Also update metadata driver if present
+                if let metaDriver = DatabaseManager.shared.metadataDriver(for: connectionId) as? MongoDBDriver {
+                    metaDriver.switchDatabase(to: database)
+                }
+
                 DatabaseManager.shared.updateSession(connectionId) { session in
                     var updatedConnection = session.connection
                     updatedConnection.database = database
@@ -294,6 +303,8 @@ extension MainContentCoordinator {
                 }
 
                 await loadSchema()
+
+                NotificationCenter.default.post(name: .refreshData, object: nil)
 
                 if let currentTab = tabManager.selectedTab, currentTab.tabType == .table {
                     runQuery()

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
@@ -126,7 +126,8 @@ extension MainContentCoordinator {
                 "DELETE FROM sqlite_sequence WHERE name = '\(escapedName)'"
             ]
         case .mongodb:
-            return ["db.\(tableName).deleteMany({})"]
+            let escaped = tableName.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+            return ["db[\"\(escaped)\"].deleteMany({})"]
         }
     }
 
@@ -139,7 +140,8 @@ extension MainContentCoordinator {
         case .mysql, .mariadb, .sqlite:
             return "DROP \(keyword) \(quotedName)"
         case .mongodb:
-            return "db.\(tableName).drop()"
+            let escaped = tableName.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+            return "db[\"\(escaped)\"].drop()"
         }
     }
 }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -73,7 +73,8 @@ struct SidebarView: View {
         }
         .frame(minWidth: 280)
         .onChange(of: tables) { _, newTables in
-            if newTables.isEmpty && DatabaseManager.shared.activeSessions[connectionId] != nil && !viewModel.isLoading {
+            let hasSession = DatabaseManager.shared.activeSessions[connectionId] != nil
+            if newTables.isEmpty && hasSession && !viewModel.isLoading {
                 viewModel.loadTables()
             }
         }

--- a/TableProTests/Core/MongoDB/MongoDBStatementGeneratorTests.swift
+++ b/TableProTests/Core/MongoDB/MongoDBStatementGeneratorTests.swift
@@ -42,7 +42,7 @@ struct MongoDBStatementGeneratorTests {
 
         #expect(statements.count == 1)
         let stmt = statements[0]
-        #expect(stmt.sql == "db.users.insertOne({\"email\": \"john@test.com\", \"name\": \"John\"})")
+        #expect(stmt.sql == "db[\"users\"].insertOne({\"email\": \"john@test.com\", \"name\": \"John\"})")
         #expect(stmt.parameters.isEmpty)
     }
 
@@ -192,7 +192,7 @@ struct MongoDBStatementGeneratorTests {
 
         #expect(statements.count == 1)
         let stmt = statements[0]
-        #expect(stmt.sql.contains("db.users.updateOne("))
+        #expect(stmt.sql.contains("db[\"users\"].updateOne("))
         #expect(stmt.sql.contains("{\"_id\": {\"$oid\": \"abc123def456abc123def456\"}}"))
         #expect(stmt.sql.contains("{\"$set\": {\"name\": \"Jane\"}}"))
         #expect(stmt.parameters.isEmpty)
@@ -382,7 +382,7 @@ struct MongoDBStatementGeneratorTests {
 
         #expect(statements.count == 1)
         let stmt = statements[0]
-        #expect(stmt.sql.contains("db.users.deleteOne("))
+        #expect(stmt.sql.contains("db[\"users\"].deleteOne("))
         #expect(stmt.sql.contains("{\"_id\": {\"$oid\": \"abc123def456abc123def456\"}}"))
         #expect(stmt.parameters.isEmpty)
     }

--- a/TableProTests/Core/MongoDB/MongoShellParserTests.swift
+++ b/TableProTests/Core/MongoDB/MongoShellParserTests.swift
@@ -382,12 +382,421 @@ struct MongoShellParserTests {
         }
     }
 
+    // MARK: - Database-Level Methods
+
+    @Test("db.getCollectionNames() returns listCollections")
+    func testGetCollectionNames() throws {
+        let op = try MongoShellParser.parse("db.getCollectionNames()")
+        if case .listCollections = op {
+            // pass
+        } else {
+            Issue.record("Expected .listCollections operation")
+        }
+    }
+
+    @Test("db.listCollections() returns listCollections")
+    func testDbListCollections() throws {
+        let op = try MongoShellParser.parse("db.listCollections()")
+        if case .listCollections = op {
+            // pass
+        } else {
+            Issue.record("Expected .listCollections operation")
+        }
+    }
+
+    @Test("db.createCollection creates collection via runCommand")
+    func testCreateCollection() throws {
+        let op = try MongoShellParser.parse("db.createCollection(\"myCollection\")")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ \"create\": \"myCollection\" }")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("db.createCollection with single quotes")
+    func testCreateCollectionSingleQuotes() throws {
+        let op = try MongoShellParser.parse("db.createCollection('myCollection')")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ \"create\": \"myCollection\" }")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("db.createCollection with no argument throws missingArgument")
+    func testCreateCollectionNoArg() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.createCollection()")
+        }
+    }
+
+    @Test("db.dropDatabase() returns runCommand with dropDatabase")
+    func testDropDatabase() throws {
+        let op = try MongoShellParser.parse("db.dropDatabase()")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ \"dropDatabase\": 1 }")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("db.version() returns runCommand with buildInfo")
+    func testVersion() throws {
+        let op = try MongoShellParser.parse("db.version()")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ \"buildInfo\": 1 }")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("db.stats() returns runCommand with dbStats")
+    func testStats() throws {
+        let op = try MongoShellParser.parse("db.stats()")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ \"dbStats\": 1 }")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("unknown db-level method throws unsupportedMethod")
+    func testUnknownDbLevelMethod() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.unknownDbMethod()")
+        }
+    }
+
+    // MARK: - Additional Find Operations
+
+    @Test("find with no arguments returns all documents")
+    func testFindNoArguments() throws {
+        let op = try MongoShellParser.parse("db.collection.find()")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(options.projection == nil)
+            #expect(options.sort == nil)
+            #expect(options.limit == nil)
+            #expect(options.skip == nil)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with unquoted key filter")
+    func testFindWithUnquotedKeyFilter() throws {
+        let op = try MongoShellParser.parse("db.collection.find({name: \"test\"})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{name: \"test\"}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with projection using unquoted keys")
+    func testFindWithUnquotedProjection() throws {
+        let op = try MongoShellParser.parse("db.collection.find({}, {name: 1})")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(options.projection == "{name: 1}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    // MARK: - Additional findOne Operations
+
+    @Test("findOne with empty filter")
+    func testFindOneEmptyFilter() throws {
+        let op = try MongoShellParser.parse("db.collection.findOne({})")
+        if case .findOne(let collection, let filter) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .findOne operation")
+        }
+    }
+
+    // MARK: - Additional Aggregate Operations
+
+    @Test("aggregate with $match stage")
+    func testAggregateWithMatch() throws {
+        let op = try MongoShellParser.parse("db.collection.aggregate([{$match: {}}])")
+        if case .aggregate(let collection, let pipeline) = op {
+            #expect(collection == "collection")
+            #expect(pipeline == "[{$match: {}}]")
+        } else {
+            Issue.record("Expected .aggregate operation")
+        }
+    }
+
+    // MARK: - Additional Chained Method Operations
+
+    @Test("find with just sort")
+    func testFindWithJustSort() throws {
+        let op = try MongoShellParser.parse("db.collection.find().sort({a: 1})")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(options.sort == "{a: 1}")
+            #expect(options.limit == nil)
+            #expect(options.skip == nil)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with just skip")
+    func testFindWithJustSkip() throws {
+        let op = try MongoShellParser.parse("db.collection.find().skip(5)")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(options.skip == 5)
+            #expect(options.sort == nil)
+            #expect(options.limit == nil)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with filter and all chained options")
+    func testFindWithFilterAndAllChained() throws {
+        let op = try MongoShellParser.parse("db.collection.find({}).sort({a:1}).limit(10).skip(5)")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(options.sort == "{a:1}")
+            #expect(options.limit == 10)
+            #expect(options.skip == 5)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    // MARK: - Dotted Collection Names
+
+    @Test("dotted collection name with find")
+    func testDottedCollectionFind() throws {
+        let op = try MongoShellParser.parse("db.system.version.find()")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "system.version")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("dotted collection name with find and filter")
+    func testDottedCollectionFindWithFilter() throws {
+        let op = try MongoShellParser.parse("db.system.profile.find({})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "system.profile")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("dotted collection name with chained methods")
+    func testDottedCollectionWithChained() throws {
+        let op = try MongoShellParser.parse("db.system.version.find().sort({a:1})")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "system.version")
+            #expect(filter == "{}")
+            #expect(options.sort == "{a:1}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("bare dotted collection name treated as find all")
+    func testBareDottedCollection() throws {
+        let op = try MongoShellParser.parse("db.system.version")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "system.version")
+            #expect(filter == "{}")
+            #expect(options.sort == nil)
+            #expect(options.limit == nil)
+            #expect(options.skip == nil)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("multiple dots in collection name")
+    func testMultipleDottedCollectionName() throws {
+        let op = try MongoShellParser.parse("db.a.b.c.find()")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "a.b.c")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("dotted collection with deleteMany")
+    func testDottedCollectionDeleteMany() throws {
+        let op = try MongoShellParser.parse("db.system.profile.deleteMany({})")
+        if case .deleteMany(let collection, let filter) = op {
+            #expect(collection == "system.profile")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .deleteMany operation")
+        }
+    }
+
+    @Test("dotted collection with insertOne")
+    func testDottedCollectionInsertOne() throws {
+        let op = try MongoShellParser.parse("db.my.collection.insertOne({\"a\": 1})")
+        if case .insertOne(let collection, let document) = op {
+            #expect(collection == "my.collection")
+            #expect(document == "{\"a\": 1}")
+        } else {
+            Issue.record("Expected .insertOne operation")
+        }
+    }
+
+    @Test("dotted collection with countDocuments")
+    func testDottedCollectionCountDocuments() throws {
+        let op = try MongoShellParser.parse("db.system.users.countDocuments({})")
+        if case .countDocuments(let collection, let filter) = op {
+            #expect(collection == "system.users")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .countDocuments operation")
+        }
+    }
+
+    @Test("dotted collection with drop")
+    func testDottedCollectionDrop() throws {
+        let op = try MongoShellParser.parse("db.system.profile.drop()")
+        if case .drop(let collection) = op {
+            #expect(collection == "system.profile")
+        } else {
+            Issue.record("Expected .drop operation")
+        }
+    }
+
+    // MARK: - Bracket Notation for Collections
+
+    @Test("bracket notation with dotted collection name and find")
+    func testBracketNotationDottedFind() throws {
+        let op = try MongoShellParser.parse("db[\"system.version\"].find()")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "system.version")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("bracket notation with deleteMany")
+    func testBracketNotationDeleteMany() throws {
+        let op = try MongoShellParser.parse("db[\"my.collection\"].deleteMany({})")
+        if case .deleteMany(let collection, let filter) = op {
+            #expect(collection == "my.collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .deleteMany operation")
+        }
+    }
+
+    @Test("bracket notation with simple collection name")
+    func testBracketNotationSimpleName() throws {
+        let op = try MongoShellParser.parse("db[\"collection\"].find()")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("bracket notation with single quotes")
+    func testBracketNotationSingleQuotes() throws {
+        let op = try MongoShellParser.parse("db['my.collection'].find({})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "my.collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("bracket notation bare reference treated as find all")
+    func testBracketNotationBareReference() throws {
+        let op = try MongoShellParser.parse("db[\"my.collection\"]")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "my.collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("bracket notation with chained methods")
+    func testBracketNotationChained() throws {
+        let op = try MongoShellParser.parse("db[\"my.collection\"].find({}).sort({a: 1}).limit(10)")
+        if case .find(let collection, let filter, let options) = op {
+            #expect(collection == "my.collection")
+            #expect(filter == "{}")
+            #expect(options.sort == "{a: 1}")
+            #expect(options.limit == 10)
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    // MARK: - Additional Special Commands
+
+    @Test("raw JSON command with unquoted key")
+    func testRawJsonUnquotedKey() throws {
+        let op = try MongoShellParser.parse("{ping: 1}")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ping: 1}")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("runCommand with unquoted key")
+    func testRunCommandUnquotedKey() throws {
+        let op = try MongoShellParser.parse("db.runCommand({ping: 1})")
+        if case .runCommand(let command) = op {
+            #expect(command == "{ping: 1}")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
+    @Test("adminCommand with serverStatus")
+    func testAdminCommandServerStatus() throws {
+        let op = try MongoShellParser.parse("db.adminCommand({serverStatus: 1})")
+        if case .runCommand(let command) = op {
+            #expect(command == "{serverStatus: 1}")
+        } else {
+            Issue.record("Expected .runCommand operation")
+        }
+    }
+
     // MARK: - Error Cases
 
     @Test("empty string throws invalidSyntax")
     func testEmptyStringThrowsInvalidSyntax() {
         #expect(throws: MongoShellParseError.self) {
             _ = try MongoShellParser.parse("")
+        }
+    }
+
+    @Test("whitespace only throws invalidSyntax")
+    func testWhitespaceOnlyThrowsInvalidSyntax() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("   ")
         }
     }
 
@@ -416,6 +825,250 @@ struct MongoShellParserTests {
     func testUpdateOneSingleArgThrowsMissingArgument() {
         #expect(throws: MongoShellParseError.self) {
             _ = try MongoShellParser.parse("db.users.updateOne({\"_id\": 1})")
+        }
+    }
+
+    @Test("db. with no collection or method throws")
+    func testDbDotIncompleteThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.")
+        }
+    }
+
+    @Test("insertMany with no argument throws missingArgument")
+    func testInsertManyNoArgThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.insertMany()")
+        }
+    }
+
+    @Test("updateMany with single argument throws missingArgument")
+    func testUpdateManySingleArgThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.updateMany({\"active\": true})")
+        }
+    }
+
+    @Test("replaceOne with single argument throws missingArgument")
+    func testReplaceOneSingleArgThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.replaceOne({\"_id\": 1})")
+        }
+    }
+
+    @Test("findOneAndUpdate with single argument throws missingArgument")
+    func testFindOneAndUpdateSingleArgThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.findOneAndUpdate({\"_id\": 1})")
+        }
+    }
+
+    @Test("findOneAndReplace with single argument throws missingArgument")
+    func testFindOneAndReplaceSingleArgThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.findOneAndReplace({\"_id\": 1})")
+        }
+    }
+
+    // MARK: - Edge Cases with Strings and Nested Objects
+
+    @Test("find with dot inside string argument")
+    func testFindWithDotInsideString() throws {
+        let op = try MongoShellParser.parse("db.collection.find({name: \"test.value\"})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{name: \"test.value\"}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with parentheses inside string argument")
+    func testFindWithParensInsideString() throws {
+        let op = try MongoShellParser.parse("db.collection.find({name: \"has(parens)\"})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{name: \"has(parens)\"}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with nested $and operator")
+    func testFindWithNestedAndOperator() throws {
+        let op = try MongoShellParser.parse("db.collection.find({$and: [{a: 1}, {b: 2}]})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{$and: [{a: 1}, {b: 2}]}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with deeply nested objects")
+    func testFindWithDeeplyNestedObjects() throws {
+        let op = try MongoShellParser.parse("db.collection.find({\"a\": {\"b\": {\"c\": 1}}})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{\"a\": {\"b\": {\"c\": 1}}}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("updateOne with nested $set and nested objects")
+    func testUpdateOneNestedSet() throws {
+        let op = try MongoShellParser.parse("db.collection.updateOne({a:1}, {$set: {b:2}})")
+        if case .updateOne(let collection, let filter, let update) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a:1}")
+            #expect(update == "{$set: {b:2}}")
+        } else {
+            Issue.record("Expected .updateOne operation")
+        }
+    }
+
+    @Test("updateMany with empty filter and $set")
+    func testUpdateManyEmptyFilterSet() throws {
+        let op = try MongoShellParser.parse("db.collection.updateMany({}, {$set: {active: true}})")
+        if case .updateMany(let collection, let filter, let update) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+            #expect(update == "{$set: {active: true}}")
+        } else {
+            Issue.record("Expected .updateMany operation")
+        }
+    }
+
+    @Test("replaceOne with full replacement document")
+    func testReplaceOneFullReplacement() throws {
+        let op = try MongoShellParser.parse("db.collection.replaceOne({a:1}, {a:2, b:3})")
+        if case .replaceOne(let collection, let filter, let replacement) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a:1}")
+            #expect(replacement == "{a:2, b:3}")
+        } else {
+            Issue.record("Expected .replaceOne operation")
+        }
+    }
+
+    @Test("findOneAndUpdate with $set")
+    func testFindOneAndUpdateWithSet() throws {
+        let op = try MongoShellParser.parse("db.collection.findOneAndUpdate({a:1}, {$set:{b:2}})")
+        if case .findOneAndUpdate(let collection, let filter, let update) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a:1}")
+            #expect(update == "{$set:{b:2}}")
+        } else {
+            Issue.record("Expected .findOneAndUpdate operation")
+        }
+    }
+
+    @Test("findOneAndReplace with replacement")
+    func testFindOneAndReplaceWithReplacement() throws {
+        let op = try MongoShellParser.parse("db.collection.findOneAndReplace({a:1}, {a:2})")
+        if case .findOneAndReplace(let collection, let filter, let replacement) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a:1}")
+            #expect(replacement == "{a:2}")
+        } else {
+            Issue.record("Expected .findOneAndReplace operation")
+        }
+    }
+
+    @Test("findOneAndDelete with filter")
+    func testFindOneAndDeleteWithFilter() throws {
+        let op = try MongoShellParser.parse("db.collection.findOneAndDelete({a:1})")
+        if case .findOneAndDelete(let collection, let filter) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a:1}")
+        } else {
+            Issue.record("Expected .findOneAndDelete operation")
+        }
+    }
+
+    @Test("deleteMany with empty filter")
+    func testDeleteManyEmptyFilter() throws {
+        let op = try MongoShellParser.parse("db.collection.deleteMany({})")
+        if case .deleteMany(let collection, let filter) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .deleteMany operation")
+        }
+    }
+
+    @Test("createIndex with unquoted key")
+    func testCreateIndexUnquotedKey() throws {
+        let op = try MongoShellParser.parse("db.collection.createIndex({name: 1})")
+        if case .createIndex(let collection, let keys, let options) = op {
+            #expect(collection == "collection")
+            #expect(keys == "{name: 1}")
+            #expect(options == nil)
+        } else {
+            Issue.record("Expected .createIndex operation")
+        }
+    }
+
+    @Test("dropIndex with string index name")
+    func testDropIndexStringName() throws {
+        let op = try MongoShellParser.parse("db.collection.dropIndex(\"idx_name\")")
+        if case .dropIndex(let collection, let indexName) = op {
+            #expect(collection == "collection")
+            #expect(indexName == "\"idx_name\"")
+        } else {
+            Issue.record("Expected .dropIndex operation")
+        }
+    }
+
+    @Test("find with single-quoted string in filter")
+    func testFindWithSingleQuotedString() throws {
+        let op = try MongoShellParser.parse("db.collection.find({name: 'test'})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{name: 'test'}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("find with comma inside nested object does not split incorrectly")
+    func testFindCommaInsideNestedObject() throws {
+        let op = try MongoShellParser.parse("db.collection.find({a: 1, b: 2})")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{a: 1, b: 2}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("input with leading and trailing whitespace is trimmed")
+    func testInputWithWhitespace() throws {
+        let op = try MongoShellParser.parse("  db.users.find({})  ")
+        if case .find(let collection, let filter, _) = op {
+            #expect(collection == "users")
+            #expect(filter == "{}")
+        } else {
+            Issue.record("Expected .find operation")
+        }
+    }
+
+    @Test("unmatched parenthesis throws invalidSyntax")
+    func testUnmatchedParenthesisThrows() {
+        #expect(throws: MongoShellParseError.self) {
+            _ = try MongoShellParser.parse("db.users.find({name: \"test\"")
+        }
+    }
+
+    @Test("deleteOne with filter containing nested array")
+    func testDeleteOneNestedArray() throws {
+        let op = try MongoShellParser.parse("db.collection.deleteOne({tags: [\"a\", \"b\"]})")
+        if case .deleteOne(let collection, let filter) = op {
+            #expect(collection == "collection")
+            #expect(filter == "{tags: [\"a\", \"b\"]}")
+        } else {
+            Issue.record("Expected .deleteOne operation")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix Cmd+K database switch not updating sidebar collections for MongoDB connections
- Fix dotted collection names (e.g. `system.version`) being misparsed in shell syntax
- Add bracket notation (`db["collection"]`) support and db-level method handling to MongoShellParser

## Changes

### Database switch fix
- `MongoDBDriver.connection` changed from `let` to `private(set) var` with `switchDatabase(to:)` method
- Coordinator now updates driver + metadata driver connection before session update
- Added `.refreshData` notification post (matching PostgreSQL branch)
- `SidebarViewModel` uses `forceLoadTables()` from notifications to prevent race conditions with stale schemaProvider cache

### Dotted collection name support
- Parser now splits on last `.` before first `(` instead of first `.`, so `db.system.version.find()` correctly parses as collection=`system.version`
- All MongoDB query generation converted to bracket notation `db["collection"]` across MongoDBStatementGenerator, TableOperations, QueryTab, ExportService, and MongoDBDriver DDL

### Shell parser improvements
- Added `parseBracketExpression()` for `db["collection"].method()` syntax
- Added `parseDbLevelMethod()` for `db.getCollectionNames()`, `db.listCollections()`, `db.createCollection()`, `db.dropDatabase()`, `db.version()`, `db.stats()`
- Added guard for `db.` with empty collection name

## Test plan
- [x] 96 MongoShellParser tests pass (65 new)
- [x] 32 MongoDBStatementGenerator tests pass (3 updated for bracket notation)
- [x] 199 total MongoDB tests pass
- [ ] Manual: connect to MongoDB, switch database via Cmd+K, verify sidebar refreshes
- [ ] Manual: open a dotted collection (e.g. `system.version`), verify CRUD operations work