### PR TITLE
fix: wave 1 safety fixes, accessibility, and test corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace CodeEditLanguages xcframework (38 grammars) with local package compiling only SQL, Bash, and JavaScript, reducing app binary size by ~55%
 
+### Fixed
+
+- Replace `.onTapGesture` with `Button` in color pickers, section headers, group headers, and connection switcher for VoiceOver accessibility
+- Fix data race on `isAppTerminating` static var in `MainContentCoordinator` using `OSAllocatedUnfairLock`
+- Fix `MainActor.assumeIsolated` crash risk in `VimKeyInterceptor` notification observer
+- Fix data race on `conn` pointer in `LibPQConnection` during disconnect and cancel
+- Fix SSH askpass script written with world-readable permissions; now uses atomic `0o700` creation and immediate cleanup
+- Fix potential dict mutation during iteration in `DatabaseManager.disconnectAll()`
+- Fix welcome screen showing blank panel when connections have orphaned group IDs
+
 ## [0.14.1] - 2026-03-06
 
 ### Added

--- a/TablePro.xcodeproj/xcshareddata/xcschemes/TablePro.xcscheme
+++ b/TablePro.xcodeproj/xcshareddata/xcschemes/TablePro.xcscheme
@@ -28,7 +28,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "NO"
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -18,6 +18,7 @@ import SwiftUI
 /// 2. **Stable and reliable**: AppKit APIs are mature and well-documented
 /// 3. **Separation of concerns**: Window configuration is separate from SwiftUI views
 /// 4. **Future-proof**: Works reliably across macOS Ventura/Sonoma and future versions
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     private static let logger = Logger(subsystem: "com.TablePro", category: "AppDelegate")
     /// Track windows that have been configured to avoid re-applying styles (which causes flicker)
@@ -655,8 +656,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         saveAllTabStates()
     }
 
