### PR TITLE
refactor: replace settings notifications with @Observable and direct calls

### DIFF
--- a/TablePro/Core/Services/Infrastructure/SettingsNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/SettingsNotifications.swift
@@ -2,78 +2,22 @@
 //  SettingsNotifications.swift
 //  TablePro
 //
-//  Notification names and payload structures for settings changes.
-//  Follows existing NotificationCenter pattern used throughout the app.
+//  Notification names for settings changes that require AppKit bridging.
+//  SwiftUI views observe @Observable AppSettingsManager directly instead.
 //
 
 import Foundation
 
-// MARK: - Settings Notification Names
-
 extension Notification.Name {
-    // MARK: - Domain-Specific Notifications
-
     /// Posted when data grid settings change (row height, date format, etc.)
+    /// Used by AppKit components that cannot observe @Observable directly.
     static let dataGridSettingsDidChange = Notification.Name("dataGridSettingsDidChange")
 
-    /// Posted when history settings change (retention, auto-cleanup, etc.)
-    static let historySettingsDidChange = Notification.Name("historySettingsDidChange")
-
     /// Posted when editor settings change (font, line numbers, etc.)
+    /// Used by AppKit components that cannot observe @Observable directly.
     static let editorSettingsDidChange = Notification.Name("editorSettingsDidChange")
-
-    /// Posted when appearance settings change (theme, accent color)
-    static let appearanceSettingsDidChange = Notification.Name("appearanceSettingsDidChange")
-
-    /// Posted when general settings change (startup behavior, confirmations)
-    static let generalSettingsDidChange = Notification.Name("generalSettingsDidChange")
-
-    /// Posted when tab settings change (reuse behavior, etc.)
-    static let tabSettingsDidChange = Notification.Name("tabSettingsDidChange")
-
-    /// Posted when keyboard shortcut settings change
-    static let keyboardSettingsDidChange = Notification.Name("keyboardSettingsDidChange")
-
-    /// Posted when AI settings change (providers, routing, context options)
-    static let aiSettingsDidChange = Notification.Name("aiSettingsDidChange")
-
-    // MARK: - System Notifications
 
     /// Posted when the system accessibility text size preference changes.
     /// Observers should reload fonts via SQLEditorTheme.reloadFromSettings().
     static let accessibilityTextSizeDidChange = Notification.Name("accessibilityTextSizeDidChange")
-
-    // MARK: - Generic Notification
-
-    /// Posted for any settings change (in addition to domain-specific notification)
-    /// Use this to listen for all settings changes regardless of domain
-    static let settingsDidChange = Notification.Name("settingsDidChange")
-}
-
-// MARK: - Settings Change Info
-
-/// Information about a settings change included in notification userInfo
-struct SettingsChangeInfo {
-    /// The settings domain that changed (e.g., "general", "dataGrid", "history")
-    let domain: String
-
-    /// Optional set of specific keys that changed within the domain
-    /// If nil, assume all settings in the domain may have changed
-    let changedKeys: Set<String>?
-
-    /// User info dictionary key for accessing SettingsChangeInfo
-    static let userInfoKey = "changeInfo"
-}
-
-// MARK: - Convenience Extensions
-
-extension Notification {
-    /// Extract SettingsChangeInfo from notification's userInfo
-    var settingsChangeInfo: SettingsChangeInfo? {
-        guard let userInfo = userInfo,
-              let changeInfo = userInfo[SettingsChangeInfo.userInfoKey] as? SettingsChangeInfo else {
-            return nil
-        }
-        return changeInfo
-    }
 }

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -23,7 +23,6 @@ final class AppSettingsManager {
         didSet {
             general.language.apply()
             storage.saveGeneral(general)
-            notifyChange(domain: "general", notification: .generalSettingsDidChange)
         }
     }
 
@@ -31,7 +30,6 @@ final class AppSettingsManager {
         didSet {
             storage.saveAppearance(appearance)
             appearance.theme.apply()
-            notifyChange(domain: "appearance", notification: .appearanceSettingsDidChange)
         }
     }
 
@@ -40,7 +38,7 @@ final class AppSettingsManager {
             storage.saveEditor(editor)
             // Update cached theme values for thread-safe access
             SQLEditorTheme.reloadFromSettings(editor)
-            notifyChange(domain: "editor", notification: .editorSettingsDidChange)
+            notifyChange(.editorSettingsDidChange)
         }
     }
 
@@ -62,7 +60,7 @@ final class AppSettingsManager {
             storage.saveDataGrid(validated)
             // Update date formatting service with new format
             DateFormattingService.shared.updateFormat(validated.dateFormat)
-            notifyChange(domain: "dataGrid", notification: .dataGridSettingsDidChange)
+            notifyChange(.dataGridSettingsDidChange)
         }
     }
 
