### PR TITLE
test: add regression tests for MySQL tab merge, MongoDB tab name, and empty collection fixes

### DIFF
--- a/TableProTests/Core/MongoDB/BsonDocumentFlattenerTests.swift
+++ b/TableProTests/Core/MongoDB/BsonDocumentFlattenerTests.swift
@@ -47,6 +47,15 @@ struct BsonDocumentFlattenerTests {
             let result = BsonDocumentFlattener.unionColumns(from: [doc])
             #expect(result == ["name"])
         }
+
+        @Test("Empty documents produce no columns — driver must handle this")
+        func emptyDocumentsProduceNoColumns() {
+            // Documents the known behavior: unionColumns returns [] for empty input.
+            // MongoDBDriver guards against this by returning a QueryResult with ["_id"]
+            // before calling buildQueryResult when find() returns no documents.
+            let result = BsonDocumentFlattener.unionColumns(from: [])
+            #expect(result.isEmpty)
+        }
     }
 
     // MARK: - flatten(documents:columns:)
@@ -124,6 +133,18 @@ struct BsonDocumentFlattenerTests {
             let result = BsonDocumentFlattener.flatten(documents: [doc], columns: columns)
             let expected = ISO8601DateFormatter().string(from: date)
             #expect(result[0][1] == expected)
+        }
+
+        @Test("Empty document array produces empty rows")
+        func emptyDocumentArrayProducesEmptyRows() {
+            let result = BsonDocumentFlattener.flatten(documents: [], columns: ["_id"])
+            #expect(result.isEmpty)
+        }
+
+        @Test("Empty document array with no columns produces empty rows")
+        func emptyDocumentArrayWithNoColumnsProducesEmptyRows() {
+            let result = BsonDocumentFlattener.flatten(documents: [], columns: [])
+            #expect(result.isEmpty)
         }
     }
 

--- a/TableProTests/Core/Services/NativeTabRegistryTests.swift
+++ b/TableProTests/Core/Services/NativeTabRegistryTests.swift
@@ -194,4 +194,77 @@ struct NativeTabRegistryTests {
         #expect(NativeTabRegistry.shared.allTabs(for: connectionId).isEmpty)
         #expect(!NativeTabRegistry.shared.hasWindows(for: connectionId))
     }
+
+    // MARK: - isRegistered
+
+    @Test("isRegistered returns true for a registered window")
+    func isRegisteredReturnsTrueForRegisteredWindow() {
+        let windowId = UUID()
+        let connectionId = UUID()
+
+        NativeTabRegistry.shared.register(windowId: windowId, connectionId: connectionId, tabs: [makeSnapshot()], selectedTabId: nil)
+        defer { NativeTabRegistry.shared.unregister(windowId: windowId) }
+
+        #expect(NativeTabRegistry.shared.isRegistered(windowId: windowId))
+    }
+
+    @Test("isRegistered returns false for an unregistered window")
+    func isRegisteredReturnsFalseForUnknownWindow() {
+        #expect(!NativeTabRegistry.shared.isRegistered(windowId: UUID()))
+    }
+
+    @Test("isRegistered returns false after unregister")
+    func isRegisteredReturnsFalseAfterUnregister() {
+        let windowId = UUID()
+        let connectionId = UUID()
+
+        NativeTabRegistry.shared.register(windowId: windowId, connectionId: connectionId, tabs: [makeSnapshot()], selectedTabId: nil)
+        NativeTabRegistry.shared.unregister(windowId: windowId)
+
+        #expect(!NativeTabRegistry.shared.isRegistered(windowId: windowId))
+    }
+
+    // MARK: - Tab group merge scenario
+
+    @Test("Tab group merge — re-register after unregister keeps window alive")
+    func tabGroupMergeReRegister() {
+        let windowId = UUID()
+        let connectionId = UUID()
+        let tab = makeSnapshot()
+
+        // Step 1: Initial register (window appears)
+        NativeTabRegistry.shared.register(windowId: windowId, connectionId: connectionId, tabs: [tab], selectedTabId: tab.id)
+        defer { NativeTabRegistry.shared.unregister(windowId: windowId) }
+
+        // Step 2: macOS tab group merge fires onDisappear → unregister
+        NativeTabRegistry.shared.unregister(windowId: windowId)
+        #expect(!NativeTabRegistry.shared.isRegistered(windowId: windowId))
+
+        // Step 3: macOS tab group merge fires onAppear → re-register same windowId
+        NativeTabRegistry.shared.register(windowId: windowId, connectionId: connectionId, tabs: [tab], selectedTabId: tab.id)
+
+        // Window should be alive — isRegistered true, hasWindows true, tabs intact
+        #expect(NativeTabRegistry.shared.isRegistered(windowId: windowId))
+        #expect(NativeTabRegistry.shared.hasWindows(for: connectionId))
+        #expect(NativeTabRegistry.shared.allTabs(for: connectionId).count == 1)
+        #expect(NativeTabRegistry.shared.allTabs(for: connectionId).first?.id == tab.id)
+    }
+
+    @Test("Tab group merge — teardown proceeds when window is not re-registered")
+    func tabGroupMergeTeardownWhenNotReRegistered() {
+        let windowId = UUID()
+        let connectionId = UUID()
+
+        // Step 1: Initial register (window appears)
+        NativeTabRegistry.shared.register(windowId: windowId, connectionId: connectionId, tabs: [makeSnapshot()], selectedTabId: nil)
+
+        // Step 2: onDisappear fires → unregister
+        NativeTabRegistry.shared.unregister(windowId: windowId)
+
+        // Step 3: No re-register happens (genuine window close, not a merge)
+        // After the delay, isRegistered should be false → teardown should proceed
+        #expect(!NativeTabRegistry.shared.isRegistered(windowId: windowId))
+        #expect(!NativeTabRegistry.shared.hasWindows(for: connectionId))
+        #expect(NativeTabRegistry.shared.allTabs(for: connectionId).isEmpty)
+    }
 }

