### PR TITLE
fix: add missing loadSchema and toolbar update for PostgreSQL switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-- The PostgreSQL Cmd+K database switcher now lists and switches both databases and schemas for PostgreSQL connections.
+- Add database and schema switching for PostgreSQL connections via ⌘K
 
 ## [0.14.0] - 2026-03-05
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -317,6 +317,8 @@ extension MainContentCoordinator {
 
                 await DatabaseManager.shared.reconnectSession(connectionId)
 
+                await loadSchema()
+
                 NotificationCenter.default.post(name: .refreshData, object: nil)
             } else if connection.type == .redshift {
                 // Redshift: switch schema
@@ -461,6 +463,8 @@ extension MainContentCoordinator {
                 session.currentSchema = schema
                 session.tables = []
             }
+
+            toolbarState.databaseName = schema
 
             closeSiblingNativeWindows()
             tabManager.tabs = []

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+URLFilter.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+URLFilter.swift
@@ -41,7 +41,6 @@ extension MainContentCoordinator {
                   let schema = userInfo["schema"] as? String else { return }
 
             Task { @MainActor [weak self] in
-                
                 guard let self else { return }
                 
                 if self.connection.type == .postgresql {


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #173 (PostgreSQL database & schema switching):

- Add missing `await loadSchema()` after PostgreSQL database reconnect so autocomplete updates
- Add missing `toolbarState.databaseName = schema` in `switchSchema()` so toolbar reflects current schema
- Remove blank line in URLFilter closure
- Fix CHANGELOG category (`Changed` → `Added`)

## Test plan

- [ ] Switch PostgreSQL database via ⌘K — verify autocomplete updates with new database's tables
- [ ] Switch PostgreSQL schema via ⌘K — verify toolbar shows the new schema name