### PR TITLE
fix: replace .inspector() with custom panel to fix jittery animation

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -278,6 +278,7 @@ struct ContentView: View {
                     .frame(maxWidth: .infinity)
 
                     if rightPanelState.isPresented {
+                        PanelResizeHandle(panelWidth: Bindable(rightPanelState).panelWidth)
                         Divider()
                         UnifiedRightPanelView(
                             state: rightPanelState,
@@ -285,7 +286,7 @@ struct ContentView: View {
                             connection: currentSession.connection,
                             tables: currentSession.tables
                         )
-                        .frame(width: 320)
+                        .frame(width: rightPanelState.panelWidth)
                         .transition(.move(edge: .trailing))
                     }
                 }

--- a/TablePro/Models/UI/RightPanelState.swift
+++ b/TablePro/Models/UI/RightPanelState.swift
@@ -12,8 +12,13 @@ import os
 
 @MainActor @Observable final class RightPanelState {
     private static let isPresentedKey = "com.TablePro.rightPanel.isPresented"
+    private static let panelWidthKey = "com.TablePro.rightPanel.width"
     private static let isPresentedChangedNotification = Notification.Name("com.TablePro.rightPanel.isPresentedChanged")
     private var isSyncing = false
+
+    static let minWidth: CGFloat = 280
+    static let maxWidth: CGFloat = 500
+    static let defaultWidth: CGFloat = 320
     @ObservationIgnored private let _didTeardown = OSAllocatedUnfairLock(initialState: false)
 
     var isPresented: Bool {
@@ -23,6 +28,14 @@ import os
                 UserDefaults.standard.set(self.isPresented, forKey: Self.isPresentedKey)
                 NotificationCenter.default.post(name: Self.isPresentedChangedNotification, object: self)
             }
+        }
+    }
+
+    var panelWidth: CGFloat {
+        didSet {
+            let clamped = min(max(panelWidth, Self.minWidth), Self.maxWidth)
+            if panelWidth != clamped { panelWidth = clamped }
+            UserDefaults.standard.set(Double(clamped), forKey: Self.panelWidthKey)
         }
     }
 
@@ -43,6 +56,8 @@ import os
 
     init() {
         self.isPresented = UserDefaults.standard.bool(forKey: Self.isPresentedKey)
+        let savedWidth = UserDefaults.standard.double(forKey: Self.panelWidthKey)
+        self.panelWidth = savedWidth > 0 ? min(max(savedWidth, Self.minWidth), Self.maxWidth) : Self.defaultWidth
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleIsPresentedChanged(_:)),

--- a/TablePro/Views/Components/PanelResizeHandle.swift
+++ b/TablePro/Views/Components/PanelResizeHandle.swift
@@ -1,0 +1,40 @@
+//
+//  PanelResizeHandle.swift
+//  TablePro
+//
+//  Draggable resize handle for the right panel.
+//
+
+import SwiftUI
+
+struct PanelResizeHandle: View {
+    @Binding var panelWidth: CGFloat
+
+    @State private var isDragging = false
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: 5)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        isDragging = true
+                        // Dragging left increases panel width (handle is on the leading edge)
+                        let newWidth = panelWidth - value.translation.width
+                        panelWidth = min(max(newWidth, RightPanelState.minWidth), RightPanelState.maxWidth)
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
+    }
+}

--- a/TablePro/Views/Toolbar/TableProToolbarView.swift
+++ b/TablePro/Views/Toolbar/TableProToolbarView.swift
@@ -21,7 +21,7 @@ struct ToolbarPrincipalContent: View {
     var body: some View {
         HStack(spacing: 10) {
             if let tagId = state.tagId,
-                let tag = TagStorage.shared.tag(for: tagId)
+               let tag = TagStorage.shared.tag(for: tagId)
             {
                 TagBadgeView(tag: tag)
             }
@@ -130,20 +130,14 @@ struct TableProToolbar: ViewModifier {
                         actions?.previewSQL()
                     } label: {
                         Label(
-                            state.databaseType == .mongodb
-                                ? "Preview MQL"
-                                : state.databaseType == .redis
-                                    ? "Preview Commands"
-                                    : "Preview SQL",
+                            state.databaseType == .mongodb ? "Preview MQL"
+                                : state.databaseType == .redis ? "Preview Commands"
+                                : "Preview SQL",
                             systemImage: "eye")
                     }
-                    .help(
-                        state.databaseType == .mongodb
-                            ? "Preview MQL (⌘⇧P)"
-                            : state.databaseType == .redis
-                                ? "Preview Commands (⌘⇧P)"
-                                : "Preview SQL (⌘⇧P)"
-                    )
+                    .help(state.databaseType == .mongodb ? "Preview MQL (⌘⇧P)"
+                        : state.databaseType == .redis ? "Preview Commands (⌘⇧P)"
+                        : "Preview SQL (⌘⇧P)")
                     .disabled(!state.hasPendingChanges || state.connectionState != .connected)
                 }
 
@@ -181,15 +175,12 @@ struct TableProToolbar: ViewModifier {
                             Label("Import", systemImage: "square.and.arrow.down")
                         }
                         .help("Import Data (⌘⇧I)")
-                        .disabled(
-                            state.connectionState != .connected
-                                || state.safeModeLevel.blocksAllWrites)
+                        .disabled(state.connectionState != .connected || state.safeModeLevel.blocksAllWrites)
                     }
                 }
             }
             .popover(isPresented: $state.showSQLReviewPopover) {
-                SQLReviewPopover(
-                    statements: state.previewStatements, databaseType: state.databaseType)
+                SQLReviewPopover(statements: state.previewStatements, databaseType: state.databaseType)
             }
             .onReceive(NotificationCenter.default.publisher(for: .openConnectionSwitcher)) { _ in
                 showConnectionSwitcher = true


### PR DESCRIPTION
## Summary
- Replaced SwiftUI's `.inspector()` modifier with a custom `HStack` + `.transition(.move(edge: .trailing))` panel for the right sidebar
- The `.inspector()` modifier uses an internal `NSSplitViewController` whose constraint-based animation becomes expensive at tight window widths, causing visible jitter/lag
- The custom approach uses SwiftUI's lightweight animation system, which only animates a single view insertion/removal without split view constraint solving

Closes #243

## Test plan
- [ ] Open a connection and toggle the right sidebar (⌘⌥B) at various window sizes
- [ ] Verify animation is smooth at both small and large window widths
- [ ] Verify the inspector content (Details tab, AI Chat tab) still renders correctly
- [ ] Verify the inspector panel width is consistent (~320pt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right panel is now resizable via a draggable handle
  * Panel width preferences are automatically saved and restored

* **Improvements**
  * Enhanced right panel layout and animation behavior for smoother user interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->