### PR TITLE
Fix port resetting to default when editing a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix MySQL/MariaDB getting `BEGIN` instead of `START TRANSACTION` in table operations and SQL preview
+- Fix port resetting to default value when editing a connection with a custom port
 - Replace `.onTapGesture` with `Button` in color pickers, section headers, group headers, and connection switcher for VoiceOver accessibility
 - Fix data race on `isAppTerminating` static var in `MainContentCoordinator` using `OSAllocatedUnfairLock`
 - Fix `MainActor.assumeIsolated` crash risk in `VimKeyInterceptor` notification observer

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -33,6 +33,7 @@ struct ConnectionFormView: View {
     @State private var connectionURL: String = ""
     @State private var urlParseError: String?
     @State private var showURLImport = false
+    @State private var hasLoadedData = false
 
     // SSH Configuration
     @State private var sshEnabled: Bool = false
@@ -122,7 +123,9 @@ struct ConnectionFormView: View {
             loadSSHConfig()
         }
         .onChange(of: type) {
-            port = String(type.defaultPort)
+            if hasLoadedData {
+                port = String(type.defaultPort)
+            }
             if type == .sqlite && (selectedTab == .ssh || selectedTab == .ssl) {
                 selectedTab = .general
             }
@@ -633,6 +636,9 @@ struct ConnectionFormView: View {
             if let savedPassword = storage.loadPassword(for: existing.id) {
                 password = savedPassword
             }
+        }
+        Task { @MainActor in
+            hasLoadedData = true
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix port field resetting to its default value (e.g., 5432 for PostgreSQL) when editing an existing connection with a custom port
- The `.onChange(of: type)` handler unconditionally reset the port whenever the database type changed, including during initial data loading when type changed from its default `.mysql` to the stored type
- Added a `hasLoadedData` flag that gates the port reset, deferred via `Task { @MainActor in }` to ensure it's set after SwiftUI's render cycle processes the `.onChange` handler

Closes #197

## Test plan

- [ ] Edit a PostgreSQL connection with custom port (e.g., 5433) → port should be retained
- [ ] Edit a MySQL connection with custom port → port should be retained
- [ ] Create a new connection, change type dropdown → port should update to new default
- [ ] Edit a connection, then change type dropdown → port should update to new default