### PR TITLE
Extract SQLite driver to downloadable plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- SQLite driver extracted from built-in bundle to downloadable plugin, reducing app size
 - Unified error formatting across all database drivers via default `PluginDriverError.errorDescription`, removing 10 per-driver implementations
 - Standardized async bridging: 5 queue-based drivers (MySQL, PostgreSQL, MongoDB, Redis, MSSQL) now use shared `pluginDispatchAsync` helper
 - Added localization to remaining driver error messages (MySQL, PostgreSQL, ClickHouse, Oracle, Redis, MongoDB)

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		5A860000A00000000 /* TableProPluginKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5A860000100000000 /* TableProPluginKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5A861000A00000000 /* TableProPluginKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A860000100000000 /* TableProPluginKit.framework */; };
 		5A862000A00000000 /* TableProPluginKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A860000100000000 /* TableProPluginKit.framework */; };
-		5A862000D00000000 /* SQLiteDriver.tableplugin in Copy Plug-Ins */ = {isa = PBXBuildFile; fileRef = 5A862000100000000 /* SQLiteDriver.tableplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5A863000A00000000 /* TableProPluginKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A860000100000000 /* TableProPluginKit.framework */; };
 		5A864000A00000000 /* TableProPluginKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A860000100000000 /* TableProPluginKit.framework */; };
 		5A864000D00000000 /* MSSQLDriver.tableplugin in Copy Plug-Ins */ = {isa = PBXBuildFile; fileRef = 5A864000100000000 /* MSSQLDriver.tableplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -164,7 +163,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				5A862000D00000000 /* SQLiteDriver.tableplugin in Copy Plug-Ins */,
 				5A864000D00000000 /* MSSQLDriver.tableplugin in Copy Plug-Ins */,
 				5A865000D00000000 /* MySQLDriver.tableplugin in Copy Plug-Ins */,
 				5A866000D00000000 /* MongoDBDriver.tableplugin in Copy Plug-Ins */,

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -228,7 +228,7 @@ enum DatabaseType: String, CaseIterable, Identifiable, Codable {
 
     var isDownloadablePlugin: Bool {
         switch self {
-        case .oracle, .clickhouse: return true
+        case .oracle, .clickhouse, .sqlite: return true
         default: return false
         }
     }


### PR DESCRIPTION
## Summary

- Flag SQLite as a downloadable plugin in `DatabaseType.isDownloadablePlugin`, activating the existing download-on-demand infrastructure (download icon, auto-download on type selection, install prompt on connect)
- Remove `SQLiteDriver.tableplugin` from the "Copy Plug-Ins" build phase so it's no longer bundled in the app
- Build target dependency preserved so SQLiteDriver still compiles during development

## Test plan

- [x] Build succeeds
- [x] `TablePro.app/Contents/PlugIns/` does not contain `SQLiteDriver.tableplugin`
- [x] Plugins settings confirms SQLite Driver is not listed as built-in
- [ ] Select SQLite in connection form — shows download icon and triggers auto-install prompt
- [ ] After installing plugin, SQLite connections work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SQLite driver is now available as a downloadable plugin instead of being bundled with the application, reducing the initial app size. Users can download the plugin when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->