### PR TITLE
feat: add "Copy as URL" to connection context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Deep link support via `tablepro://` URL scheme for opening connections, tables, queries, and importing connections
+- "Copy as URL" context menu action on connections to copy connection details as a URL string (e.g., `mysql://user:pass@host/db`)
 
 ## [0.11.1] - 2026-03-02
 

--- a/TablePro/Core/Utilities/ConnectionURLFormatter.swift
+++ b/TablePro/Core/Utilities/ConnectionURLFormatter.swift
@@ -1,0 +1,152 @@
+//
+//  ConnectionURLFormatter.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ConnectionURLFormatter {
+    static func format(_ connection: DatabaseConnection, password: String?, sshPassword: String?) -> String {
+        let scheme = urlScheme(for: connection.type)
+
+        if connection.type == .sqlite {
+            return formatSQLite(connection.database)
+        }
+
+        if connection.sshConfig.enabled {
+            return formatSSH(connection, scheme: scheme, password: password)
+        }
+
+        return formatStandard(connection, scheme: scheme, password: password)
+    }
+
+    // MARK: - Private
+
+    private static func urlScheme(for type: DatabaseType) -> String {
+        switch type {
+        case .mysql: return "mysql"
+        case .mariadb: return "mariadb"
+        case .postgresql: return "postgresql"
+        case .sqlite: return "sqlite"
+        case .mongodb: return "mongodb"
+        }
+    }
+
+    private static func formatSQLite(_ database: String) -> String {
+        if database.hasPrefix("/") {
+            return "sqlite:///\(database.dropFirst())"
+        }
+        return "sqlite://\(database)"
+    }
+
+    private static func formatSSH(
+        _ connection: DatabaseConnection,
+        scheme: String,
+        password: String?
+    ) -> String {
+        var result = "\(scheme)+ssh://"
+
+        let ssh = connection.sshConfig
+        if !ssh.username.isEmpty {
+            result += "\(percentEncodeUserinfo(ssh.username))@"
+        }
+        result += ssh.host
+        if ssh.port != 22 {
+            result += ":\(ssh.port)"
+        }
+
+        result += "/"
+
+        if !connection.username.isEmpty {
+            result += percentEncodeUserinfo(connection.username)
+            if let password, !password.isEmpty {
+                result += ":\(percentEncodeUserinfo(password))"
+            }
+            result += "@"
+        }
+
+        result += connection.host
+        if connection.port != connection.type.defaultPort {
+            result += ":\(connection.port)"
+        }
+
+        result += "/\(connection.database)"
+
+        let query = buildQueryString(connection)
+        if !query.isEmpty {
+            result += "?\(query)"
+        }
+
+        return result
+    }
+
+    private static func formatStandard(
+        _ connection: DatabaseConnection,
+        scheme: String,
+        password: String?
+    ) -> String {
+        var result = "\(scheme)://"
+
+        if !connection.username.isEmpty {
+            result += percentEncodeUserinfo(connection.username)
+            if let password, !password.isEmpty {
+                result += ":\(percentEncodeUserinfo(password))"
+            }
+            result += "@"
+        }
+
+        result += connection.host
+        if connection.port != connection.type.defaultPort {
+            result += ":\(connection.port)"
+        }
+
+        result += "/\(connection.database)"
+
+        let query = buildQueryString(connection)
+        if !query.isEmpty {
+            result += "?\(query)"
+        }
+
+        return result
+    }
+
+    private static func buildQueryString(_ connection: DatabaseConnection) -> String {
+        var params: [String] = []
+
+        if !connection.name.isEmpty {
+            let encoded = connection.name
+                .replacingOccurrences(of: " ", with: "+")
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)?
+                .replacingOccurrences(of: "&", with: "%26")
+                .replacingOccurrences(of: "=", with: "%3D")
+                ?? connection.name
+            params.append("name=\(encoded)")
+        }
+
+        if connection.sshConfig.enabled && connection.sshConfig.authMethod == .privateKey {
+            params.append("usePrivateKey=true")
+        }
+
+        if let sslParam = sslModeParam(connection.sslConfig.mode) {
+            params.append("sslmode=\(sslParam)")
+        }
+
+        return params.joined(separator: "&")
+    }
+
+    private static func sslModeParam(_ mode: SSLMode) -> String? {
+        switch mode {
+        case .disabled: return nil
+        case .preferred: return "prefer"
+        case .required: return "require"
+        case .verifyCa: return "verify-ca"
+        case .verifyIdentity: return "verify-full"
+        }
+    }
+
+    private static func percentEncodeUserinfo(_ value: String) -> String {
+        var allowed = CharacterSet.urlUserAllowed
+        allowed.remove(charactersIn: ":@")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+}

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -2256,6 +2256,9 @@
         }
       }
     },
