### PR TITLE
feat: add TablePlus-compatible database URL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Redis database support with key-value browsing, database-level sidebar (db0–db15), TTL management, and interactive CLI
+- TablePlus-compatible database URL handling: `open -a TablePro "postgresql://user@host/db"` with support for schema switching, table opening, filters, color, and environment tags
 
 ## [0.12.0] - 2026-03-03
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -35,6 +35,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// cleanup pass.  While > 0 the welcome window is suppressed.
     private var fileOpenSuppressionCount = 0
 
+    private static let databaseURLSchemes: Set<String> = [
+        "postgresql", "postgres", "mysql", "mariadb", "sqlite",
+        "mongodb", "redis", "rediss", "redshift"
+    ]
+
     func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
         let menu = NSMenu()
 
@@ -133,6 +138,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 for url in deeplinkURLs {
                     self.handleDeeplink(url)
+                }
+            }
+        }
+
+        // Handle database connection URLs (e.g. postgresql://user@host/db)
+        let databaseURLs = urls.filter { url in
+            guard let scheme = url.scheme?.lowercased() else { return false }
+            let baseScheme = scheme.replacingOccurrences(of: "+ssh", with: "")
+            return Self.databaseURLSchemes.contains(baseScheme)
+        }
+        if !databaseURLs.isEmpty {
+            Task { @MainActor in
+                for url in databaseURLs {
+                    self.handleDatabaseURL(url)
                 }
             }
         }
