### PR TITLE
feat: add shared PluginKit types

### DIFF
--- a/Plugins/TableProPluginKit/PluginConcurrencySupport.swift
+++ b/Plugins/TableProPluginKit/PluginConcurrencySupport.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public func pluginDispatchAsync<T: Sendable>(
+    on queue: DispatchQueue,
+    execute work: @escaping @Sendable () throws -> T
+) async throws -> T {
+    try await withCheckedThrowingContinuation { continuation in
+        queue.async {
+            do {
+                let result = try work()
+                continuation.resume(returning: result)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
+public func pluginDispatchAsync(
+    on queue: DispatchQueue,
+    execute work: @escaping @Sendable () throws -> Void
+) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        queue.async {
+            do {
+                try work()
+                continuation.resume()
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Plugins/TableProPluginKit/PluginDriverError.swift
+++ b/Plugins/TableProPluginKit/PluginDriverError.swift
@@ -1,0 +1,19 @@
+//
+//  PluginDriverError.swift
+//  TableProPluginKit
+//
+
+import Foundation
+
+public protocol PluginDriverError: LocalizedError, Sendable {
+    var pluginErrorMessage: String { get }
+    var pluginErrorCode: Int? { get }
+    var pluginSqlState: String? { get }
+    var pluginErrorDetail: String? { get }
+}
+
+public extension PluginDriverError {
+    var pluginErrorCode: Int? { nil }
+    var pluginSqlState: String? { nil }
+    var pluginErrorDetail: String? { nil }
+}

--- a/Plugins/TableProPluginKit/PluginRowLimits.swift
+++ b/Plugins/TableProPluginKit/PluginRowLimits.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum PluginRowLimits {
+    public static let defaultMax = 100_000
+}


### PR DESCRIPTION
## Summary
- Add 3 untracked TableProPluginKit files that were created during Phase 1 plugin standardization but never committed
- `PluginDriverError.swift` — shared error protocol for plugin drivers
- `PluginConcurrencySupport.swift` — async bridging utility
- `PluginRowLimits.swift` — shared row limit constant

## Test plan
- [x] Xcode build passes with no errors
- [ ] Verify plugin loading works at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async/await support utilities for plugin developers to execute code on specified dispatch queues
  * Introduced a standardized error protocol for plugins with consistent error messaging and optional error codes
  * Defined default row limit configuration for plugin data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->