+    "Copy as URL" : {
+
+    },
     "Copy Cell Value" : {
       "localizations" : {
         "vi" : {

--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -310,6 +310,12 @@ struct WelcomeWindowView: View {
             onDuplicate: {
                 duplicateConnection(connection)
             },
+            onCopyURL: {
+                let pw = ConnectionStorage.shared.loadPassword(for: connection.id)
+                let sshPw = ConnectionStorage.shared.loadSSHPassword(for: connection.id)
+                let url = ConnectionURLFormatter.format(connection, password: pw, sshPassword: sshPw)
+                ClipboardService.shared.writeText(url)
+            },
             onDelete: {
                 connectionToDelete = connection
                 showDeleteConfirmation = true
@@ -570,6 +576,7 @@ private struct ConnectionRow: View {
     var onConnect: (() -> Void)?
     var onEdit: (() -> Void)?
     var onDuplicate: (() -> Void)?
+    var onCopyURL: (() -> Void)?
     var onDelete: (() -> Void)?
 
     private var displayTag: ConnectionTag? {
@@ -637,6 +644,12 @@ private struct ConnectionRow: View {
             if let onDuplicate = onDuplicate {
                 Button(action: onDuplicate) {
                     Label("Duplicate", systemImage: "doc.on.doc")
+                }
+            }
+
+            if let onCopyURL = onCopyURL {
+                Button(action: onCopyURL) {
+                    Label("Copy as URL", systemImage: "link")
                 }
             }
 

--- a/TableProTests/Core/Utilities/ConnectionURLFormatterTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLFormatterTests.swift
@@ -1,0 +1,298 @@
+//
+//  ConnectionURLFormatterTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Connection URL Formatter")
+struct ConnectionURLFormatterTests {
+    // MARK: - Basic URLs
+
+    @Test("Basic MySQL URL")
+    func testBasicMySQLURL() {
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 3_306, database: "testdb",
+            username: "root", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url == "mysql://root:pass@localhost/testdb")
+    }
+
+    @Test("Basic PostgreSQL URL")
+    func testBasicPostgreSQLURL() {
+        let conn = DatabaseConnection(
+            name: "", host: "db.example.com", port: 5_432, database: "mydb",
+            username: "admin", type: .postgresql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "secret", sshPassword: nil)
+        #expect(url == "postgresql://admin:secret@db.example.com/mydb")
+    }
+
+    // MARK: - Port Handling
+
+    @Test("Default port omitted for MySQL")
+    func testDefaultPortOmittedMySQL() {
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 3_306, database: "db",
+            username: "root", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(!url.contains(":3306"))
+        #expect(url == "mysql://root:pass@localhost/db")
+    }
+
+    @Test("Non-default port included for MySQL")
+    func testNonDefaultPortIncludedMySQL() {
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 3_307, database: "db",
+            username: "root", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains(":3307"))
+        #expect(url == "mysql://root:pass@localhost:3307/db")
+    }
+
+    @Test("Default port omitted for PostgreSQL")
+    func testDefaultPortOmittedPostgreSQL() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 5_432, database: "db",
+            username: "user", type: .postgresql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(!url.contains(":5432"))
+    }
+
+    @Test("Default port omitted for MongoDB")
+    func testDefaultPortOmittedMongoDB() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 27_017, database: "db",
+            username: "user", type: .mongodb
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(!url.contains(":27017"))
+        #expect(url == "mongodb://user:pass@host/db")
+    }
+
+    // MARK: - Credentials
+
+    @Test("No credentials when username is empty")
+    func testNoCredentialsWhenUsernameEmpty() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 3_306, database: "db",
+            username: "", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "mysql://host/db")
+    }
+
+    @Test("Username without password")
+    func testUsernameWithoutPassword() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 3_306, database: "db",
+            username: "user", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "mysql://user@host/db")
+    }
+
+    @Test("Username with empty password")
+    func testUsernameWithEmptyPassword() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 3_306, database: "db",
+            username: "user", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "", sshPassword: nil)
+        #expect(url == "mysql://user@host/db")
+    }
+
+    // MARK: - Special Characters
+
+    @Test("Special characters in password are percent-encoded")
+    func testSpecialCharsInPasswordEncoded() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 5_432, database: "db",
+            username: "user", type: .postgresql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "p@ss#word", sshPassword: nil)
+        #expect(url.contains("p%40ss%23word"))
+        #expect(url == "postgresql://user:p%40ss%23word@host/db")
+    }
+
+    @Test("Special characters in username are percent-encoded")
+    func testSpecialCharsInUsernameEncoded() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 5_432, database: "db",
+            username: "user@domain", type: .postgresql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("user%40domain"))
+    }
+
+    // MARK: - SQLite
+
+    @Test("SQLite with absolute path")
+    func testSQLiteAbsolutePath() {
+        let conn = DatabaseConnection(
+            name: "", host: "", port: 0, database: "/Users/me/data.db",
+            username: "", type: .sqlite
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "sqlite:///Users/me/data.db")
+    }
+
+    @Test("SQLite with relative path")
+    func testSQLiteRelativePath() {
+        let conn = DatabaseConnection(
+            name: "", host: "", port: 0, database: "data.db",
+            username: "", type: .sqlite
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "sqlite://data.db")
+    }
+
+    // MARK: - SSH Tunnel
+
+    @Test("SSH tunnel URL")
+    func testSSHTunnelURL() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "sshhost"
+        sshConfig.port = 1_234
+        sshConfig.username = "sshuser"
+
+        let conn = DatabaseConnection(
+            name: "", host: "127.0.0.1", port: 3_306, database: "db",
+            username: "dbuser", type: .mysql, sshConfig: sshConfig
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "dbpass", sshPassword: nil)
+        #expect(url == "mysql+ssh://sshuser@sshhost:1234/dbuser:dbpass@127.0.0.1/db")
+    }
+
+    @Test("SSH with default port omitted")
+    func testSSHDefaultPortOmitted() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "sshhost"
+        sshConfig.port = 22
+        sshConfig.username = "sshuser"
+
+        let conn = DatabaseConnection(
+            name: "", host: "127.0.0.1", port: 3_306, database: "db",
+            username: "dbuser", type: .mysql, sshConfig: sshConfig
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "dbpass", sshPassword: nil)
+        #expect(url == "mysql+ssh://sshuser@sshhost/dbuser:dbpass@127.0.0.1/db")
+        #expect(!url.contains(":22"))
+    }
+
+    @Test("SSH with private key adds query param")
+    func testSSHPrivateKey() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "sshhost"
+        sshConfig.port = 22
+        sshConfig.username = "root"
+        sshConfig.authMethod = .privateKey
+
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 3_306, database: "db",
+            username: "user", type: .mysql, sshConfig: sshConfig
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("usePrivateKey=true"))
+    }
+
+    // MARK: - SSL Mode
+
+    @Test("SSL mode included in query string")
+    func testSSLModeIncluded() {
+        var sslConfig = SSLConfiguration()
+        sslConfig.mode = .required
+
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 5_432, database: "db",
+            username: "user", type: .postgresql, sslConfig: sslConfig
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("sslmode=require"))
+    }
+
+    @Test("SSL disabled produces no sslmode param")
+    func testSSLDisabledNoParam() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 5_432, database: "db",
+            username: "user", type: .postgresql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(!url.contains("sslmode"))
+    }
+
+    // MARK: - Connection Name
+
+    @Test("Connection name in query string")
+    func testConnectionNameInQuery() {
+        let conn = DatabaseConnection(
+            name: "My Connection", host: "host", port: 3_306, database: "db",
+            username: "user", type: .mysql
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("name=My+Connection"))
+    }
+
+    // MARK: - Round-trip
+
+    @Test("Round-trip: format then parse preserves fields")
+    func testRoundTrip() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "jumpbox.example.com"
+        sshConfig.port = 2_222
+        sshConfig.username = "deploy"
+        sshConfig.authMethod = .privateKey
+
+        var sslConfig = SSLConfiguration()
+        sslConfig.mode = .required
+
+        let original = DatabaseConnection(
+            name: "Production DB", host: "10.0.0.5", port: 5_433, database: "appdb",
+            username: "admin", type: .postgresql, sshConfig: sshConfig, sslConfig: sslConfig
+        )
+        let password = "s3cret"
+
+        let url = ConnectionURLFormatter.format(original, password: password, sshPassword: nil)
+        let parseResult = ConnectionURLParser.parse(url)
+
+        guard case .success(let parsed) = parseResult else {
+            Issue.record("Expected successful parse of formatted URL: \(url)")
+            return
+        }
+
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.host == "10.0.0.5")
+        #expect(parsed.port == 5_433)
+        #expect(parsed.database == "appdb")
+        #expect(parsed.username == "admin")
+        #expect(parsed.password == password)
+        #expect(parsed.sshHost == "jumpbox.example.com")
+        #expect(parsed.sshPort == 2_222)
+        #expect(parsed.sshUsername == "deploy")
+        #expect(parsed.usePrivateKey == true)
+        #expect(parsed.sslMode == .required)
+        #expect(parsed.connectionName == "Production DB")
+    }
+
+    // MARK: - MariaDB
+
+    @Test("MariaDB uses mariadb scheme")
+    func testMariaDBScheme() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 3_306, database: "db",
+            username: "root", type: .mariadb
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.hasPrefix("mariadb://"))
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ConnectionURLFormatter` that converts a `DatabaseConnection` back into a URL string (reverse of `ConnectionURLParser`)
- Add "Copy as URL" context menu item to connections in the welcome window, placing it after "Duplicate"
- Supports all database types (MySQL, MariaDB, PostgreSQL, SQLite, MongoDB), SSH tunnels, SSL modes, percent-encoded credentials, and connection names

Closes #148

## Test plan

- [x] 21 unit tests covering all database types, port handling, credentials, special characters, SQLite paths, SSH tunnels, SSL modes, connection names, and a format→parse round-trip
- [x] `swiftlint lint --strict` passes with 0 violations
- [ ] Manual: right-click a connection → "Copy as URL" → paste and verify the URL matches the connection details
- [ ] Manual: verify round-trip by pasting the copied URL into the "Import from URL" flow