@@ -263,6 +282,154 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if let openWindow = WindowOpener.shared.openWindow {
             openWindow(id: "connection-form", value: connection.id)
+        }
+    }
+
+    @MainActor
+    private func handleDatabaseURL(_ url: URL) {
+        let result = ConnectionURLParser.parse(url.absoluteString)
+        guard case .success(let parsed) = result else {
+            Self.logger.error("Failed to parse database URL: \(url.absoluteString, privacy: .public)")
+            return
+        }
+
+        // Try to find a matching saved connection
+        let connections = ConnectionStorage.shared.loadConnections()
+        let matchedConnection = connections.first { conn in
+            conn.type == parsed.type
+                && conn.host == parsed.host
+                && (parsed.port == nil || conn.port == parsed.port)
+                && conn.database == parsed.database
+                && (parsed.username.isEmpty || conn.username == parsed.username)
+        }
+
+        let connection: DatabaseConnection
+        if let matched = matchedConnection {
+            connection = matched
+        } else {
+            // Create a transient connection (not saved to storage)
+            var sshConfig = SSHConfiguration()
+            if let sshHost = parsed.sshHost {
+                sshConfig.enabled = true
+                sshConfig.host = sshHost
+                sshConfig.port = parsed.sshPort ?? 22
+                sshConfig.username = parsed.sshUsername ?? ""
+                if parsed.usePrivateKey == true {
+                    sshConfig.authMethod = .privateKey
+                }
+            }
+
+            var sslConfig = SSLConfiguration()
+            if let sslMode = parsed.sslMode {
+                sslConfig.mode = sslMode
+            }
+
+            var color: ConnectionColor = .none
+            if let hex = parsed.statusColor {
+                color = ConnectionURLParser.connectionColor(fromHex: hex)
+            }
+
+            var tagId: UUID?
+            if let envName = parsed.envTag {
+                tagId = ConnectionURLParser.tagId(fromEnvName: envName)
+            }
+
+            connection = DatabaseConnection(
+                name: parsed.connectionName ?? parsed.suggestedName,
+                host: parsed.host,
+                port: parsed.port ?? parsed.type.defaultPort,
+                database: parsed.database,
+                username: parsed.username,
+                type: parsed.type,
+                sshConfig: sshConfig,
+                sslConfig: sslConfig,
+                color: color,
+                tagId: tagId,
+                redisDatabase: parsed.redisDatabase
+            )
+        }
+
+        // Store password in Keychain if provided
+        if !parsed.password.isEmpty {
+            ConnectionStorage.shared.savePassword(parsed.password, for: connection.id)
+        }
+
+        // If already connected to this connection, just handle post-connect actions
+        if DatabaseManager.shared.activeSessions[connection.id]?.driver != nil {
+            handlePostConnectionActions(parsed, connectionId: connection.id)
+            for window in NSApp.windows where isMainWindow(window) {
+                window.makeKeyAndOrderFront(nil)
+            }
+            return
+        }
+
+        // Connect using the same pattern as connectViaDeeplink
+        NotificationCenter.default.post(name: .openMainWindow, object: connection.id)
+
+        Task { @MainActor in
+            do {
+                try await DatabaseManager.shared.connectToSession(connection)
+                for window in NSApp.windows where self.isWelcomeWindow(window) {
+                    window.close()
+                }
+                self.handlePostConnectionActions(parsed, connectionId: connection.id)
+            } catch {
+                Self.logger.error("Database URL connect failed: \(error.localizedDescription)")
+                for window in NSApp.windows where self.isMainWindow(window) {
+                    window.close()
+                }
+                self.openWelcomeWindow()
+                AlertHelper.showErrorSheet(
+                    title: String(localized: "Connection Failed"),
+                    message: error.localizedDescription,
+                    window: NSApp.keyWindow
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func handlePostConnectionActions(_ parsed: ParsedConnectionURL, connectionId: UUID) {
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+
+            // Switch schema if specified (PostgreSQL/Redshift only)
+            if let schema = parsed.schema,
+               parsed.type == .postgresql || parsed.type == .redshift {
+                NotificationCenter.default.post(
+                    name: .switchSchemaFromURL,
+                    object: nil,
+                    userInfo: ["connectionId": connectionId, "schema": schema]
+                )
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+
+            // Open table/view if specified
+            if let tableName = parsed.tableName {
+                let payload = EditorTabPayload(
+                    connectionId: connectionId,
+                    tabType: .table,
+                    tableName: tableName,
+                    isView: parsed.isView
+                )
+                WindowOpener.shared.openNativeTab(payload)
+
+                // Apply filter after table loads
+                if parsed.filterColumn != nil || parsed.filterCondition != nil {
+                    try? await Task.sleep(for: .milliseconds(800))
+                    NotificationCenter.default.post(
+                        name: .applyURLFilter,
+                        object: nil,
+                        userInfo: [
+                            "connectionId": connectionId,
+                            "column": parsed.filterColumn as Any,
+                            "operation": parsed.filterOperation as Any,
+                            "value": parsed.filterValue as Any,
+                            "condition": parsed.filterCondition as Any
+                        ]
+                    )
+                }
+            }
         }
     }
 

--- a/TablePro/Core/Utilities/ConnectionURLFormatter.swift
+++ b/TablePro/Core/Utilities/ConnectionURLFormatter.swift
@@ -133,7 +133,36 @@ struct ConnectionURLFormatter {
             params.append("sslmode=\(sslParam)")
         }
 
+        if let hex = colorHex(connection.color) {
+            params.append("statusColor=\(hex)")
+        }
+
+        if let tagId = connection.tagId,
+           let tag = TagStorage.shared.tag(for: tagId) {
+            let encoded = tag.name
+                .replacingOccurrences(of: " ", with: "+")
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)?
+                .replacingOccurrences(of: "&", with: "%26")
+                .replacingOccurrences(of: "=", with: "%3D")
+                ?? tag.name
+            params.append("env=\(encoded)")
+        }
+
         return params.joined(separator: "&")
+    }
+
+    private static func colorHex(_ color: ConnectionColor) -> String? {
+        switch color {
+        case .none: return nil
+        case .red: return "FF3B30"
+        case .orange: return "FF9500"
+        case .yellow: return "FFCC00"
+        case .green: return "34C759"
+        case .blue: return "007AFF"
+        case .purple: return "AF52DE"
+        case .pink: return "FF2D55"
+        case .gray: return "8E8E93"
+        }
     }
 
     private static func sslModeParam(_ mode: SSLMode) -> String? {

--- a/TablePro/Core/Utilities/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/ConnectionURLParser.swift
@@ -20,6 +20,15 @@ struct ParsedConnectionURL {
     let usePrivateKey: Bool?
     let connectionName: String?
     let redisDatabase: Int?
+    let statusColor: String?
+    let envTag: String?
+    let schema: String?
+    let tableName: String?
+    let isView: Bool
+    let filterColumn: String?
+    let filterOperation: String?
+    let filterValue: String?
+    let filterCondition: String?
 
     var suggestedName: String {
         if let connectionName, !connectionName.isEmpty {
@@ -111,7 +120,16 @@ struct ConnectionURLParser {
                 sshUsername: nil,
                 usePrivateKey: nil,
                 connectionName: nil,
-                redisDatabase: nil
+                redisDatabase: nil,
+                statusColor: nil,
+                envTag: nil,
+                schema: nil,
+                tableName: nil,
+                isView: false,
+                filterColumn: nil,
+                filterOperation: nil,
+                filterValue: nil,
+                filterCondition: nil
             ))
         }
 
@@ -128,7 +146,8 @@ struct ConnectionURLParser {
             return .failure(.missingHost)
         }
 
-        let port = components.port
+        let rawPort = components.port
+        let port = (rawPort == dbType.defaultPort) ? nil : rawPort
         let username = components.percentEncodedUser.flatMap {
             $0.removingPercentEncoding
         } ?? ""
@@ -141,19 +160,9 @@ struct ConnectionURLParser {
             database = String(database.dropFirst())
         }
 
-        var sslMode: SSLMode?
-        var authSource: String?
-        if let queryItems = components.queryItems {
-            for item in queryItems {
-                if item.name == "sslmode", let value = item.value {
-                    sslMode = parseSSLMode(value)
-                }
-                if item.name == "authSource" || item.name == "authsource" {
-                    authSource = item.value
-                }
-            }
-        }
+        let ext = parseQueryItems(components.queryItems)
 
+        var sslMode = ext.sslMode
         // Redis-specific: parse database index from path and handle TLS scheme
         var redisDatabase: Int?
         if dbType == .redis {
@@ -174,13 +183,22 @@ struct ConnectionURLParser {
             username: username,
             password: password,
             sslMode: sslMode,
-            authSource: authSource,
+            authSource: ext.authSource,
             sshHost: nil,
             sshPort: nil,
             sshUsername: nil,
             usePrivateKey: nil,
-            connectionName: nil,
-            redisDatabase: redisDatabase
+            connectionName: ext.connectionName,
+            redisDatabase: redisDatabase,
+            statusColor: ext.statusColor,
+            envTag: ext.envTag,
+            schema: ext.schema,
+            tableName: ext.tableName,
+            isView: ext.isView,
+            filterColumn: ext.filterColumn,
+            filterOperation: ext.filterOperation,
+            filterValue: ext.filterValue,
+            filterCondition: ext.filterCondition
         ))
     }
 
@@ -267,7 +285,7 @@ struct ConnectionURLParser {
         var port: Int?
         if let (h, p) = parseHostPort(dbHostPort) {
             host = h
-            port = p
+            port = (p == dbType.defaultPort) ? nil : p
         } else {
             host = dbHostPort
         }
@@ -276,36 +294,7 @@ struct ConnectionURLParser {
             host = "127.0.0.1"
         }
 
-        var connectionName: String?
-        var usePrivateKey: Bool?
-        var sslMode: SSLMode?
-        var authSource: String?
-
-        if let queryString {
-            let params = queryString.split(separator: "&", omittingEmptySubsequences: true)
-            for param in params {
-                let parts = param.split(separator: "=", maxSplits: 1)
-                guard let key = parts.first else { continue }
-                let value = parts.count > 1 ? String(parts[1]) : nil
-
-                switch String(key) {
-                case "name":
-                    connectionName = value?
-                        .replacingOccurrences(of: "+", with: " ")
-                        .removingPercentEncoding ?? value
-                case "usePrivateKey":
-                    usePrivateKey = value?.lowercased() == "true"
-                case "sslmode":
-                    if let value {
-                        sslMode = parseSSLMode(value)
-                    }
-                case "authSource", "authsource":
-                    authSource = value
-                default:
-                    break
-                }
-            }
-        }
+        let ext = parseSSHQueryString(queryString)
 
         return .success(ParsedConnectionURL(
             type: dbType,
@@ -314,16 +303,114 @@ struct ConnectionURLParser {
             database: database,
             username: dbUsername,
             password: dbPassword,
-            sslMode: sslMode,
-            authSource: authSource,
+            sslMode: ext.sslMode,
+            authSource: ext.authSource,
             sshHost: sshHost,
             sshPort: sshPort,
             sshUsername: sshUsername,
-            usePrivateKey: usePrivateKey,
-            connectionName: connectionName,
-            redisDatabase: nil
+            usePrivateKey: ext.usePrivateKey,
+            connectionName: ext.connectionName,
+            redisDatabase: nil,
+            statusColor: ext.statusColor,
+            envTag: ext.envTag,
+            schema: ext.schema,
+            tableName: ext.tableName,
+            isView: ext.isView,
+            filterColumn: ext.filterColumn,
+            filterOperation: ext.filterOperation,
+            filterValue: ext.filterValue,
+            filterCondition: ext.filterCondition
         ))
     }
+
+    // MARK: - Query Parameter Helpers
+
+    private struct ExtendedParams {
+        var sslMode: SSLMode?
+        var authSource: String?
+        var connectionName: String?
+        var usePrivateKey: Bool?
+        var statusColor: String?
+        var envTag: String?
+        var schema: String?
+        var tableName: String?
+        var isView = false
+        var filterColumn: String?
+        var filterOperation: String?
+        var filterValue: String?
+        var filterCondition: String?
+    }
+
+    private static func parseQueryItems(_ queryItems: [URLQueryItem]?) -> ExtendedParams {
+        var ext = ExtendedParams()
+        guard let queryItems else { return ext }
+        for item in queryItems {
+            guard let value = item.value, !value.isEmpty else { continue }
+            applyQueryParam(key: item.name, value: value, to: &ext)
+        }
+        return ext
+    }
+
+    private static func parseSSHQueryString(_ queryString: String?) -> ExtendedParams {
+        var ext = ExtendedParams()
+        guard let queryString else { return ext }
+        let params = queryString.split(separator: "&", omittingEmptySubsequences: true)
+        for param in params {
+            let parts = param.split(separator: "=", maxSplits: 1)
+            guard let key = parts.first else { continue }
+            let value = parts.count > 1 ? String(parts[1]) : nil
+            guard let value else { continue }
+            if String(key) == "usePrivateKey" {
+                ext.usePrivateKey = value.lowercased() == "true"
+                continue
+            }
+            applyQueryParam(key: String(key), value: value, to: &ext)
+        }
+        return ext
+    }
+
+    private static func applyQueryParam(key: String, value: String, to ext: inout ExtendedParams) {
+        switch key {
+        case "sslmode":
+            ext.sslMode = parseSSLMode(value)
+        case "authSource", "authsource":
+            ext.authSource = value
+        case "statusColor", "statuscolor":
+            ext.statusColor = value
+        case "env":
+            ext.envTag = value.removingPercentEncoding ?? value
+        case "schema":
+            ext.schema = value
+        case "table":
+            ext.tableName = value.replacingOccurrences(of: "+", with: " ")
+                .removingPercentEncoding ?? value
+        case "name":
+            ext.connectionName = value.replacingOccurrences(of: "+", with: " ")
+                .removingPercentEncoding ?? value
+        case "view":
+            ext.tableName = value.replacingOccurrences(of: "+", with: " ")
+                .removingPercentEncoding ?? value
+            ext.isView = true
+        case "column":
+            ext.filterColumn = value
+        case "operation", "operator":
+            ext.filterOperation = value
+        case "value":
+            ext.filterValue = value.replacingOccurrences(of: "+", with: " ")
+                .removingPercentEncoding ?? value
+        case "condition", "raw", "query":
+            ext.filterCondition = value.replacingOccurrences(of: "+", with: " ")
+                .removingPercentEncoding ?? value
+        case "tLSMode", "tlsmode":
+            if ext.sslMode == nil, let intValue = Int(value) {
+                ext.sslMode = parseTlsModeInteger(intValue)
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Host/Port Parsing
 
     /// Parse a host:port string, handling IPv6 bracket notation ([::1]:port).
     /// Returns nil if the string is empty or contains only a bare host with no port.
@@ -364,5 +451,58 @@ struct ConnectionURLParser {
         default:
             return nil
         }
+    }
+
+    private static func parseTlsModeInteger(_ value: Int) -> SSLMode? {
+        switch value {
+        case 0: return .disabled
+        case 1: return .preferred
+        case 2: return .required
+        case 3: return .verifyCa
+        case 4: return .verifyIdentity
+        default: return nil
+        }
+    }
+
+    internal static func connectionColor(fromHex hex: String) -> ConnectionColor {
+        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard cleaned.count == 6, let hexInt = UInt32(cleaned, radix: 16) else {
+            return .none
+        }
+
+        let r = Int((hexInt >> 16) & 0xFF)
+        let g = Int((hexInt >> 8) & 0xFF)
+        let b = Int(hexInt & 0xFF)
+
+        let palette: [(ConnectionColor, Int, Int, Int)] = [
+            (.red, 255, 59, 48),
+            (.orange, 255, 149, 0),
+            (.yellow, 255, 204, 0),
+            (.green, 52, 199, 89),
+            (.blue, 0, 122, 255),
+            (.purple, 175, 82, 222),
+            (.pink, 255, 45, 85),
+            (.gray, 142, 142, 147)
+        ]
+
+        var bestColor: ConnectionColor = .none
+        var bestDistance = Int.max
+        for (color, pr, pg, pb) in palette {
+            let dr = r - pr
+            let dg = g - pg
+            let db = b - pb
+            let distance = dr * dr + dg * dg + db * db
+            if distance < bestDistance {
+                bestDistance = distance
+                bestColor = color
+            }
+        }
+
+        return bestColor
+    }
+
+    internal static func tagId(fromEnvName name: String) -> UUID? {
+        let tags = TagStorage.shared.loadTags()
+        return tags.first(where: { $0.name.lowercased() == name.lowercased() })?.id
     }
 }

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -63,6 +63,24 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.TablePro.database-url</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>postgresql</string>
+				<string>postgres</string>
+				<string>mysql</string>
+				<string>mariadb</string>
+				<string>sqlite</string>
+				<string>mongodb</string>
+				<string>redis</string>
+				<string>rediss</string>
+				<string>redshift</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/TablePro/OpenTableApp.swift
+++ b/TablePro/OpenTableApp.swift
@@ -492,6 +492,10 @@ extension Notification.Name {
     static let openMainWindow = Notification.Name("openMainWindow")
     static let openWelcomeWindow = Notification.Name("openWelcomeWindow")
 
+    // Database URL handling notifications
+    static let switchSchemaFromURL = Notification.Name("switchSchemaFromURL")
+    static let applyURLFilter = Notification.Name("applyURLFilter")
+
     // License notifications
     static let licenseStatusDidChange = Notification.Name("licenseStatusDidChange")
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+URLFilter.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+URLFilter.swift
@@ -1,0 +1,116 @@
+//
+//  MainContentCoordinator+URLFilter.swift
+//  TablePro
+//
+
+import Foundation
+
+extension MainContentCoordinator {
+    func setupURLNotificationObservers() {
+        NotificationCenter.default.addObserver(
+            forName: .applyURLFilter,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let targetId = userInfo["connectionId"] as? UUID,
+                  targetId == self.connectionId else { return }
+
+            Task { @MainActor in
+                self.applyURLFilter(userInfo: userInfo)
+            }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .switchSchemaFromURL,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let targetId = userInfo["connectionId"] as? UUID,
+                  targetId == self.connectionId,
+                  let schema = userInfo["schema"] as? String else { return }
+
+            Task { @MainActor in
+                await self.switchDatabase(to: schema)
+            }
+        }
+    }
+
+    private func applyURLFilter(userInfo: [AnyHashable: Any]) {
+        if let condition = userInfo["condition"] as? String, !condition.isEmpty {
+            let filter = TableFilter(
+                id: UUID(),
+                columnName: TableFilter.rawSQLColumn,
+                filterOperator: .equal,
+                value: "",
+                isSelected: true,
+                isEnabled: true,
+                rawSQL: condition
+            )
+            filterStateManager.applySingleFilter(filter)
+            return
+        }
+
+        guard let column = userInfo["column"] as? String, !column.isEmpty else { return }
+
+        let operationString = userInfo["operation"] as? String ?? "Equal"
+        let filterOp = mapTablePlusOperation(operationString)
+        let value = userInfo["value"] as? String ?? ""
+
+        let filter = TableFilter(
+            id: UUID(),
+            columnName: column,
+            filterOperator: filterOp,
+            value: value,
+            isSelected: true,
+            isEnabled: true
+        )
+        filterStateManager.applySingleFilter(filter)
+    }
+
+    private func mapTablePlusOperation(_ operation: String) -> FilterOperator {
+        switch operation.lowercased() {
+        case "equal", "equals", "=":
+            return .equal
+        case "not equal", "notequal", "!=":
+            return .notEqual
+        case "contains", "like":
+            return .contains
+        case "not contains", "notcontains", "not like":
+            return .notContains
+        case "starts with", "startswith":
+            return .startsWith
+        case "ends with", "endswith":
+            return .endsWith
+        case "greater than", "greaterthan", ">":
+            return .greaterThan
+        case "greater or equal", "greaterorequal", ">=":
+            return .greaterOrEqual
+        case "less than", "lessthan", "<":
+            return .lessThan
+        case "less or equal", "lessorequal", "<=":
+            return .lessOrEqual
+        case "is null", "isnull":
+            return .isNull
+        case "is not null", "isnotnull":
+            return .isNotNull
+        case "is empty", "isempty":
+            return .isEmpty
+        case "is not empty", "isnotempty":
+            return .isNotEmpty
+        case "in":
+            return .inList
+        case "not in", "notin":
+            return .notInList
+        case "between":
+            return .between
+        case "regex":
+            return .regex
+        default:
+            return .contains
+        }
+    }
+}

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -136,6 +136,7 @@ final class MainContentCoordinator {
         }
 
         Self.retainSchemaProvider(for: connection.id)
+        setupURLNotificationObservers()
     }
 
     /// Explicit cleanup called from `onDisappear`. Releases schema provider

--- a/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
@@ -20,7 +20,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .postgresql)
         #expect(parsed.host == "db.example.com")
-        #expect(parsed.port == 5432)
+        #expect(parsed.port == nil)
         #expect(parsed.database == "mydb")
         #expect(parsed.username == "admin")
         #expect(parsed.password == "secret")
@@ -68,7 +68,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .mysql)
         #expect(parsed.host == "localhost")
-        #expect(parsed.port == 3306)
+        #expect(parsed.port == nil)
         #expect(parsed.database == "testdb")
         #expect(parsed.username == "root")
         #expect(parsed.password == "password")
@@ -277,7 +277,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .mongodb)
         #expect(parsed.host == "mongo.example.com")
-        #expect(parsed.port == 27017)
+        #expect(parsed.port == nil)
         #expect(parsed.database == "mydb")
         #expect(parsed.username == "admin")
         #expect(parsed.password == "secret")
@@ -358,6 +358,46 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .postgresql)
         #expect(parsed.sshHost == "host")
+    }
+
+    @Test("SSH URL with default DB port omits port")
+    func testSSHURLDefaultPortOmitted() {
+        let result = ConnectionURLParser.parse(
+            "postgresql+ssh://deploy@bastion:22/postgres@dbhost:5432/mydb?usePrivateKey=true"
+        )
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.host == "dbhost")
+        #expect(parsed.port == nil)
+        #expect(parsed.database == "mydb")
+        #expect(parsed.username == "postgres")
+        #expect(parsed.sshHost == "bastion")
+        #expect(parsed.sshPort == 22)
+        #expect(parsed.sshUsername == "deploy")
+        #expect(parsed.usePrivateKey == true)
+    }
+
+    @Test("SSH URL with non-default DB port preserves port")
+    func testSSHURLNonDefaultPortPreserved() {
+        let result = ConnectionURLParser.parse(
+            "postgresql+ssh://deploy@bastion:22/postgres@dbhost:5433/mydb"
+        )
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.port == 5433)
+        #expect(parsed.sshPort == 22)
+    }
+
+    @Test("Non-default port preserved in standard URL")
+    func testNonDefaultPortPreserved() {
+        let result = ConnectionURLParser.parse("postgresql://user:pass@host:5433/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.port == 5433)
     }
 
     @Test("MariaDB SSH URL")
@@ -456,7 +496,7 @@ struct ConnectionURLParserTests {
         #expect(parsed.sshHost == "::1")
         #expect(parsed.sshPort == 22)
         #expect(parsed.host == "fe80::1")
-        #expect(parsed.port == 3306)
+        #expect(parsed.port == nil)
     }
 
     // MARK: - Redshift
@@ -469,7 +509,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .redshift)
         #expect(parsed.host == "cluster.us-east-1.redshift.amazonaws.com")
