### PR TITLE
fix: suppress spurious teardown warnings for unused SwiftUI coordinators

### DIFF
--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -95,8 +95,31 @@ final class MainContentCoordinator {
     /// side-effect window creation during the switch cascade.
     var isSwitchingDatabase = false
 
+    /// True once the coordinator's view has appeared (onAppear fired).
+    /// Coordinators that SwiftUI creates during body re-evaluation but never
+    /// adopts into @State are silently discarded — no teardown warning needed.
+    @ObservationIgnored nonisolated(unsafe) private var didActivate = false
+
     /// Tracks whether teardown() was called; used by deinit to log missed teardowns
-    @ObservationIgnored private var didTeardown = false
+    @ObservationIgnored nonisolated(unsafe) private var didTeardown = false
+
+    /// Tracks whether teardown has been scheduled (but not yet executed)
+    /// so deinit doesn't warn if SwiftUI deallocates before the delayed Task fires
+    @ObservationIgnored nonisolated(unsafe) private var teardownScheduled = false
+
+    /// Set when NSApplication is terminating — suppresses deinit warning since
+    /// SwiftUI does not call onDisappear during app termination
+    nonisolated(unsafe) private static var isAppTerminating = false
+
+    private static let registerTerminationObserver: Void = {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainContentCoordinator.isAppTerminating = true
+        }
+    }()
 
     /// Remove sort cache entries for tabs that no longer exist
     func cleanupSortCache(openTabIds: Set<UUID>) {
@@ -137,6 +160,20 @@ final class MainContentCoordinator {
 
         Self.retainSchemaProvider(for: connection.id)
         setupURLNotificationObservers()
+
+        _ = Self.registerTerminationObserver
+    }
+
+    func markActivated() {
+        didActivate = true
+    }
+
+    func markTeardownScheduled() {
+        teardownScheduled = true
+    }
+
+    func clearTeardownScheduled() {
+        teardownScheduled = false
     }
 
     /// Explicit cleanup called from `onDisappear`. Releases schema provider
@@ -162,12 +199,30 @@ final class MainContentCoordinator {
 
     deinit {
         let connectionId = connection.id
-        guard !didTeardown else { return }
-        let logger = Logger(subsystem: "com.TablePro", category: "MainContentCoordinator")
-        logger.warning("teardown() was not called before deallocation for connection \(connectionId)")
-        Task { @MainActor in
-            MainContentCoordinator.releaseSchemaProvider(for: connectionId)
-            MainContentCoordinator.purgeUnusedSchemaProviders()
+        let alreadyHandled = didTeardown || teardownScheduled
+
+        // Never-activated coordinators are throwaway instances created by SwiftUI
+        // during body re-evaluation — @State only keeps the first, rest are discarded
+        guard didActivate else {
+            if !alreadyHandled {
+                Task { @MainActor in
+                    MainContentCoordinator.releaseSchemaProvider(for: connectionId)
+                    MainContentCoordinator.purgeUnusedSchemaProviders()
+                }
+            }
+            return
+        }
+
+        if !alreadyHandled && !Self.isAppTerminating {
+            let logger = Logger(subsystem: "com.TablePro", category: "MainContentCoordinator")
+            logger.warning("teardown() was not called before deallocation for connection \(connectionId)")
+        }
+
+        if !alreadyHandled {
+            Task { @MainActor in
+                MainContentCoordinator.releaseSchemaProvider(for: connectionId)
+                MainContentCoordinator.purgeUnusedSchemaProviders()
+            }
         }
     }
 

--- a/TablePro/Views/MainContentView.swift
+++ b/TablePro/Views/MainContentView.swift
@@ -217,6 +217,8 @@ struct MainContentView: View {
                 scheduleInspectorUpdate()
             }
             .onAppear {
+                coordinator.markActivated()
+
                 // Set window title for empty state (no tabs restored)
                 if tabManager.tabs.isEmpty {
                     windowTitle = connection.name
@@ -252,6 +254,10 @@ struct MainContentView: View {
             .onDisappear {
                 NativeTabRegistry.shared.unregister(windowId: windowId)
 
+                // Mark teardown intent synchronously so deinit doesn't warn
+                // if SwiftUI deallocates the coordinator before the delayed Task fires
+                coordinator.markTeardownScheduled()
+
                 let capturedWindowId = windowId
                 let connectionId = connection.id
                 let connectionName = connection.name
@@ -260,6 +266,7 @@ struct MainContentView: View {
 
                     // If this window re-registered (temporary disappear during tab group merge), skip cleanup
                     if NativeTabRegistry.shared.isRegistered(windowId: capturedWindowId) {
+                        coordinator.clearTeardownScheduled()
                         return
                     }
 


### PR DESCRIPTION
## Summary
- SwiftUI calls `MainContentView.init()` on every body re-evaluation, creating throwaway `MainContentCoordinator` instances that `@State` discards
- These never go through `onAppear`/`onDisappear`, so `teardown()` is never called, spamming the console with warnings
- Added `didActivate` flag set from `onAppear` — deinit now silently cleans up never-activated coordinators
- Also added `teardownScheduled` flag and app termination observer to suppress warnings during normal shutdown

## Test plan
- [ ] Open a connection, verify no teardown warnings in Console
- [ ] Close a connection window, verify no warnings
- [ ] Quit the app with connections open, verify no warnings