### PR TITLE
fix: MySQL empty second tab, MongoDB tab name regression, and empty collection display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MySQL second tab showing empty rows due to premature coordinator teardown during native macOS tab group merging
+- MongoDB tab name showing "MQL Query" instead of collection name when using bracket notation `db["collection"].find()`
+
 ## [0.11.0] - 2026-03-02
 
 ### Added

--- a/TablePro/Core/Database/MongoDBDriver.swift
+++ b/TablePro/Core/Database/MongoDBDriver.swift
@@ -600,6 +600,16 @@ private extension MongoDBDriver {
                 skip: options.skip ?? 0,
                 limit: options.limit ?? DriverRowLimits.defaultMax
             )
+            if docs.isEmpty {
+                return QueryResult(
+                    columns: ["_id"],
+                    columnTypes: [.text(rawType: "ObjectId")],
+                    rows: [],
+                    rowsAffected: 0,
+                    executionTime: Date().timeIntervalSince(startTime),
+                    error: nil
+                )
+            }
             return buildQueryResult(from: docs, startTime: startTime)
 
         case .findOne(let collection, let filter):

--- a/TablePro/Core/Services/NativeTabRegistry.swift
+++ b/TablePro/Core/Services/NativeTabRegistry.swift
@@ -94,4 +94,9 @@ internal final class NativeTabRegistry {
     internal func hasWindows(for connectionId: UUID) -> Bool {
         entries.values.contains { $0.connectionId == connectionId }
     }
+
+    /// Check if a specific window is still registered
+    internal func isRegistered(windowId: UUID) -> Bool {
+        entries[windowId] != nil
+    }
 }

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -8,10 +8,7 @@
 
 import AppKit
 import CodeEditSourceEditor
-import os
 import SwiftUI
-
-private let editorContentLogger = Logger(subsystem: "com.TablePro", category: "MainEditorContentView")
 
 /// Cache for sorted query result rows to avoid re-sorting on every SwiftUI body evaluation
 private struct SortedRowsCache {
@@ -139,7 +136,9 @@ struct MainEditorContentView: View {
             }
         }
         .onChange(of: tabManager.selectedTab?.resultVersion) { _, newVersion in
-            guard let tab = tabManager.selectedTab, newVersion != nil else { return }
+            guard let tab = tabManager.selectedTab, newVersion != nil else {
+                return
+            }
             let provider = makeRowProvider(for: tab)
             tabRowProviders[tab.id] = provider
             tabProviderVersions[tab.id] = tab.resultVersion

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -103,7 +103,6 @@ extension MainContentCoordinator {
                     needsLazyLoad = true
                 }
             } else {
-                // Data already cached or not a table tab — bump reload and finish
                 changeManager.reloadVersion += 1
             }
         } else {

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -249,6 +249,11 @@ final class MainContentCoordinator: ObservableObject {
         options: []
     )
 
+    private static let mongoBracketCollectionRegex = try? NSRegularExpression(
+        pattern: #"^\s*db\["([^"]+)"\]"#,
+        options: []
+    )
+
     // MARK: - Query Execution
 
     func runQuery() {
@@ -621,7 +626,14 @@ final class MainContentCoordinator: ObservableObject {
             return String(sql[range])
         }
 
-        // MQL: db.collectionName.find(...)
+        // MQL bracket notation: db["collectionName"].find(...)
+        if let regex = Self.mongoBracketCollectionRegex,
+           let match = regex.firstMatch(in: sql, options: [], range: nsRange),
+           let range = Range(match.range(at: 1), in: sql) {
+            return String(sql[range])
+        }
+
+        // MQL dot notation: db.collectionName.find(...)
         if let regex = Self.mongoCollectionRegex,
            let match = regex.firstMatch(in: sql, options: [], range: nsRange),
            let range = Range(match.range(at: 1), in: sql) {

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -7,7 +7,6 @@
 //
 
 import Combine
-import os
 import SwiftUI
 
 /// Main content view - thin presentation layer
@@ -54,8 +53,6 @@ struct MainContentView: View {
     @EnvironmentObject private var appState: AppState
 
     // MARK: - Initialization
-
-    private static let initLogger = Logger(subsystem: "com.TablePro", category: "MainContentView")
 
     init(
         connection: DatabaseConnection,
@@ -249,16 +246,21 @@ struct MainContentView: View {
             .onDisappear {
                 NativeTabRegistry.shared.unregister(windowId: windowId)
 
-                // Defer the disconnect check — SwiftUI fires onDisappear+onAppear in
-                // rapid succession during body re-evaluations (e.g., when session status
-                // changes from .connecting to .connected). The short delay lets the
-                // re-registration from onAppear fire first, preventing false disconnects.
+                let capturedWindowId = windowId
                 let connectionId = connection.id
                 let connectionName = connection.name
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(200))
 
-                    // After the delay, check if any windows re-registered for this connection
+                    // If this window re-registered (temporary disappear during tab group merge), skip cleanup
+                    if NativeTabRegistry.shared.isRegistered(windowId: capturedWindowId) {
+                        return
+                    }
+
+                    // Window truly closed — teardown coordinator
+                    coordinator.teardown()
+
+                    // If no more windows for this connection, disconnect
                     guard !NativeTabRegistry.shared.hasWindows(for: connectionId) else { return }
                     let hasVisibleWindow = NSApp.windows.contains { window in
                         window.isVisible && window.subtitle == connectionName
@@ -267,8 +269,6 @@ struct MainContentView: View {
                         await DatabaseManager.shared.disconnectSession(connectionId)
                     }
                 }
-
-                coordinator.teardown()
             }
             .onChange(of: pendingChangeTrigger) {
                 updateToolbarPendingState()


### PR DESCRIPTION
## Summary

- **MySQL second tab empty rows**: `coordinator.teardown()` ran during the transient `onDisappear`/`onAppear` cycle that macOS triggers when merging a new window into a tab group, cancelling in-flight queries. Now deferred behind a 200ms re-registration check so teardown only runs when the window truly closes.
- **MongoDB tab name regression**: `extractTableName()` didn't match the bracket notation `db["collection"].find()` introduced in v0.11.0 for dotted collection names. Added `mongoBracketCollectionRegex` and updated the extraction order.
- **MongoDB empty collection display**: `find()` on an empty collection (e.g., `config.system.sessions`) showed "Query executed successfully - 0 rows affected" instead of an empty data grid. Now returns `_id` column for empty `find()` results.
- **Cleanup**: Removed all `[TAB-DEBUG]` diagnostic logs from 4 files.

## Test plan

- [ ] MySQL: connect, open first table (data shows), open second table (data shows with rows)
- [ ] MongoDB: open a collection, verify tab name stays as collection name (not "MQL Query")
- [ ] MongoDB: open a dotted collection (e.g., `system.sessions` in config) and verify tab name
- [ ] MongoDB: open an empty collection and verify empty data grid with `_id` column header (not success message)
- [ ] Close individual tabs, verify no warnings about missed teardown