@@ -84,28 +82,24 @@ final class AppSettingsManager {
             storage.saveHistory(validated)
             // Apply history settings immediately (cleanup if auto-cleanup enabled)
             Task { await applyHistorySettingsImmediately() }
-            notifyChange(domain: "history", notification: .historySettingsDidChange)
         }
     }
 
     var tabs: TabSettings {
         didSet {
             storage.saveTabs(tabs)
-            notifyChange(domain: "tabs", notification: .tabSettingsDidChange)
         }
     }
 
     var keyboard: KeyboardSettings {
         didSet {
             storage.saveKeyboard(keyboard)
-            notifyChange(domain: "keyboard", notification: .keyboardSettingsDidChange)
         }
     }
 
     var ai: AISettings {
         didSet {
             storage.saveAI(ai)
-            notifyChange(domain: "ai", notification: .aiSettingsDidChange)
         }
     }
 
@@ -147,24 +141,8 @@ final class AppSettingsManager {
 
     // MARK: - Notification Propagation
 
-    /// Notify listeners that settings have changed
-    /// Posts both domain-specific and generic notifications
-    private func notifyChange(domain: String, notification: Notification.Name) {
-        let changeInfo = SettingsChangeInfo(domain: domain, changedKeys: nil)
-
-        // Post domain-specific notification
-        NotificationCenter.default.post(
-            name: notification,
-            object: self,
-            userInfo: [SettingsChangeInfo.userInfoKey: changeInfo]
-        )
-
-        // Post generic notification for listeners that want all settings changes
-        NotificationCenter.default.post(
-            name: .settingsDidChange,
-            object: self,
-            userInfo: [SettingsChangeInfo.userInfoKey: changeInfo]
-        )
+    private func notifyChange(_ notification: Notification.Name) {
+        NotificationCenter.default.post(name: notification, object: self)
     }
 
     // MARK: - Accessibility Text Size
@@ -197,11 +175,8 @@ final class AppSettingsManager {
         }
     }
 
-    /// Apply history settings immediately (triggered on settings change)
     private func applyHistorySettingsImmediately() async {
-        // This will be called by QueryHistoryManager
-        // We post a notification and let the manager handle the actual cleanup
-        // This keeps the settings manager decoupled from history storage implementation
+        QueryHistoryManager.shared.applySettingsChange()
     }
 
     // MARK: - Actions

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -3,10 +3,8 @@
 //  TablePro
 //
 //  Thread-safe coordinator for query history
-//  Communicates via NotificationCenter (NOT ObservableObject)
 //
 
-import Combine
 import Foundation
 
 /// Thread-safe manager for query history
@@ -16,9 +14,6 @@ final class QueryHistoryManager {
 
     private let storage: QueryHistoryStorage
 
-    // Settings observer for immediate cleanup when settings change
-    private var settingsObserver: AnyCancellable?
-
     /// Creates an isolated manager with its own storage. For testing only.
     init(isolatedStorage: QueryHistoryStorage) {
         self.storage = isolatedStorage
@@ -26,22 +21,6 @@ final class QueryHistoryManager {
 
     private init() {
         self.storage = QueryHistoryStorage.shared
-        // Subscribe to history settings changes for immediate cleanup
-        settingsObserver = NotificationCenter.default.publisher(for: .historySettingsDidChange)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self else { return }
-
-                MainActor.assumeIsolated {
-                    // Update settings cache
-                    self.storage.updateSettingsCache()
-
-                    // Perform cleanup if auto-cleanup is enabled
-                    if AppSettingsManager.shared.history.autoCleanup {
-                        self.storage.cleanup()
-                    }
-                }
-            }
     }
 
     /// Perform cleanup if auto-cleanup is enabled in settings
@@ -56,6 +35,15 @@ final class QueryHistoryManager {
 
         // Perform cleanup
         storage.cleanup()
+    }
+
+    /// Apply settings changes directly (called by AppSettingsManager)
+    @MainActor
+    func applySettingsChange() {
+        storage.updateSettingsCache()
+        if AppSettingsManager.shared.history.autoCleanup {
+            storage.cleanup()
+        }
     }
 
     // MARK: - History Capture

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -2226,6 +2226,7 @@
       }
     },
     "Are you sure you want to disconnect from this database?" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -5602,6 +5603,7 @@
       }
     },
     "Disconnect" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -24,7 +24,6 @@ struct QueryEditorView: View {
     var onExecuteQuery: (() -> Void)?
 
     @State private var vimMode: VimMode = .normal
-    @State private var isVimEnabled = AppSettingsManager.shared.editor.vimModeEnabled
 
     var body: some View {
         let hasQuery = appState.hasQueryText
@@ -50,9 +49,6 @@ struct QueryEditorView: View {
             .clipped()
         }
         .background(Color(nsColor: .textBackgroundColor))
-        .onReceive(NotificationCenter.default.publisher(for: .editorSettingsDidChange)) { _ in
-            isVimEnabled = AppSettingsManager.shared.editor.vimModeEnabled
-        }
     }
 
     // MARK: - Toolbar
@@ -63,7 +59,7 @@ struct QueryEditorView: View {
                 .font(.headline)
                 .foregroundStyle(.secondary)
 
-            if isVimEnabled {
+            if AppSettingsManager.shared.editor.vimModeEnabled {
                 VimModeIndicatorView(mode: vimMode)
             }
 

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -77,7 +77,7 @@ struct SQLEditorView: View {
             .onChange(of: colorScheme) {
                 editorConfiguration = Self.makeConfiguration()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .editorSettingsDidChange)) { _ in
+            .onChange(of: AppSettingsManager.shared.editor) {
                 editorConfiguration = Self.makeConfiguration()
             }
             .onReceive(NotificationCenter.default.publisher(for: .accessibilityTextSizeDidChange)) { _ in

--- a/docs/development/plugin-settings-tracking.md
+++ b/docs/development/plugin-settings-tracking.md
@@ -18,7 +18,7 @@ Plugin enable/disable state lives in `UserDefaults["com.TablePro.disabledPlugins
 | Feature                                                  | Status | File                                                | Notes                                                       |
 | -------------------------------------------------------- | ------ | --------------------------------------------------- | ----------------------------------------------------------- |
 | Installed plugins list with toggle                       | Done   | `Views/Settings/Plugins/InstalledPluginsView.swift` | One row per `PluginEntry`, inline detail expansion          |
-| Enable/disable toggle (live)                             | Done   | `Core/Plugins/PluginManager.swift:365`              | Immediate capability register/unregister, no restart needed |
+| Enable/disable toggle (live)                             | Done   | `Core/Plugins/PluginManager.swift:382`              | Immediate capability register/unregister, no restart needed |
 | Plugin detail (version, bundle ID, source, capabilities) | Done   | `Views/Settings/Plugins/InstalledPluginsView.swift` | Shown on row expansion                                      |
 | Install from file (.tableplugin, .zip)                   | Done   | `Views/Settings/Plugins/InstalledPluginsView.swift` | NSOpenPanel + drag-and-drop                                 |
 | Uninstall user plugins                                   | Done   | `Views/Settings/Plugins/InstalledPluginsView.swift` | Destructive button with AlertHelper.confirmDestructive      |
@@ -26,7 +26,7 @@ Plugin enable/disable state lives in `UserDefaults["com.TablePro.disabledPlugins
 | Browse registry                                          | Done   | `Views/Settings/Plugins/BrowsePluginsView.swift`    | Remote manifest from GitHub, search + category filter       |
 | Registry install with progress                           | Done   | `Views/Settings/Plugins/RegistryPluginRow.swift`    | Download + SHA-256 verification, multi-phase progress       |
 | Contextual install prompt (connection flow)              | Done   | `Views/Connection/PluginInstallModifier.swift`      | Alert when opening DB type with missing driver              |
-| Code signature verification                              | Done   | `Core/Plugins/PluginManager.swift:558`              | Team ID `D7HJ5TFYCU` for user-installed plugins            |
+| Code signature verification                              | Done   | `Core/Plugins/PluginManager.swift:586`              | Team ID `D7HJ5TFYCU` for user-installed plugins            |
 
 ## Per-Plugin Configuration
 
@@ -50,7 +50,7 @@ All export plugins conform to `SettablePlugin` which provides automatic `loadSet
 
 ### Driver Plugins
 
-All 8 driver plugins have zero per-plugin settings. They can adopt `SettablePlugin` when settings are needed.
+All 9 driver plugins have zero per-plugin settings. They can adopt `SettablePlugin` when settings are needed.
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove 7 dead `NotificationCenter` notification names (`appearanceSettingsDidChange`, `generalSettingsDidChange`, `tabSettingsDidChange`, `keyboardSettingsDidChange`, `aiSettingsDidChange`, `settingsDidChange`, `historySettingsDidChange`) and the `SettingsChangeInfo` infrastructure
- Replace `historySettingsDidChange` Combine subscriber in `QueryHistoryManager` with a direct `applySettingsChange()` call from `AppSettingsManager`
- Convert 2 SwiftUI `.onReceive` notification subscribers to `@Observable` observation (`.onChange(of:)` in `SQLEditorView`, direct property read in `QueryEditorView`)
- Remove 11 dead notification observers and their notification definitions from Phase 1
- 3 notifications remain: `dataGridSettingsDidChange`, `editorSettingsDidChange` (AppKit bridges), `accessibilityTextSizeDidChange` (system event)

Net: **-259 lines** across both commits. Zero `Combine` imports remain in settings code.

## Test plan

- [ ] Build succeeds with no warnings in changed files
- [ ] Change editor settings (font size, vim mode, word wrap) — editor updates live
- [ ] Change data grid settings (row height, date format) — grid updates live
- [ ] Change history settings (auto-cleanup, retention) — cleanup runs immediately
- [ ] Toggle vim mode on/off — indicator in `QueryEditorView` toolbar appears/disappears
- [ ] Grep for removed notification names returns zero hits in `TablePro/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined settings change propagation system, consolidating multiple notification types into a unified mechanism for improved efficiency and reliability.
  * Simplified editor settings synchronization to enable more direct, responsive UI updates for features like Vim mode indication.

* **Documentation**
  * Updated plugin settings tracking documentation with current line references and driver plugin count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->