### PR TITLE
fix: inspector border overlap and laggy toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Inspector separator no longer bleeds into toolbar area with default connection color (#228)
+- Inspector toggle no longer lags due to synchronous UserDefaults writes during animation (#229)
+
 ### Added
 
 - Direct `.tableplugin` bundle installation via file picker, Finder double-click, and drag-and-drop

--- a/TablePro/Models/UI/RightPanelState.swift
+++ b/TablePro/Models/UI/RightPanelState.swift
@@ -13,15 +13,16 @@ import os
 @MainActor @Observable final class RightPanelState {
     private static let isPresentedKey = "com.TablePro.rightPanel.isPresented"
     private static let isPresentedChangedNotification = Notification.Name("com.TablePro.rightPanel.isPresentedChanged")
-
     private var isSyncing = false
     @ObservationIgnored private let _didTeardown = OSAllocatedUnfairLock(initialState: false)
 
     var isPresented: Bool {
         didSet {
             guard !isSyncing else { return }
-            UserDefaults.standard.set(isPresented, forKey: Self.isPresentedKey)
-            NotificationCenter.default.post(name: Self.isPresentedChangedNotification, object: self)
+            DispatchQueue.main.async { [self] in
+                UserDefaults.standard.set(self.isPresented, forKey: Self.isPresentedKey)
+                NotificationCenter.default.post(name: Self.isPresentedChangedNotification, object: self)
+            }
         }
     }
 

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -861,7 +861,6 @@ private struct ToolbarTintModifier: ViewModifier {
     func body(content: Content) -> some View {
         if connectionColor.isDefault {
             content
-                .toolbarBackground(.hidden, for: .windowToolbar)
         } else {
             content
                 .toolbarBackground(connectionColor.color.opacity(0.12), for: .windowToolbar)


### PR DESCRIPTION
## Summary

- **#228**: Remove `.toolbarBackground(.hidden)` for default connection colors so the system toolbar background covers the NSSplitViewController divider, preventing it from bleeding into the toolbar area.
- **#229**: Defer `isPresented.didSet` side effects (UserDefaults write + NotificationCenter post) off the animation frame via `DispatchQueue.main.async`, eliminating the lag on toggle.

## Test plan

- [ ] Connect to a database with default (no) connection color — verify inspector divider does not extend into the toolbar
- [ ] Connect with a colored connection — verify toolbar tint still works
- [ ] Toggle inspector (Cmd+I) — verify smooth native animation matching the left sidebar
- [ ] Select a row with auto-show inspector enabled — verify inspector opens smoothly
- [ ] Open 2+ native tabs — verify inspector state syncs across tabs