-        #expect(parsed.port == 5439)
+        #expect(parsed.port == nil)
         #expect(parsed.database == "mydb")
         #expect(parsed.username == "admin")
         #expect(parsed.password == "secret")
@@ -495,7 +535,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .redshift)
         #expect(parsed.sslMode == .required)
-        #expect(parsed.port == 5439)
+        #expect(parsed.port == nil)
     }
 
     @Test("Redshift suggested name includes host and database")
@@ -537,7 +577,7 @@ struct ConnectionURLParserTests {
         }
         #expect(parsed.type == .redis)
         #expect(parsed.host == "localhost")
-        #expect(parsed.port == 6379)
+        #expect(parsed.port == nil)
         #expect(parsed.redisDatabase == nil)
     }
 
@@ -594,7 +634,7 @@ struct ConnectionURLParserTests {
         #expect(parsed.username == "user")
         #expect(parsed.password == "pass")
         #expect(parsed.host == "localhost")
-        #expect(parsed.port == 6379)
+        #expect(parsed.port == nil)
         #expect(parsed.redisDatabase == 2)
         #expect(parsed.database == "")
     }
@@ -608,5 +648,186 @@ struct ConnectionURLParserTests {
         #expect(parsed.type == .redis)
         #expect(parsed.redisDatabase == 0)
         #expect(parsed.database == "")
+    }
+
+    // MARK: - TablePlus Query Parameters
+
+    @Test("Parse statusColor parameter")
+    func testStatusColorParameter() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?statusColor=FF0000")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.statusColor == "FF0000")
+    }
+
+    @Test("Parse env parameter")
+    func testEnvParameter() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?env=production")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.envTag == "production")
+    }
+
+    @Test("Parse schema parameter")
+    func testSchemaParameter() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?schema=public")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.schema == "public")
+    }
+
+    @Test("Parse table parameter")
+    func testTableParameter() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?table=users")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.tableName == "users")
+        #expect(parsed.isView == false)
+    }
+
+    @Test("Parse view parameter sets isView flag")
+    func testViewParameterSetsIsView() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?view=active_users")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.tableName == "active_users")
+        #expect(parsed.isView == true)
+    }
+
+    @Test("Parse filter column, operation, and value")
+    func testFilterParameters() {
+        let result = ConnectionURLParser.parse(
+            "postgresql://user@host/db?table=comments&column=content&operation=contains&value=test"
+        )
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.tableName == "comments")
+        #expect(parsed.filterColumn == "content")
+        #expect(parsed.filterOperation == "contains")
+        #expect(parsed.filterValue == "test")
+    }
+
+    @Test("Parse raw SQL condition parameter")
+    func testConditionParameter() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?condition=age+%3E+18")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.filterCondition == "age > 18")
+    }
+
+    @Test("tLSMode integer maps to SSLMode")
+    func testTlsModeMapping() {
+        let cases: [(String, SSLMode)] = [
+            ("0", .disabled), ("1", .preferred), ("2", .required),
+            ("3", .verifyCa), ("4", .verifyIdentity)
+        ]
+        for (value, expected) in cases {
+            let result = ConnectionURLParser.parse("postgresql://user@host/db?tLSMode=\(value)")
+            guard case .success(let parsed) = result else {
+                Issue.record("Expected success for tLSMode=\(value)"); continue
+            }
+            #expect(parsed.sslMode == expected)
+        }
+    }
+
+    @Test("sslmode parameter takes priority over tLSMode")
+    func testSslModePriorityOverTlsMode() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db?sslmode=require&tLSMode=0")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sslMode == .required)
+    }
+
+    @Test("Full TablePlus canonical URL")
+    func testFullTablePlusCanonicalURL() {
+        let result = ConnectionURLParser.parse(
+            "postgresql://postgres@127.0.0.1/tools?schema=public&table=comments&column=content&operation=contains&value=test"
+        )
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.host == "127.0.0.1")
+        #expect(parsed.database == "tools")
+        #expect(parsed.username == "postgres")
+        #expect(parsed.schema == "public")
+        #expect(parsed.tableName == "comments")
+        #expect(parsed.filterColumn == "content")
+        #expect(parsed.filterOperation == "contains")
+        #expect(parsed.filterValue == "test")
+        #expect(parsed.isView == false)
+    }
+
+    @Test("Connection name from name parameter in standard URL")
+    func testConnectionNameFromStandardURL() {
+        let result = ConnectionURLParser.parse("mysql://root@localhost/db?name=My+Database")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.connectionName == "My Database")
+    }
+
+    @Test("Default isView is false when no view/table param")
+    func testDefaultIsViewFalse() {
+        let result = ConnectionURLParser.parse("postgresql://user@host/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.isView == false)
+        #expect(parsed.tableName == nil)
+    }
+
+    @Test("SSH URL parses TablePlus parameters")
+    func testSSHURLTablePlusParameters() {
+        let result = ConnectionURLParser.parse(
+            "postgresql+ssh://sshuser@sshhost:22/dbuser@dbhost/mydb?table=users&schema=public&env=staging"
+        )
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.tableName == "users")
+        #expect(parsed.schema == "public")
+        #expect(parsed.envTag == "staging")
+        #expect(parsed.sshHost == "sshhost")
+    }
+
+    // MARK: - Color Hex Helper
+
+    @Test("connectionColor(fromHex:) maps red hex")
+    func testColorFromHexRed() {
+        let color = ConnectionURLParser.connectionColor(fromHex: "FF0000")
+        #expect(color == .red)
+    }
+
+    @Test("connectionColor(fromHex:) maps green hex")
+    func testColorFromHexGreen() {
+        let color = ConnectionURLParser.connectionColor(fromHex: "007F3D")
+        #expect(color == .green)
+    }
+
+    @Test("connectionColor(fromHex:) maps blue hex")
+    func testColorFromHexBlue() {
+        let color = ConnectionURLParser.connectionColor(fromHex: "0000FF")
+        #expect(color == .blue)
+    }
+
+    @Test("connectionColor(fromHex:) handles hash prefix")
+    func testColorFromHexWithHash() {
+        let color = ConnectionURLParser.connectionColor(fromHex: "#FF3B30")
+        #expect(color == .red)
+    }
+
+    @Test("connectionColor(fromHex:) returns none for invalid hex")
+    func testColorFromHexInvalid() {
+        let color = ConnectionURLParser.connectionColor(fromHex: "invalid")
+        #expect(color == .none)
     }
 }


