### PR TITLE
Simplify data table context menu

### DIFF
--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -2716,7 +2716,14 @@
       }
     },
     "Cell Value" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị ô"
+          }
+        }
+      }
     },
     "Change Color" : {
       "localizations" : {
@@ -4100,23 +4107,6 @@
         }
       }
     },
-    "Copy Cell Value" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sao chép giá trị ô"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制单元格值"
-          }
-        }
-      }
-    },
     "Copy Column Name" : {
       "localizations" : {
         "vi" : {
@@ -4215,20 +4205,7 @@
       }
     },
     "Copy with Headers" : {
-      "localizations" : {
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sao chép kèm tiêu đề"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制（含表头）"
-          }
-        }
-      }
+
     },
     "Could not fetch plugin registry" : {
 
@@ -17195,7 +17172,14 @@
       }
     },
     "With Headers" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kèm tiêu đề"
+          }
+        }
+      }
     },
     "Word wrap" : {
       "localizations" : {

--- a/TablePro/Views/Results/TableRowViewWithMenu.swift
+++ b/TablePro/Views/Results/TableRowViewWithMenu.swift
@@ -94,7 +94,9 @@ final class TableRowViewWithMenu: NSTableRowView {
                 menu.addItem(pasteItem)
             }
 
-            menu.addItem(NSMenuItem.separator())
+            if coordinator.isEditable {
+                menu.addItem(NSMenuItem.separator())
+            }
 
             // Set Value (editable + column clicked)
             if coordinator.isEditable && dataColumnIndex >= 0 {


### PR DESCRIPTION
## Summary
- Consolidate copy-related items: moved "Copy Cell Value" and "Copy with Headers" into the "Copy as" submenu
- Moved "Set Value" below the separator to group all edit actions together
- Reduced top-level menu items from 9 to 7

## Before
```
Set Value >
---
Copy Cell Value
Copy          ⌘C
Copy with Headers  ⇧⌘C
Copy as >
Paste         ⌘V
---
Duplicate     ⌘D
Delete        ⌫
```

## After
```
Copy          ⌘C
Copy as >  (Cell Value, With Headers, INSERT, UPDATE)
Paste         ⌘V
---
Set Value >
Duplicate     ⌘D
Delete        ⌫
```

## Test plan
- [ ] Right-click a row in data view — verify simplified menu layout
- [ ] Verify "Copy as" submenu shows Cell Value + With Headers for all databases
- [ ] Verify INSERT/UPDATE items appear in submenu only for SQL databases
- [ ] Verify "Set Value" submenu appears when editable and column clicked
- [ ] Verify all keyboard shortcuts still work (⌘C, ⇧⌘C, ⌘V, ⌘D, ⌫)