-    deinit {
-        // Remove all NotificationCenter observers added in applicationDidFinishLaunching
+    nonisolated deinit {
         NotificationCenter.default.removeObserver(self)
     }
 

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -283,12 +283,13 @@ final class DatabaseManager {
 
     /// Disconnect all sessions
     func disconnectAll() async {
-        // Stop all health monitors
-        for sessionId in healthMonitors.keys {
+        let monitorIds = Array(healthMonitors.keys)
+        for sessionId in monitorIds {
             await stopHealthMonitor(for: sessionId)
         }
 
-        for sessionId in activeSessions.keys {
+        let sessionIds = Array(activeSessions.keys)
+        for sessionId in sessionIds {
             await disconnectSession(sessionId)
         }
     }

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -103,7 +103,7 @@ struct FilterSQLGenerator {
         case .regex:
             // SQLite doesn't support REGEXP without a custom function;
             // MongoDB filters are handled natively by MongoDBQueryBuilder
-            if databaseType == .sqlite || databaseType == .mongodb || databaseType == .redis { return nil }
+            if databaseType == .mongodb || databaseType == .redis { return nil }
             return generateRegexCondition(column: quotedColumn, pattern: filter.value)
         }
     }
@@ -192,14 +192,24 @@ struct FilterSQLGenerator {
             .replacingOccurrences(of: "'", with: "''")
     }
 
-    /// Escape LIKE pattern wildcards (% and _) in user input
     private func escapeLikeWildcards(_ value: String) -> String {
-        // Fast path: most values have no special chars
         guard value.contains("\\") || value.contains("%") || value.contains("_") else { return value }
-        return value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "%", with: "\\%")
-            .replacingOccurrences(of: "_", with: "\\_")
+
+        switch databaseType {
+        case .mysql, .mariadb:
+            // MySQL uses \ as both string escape and default LIKE escape.
+            // Need double backslash in SQL string so string layer yields single \
+            // which LIKE then uses as escape char.
+            return value
+                .replacingOccurrences(of: "\\", with: "\\\\\\\\")
+                .replacingOccurrences(of: "%", with: "\\\\%")
+                .replacingOccurrences(of: "_", with: "\\\\_")
+        default:
+            return value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "%", with: "\\%")
+                .replacingOccurrences(of: "_", with: "\\_")
+        }
     }
 
     // MARK: - List Parsing

--- a/TablePro/Core/Database/LibPQConnection.swift
+++ b/TablePro/Core/Database/LibPQConnection.swift
@@ -105,7 +105,7 @@ final class LibPQConnection: @unchecked Sendable {
     // MARK: - Properties
 
     /// The underlying PGconn pointer (opaque handle)
-    /// Access only through the serial queue
+    /// Protected by `stateLock` for reads/writes from any thread
     private var conn: OpaquePointer?
 
     /// Serial queue for thread-safe access to the C library
@@ -255,8 +255,6 @@ final class LibPQConnection: @unchecked Sendable {
                     PQexec(connection, cStr)
                 }
 
-                self.conn = connection
-
                 // Cache server version while on the serial queue
                 let version = PQserverVersion(connection)
                 if version > 0 {
@@ -267,6 +265,7 @@ final class LibPQConnection: @unchecked Sendable {
                 }
 
                 self.stateLock.lock()
+                self.conn = connection
                 self._isConnected = true
                 self.stateLock.unlock()
                 continuation.resume()
@@ -278,17 +277,15 @@ final class LibPQConnection: @unchecked Sendable {
     func disconnect() {
         isShuttingDown = true
 
-        // Capture handle for async cleanup — avoids queue.sync deadlock
-        let handle = conn
-        conn = nil
-
         stateLock.lock()
         _isConnected = false
+        let handle = conn
+        conn = nil
         stateLock.unlock()
 
         _cachedServerVersion = nil
 
-        if let handle = handle {
+        if let handle {
             queue.async {
                 PQfinish(handle)
             }
@@ -302,11 +299,12 @@ final class LibPQConnection: @unchecked Sendable {
     func cancelCurrentQuery() {
         stateLock.lock()
         _isCancelled = true
+        let currentConn = conn
         stateLock.unlock()
 
-        guard let conn = conn else { return }
-        let cancelObj = PQgetCancel(conn)
-        guard let cancelObj = cancelObj else { return }
+        guard let currentConn else { return }
+        let cancelObj = PQgetCancel(currentConn)
+        guard let cancelObj else { return }
         defer { PQfreeCancel(cancelObj) }
 
         var errbuf = [CChar](repeating: 0, count: 256)
@@ -371,7 +369,11 @@ final class LibPQConnection: @unchecked Sendable {
 
     /// Synchronous query execution - must be called on the serial queue
     private func executeQuerySync(_ query: String) throws -> LibPQQueryResult {
-        guard !isShuttingDown, let conn = self.conn else {
+        stateLock.lock()
+        let conn = self.conn
+        stateLock.unlock()
+
+        guard !isShuttingDown, let conn else {
             throw LibPQError.notConnected
         }
 
@@ -425,7 +427,11 @@ final class LibPQConnection: @unchecked Sendable {
     /// Synchronous parameterized query execution using PQexecParams
     /// MUST be called on the serial queue
     private func executeParameterizedQuerySync(_ query: String, parameters: [Any?]) throws -> LibPQQueryResult {
-        guard !isShuttingDown, let conn = self.conn else {
+        stateLock.lock()
+        let conn = self.conn
+        stateLock.unlock()
+
+        guard !isShuttingDown, let conn else {
             throw LibPQError.notConnected
         }
 

--- a/TablePro/Core/SSH/SSHTunnelManager.swift
+++ b/TablePro/Core/SSH/SSHTunnelManager.swift
@@ -184,19 +184,17 @@ actor SSHTunnelManager {
         process.arguments = arguments
 
         // Set up SSH_ASKPASS for passphrase or password
-        var askpassScript: String?
+        var askpassScriptPath: String?
 
         if authMethod == .privateKey, let passphrase = keyPassphrase {
-            // Private key with passphrase - use SSH_ASKPASS to provide it
-            askpassScript = try await createAskpassScript(password: passphrase)
+            askpassScriptPath = try createAskpassScript(password: passphrase)
         } else if authMethod == .password, let password = sshPassword {
-            // Password authentication
-            askpassScript = try await createAskpassScript(password: password)
+            askpassScriptPath = try createAskpassScript(password: password)
         }
 
-        if let script = askpassScript {
+        if let scriptPath = askpassScriptPath {
             var environment = ProcessInfo.processInfo.environment
-            environment["SSH_ASKPASS"] = script
+            environment["SSH_ASKPASS"] = scriptPath
             environment["SSH_ASKPASS_REQUIRE"] = "force"
             environment["DISPLAY"] = ":0"  // Required for SSH_ASKPASS to work
             process.environment = environment
@@ -211,6 +209,7 @@ actor SSHTunnelManager {
         do {
             try process.run()
         } catch {
+            removeAskpassScript(askpassScriptPath)
             throw SSHTunnelError.tunnelCreationFailed(error.localizedDescription)
         }
 
@@ -220,6 +219,8 @@ actor SSHTunnelManager {
             process: process,
             timeoutSeconds: 15
         )
+
+        removeAskpassScript(askpassScriptPath)
 
         if !tunnelReady {
             // Process died or timed out — read stderr for diagnostics
@@ -248,11 +249,6 @@ actor SSHTunnelManager {
             createdAt: Date()
         )
         tunnels[connectionId] = tunnel
-
-        // Clean up askpass script if created (for password or passphrase)
-        if authMethod == .password || keyPassphrase != nil {
-            cleanupAskpassScript()
-        }
 
         return localPort
     }
@@ -331,22 +327,23 @@ actor SSHTunnelManager {
         return path
     }
 
-    /// Create a temporary script for SSH_ASKPASS
-    private func createAskpassScript(password: String) async throws -> String {
+    private func createAskpassScript(password: String) throws -> String {
         let scriptPath = NSTemporaryDirectory() + "ssh_askpass_\(UUID().uuidString)"
-        let scriptContent = """
-            #!/bin/bash
-            echo '\(password.replacingOccurrences(of: "'", with: "'\\''"))'
-            """
+        let scriptContent = "#!/bin/bash\necho '\(password.replacingOccurrences(of: "'", with: "'\\''"))'\n"
 
-        try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+        guard let data = scriptContent.data(using: .utf8) else {
+            throw SSHTunnelError.tunnelCreationFailed("Failed to encode askpass script")
+        }
 
-        // Make it executable
-        let chmod = Process()
-        chmod.executableURL = URL(fileURLWithPath: "/bin/chmod")
-        chmod.arguments = ["+x", scriptPath]
-        try chmod.run()
-        await waitForProcessExit(chmod)
+        let created = FileManager.default.createFile(
+            atPath: scriptPath,
+            contents: data,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        guard created else {
+            throw SSHTunnelError.tunnelCreationFailed("Failed to create askpass script")
+        }
 
         return scriptPath
     }
@@ -440,15 +437,12 @@ actor SSHTunnelManager {
         return .tunnelCreationFailed(errorMessage)
     }
 
-    private func cleanupAskpassScript() {
-        // Clean up any temporary askpass scripts
-        let tempDir = NSTemporaryDirectory()
-        if let enumerator = FileManager.default.enumerator(atPath: tempDir) {
-            while let file = enumerator.nextObject() as? String {
-                if file.hasPrefix("ssh_askpass_") {
-                    try? FileManager.default.removeItem(atPath: tempDir + file)
-                }
-            }
+    private func removeAskpassScript(_ path: String?) {
+        guard let path else { return }
+        do {
+            try FileManager.default.removeItem(atPath: path)
+        } catch {
+            Self.logger.warning("Failed to remove askpass script at \(path): \(error.localizedDescription)")
         }
     }
 }

--- a/TablePro/Core/Services/SQLFormatterService.swift
+++ b/TablePro/Core/Services/SQLFormatterService.swift
@@ -22,6 +22,13 @@ protocol SQLFormatterProtocol {
 // MARK: - Main Formatter Service
 
 struct SQLFormatterService: SQLFormatterProtocol {
+    private static func regex(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern, options: options)
+        } catch {
+            preconditionFailure("Invalid regex pattern: \(pattern)")
+        }
+    }
     // MARK: - Constants
 
     /// Maximum input size: 10MB (protection against DoS)
@@ -38,22 +45,19 @@ struct SQLFormatterService: SQLFormatterProtocol {
         for quoteChar in ["'", "\"", "`"] {
             let escaped = NSRegularExpression.escapedPattern(for: quoteChar)
             let pattern = "\(escaped)((?:\\\\\\\\\(quoteChar)|[^\(quoteChar)])*?)\(escaped)"
-            // swiftlint:disable:next force_try
-            result[quoteChar] = try! NSRegularExpression(pattern: pattern)
+            result[quoteChar] = regex(pattern)
         }
         return result
     }()
 
     /// Line comment pattern: --[^\n]*
     private static let lineCommentRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "--[^\\n]*")
+        regex("--[^\\n]*")
     }()
 
     /// Block comment pattern: /* ... */
     private static let blockCommentRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "/\\*.*?\\*/", options: .dotMatchesLineSeparators)
+        regex("/\\*.*?\\*/", options: .dotMatchesLineSeparators)
     }()
 
     /// Line break keyword patterns — pre-compiled for all 16 keywords (CPU-9)
@@ -67,34 +71,29 @@ struct SQLFormatterService: SQLFormatterProtocol {
         return keywords.sorted(by: { $0.count > $1.count }).map { keyword in
             let escapedKeyword = NSRegularExpression.escapedPattern(for: keyword)
             let pattern = "\\s+\(escapedKeyword)\\b"
-            // swiftlint:disable:next force_try
-            let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let regex = regex(pattern, options: .caseInsensitive)
             return (keyword, regex)
         }
     }()
 
     /// Subquery pattern: \(\s*SELECT\b  (CPU-10)
     private static let subqueryRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "\\(\\s*SELECT\\b", options: .caseInsensitive)
+        regex("\\(\\s*SELECT\\b", options: .caseInsensitive)
     }()
 
     /// Word boundary pattern for "END" keyword (CPU-10)
     private static let endWordBoundaryRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "\\bEND\\b", options: .caseInsensitive)
+        regex("\\bEND\\b", options: .caseInsensitive)
     }()
 
     /// Word boundary pattern for "CASE" keyword (CPU-10)
     private static let caseWordBoundaryRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "\\bCASE\\b", options: .caseInsensitive)
+        regex("\\bCASE\\b", options: .caseInsensitive)
     }()
 
     /// WHERE condition alignment pattern: \s+(AND|OR)\s+
     private static let whereConditionRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "\\s+(AND|OR)\\s+", options: .caseInsensitive)
+        regex("\\s+(AND|OR)\\s+", options: .caseInsensitive)
     }()
 
     /// Keyword uppercasing regex cache per DatabaseType (CPU-5)

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -51,15 +51,27 @@ final class QueryHistoryStorage {
     // Throttle cleanup: only run every 100 inserts
     private var insertsSinceCleanup: Int = 0
 
+    private static var isRunningTests: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+
     private init() {
         queue.async { [weak self] in
             self?.setupDatabase()
         }
     }
 
+    private var dbPath: String?
+
     deinit {
         if let db = db {
             sqlite3_close(db)
+        }
+        if Self.isRunningTests, let dbPath = dbPath {
+            try? FileManager.default.removeItem(atPath: dbPath)
+            for suffix in ["-wal", "-shm"] {
+                try? FileManager.default.removeItem(atPath: dbPath + suffix)
+            }
         }
     }
 
@@ -106,7 +118,12 @@ final class QueryHistoryStorage {
         // Create directory if needed
         try? fileManager.createDirectory(at: TableProDir, withIntermediateDirectories: true)
 
-        let dbPath = TableProDir.appendingPathComponent("query_history.db").path(percentEncoded: false)
+        let dbFileName = Self.isRunningTests
+            ? "query_history_test_\(ProcessInfo.processInfo.processIdentifier).db"
+            : "query_history.db"
+        let dbPath = TableProDir.appendingPathComponent(dbFileName).path(percentEncoded: false)
+
+        self.dbPath = dbPath
 
         // Open database
         if sqlite3_open(dbPath, &db) != SQLITE_OK {

--- a/TablePro/Core/Vim/VimKeyInterceptor.swift
+++ b/TablePro/Core/Vim/VimKeyInterceptor.swift
@@ -39,28 +39,26 @@ final class VimKeyInterceptor {
 
         // Observe autocomplete popup close. When SuggestionController's popup
         // consumes Escape (closes itself), we also need to exit Insert/Visual mode.
-        // queue: nil → handler runs synchronously during close(), so NSApp.currentEvent
-        // is still the Escape keyDown event.
+        // queue: .main → handler runs synchronously when posted from main thread,
+        // so NSApp.currentEvent is still the Escape keyDown event.
         popupCloseObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] notification in
-            MainActor.assumeIsolated {
-                guard let self,
-                      let closingWindow = notification.object as? NSWindow,
-                      closingWindow.windowController is SuggestionController,
-                      let editorWindow = self.controller?.textView.window,
-                      editorWindow.childWindows?.contains(closingWindow) == true,
-                      let currentEvent = NSApp.currentEvent,
-                      currentEvent.type == .keyDown,
-                      currentEvent.keyCode == 53,
-                      self.engine.mode != .normal else {
-                    return
-                }
-                self.inlineSuggestionManager?.dismissSuggestion()
-                _ = self.engine.process("\u{1B}", shift: false)
+            guard let self,
+                  let closingWindow = notification.object as? NSWindow,
+                  closingWindow.windowController is SuggestionController,
+                  let editorWindow = self.controller?.textView.window,
+                  editorWindow.childWindows?.contains(closingWindow) == true,
+                  let currentEvent = NSApp.currentEvent,
+                  currentEvent.type == .keyDown,
+                  currentEvent.keyCode == 53,
+                  self.engine.mode != .normal else {
+                return
             }
+            self.inlineSuggestionManager?.dismissSuggestion()
+            _ = self.engine.process("\u{1B}", shift: false)
         }
     }
 

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -262,6 +262,16 @@
         }
       }
     },
+    "%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
     "%@." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1755,6 +1765,7 @@
       }
     },
     "Click + to create your first connection" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -1907,6 +1918,9 @@
           }
         }
       }
+    },
+    "Color %@" : {
+
     },
     "Column" : {
       "localizations" : {
@@ -2472,6 +2486,9 @@
           }
         }
       }
+    },
+    "Create a connection to get started" : {
+
     },
     "Create a connection to get started with\nyour databases." : {
       "localizations" : {
@@ -5852,7 +5869,11 @@
         }
       }
     },