### PR DESCRIPTION
## Summary

- Support opening connections via standard database URLs: `open -a TablePro "postgresql://user@host/db"` — registers `postgresql`, `postgres`, `mysql`, `mariadb`, `sqlite`, `mongodb`, `redis`, `rediss`, `redshift` URL schemes in Info.plist and handles them in AppDelegate
- Parse TablePlus query parameters (`statusColor`, `env`, `schema`, `table`, `view`, `column`, `operation`, `value`, `condition`, `name`, `tLSMode`, `usePrivateKey`) for full migration compatibility
- Post-connection actions: auto-switch schema, open table/view tab, and apply column or raw SQL filters via NotificationCenter
- Normalize default ports to `nil` (e.g. 5432 for PostgreSQL) so explicit default ports don't clutter the UI or break connection matching
- Round-trip support: `ConnectionURLFormatter` now emits `statusColor` and `env` params in generated URLs

## Test plan

- [ ] Run `ConnectionURLParserTests` — 19 new/updated test cases covering all TablePlus params, default port normalization, `connectionColor(fromHex:)`, SSH URLs with params
- [ ] `open -a TablePro "postgresql://postgres@127.0.0.1/tools"` — should connect
- [ ] `open -a TablePro "postgresql://postgres@127.0.0.1/tools?schema=public&table=users"` — should connect and open users table
- [ ] `open -a TablePro "mysql://root@localhost/mydb?statusColor=FF0000&env=production"` — should connect with red color and production tag
- [ ] `open -a TablePro "postgresql+ssh://deploy@bastion:22/postgres@dbhost:5432/mydb?usePrivateKey=true"` — port should be nil (default), SSH port 22
- [ ] Lint: `swiftlint lint --strict`