### PR TITLE
fix: cleanup debug prints and improve ENUM/SET sidebar editing

### DIFF
--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1263,9 +1263,14 @@ private extension MainContentCoordinator {
               tab.primaryKeyColumn != nil else {
             return false
         }
-        // If tab has enum/set columns but no enum values loaded, not fully cached
-        let hasEnumColumns = tab.columnTypes.contains { $0.isEnumType || $0.isSetType }
-        if hasEnumColumns && tab.columnEnumValues.isEmpty {
+        // Ensure every ENUM/SET column has its allowed values loaded
+        let enumSetColumnNames: [String] = tab.resultColumns.enumerated().compactMap { i, name in
+            guard i < tab.columnTypes.count,
+                  tab.columnTypes[i].isEnumType || tab.columnTypes[i].isSetType else { return nil }
+            return name
+        }
+        if !enumSetColumnNames.isEmpty,
+           !enumSetColumnNames.allSatisfy({ tab.columnEnumValues[$0] != nil }) {
             return false
         }
         return true

--- a/TablePro/Views/RightSidebar/EditableFieldView.swift
+++ b/TablePro/Views/RightSidebar/EditableFieldView.swift
@@ -27,6 +27,7 @@ struct EditableFieldView: View {
 
     @FocusState private var isFocused: Bool
     @State private var isHovered = false
+    @State private var isSetPopoverPresented = false
 
     private var placeholderText: String {
         if hasMultipleValues {
@@ -78,14 +79,17 @@ struct EditableFieldView: View {
 
     @ViewBuilder
     private var typeAwareEditor: some View {
-        if (columnTypeEnum.isEnumType || columnTypeEnum.isSetType),
-           let values = columnTypeEnum.enumValues, !values.isEmpty {
-            enumPicker(values: values)
-        } else if isPendingNull || isPendingDefault {
+        if isPendingNull || isPendingDefault {
             TextField(isPendingNull ? "NULL" : "DEFAULT", text: .constant(""))
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: DesignConstants.FontSize.small))
                 .disabled(true)
+        } else if columnTypeEnum.isEnumType,
+                  let values = columnTypeEnum.enumValues, !values.isEmpty {
+            enumPicker(values: values)
+        } else if columnTypeEnum.isSetType,
+                  let values = columnTypeEnum.enumValues, !values.isEmpty {
+            setPicker(values: values)
         } else if columnTypeEnum.isBooleanType {
             booleanPicker
         } else if isLongText || columnTypeEnum.isJsonType {
@@ -103,20 +107,49 @@ struct EditableFieldView: View {
     }
 
     private func enumPicker(values: [String]) -> some View {
-        let label: String = if isPendingNull {
-            "NULL"
-        } else if isPendingDefault {
-            "DEFAULT"
-        } else if value.isEmpty {
-            values.first ?? ""
-        } else {
-            value
-        }
+        let label = value.isEmpty ? (values.first ?? "") : value
         return dropdownField(label: label) {
             ForEach(values, id: \.self) { val in
                 Button(val) { value = val }
             }
         }
+    }
+
+    private func setPicker(values: [String]) -> some View {
+        let displayLabel = value.isEmpty ? String(localized: "No selection") : value
+        return Button {
+            isSetPopoverPresented = true
+        } label: {
+            Text(displayLabel)
+                .font(.system(size: DesignConstants.FontSize.small))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
+        .background(.quinary, in: RoundedRectangle(cornerRadius: 5))
+        .popover(isPresented: $isSetPopoverPresented) {
+            SetPopoverContentView(
+                allowedValues: values,
+                initialSelections: parseSetSelections(from: value, allowed: values),
+                onCommit: { result in
+                    value = result ?? ""
+                },
+                onDismiss: {
+                    isSetPopoverPresented = false
+                }
+            )
+        }
+    }
+
+    private func parseSetSelections(from value: String, allowed: [String]) -> [String: Bool] {
+        let selected = Set(value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
+        var dict: [String: Bool] = [:]
+        for val in allowed {
+            dict[val] = selected.contains(val)
+        }
+        return dict
     }
 
     private func dropdownField<Content: View>(


### PR DESCRIPTION
## Summary

- Wire ENUM/SET dropdown pickers into the right sidebar with proper type-aware editing
- Style sidebar enum/set/boolean pickers to match text field width
- Fix sidebar edit state sync and dropdown UX (pending null/default display)
- SET columns now use multi-select checkbox popover (reuses `SetPopoverContentView`)
- NULL/DEFAULT always takes priority over type-specific pickers
- Stricter `isMetadataCached` check ensures every ENUM/SET column has values loaded
- Preserve original connection config on database switch
- Add ColumnType and MultiRowEditState unit tests

## Test plan

- [ ] Open a MySQL table with ENUM column — sidebar shows single-select dropdown
- [ ] Open a MySQL table with SET column — sidebar shows popover with checkboxes
- [ ] Set an ENUM/SET field to NULL via field menu — sidebar shows disabled "NULL" text field
- [ ] Set an ENUM/SET field to DEFAULT — sidebar shows disabled "DEFAULT" text field
- [ ] Clear NULL/DEFAULT — picker reappears
- [ ] Switch databases — original connection config is preserved
- [ ] Run `xcodebuild test` — all new unit tests pass