### PR TITLE
fix: hide disabled plugin database types from connection form picker

### DIFF
--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -23,6 +23,22 @@ struct ConnectionFormView: View {
     // Computed property for isNew
     private var isNew: Bool { connectionId == nil }
 
+    private var availableDatabaseTypes: [DatabaseType] {
+        let pluginManager = PluginManager.shared
+        pluginManager.loadPendingPlugins()
+        let enabled = DatabaseType.allCases.filter { dbType in
+            pluginManager.plugins.contains { entry in
+                entry.isEnabled && (entry.databaseTypeId == dbType.pluginTypeId
+                    || entry.additionalTypeIds.contains(dbType.pluginTypeId))
+            }
+        }
+        // When editing, always include the current type so the picker binding stays valid
+        if !isNew, !enabled.contains(type) {
+            return [type] + enabled
+        }
+        return enabled
+    }
+
     @State private var name: String = ""
     @State private var host: String = ""
     @State private var port: String = ""
@@ -178,7 +194,7 @@ struct ConnectionFormView: View {
         Form {
             Section {
                 Picker(String(localized: "Type"), selection: $type) {
-                    ForEach(DatabaseType.allCases) { t in
+                    ForEach(availableDatabaseTypes) { t in
                         Text(t.rawValue).tag(t)
                     }
                 }


### PR DESCRIPTION
## Summary
- Filter the database Type picker in the connection form to only show types whose plugin is enabled
- When editing an existing connection whose plugin is disabled, the current type is still shown so the picker binding stays valid
- Calls `loadPendingPlugins()` to handle lazy plugin loading

Follow-up to #236.

## Test plan
- [ ] Disable a plugin (e.g., MySQL) in Settings > Plugins
- [ ] Open the connection form (New Connection)
- [ ] Verify MySQL/MariaDB are not in the Type picker
- [ ] Re-enable the plugin, verify they reappear
- [ ] Edit an existing MySQL connection while the plugin is disabled — verify the type still shows in the picker