### PR TITLE
fix: close main window before reopening welcome on connection failure

### DIFF
--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -473,19 +473,24 @@ struct WelcomeWindowView: View {
             do {
                 try await dbManager.connectToSession(connection)
             } catch {
-                // Show error to user and re-open welcome window
-                await MainActor.run {
-                    AlertHelper.showErrorSheet(
-                        title: String(localized: "Connection Failed"),
-                        message: error.localizedDescription,
-                        window: nil
-                    )
-                    openWindow(id: "welcome")
-                }
                 Self.logger.error(
                     "Failed to connect: \(error.localizedDescription, privacy: .public)")
+                handleConnectionFailure(error: error)
             }
         }
+    }
+
+    private func handleConnectionFailure(error: Error) {
+        // Close the main window first so macOS doesn't merge it with the welcome window
+        NSApplication.shared.closeWindows(withId: "main")
+        openWindow(id: "welcome")
+
+        // Show error as modal — welcome window is now the only window
+        AlertHelper.showErrorSheet(
+            title: String(localized: "Connection Failed"),
+            message: error.localizedDescription,
+            window: nil
+        )
     }
 
     private func deleteConnection(_ connection: DatabaseConnection) {


### PR DESCRIPTION
## Summary
- When a connection fails (e.g., disabled plugin), the main window was left open behind the welcome screen, causing macOS automatic window tabbing to merge them — resulting in a visual flicker and the main window tab appearing inside the welcome window.
- Now closes the main window **before** reopening the welcome window, preventing the tab merge. Extracted `handleConnectionFailure` for clarity.

## Test plan
- [ ] Disable a plugin (e.g., MySQL) in Settings > Plugins
- [ ] Double-click a MySQL connection in the welcome screen
- [ ] Verify: error alert appears, main window is gone, welcome screen is clean with no extra tabs