--- a/TableProTests/Views/Main/ExtractTableNameTests.swift
+++ b/TableProTests/Views/Main/ExtractTableNameTests.swift
@@ -1,0 +1,166 @@
+//
+//  ExtractTableNameTests.swift
+//  TableProTests
+//
+//  Tests for extractTableName(from:) — verifies SQL and MQL
+//  query patterns including the MongoDB bracket notation fix.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("ExtractTableName")
+@MainActor
+struct ExtractTableNameTests {
+    private func makeCoordinator() -> MainContentCoordinator {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let changeManager = DataChangeManager()
+        let filterStateManager = FilterStateManager()
+        let toolbarState = ConnectionToolbarState()
+
+        return MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: changeManager,
+            filterStateManager: filterStateManager,
+            toolbarState: toolbarState
+        )
+    }
+
+    // MARK: - SQL extraction
+
+    @Test("SQL: SELECT * FROM users")
+    func sqlSelectStar() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "SELECT * FROM users")
+        #expect(result == "users")
+    }
+
+    @Test("SQL: SELECT with columns and WHERE clause")
+    func sqlSelectWithWhere() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "SELECT id, name FROM orders WHERE id = 1")
+        #expect(result == "orders")
+    }
+
+    @Test("SQL: extra whitespace and LIMIT")
+    func sqlWhitespaceAndLimit() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "  SELECT * FROM  products  LIMIT 10")
+        #expect(result == "products")
+    }
+
+    @Test("SQL: backtick-quoted table name")
+    func sqlBacktickQuoted() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "SELECT * FROM `quoted_table` WHERE 1")
+        #expect(result == "quoted_table")
+    }
+
+    // MARK: - MQL bracket notation (regression fix)
+
+    @Test("MQL bracket: db[\"users\"].find()")
+    func mqlBracketSimple() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "db[\"users\"].find()")
+        #expect(result == "users")
+    }
+
+    @Test("MQL bracket: hyphenated collection name")
+    func mqlBracketHyphenated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "db[\"my-collection\"].find({})")
+        #expect(result == "my-collection")
+    }
+
+    @Test("MQL bracket: dotted collection name")
+    func mqlBracketDotted() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "db[\"my.dotted.collection\"].find()")
+        #expect(result == "my.dotted.collection")
+    }
+
+    @Test("MQL bracket: leading whitespace with aggregate")
+    func mqlBracketLeadingWhitespace() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "  db[\"users\"].aggregate([])")
+        #expect(result == "users")
+    }
+
+    // MARK: - MQL dot notation
+
+    @Test("MQL dot: db.users.find()")
+    func mqlDotSimple() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "db.users.find()")
+        #expect(result == "users")
+    }
+
+    @Test("MQL dot: db.orders.aggregate([])")
+    func mqlDotAggregate() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "db.orders.aggregate([])")
+        #expect(result == "orders")
+    }
+
+    @Test("MQL dot: leading whitespace")
+    func mqlDotLeadingWhitespace() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "  db.products.find({})")
+        #expect(result == "products")
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Empty string returns nil")
+    func emptyString() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "")
+        #expect(result == nil)
+    }
+
+    @Test("Random text returns nil")
+    func randomText() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "hello world this is not a query")
+        #expect(result == nil)
+    }
+
+    @Test("Non-SELECT SQL returns nil")
+    func nonSelectSql() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let result = coordinator.extractTableName(from: "INSERT INTO users VALUES (1)")
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Add 22 regression tests covering the three bugs fixed in c1ce9e5:
  - **NativeTabRegistry.isRegistered** (5 tests): validates the new `isRegistered(windowId:)` method and simulates the macOS tab group merge sequence (register → unregister → re-register) that previously caused premature coordinator teardown
  - **ExtractTableName** (14 tests): covers SQL `SELECT ... FROM`, MQL dot notation `db.collection.find()`, and the previously broken MQL bracket notation `db["collection"].find()` including hyphenated and dotted collection names
  - **BsonDocumentFlattener empty docs** (3 tests): documents that `unionColumns` returns empty for empty input (why MongoDBDriver needs its early-return guard) and verifies `flatten` handles empty document arrays

## Test plan

- [ ] Run `xcodebuild test` to verify all new tests pass
- [ ] Verify no existing tests are broken