### PR TITLE
refactor: remove 11 dead notifications and their observers

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -69,25 +69,6 @@ struct ContentView: View {
             .onReceive(NotificationCenter.default.publisher(for: .newConnection)) { _ in
                 openWindow(id: "connection-form", value: nil as UUID?)
             }
-            .onReceive(NotificationCenter.default.publisher(for: .deselectConnection)) { _ in
-                let sessionId = payload?.connectionId ?? DatabaseManager.shared.currentSessionId
-                if let sessionId {
-                    Task { @MainActor in
-                        let window = NSApp.keyWindow
-                        let confirmed = await AlertHelper.confirmDestructive(
-                            title: String(localized: "Disconnect"),
-                            message: String(localized: "Are you sure you want to disconnect from this database?"),
-                            confirmButton: String(localized: "Disconnect"),
-                            cancelButton: String(localized: "Cancel"),
-                            window: window
-                        )
-
-                        if confirmed {
-                            await DatabaseManager.shared.disconnectSession(sessionId)
-                        }
-                    }
-                }
-            }
             // Right sidebar toggle is handled by MainContentView (has the binding)
             // Left sidebar toggle uses native NSSplitViewController.toggleSidebar via responder chain
             .onChange(of: DatabaseManager.shared.currentSessionId, initial: true) { _, newSessionId in

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -402,7 +402,6 @@ final class PluginManager {
         }
 
         Self.logger.info("Plugin '\(pluginId)' \(enabled ? "enabled" : "disabled")")
-        NotificationCenter.default.post(name: .pluginStateDidChange, object: nil, userInfo: ["pluginId": pluginId])
     }
 
     // MARK: - Install / Uninstall

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -12,8 +12,6 @@ import Foundation
 extension Notification.Name {
     // MARK: - Query Editor
 
-    static let formatQueryRequested = Notification.Name("formatQueryRequested")
-    static let sendAIPrompt = Notification.Name("sendAIPrompt")
     static let aiFixError = Notification.Name("aiFixError")
     static let aiExplainSelection = Notification.Name("aiExplainSelection")
     static let aiOptimizeSelection = Notification.Name("aiOptimizeSelection")
@@ -28,14 +26,9 @@ extension Notification.Name {
 
     static let connectionUpdated = Notification.Name("connectionUpdated")
     static let databaseDidConnect = Notification.Name("databaseDidConnect")
-    static let connectionHealthStateChanged = Notification.Name("connectionHealthStateChanged")
 
     // MARK: - SSH
 
     static let sshTunnelDied = Notification.Name("sshTunnelDied")
     static let lastWindowDidClose = Notification.Name("lastWindowDidClose")
-
-    // MARK: - Plugins
-
-    static let pluginStateDidChange = Notification.Name("pluginStateDidChange")
 }

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -143,7 +143,6 @@ final class LicenseManager {
             license = newLicense
             evaluateStatus()
 
-            NotificationCenter.default.post(name: .licenseStatusDidChange, object: nil)
             Self.logger.info("License activated for \(payloadData.email)")
         } catch let error as LicenseError {
             lastError = error
@@ -187,7 +186,6 @@ final class LicenseManager {
         revalidationTask?.cancel()
         revalidationTask = nil
 
-        NotificationCenter.default.post(name: .licenseStatusDidChange, object: nil)
         Self.logger.info("License deactivated")
     }
 
@@ -232,8 +230,6 @@ final class LicenseManager {
             }
             // Otherwise keep using cached license (still within grace period)
         }
-
-        NotificationCenter.default.post(name: .licenseStatusDidChange, object: nil)
     }
 
     // MARK: - Status Evaluation

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -449,13 +449,10 @@ struct TableProApp: App {
 extension Notification.Name {
     // Connection lifecycle
     static let newConnection = Notification.Name("newConnection")
-    static let deselectConnection = Notification.Name("deselectConnection")
     static let openConnectionSwitcher = Notification.Name("openConnectionSwitcher")
-    static let reconnectDatabase = Notification.Name("reconnectDatabase")
 
     // Multi-listener broadcasts (Sidebar + Coordinator + StructureView)
     static let refreshData = Notification.Name("refreshData")
-    static let refreshAll = Notification.Name("refreshAll")
 
     // Data operations (still posted by DataGrid / context menus / StructureView subscribers)
     static let deleteSelectedRows = Notification.Name("deleteSelectedRows")
@@ -486,11 +483,6 @@ extension Notification.Name {
     static let showTableStructure = Notification.Name("showTableStructure")
     static let editViewDefinition = Notification.Name("editViewDefinition")
 
-    // Filter notifications
-    static let applyAllFilters = Notification.Name("applyAllFilters")
-    static let duplicateFilter = Notification.Name("duplicateFilter")
-    static let removeFilter = Notification.Name("removeFilter")
-
     // File opening notifications
     static let openSQLFiles = Notification.Name("openSQLFiles")
 
@@ -502,9 +494,6 @@ extension Notification.Name {
     // Database URL handling notifications
     static let switchSchemaFromURL = Notification.Name("switchSchemaFromURL")
     static let applyURLFilter = Notification.Name("applyURLFilter")
-
-    // License notifications
-    static let licenseStatusDidChange = Notification.Name("licenseStatusDidChange")
 }
 
 // MARK: - Check for Updates

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -152,10 +152,9 @@ final class SidebarViewModel {
         guard !hasSetupNotifications else { return }
         hasSetupNotifications = true
 
-        Publishers.Merge3(
+        Publishers.Merge(
             NotificationCenter.default.publisher(for: .databaseDidConnect),
-            NotificationCenter.default.publisher(for: .refreshData),
-            NotificationCenter.default.publisher(for: .refreshAll)
+            NotificationCenter.default.publisher(for: .refreshData)
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -69,14 +69,6 @@ struct AIChatPanelView: View {
         .task(id: tables) {
             await fetchSchemaContext()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .sendAIPrompt)) { notification in
-            guard let userInfo = notification.userInfo,
-                  let prompt = userInfo["prompt"] as? String,
-                  let featureRaw = userInfo["feature"] as? String,
-                  let feature = AIFeature(rawValue: featureRaw) else { return }
-            updateContext()
-            viewModel.sendWithContext(prompt: prompt, feature: feature)
-        }
         .onReceive(NotificationCenter.default.publisher(for: .aiFixError)) { notification in
             guard let userInfo = notification.userInfo,
                   let query = userInfo["query"] as? String,

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -50,9 +50,6 @@ struct QueryEditorView: View {
             .clipped()
         }
         .background(Color(nsColor: .textBackgroundColor))
-        .onReceive(NotificationCenter.default.publisher(for: .formatQueryRequested)) { _ in
-            formatQuery()
-        }
         .onReceive(NotificationCenter.default.publisher(for: .editorSettingsDidChange)) { _ in
             isVimEnabled = AppSettingsManager.shared.editor.vimModeEnabled
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
@@ -95,7 +95,7 @@ extension MainContentCoordinator {
     /// Generate appropriate message for discard action type
     private func discardMessage(for action: DiscardAction) -> String {
         switch action {
-        case .refresh, .refreshAll:
+        case .refresh:
             return String(localized: "Refreshing will discard all unsaved changes.")
         }
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -11,35 +11,6 @@ import Foundation
 extension MainContentCoordinator {
     // MARK: - Refresh Handling
 
-    func handleRefreshAll(
-        hasPendingTableOps: Bool,
-        onDiscard: @escaping () -> Void
-    ) {
-        // If showing structure view, let it handle refresh notifications
-        if let tabIndex = tabManager.selectedTabIndex,
-           tabManager.tabs[tabIndex].showStructure {
-            return
-        }
-
-        let hasEditedCells = changeManager.hasChanges
-
-        if hasEditedCells || hasPendingTableOps {
-            Task { @MainActor in
-                let window = NSApp.keyWindow
-                let confirmed = await confirmDiscardChanges(action: .refreshAll, window: window)
-                if confirmed {
-                    onDiscard()
-                    changeManager.clearChanges()
-                    NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
-                    runQuery()
-                }
-            }
-        } else {
-            NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
-            runQuery()
-        }
-    }
-
     func handleRefresh(
         hasPendingTableOps: Bool,
         onDiscard: @escaping () -> Void

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -139,14 +139,12 @@ final class MainContentCommandActions {
 
     private func setupObservers() {
         setupNonMenuNotificationObservers()
-        setupFilterBroadcastObservers()
         setupDataBroadcastObservers()
         setupTabBroadcastObservers()
         setupDatabaseBroadcastObservers()
         setupUIBroadcastObservers()
         setupWindowObservers()
         setupFileOpenObservers()
-        setupReconnectObservers()
     }
 
     /// Observers for notifications still posted by non-menu views (DataGrid, SidebarView,
@@ -546,38 +544,10 @@ final class MainContentCommandActions {
 
     // MARK: - Group B Broadcast Subscribers
 
-    // MARK: Filter Broadcasts
-
-    private func setupFilterBroadcastObservers() {
-        observeKeyWindowOnly(.applyAllFilters) { [weak self] _ in self?.handleApplyAllFilters() }
-        observeKeyWindowOnly(.duplicateFilter) { [weak self] _ in self?.handleDuplicateFilter() }
-        observeKeyWindowOnly(.removeFilter) { [weak self] _ in self?.handleRemoveFilter() }
-    }
-
-    private func handleApplyAllFilters() {
-        if filterStateManager.hasSelectedFilters {
-            filterStateManager.applySelectedFilters()
-            coordinator?.applyFilters(filterStateManager.appliedFilters)
-        }
-    }
-
-    private func handleDuplicateFilter() {
-        if filterStateManager.isVisible, let focusedFilter = filterStateManager.focusedFilter {
-            filterStateManager.duplicateFilter(focusedFilter)
-        }
-    }
-
-    private func handleRemoveFilter() {
-        if filterStateManager.isVisible, let focusedFilter = filterStateManager.focusedFilter {
-            filterStateManager.removeFilter(focusedFilter)
-        }
-    }
-
     // MARK: Data Broadcasts
 
     private func setupDataBroadcastObservers() {
         observeKeyWindowOnly(.refreshData) { [weak self] _ in self?.handleRefreshData() }
-        observeKeyWindowOnly(.refreshAll) { [weak self] _ in self?.handleRefreshAll() }
 
         observeKeyWindowOnly(.showTableStructure) { [weak self] notification in
             if let tableName = notification.object as? String {
@@ -589,17 +559,6 @@ final class MainContentCommandActions {
     private func handleRefreshData() {
         let hasPendingTableOps = !pendingTruncates.wrappedValue.isEmpty || !pendingDeletes.wrappedValue.isEmpty
         coordinator?.handleRefresh(
-            hasPendingTableOps: hasPendingTableOps,
-            onDiscard: { [weak self] in
-                self?.pendingTruncates.wrappedValue.removeAll()
-                self?.pendingDeletes.wrappedValue.removeAll()
-            }
-        )
-    }
-
-    private func handleRefreshAll() {
-        let hasPendingTableOps = !pendingTruncates.wrappedValue.isEmpty || !pendingDeletes.wrappedValue.isEmpty
-        coordinator?.handleRefreshAll(
             hasPendingTableOps: hasPendingTableOps,
             onDiscard: { [weak self] in
                 self?.pendingTruncates.wrappedValue.removeAll()
@@ -798,17 +757,6 @@ final class MainContentCommandActions {
         }
     }
 
-    // MARK: Reconnect Broadcasts
-
-    private func setupReconnectObservers() {
-        observeKeyWindowOnly(.reconnectDatabase) { [weak self] _ in self?.handleReconnect() }
-    }
-
-    private func handleReconnect() {
-        Task { @MainActor in
-            await DatabaseManager.shared.reconnectSession(self.connection.id)
-        }
-    }
 }
 
 // MARK: - Focused Value Key

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -14,7 +14,7 @@ import SwiftUI
 
 /// Discard action types for unified alert handling
 enum DiscardAction {
-    case refresh, refreshAll
+    case refresh
 }
 
 /// Cache entry for async-sorted query tab rows (stores index permutation, not row copies)


### PR DESCRIPTION
## Summary

- Remove 11 dead `NotificationCenter` notifications: 9 observed but never posted (`formatQueryRequested`, `sendAIPrompt`, `reconnectDatabase`, `refreshAll`, `connectionHealthStateChanged`, `applyAllFilters`, `duplicateFilter`, `removeFilter`, `deselectConnection`) and 2 posted but never observed (`licenseStatusDidChange`, `pluginStateDidChange`)
- Remove cascading dead code only reachable via removed notifications: `handleRefreshAll`, `handleReconnect`, filter broadcast handlers, and `DiscardAction.refreshAll` enum case
- Reduces notification surface from 62 to 51 names across 12 files (net -139 lines)

## Test plan

- [x] Build succeeds (`xcodebuild -configuration Debug build`)
- [ ] Grep confirms no remaining references to removed notification names
- [ ] Run full test suite
- [ ] Manual smoke test: refresh data, filter operations, reconnect, license activation all still work through their live code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined refresh and data synchronization workflows within the application.
  * Adjusted filter management and connection handling processes.
  * Simplified automatic update mechanisms for database connections and query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->