+    "No Connections" : {
+
+    },
     "No connections yet" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -5934,6 +5955,7 @@
       }
     },
     "No matching connections" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -5942,6 +5964,9 @@
           }
         }
       }
+    },
+    "No Matching Connections" : {
+
     },
     "No matching databases" : {
       "localizations" : {
@@ -9328,6 +9353,9 @@
           }
         }
       }
+    },
+    "Try a different search term" : {
+
     },
     "Try adjusting your search terms\nor date filter." : {
       "localizations" : {

--- a/TablePro/Views/Components/SectionHeaderView.swift
+++ b/TablePro/Views/Components/SectionHeaderView.swift
@@ -33,8 +33,19 @@ struct SectionHeaderView<Actions: View>: View {
     }
 
     var body: some View {
+        if isCollapsible {
+            Button(action: { isExpanded.toggle() }) {
+                headerContent
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "\(title), \(isExpanded ? "collapse" : "expand")"))
+        } else {
+            headerContent
+        }
+    }
+
+    private var headerContent: some View {
         HStack(spacing: DesignConstants.Spacing.xs) {
-            // Collapse/expand chevron (if collapsible)
             if isCollapsible {
                 Image(systemName: "chevron.right")
                     .font(.system(size: DesignConstants.FontSize.caption, weight: .semibold))
@@ -43,19 +54,16 @@ struct SectionHeaderView<Actions: View>: View {
                     .animation(.easeInOut(duration: DesignConstants.AnimationDuration.normal), value: isExpanded)
             }
 
-            // Icon (optional)
             if let icon = icon {
                 Image(systemName: icon)
                     .font(.system(size: DesignConstants.FontSize.body))
                     .foregroundStyle(DesignConstants.Colors.secondaryText)
             }
 
-            // Title
             Text(title)
                 .font(.system(size: DesignConstants.FontSize.title3, weight: .semibold))
                 .foregroundStyle(DesignConstants.Colors.primaryText)
 
-            // Count badge (optional)
             if let count = count {
                 Text("(\(count))")
                     .font(.system(size: DesignConstants.FontSize.small))
@@ -64,7 +72,6 @@ struct SectionHeaderView<Actions: View>: View {
 
             Spacer()
 
-            // Action buttons
             actions()
         }
         .padding(.horizontal, DesignConstants.Spacing.sm)
@@ -76,11 +83,6 @@ struct SectionHeaderView<Actions: View>: View {
         )
         .cornerRadius(DesignConstants.CornerRadius.medium)
         .contentShape(Rectangle())
-        .onTapGesture {
-            if isCollapsible {
-                isExpanded.toggle()
-            }
-        }
     }
 }
 

--- a/TablePro/Views/Connection/ConnectionColorPicker.swift
+++ b/TablePro/Views/Connection/ConnectionColorPicker.swift
@@ -14,13 +14,14 @@ struct ConnectionColorPicker: View {
     var body: some View {
         HStack(spacing: 8) {
             ForEach(ConnectionColor.allCases) { color in
-                ColorDot(
-                    color: color,
-                    isSelected: selectedColor == color
-                )
-                .onTapGesture {
-                    selectedColor = color
+                Button(action: { selectedColor = color }) {
+                    ColorDot(
+                        color: color,
+                        isSelected: selectedColor == color
+                    )
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Color \(color.rawValue)"))
             }
         }
     }

--- a/TablePro/Views/Connection/ConnectionGroupPicker.swift
+++ b/TablePro/Views/Connection/ConnectionGroupPicker.swift
@@ -159,20 +159,21 @@ private struct GroupColorPicker: View {
     var body: some View {
         HStack(spacing: 6) {
             ForEach(ConnectionColor.allCases) { color in
-                Circle()
-                    .fill(color == .none ? Color(nsColor: .quaternaryLabelColor) : color.color)
-                    .frame(width: DesignConstants.IconSize.medium, height: DesignConstants.IconSize.medium)
-                    .overlay(
-                        Circle()
-                            .stroke(Color.primary, lineWidth: selectedColor == color ? 2 : 0)
-                            .frame(
-                                width: DesignConstants.IconSize.large,
-                                height: DesignConstants.IconSize.large
-                            )
-                    )
-                    .onTapGesture {
-                        selectedColor = color
-                    }
+                Button(action: { selectedColor = color }) {
+                    Circle()
+                        .fill(color == .none ? Color(nsColor: .quaternaryLabelColor) : color.color)
+                        .frame(width: DesignConstants.IconSize.medium, height: DesignConstants.IconSize.medium)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.primary, lineWidth: selectedColor == color ? 2 : 0)
+                                .frame(
+                                    width: DesignConstants.IconSize.large,
+                                    height: DesignConstants.IconSize.large
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Color \(color.rawValue)"))
             }
         }
     }

--- a/TablePro/Views/Connection/ConnectionTagEditor.swift
+++ b/TablePro/Views/Connection/ConnectionTagEditor.swift
@@ -183,20 +183,21 @@ private struct TagColorPicker: View {
     var body: some View {
         HStack(spacing: 6) {
             ForEach(availableColors) { color in
-                Circle()
-                    .fill(color.color)
-                    .frame(width: DesignConstants.IconSize.medium, height: DesignConstants.IconSize.medium)
-                    .overlay(
-                        Circle()
-                            .stroke(Color.primary, lineWidth: selectedColor == color ? 2 : 0)
-                            .frame(
-                                width: DesignConstants.IconSize.large,
-                                height: DesignConstants.IconSize.large
-                            )
-                    )
-                    .onTapGesture {
-                        selectedColor = color
-                    }
+                Button(action: { selectedColor = color }) {
+                    Circle()
+                        .fill(color.color)
+                        .frame(width: DesignConstants.IconSize.medium, height: DesignConstants.IconSize.medium)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.primary, lineWidth: selectedColor == color ? 2 : 0)
+                                .frame(
+                                    width: DesignConstants.IconSize.large,
+                                    height: DesignConstants.IconSize.large
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Color \(color.rawValue)"))
             }
         }
     }

--- a/TablePro/Views/Editor/HistoryPanelView.swift
+++ b/TablePro/Views/Editor/HistoryPanelView.swift
@@ -117,8 +117,9 @@ private extension HistoryPanelView {
         .alert(String(localized: "Clear All History?"), isPresented: $showClearAllAlert) {
             Button(String(localized: "Cancel"), role: .cancel) {}
             Button(String(localized: "Clear All"), role: .destructive) {
-                Task {
+                Task { @MainActor in
                     _ = await dataProvider.clearAll()
+                    entries = dataProvider.historyEntries
                 }
             }
         } message: {
@@ -319,8 +320,9 @@ private extension HistoryPanelView {
     }
 
     func deleteEntry(_ entry: QueryHistoryEntry) {
-        Task {
+        Task { @MainActor in
             _ = await dataProvider.deleteEntry(id: entry.id)
+            entries = dataProvider.historyEntries
         }
     }
 
@@ -329,7 +331,7 @@ private extension HistoryPanelView {
         let currentIndex = entries.firstIndex(of: entry)
         deleteEntry(entry)
 
-        // After deletion notification triggers reload, select adjacent entry
+        // After deletion triggers reload, select adjacent entry
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             if let idx = currentIndex, !entries.isEmpty {
                 let newIndex = min(idx, entries.count - 1)

--- a/TablePro/Views/History/HistoryDataProvider.swift
+++ b/TablePro/Views/History/HistoryDataProvider.swift
@@ -104,14 +104,22 @@ final class HistoryDataProvider {
         guard let entry = historyEntry(at: index) else {
             return false
         }
-        return await QueryHistoryManager.shared.deleteHistory(id: entry.id)
+        return await deleteEntry(id: entry.id)
     }
 
     func deleteEntry(id: UUID) async -> Bool {
-        await QueryHistoryManager.shared.deleteHistory(id: id)
+        let success = await QueryHistoryStorage.shared.deleteHistory(id: id)
+        if success {
+            await loadData()
+        }
+        return success
     }
 
     func clearAll() async -> Bool {
-        await QueryHistoryManager.shared.clearAllHistory()
+        let success = await QueryHistoryStorage.shared.clearAllHistory()
+        if success {
+            await loadData()
+        }
+        return success
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -109,7 +109,11 @@ final class MainContentCoordinator {
 
     /// Set when NSApplication is terminating — suppresses deinit warning since
     /// SwiftUI does not call onDisappear during app termination
-    nonisolated(unsafe) private static var isAppTerminating = false
+    private nonisolated(unsafe) static let _isAppTerminating = OSAllocatedUnfairLock(initialState: false)
+    nonisolated static var isAppTerminating: Bool {
+        get { _isAppTerminating.withLock { $0 } }
+        set { _isAppTerminating.withLock { $0 = newValue } }
+    }
 
     private static let registerTerminationObserver: Void = {
         NotificationCenter.default.addObserver(

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -56,15 +56,15 @@ struct ConnectionSwitcherPopover: View {
                 if !sortedSessions.isEmpty {
                     Section {
                         ForEach(Array(sortedSessions.enumerated()), id: \.element.id) { index, session in
-                            connectionRow(
-                                connection: session.connection,
-                                isActive: session.id == currentSessionId,
-                                isConnected: session.status.isConnected,
-                                isHighlighted: index == selectedIndex
-                            )
-                            .onTapGesture {
-                                switchToSession(session.id)
+                            Button(action: { switchToSession(session.id) }) {
+                                connectionRow(
+                                    connection: session.connection,
+                                    isActive: session.id == currentSessionId,
+                                    isConnected: session.status.isConnected,
+                                    isHighlighted: index == selectedIndex
+                                )
                             }
+                            .buttonStyle(.plain)
                             .listRowBackground(
                                 RoundedRectangle(cornerRadius: 4)
                                     .fill(
@@ -89,16 +89,16 @@ struct ConnectionSwitcherPopover: View {
                     Section {
                         ForEach(Array(inactiveSaved.enumerated()), id: \.element.id) { index, connection in
                             let itemIndex = sortedSessions.count + index
-                            connectionRow(
-                                connection: connection,
-                                isActive: false,
-                                isConnected: false,
-                                isConnecting: isConnecting == connection.id,
-                                isHighlighted: itemIndex == selectedIndex
-                            )
-                            .onTapGesture {
-                                connectToSaved(connection)
+                            Button(action: { connectToSaved(connection) }) {
+                                connectionRow(
+                                    connection: connection,
+                                    isActive: false,
+                                    isConnected: false,
+                                    isConnecting: isConnecting == connection.id,
+                                    isHighlighted: itemIndex == selectedIndex
+                                )
                             }
+                            .buttonStyle(.plain)
                             .listRowBackground(
                                 RoundedRectangle(cornerRadius: 4)
                                     .fill(

--- a/TablePro/Views/WelcomeWindowView.swift
+++ b/TablePro/Views/WelcomeWindowView.swift
@@ -55,7 +55,11 @@ struct WelcomeWindowView: View {
     }
 
     private var ungroupedConnections: [DatabaseConnection] {
-        filteredConnections.filter { $0.groupId == nil }
+        let validGroupIds = Set(groups.map(\.id))
+        return filteredConnections.filter { conn in
+            guard let groupId = conn.groupId else { return true }
+            return !validGroupIds.contains(groupId)
+        }
     }
 
     private var activeGroups: [ConnectionGroup] {
@@ -328,30 +332,7 @@ struct WelcomeWindowView: View {
     }
 
     private func groupHeader(for group: ConnectionGroup) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: collapsedGroupIds.contains(group.id) ? "chevron.right" : "chevron.down")
-                .font(.system(size: DesignConstants.FontSize.small, weight: .medium))
-                .foregroundStyle(.tertiary)
-                .frame(width: 12)
-
-            if !group.color.isDefault {
-                Circle()
-                    .fill(group.color.color)
-                    .frame(width: 8, height: 8)
-            }
-
-            Text(group.name)
-                .font(.system(size: DesignConstants.FontSize.small, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            Text("\(connections(in: group).count)")
-                .font(.system(size: DesignConstants.FontSize.tiny))
-                .foregroundStyle(.tertiary)
-
-            Spacer()
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
+        Button(action: {
             withAnimation(.easeInOut(duration: 0.2)) {
                 if collapsedGroupIds.contains(group.id) {
                     collapsedGroupIds.remove(group.id)
@@ -363,7 +344,33 @@ struct WelcomeWindowView: View {
                     forKey: "com.TablePro.collapsedGroupIds"
                 )
             }
+        }) {
+            HStack(spacing: 6) {
+                Image(systemName: collapsedGroupIds.contains(group.id) ? "chevron.right" : "chevron.down")
+                    .font(.system(size: DesignConstants.FontSize.small, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 12)
+
+                if !group.color.isDefault {
+                    Circle()
+                        .fill(group.color.color)
+                        .frame(width: 8, height: 8)
+                }
+
+                Text(group.name)
+                    .font(.system(size: DesignConstants.FontSize.small, weight: .semibold))
+                    .foregroundStyle(.secondary)
+
+                Text("\(connections(in: group).count)")
+                    .font(.system(size: DesignConstants.FontSize.tiny))
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+            }
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(localized: "\(group.name), \(collapsedGroupIds.contains(group.id) ? "expand" : "collapse")"))
         .contextMenu {
             Button {
                 renameGroup(group)
@@ -412,20 +419,30 @@ struct WelcomeWindowView: View {
 
             Image(systemName: "cylinder.split.1x2")
                 .font(.system(size: DesignConstants.IconSize.huge))
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(.tertiary)
 
             if searchText.isEmpty {
-                Text("No connections yet")
+                Text("No Connections")
                     .font(.system(size: DesignConstants.FontSize.title3, weight: .medium))
                     .foregroundStyle(.secondary)
 
-                Text("Click + to create your first connection")
+                Text("Create a connection to get started")
                     .font(.system(size: DesignConstants.FontSize.medium))
                     .foregroundStyle(.tertiary)
+
+                Button(action: { openWindow(id: "connection-form") }) {
+                    Label("New Connection", systemImage: "plus")
+                }
+                .controlSize(.large)
+                .padding(.top, DesignConstants.Spacing.xxs)
             } else {
-                Text("No matching connections")
+                Text("No Matching Connections")
                     .font(.system(size: DesignConstants.FontSize.title3, weight: .medium))
                     .foregroundStyle(.secondary)
+
+                Text("Try a different search term")
+                    .font(.system(size: DesignConstants.FontSize.medium))
+                    .foregroundStyle(.tertiary)
             }
 
             Spacer()

--- a/TableProTests/Models/DatabaseTypeTests.swift
+++ b/TableProTests/Models/DatabaseTypeTests.swift
@@ -71,9 +71,9 @@ struct DatabaseTypeTests {
         #expect(result == "\"user\"\"s\"")
     }
 
-    @Test("CaseIterable count is 7")
+    @Test("CaseIterable count is 8")
     func testCaseIterableCount() {
-        #expect(DatabaseType.allCases.count == 7)
+        #expect(DatabaseType.allCases.count == 8)
     }
 
     @Test("Raw value matches display name", arguments: [
@@ -82,7 +82,9 @@ struct DatabaseTypeTests {
         (DatabaseType.postgresql, "PostgreSQL"),
         (DatabaseType.sqlite, "SQLite"),
         (DatabaseType.mongodb, "MongoDB"),
-        (DatabaseType.redis, "Redis")
+        (DatabaseType.redis, "Redis"),
+        (DatabaseType.redshift, "Redshift"),
+        (DatabaseType.mssql, "SQL Server")
     ])
     func testRawValueMatchesDisplayName(dbType: DatabaseType, expectedRawValue: String) {
         #expect(dbType.rawValue == expectedRawValue)

--- a/TableProTests/Models/ExportModelsTests.swift
+++ b/TableProTests/Models/ExportModelsTests.swift
@@ -32,9 +32,9 @@ struct ExportModelsTests {
         #expect(ExportFormat.xlsx.fileExtension == "xlsx")
     }
 
-    @Test("Export format has four cases")
+    @Test("Export format has five cases")
     func exportFormatCaseCount() {
-        #expect(ExportFormat.allCases.count == 4)
+        #expect(ExportFormat.allCases.count == 5)
     }
 
     @Test("CSV delimiter comma actual value")


### PR DESCRIPTION
## Summary

Addresses Wave 1 safety issues from the codebase audit, improves accessibility, and fixes pre-existing test failures.

### Safety & Data Races
- **`MainContentCoordinator`**: Replace `nonisolated(unsafe)` static var with `OSAllocatedUnfairLock` for thread-safe `isAppTerminating`
- **`VimKeyInterceptor`**: Use `.main` queue for notification observer instead of `MainActor.assumeIsolated`
- **`LibPQConnection`**: Protect `conn` pointer reads/writes with `stateLock` during disconnect and cancel
- **`DatabaseManager`**: Snapshot dictionary keys before iterating in `disconnectAll()`
- **`SSHTunnelManager`**: Atomic file creation with `0o700` permissions + immediate askpass cleanup
- **`SQLFormatterService`**: Replace 9 `try!` regex calls with `preconditionFailure` helper

### Accessibility
- Replace `.onTapGesture` with `Button` + `.accessibilityLabel` in 6 views: `ConnectionColorPicker`, `ConnectionGroupPicker`, `ConnectionTagEditor`, `SectionHeaderView`, `WelcomeWindowView`, `ConnectionSwitcherPopover`

### Bug Fixes
- **`FilterSQLGenerator`**: Fix MySQL LIKE wildcard escaping (requires double-backslash); fix SQLite regex filter incorrectly returning nil
- **`WelcomeWindowView`**: Fix blank right panel when connections have orphaned group IDs (deleted groups) — now shows them in ungrouped section
- **`HistoryDataProvider`**: Fix history panel deletion/clear using correct storage path

### Test Fixes
- Fix `DatabaseTypeTests` and `ExportModelsTests` for new `allCases` counts (Redshift, MSSQL, YAML)
- Fix `QueryHistoryStorage` test isolation with PID-specific database files

## Test plan

- [x] Project builds with zero errors
- [ ] Run full test suite — all 2421 tests should pass
- [ ] Verify welcome screen shows "No Connections" empty state when connection list is empty
- [ ] Verify connections with deleted groups appear in ungrouped section
- [ ] Verify VoiceOver can navigate color pickers, group headers, and section headers