### PR TITLE
refactor: replace data refresh broadcasts with direct coordinator-to-sidebar calls

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -227,7 +227,8 @@ struct ContentView: View {
                         tableOperationOptions: sessionTableOperationOptionsBinding,
                         databaseType: currentSession.connection.type,
                         connectionId: currentSession.connection.id,
-                        schemaProvider: SchemaProviderRegistry.shared.provider(for: currentSession.connection.id)
+                        schemaProvider: SchemaProviderRegistry.shared.provider(for: currentSession.connection.id),
+                        coordinator: sessionState.coordinator
                     )
                 }
                 .searchable(

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -152,18 +152,6 @@ final class SidebarViewModel {
         guard !hasSetupNotifications else { return }
         hasSetupNotifications = true
 
-        Publishers.Merge(
-            NotificationCenter.default.publisher(for: .databaseDidConnect),
-            NotificationCenter.default.publisher(for: .refreshData)
-        )
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] _ in
-            Task { @MainActor in
-                self?.forceLoadTables()
-            }
-        }
-        .store(in: &cancellables)
-
         NotificationCenter.default.publisher(for: .copyTableNames)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
@@ -79,6 +79,6 @@ extension MainContentCoordinator {
             tabManager.tabs[index].pendingChanges = TabPendingChanges()
         }
 
-        NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
+        reloadSidebar()
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -438,7 +438,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .postgresql {
                 DatabaseManager.shared.updateSession(connectionId) { session in
                     session.connection.database = database
@@ -450,7 +450,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .redshift {
                 guard let schemaDriver = driver as? SchemaSwitchable else { return }
                 try await schemaDriver.switchSchema(to: database)
@@ -461,7 +461,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .oracle {
                 guard let schemaDriver = driver as? SchemaSwitchable else { return }
                 try await schemaDriver.switchSchema(to: database)
@@ -472,7 +472,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .mssql {
                 if let adapter = driver as? PluginDriverAdapter {
                     try await adapter.switchDatabase(to: database)
@@ -486,7 +486,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .mongodb {
                 if let adapter = driver as? PluginDriverAdapter {
                     try await adapter.switchDatabase(to: database)
@@ -498,7 +498,7 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             } else if connection.type == .redis {
                 guard let dbIndex = Int(database) else { return }
 
@@ -512,13 +512,13 @@ extension MainContentCoordinator {
 
                 await loadSchema()
 
-                NotificationCenter.default.post(name: .refreshData, object: nil)
+                reloadSidebar()
             }
         } catch {
             // Restore toolbar to previous database on failure
             toolbarState.databaseName = previousDatabase
             // Reload previous tables so sidebar isn't left empty
-            NotificationCenter.default.post(name: .refreshData, object: nil)
+            reloadSidebar()
 
             navigationLogger.error("Failed to switch database: \(error.localizedDescription, privacy: .public)")
             AlertHelper.showErrorSheet(
@@ -560,11 +560,11 @@ extension MainContentCoordinator {
 
             await loadSchema()
 
-            NotificationCenter.default.post(name: .refreshData, object: nil)
+            reloadSidebar()
         } catch {
             // Restore toolbar to previous schema on failure
             toolbarState.databaseName = previousSchema
-            NotificationCenter.default.post(name: .refreshData, object: nil)
+            reloadSidebar()
 
             navigationLogger.error("Failed to switch schema: \(error.localizedDescription, privacy: .public)")
             AlertHelper.showErrorSheet(

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
@@ -233,7 +233,7 @@ extension MainContentCoordinator {
                         }
                     }
 
-                    NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
+                    reloadSidebar()
                 }
 
                 if tabManager.selectedTabIndex != nil && !tabManager.tabs.isEmpty {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -565,6 +565,7 @@ final class MainContentCommandActions {
                 self?.pendingDeletes.wrappedValue.removeAll()
             }
         )
+        coordinator?.reloadSidebar()
     }
 
     // MARK: Tab Broadcasts
@@ -694,6 +695,7 @@ final class MainContentCommandActions {
             if let driver = DatabaseManager.shared.driver(for: self.connection.id) {
                 coordinator?.toolbarState.databaseVersion = driver.serverVersion
             }
+            coordinator?.reloadSidebar()
         }
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -61,6 +61,9 @@ final class MainContentCoordinator {
     /// Stable identifier for this coordinator's window (set by MainContentView on appear)
     var windowId: UUID?
 
+    /// Direct reference to sidebar viewmodel — eliminates global notification broadcasts
+    weak var sidebarViewModel: SidebarViewModel?
+
     // MARK: - Published State
 
     var schemaProvider: SQLSchemaProvider
@@ -281,6 +284,10 @@ final class MainContentCoordinator {
 
     func clearTeardownScheduled() {
         _teardownScheduled.withLock { $0 = false }
+    }
+
+    func reloadSidebar() {
+        sidebarViewModel?.forceLoadTables()
     }
 
     /// Explicit cleanup called from `onDisappear`. Releases schema provider

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -24,6 +24,7 @@ struct SidebarView: View {
     var onShowAllTables: (() -> Void)?
     var onDoubleClick: ((TableInfo) -> Void)?
     var connectionId: UUID
+    private weak var coordinator: MainContentCoordinator?
 
     /// Computed on the view (not ViewModel) so SwiftUI tracks both
     /// `@Binding var tables` and `@Published var searchText` as dependencies.
@@ -50,7 +51,8 @@ struct SidebarView: View {
         tableOperationOptions: Binding<[String: TableOperationOptions]>,
         databaseType: DatabaseType,
         connectionId: UUID,
-        schemaProvider: SQLSchemaProvider? = nil
+        schemaProvider: SQLSchemaProvider? = nil,
+        coordinator: MainContentCoordinator? = nil
     ) {
         _tables = tables
         self.sidebarState = sidebarState
@@ -76,6 +78,7 @@ struct SidebarView: View {
         self.activeTableName = activeTableName
         self.onShowAllTables = onShowAllTables
         self.connectionId = connectionId
+        self.coordinator = coordinator
     }
 
     // MARK: - Body
@@ -97,6 +100,7 @@ struct SidebarView: View {
         .onAppear {
             viewModel.setupNotifications()
             viewModel.onAppear()
+            coordinator?.sidebarViewModel = viewModel
         }
         .sheet(isPresented: $viewModel.showOperationDialog) {
             if let operationType = viewModel.pendingOperationType {

--- a/docs/development/notification-refactor.md
+++ b/docs/development/notification-refactor.md
@@ -1,0 +1,235 @@
+# NotificationCenter Refactor Plan
+
+## Problem
+
+TablePro uses ~40 custom `NotificationCenter` notifications for cross-component communication. This creates:
+
+- **Untraceable coupling** — global broadcasts with no compile-time safety
+- **Untyped payloads** — `userInfo` dictionaries with stringly-typed keys
+- **Fan-out bugs** — `.refreshData` triggers ALL sidebar instances, not just the target connection
+- **Overloaded semantics** — `databaseDidConnect` used both for "connection established" and "please reload sidebar"
+
+## Target Architecture
+
+Replace `NotificationCenter` with proper Swift patterns:
+
+| Pattern                                 | When to Use                                               |
+| --------------------------------------- | --------------------------------------------------------- |
+| **`@Observable` + SwiftUI observation** | Settings, license status, any model already `@Observable` |
+| **Direct method calls**                 | Parent → child, coordinator → owned viewmodel             |
+| **`@FocusedValue`**                     | Menu/toolbar → active window's coordinator                |
+| **Delegate/closure callbacks**          | 1:1 relationships (SSH tunnel → DatabaseManager)          |
+| **Typed event bus (per-connection)**    | Multi-subscriber signals scoped to a connection ID        |
+
+Keep `NotificationCenter` only for: AppKit → SwiftUI bridges where no shared reference exists (e.g., `NSApplicationDelegate` → SwiftUI scene).
+
+---
+
+## Phase 1: Remove Dead Notifications
+
+**Status:** Done (PR [#281](https://github.com/datlechin/TablePro/pull/281))
+
+Removed 11 notifications that had no sender OR no subscriber. Pure cleanup, zero risk.
+
+### Removed (defined + observed, never posted):
+
+- [x] `formatQueryRequested` — subscriber in `QueryEditorView`, no sender
+- [x] `sendAIPrompt` — subscriber in `AIChatPanelView`, no sender
+- [x] `reconnectDatabase` — subscriber in `MainContentCommandActions`, no sender
+- [x] `refreshAll` — subscribers in `SidebarViewModel` + `MainContentCommandActions`, no sender
+- [x] `connectionHealthStateChanged` — defined in `AppNotifications.swift`, no sender or subscriber
+- [x] `applyAllFilters` — subscriber in `MainContentCommandActions`, no sender
+- [x] `duplicateFilter` — subscriber in `MainContentCommandActions`, no sender
+- [x] `removeFilter` — subscriber in `MainContentCommandActions`, no sender
+- [x] `deselectConnection` — subscriber in `ContentView`, no sender
+
+### Removed (posted, never observed):
+
+- [x] `licenseStatusDidChange` — posted by `LicenseManager` (which is `@Observable`, consumers already use observation)
+- [x] `pluginStateDidChange` — posted by `PluginManager`, no subscriber
+
+Also removed cascading dead code: `handleRefreshAll`, `handleReconnect`, filter broadcast handlers, `DiscardAction.refreshAll` enum case. Net -139 lines across 12 files.
+
+---
+
+## Phase 2: Replace Settings Notifications with `@Observable`
+
+**Status:** Done (PR [#282](https://github.com/datlechin/TablePro/pull/282))
+
+Removed 7 notification names and `SettingsChangeInfo` infrastructure. Replaced Combine subscriber with direct call, converted 2 SwiftUI subscribers to `@Observable` observation.
+
+### Removed (dead — zero subscribers):
+
+- [x] `appearanceSettingsDidChange`
+- [x] `generalSettingsDidChange`
+- [x] `tabSettingsDidChange`
+- [x] `keyboardSettingsDidChange`
+- [x] `aiSettingsDidChange`
+- [x] `settingsDidChange` (generic catch-all)
+
+### Converted:
+
+- [x] `historySettingsDidChange` — replaced Combine subscriber in `QueryHistoryManager` with direct `applySettingsChange()` call from `AppSettingsManager`
+- [x] `editorSettingsDidChange` (SwiftUI) — `SQLEditorView` uses `.onChange(of: AppSettingsManager.shared.editor)`, `QueryEditorView` reads `@Observable` directly in `body`
+
+### Kept (AppKit bridges):
+
+- [x] `dataGridSettingsDidChange` — `DataGridView` (AppKit), `DataGridCellFactory` (AppKit)
+- [x] `editorSettingsDidChange` — `SQLEditorCoordinator` (AppKit)
+- [x] `accessibilityTextSizeDidChange` — system event bridge
+
+Also removed: `SettingsChangeInfo` struct, `Notification.settingsChangeInfo` extension, `import Combine` from `QueryHistoryManager`. Net -120 lines.
+
+---
+
+## Phase 3: Replace Data Refresh with Direct Coordinator-to-Sidebar Calls
+
+**Status:** Done (PR [#283](https://github.com/datlechin/TablePro/pull/283))
+
+Gave the coordinator a direct `weak var sidebarViewModel` reference, replacing 12 global broadcasts with scoped `reloadSidebar()` calls. Fixed `.databaseDidConnect` abuse in save/discard paths. Sidebar reloads are now per-window instead of global.
+
+### What changed:
+
+- [x] `MainContentCoordinator` — added `weak var sidebarViewModel` + `reloadSidebar()` method
+- [x] `SidebarView` — accepts `coordinator` parameter, wires `coordinator.sidebarViewModel = viewModel` on appear
+- [x] `ContentView` — passes `coordinator: sessionState.coordinator` to `SidebarView`
+- [x] `+Navigation.swift` — replaced all 10 `.refreshData` posts with `reloadSidebar()`
+- [x] `+SaveChanges.swift` — replaced `.databaseDidConnect` abuse with `reloadSidebar()`
+- [x] `+Discard.swift` — replaced `.databaseDidConnect` abuse with `reloadSidebar()`
+- [x] `SidebarViewModel` — removed `Publishers.Merge` subscription for `.databaseDidConnect`/`.refreshData`
+- [x] `MainContentCommandActions` — chained `coordinator?.reloadSidebar()` into `handleRefreshData()` and `handleDatabaseDidConnect()` so menu/toolbar/import/DatabaseManager signals still reach the sidebar
+
+### What's kept:
+
+- `.refreshData` — still posted by menu (Cmd+R), toolbar, `ImportDialog`, `DatabaseManager.applySchemaChanges()`. Flows through `MainContentCommandActions.handleRefreshData()` → chains `reloadSidebar()`.
+- `.databaseDidConnect` — still posted by `DatabaseManager` (legitimate). Flows through `MainContentCommandActions.handleDatabaseDidConnect()` → chains `reloadSidebar()`. `AppDelegate` subscribers kept for file queue draining.
+
+---
+
+## Phase 4: Replace Sidebar Action Notifications with `@FocusedValue`
+
+**Status:** Not started
+
+Menu items post global notifications to reach the sidebar. These should use `@FocusedValue` to call the active window's sidebar directly.
+
+- [ ] `copyTableNames` — menu → `SidebarViewModel.copySelectedTableNames()`
+- [ ] `truncateTables` — menu → `SidebarViewModel.batchToggleTruncate()`
+- [ ] `clearSelection` — menu → `SidebarViewModel.selectedTables.removeAll()`
+- [ ] `showAllTables` — menu → coordinator action
+- [ ] `showTableStructure` — sidebar context menu → coordinator
+- [ ] `editViewDefinition` — sidebar context menu → coordinator
+- [ ] `createView` — sidebar context menu → coordinator
+- [ ] `exportTables` — sidebar context menu → coordinator
+- [ ] `importTables` — sidebar context menu → coordinator
+
+### Pattern:
+
+```swift
+// Define focused value
+struct SidebarActionsKey: FocusedValueKey {
+    typealias Value = SidebarViewModel
+}
+
+extension FocusedValues {
+    var sidebarActions: SidebarViewModel? { ... }
+}
+
+// In SidebarView
+.focusedValue(\.sidebarActions, viewModel)
+
+// In menu
+Button("Copy Table Names") {
+    focusedSidebarActions?.copySelectedTableNames()
+}
+```
+
+---
+
+## Phase 5: Replace Structure View Notifications with Coordinator Pattern
+
+**Status:** Not started
+
+`MainContentCommandActions` routes commands to `TableStructureView` via notifications because the structure view is deeply embedded and not directly accessible.
+
+### Notifications to replace:
+
+- [ ] `copySelectedRows` (structure path)
+- [ ] `pasteRows` (structure path)
+- [ ] `undoChange` (structure path)
+- [ ] `redoChange` (structure path)
+- [ ] `saveStructureChanges`
+- [ ] `previewStructureSQL`
+
+### Strategy:
+
+Create a `StructureViewActions` protocol/class that `TableStructureView` registers with the coordinator. The coordinator calls methods directly instead of broadcasting.
+
+---
+
+## Phase 6: Replace Editor/AI Notifications with Direct References
+
+**Status:** Not started
+
+### Editor notifications:
+
+- [ ] `loadQueryIntoEditor` — posted by `HistoryPanelView`, `QuickSwitcher+`. Coordinator should have a method `loadQueryIntoEditor(_:)` called directly.
+- [ ] `insertQueryFromAI` — posted by `AIChatCodeBlockView`. AI panel needs a callback/delegate to the coordinator.
+- [ ] `newQueryTab` — posted by `HistoryPanelView`. Direct coordinator call.
+- [ ] `explainQuery` — posted by `QueryEditorView`. Direct coordinator call.
+
+### AI notifications:
+
+- [ ] `aiFixError` — posted by coordinator, received by `AIChatPanelView`. Could use a shared `AIChatViewModel` reference or `@FocusedValue`.
+- [ ] `aiExplainSelection` — posted by editor context menu, received by AI panel. Same approach.
+- [ ] `aiOptimizeSelection` — same.
+
+---
+
+## Phase 7: Replace Window Lifecycle Notifications
+
+**Status:** Not started
+
+### Keep (AppKit → SwiftUI bridge, no alternative):
+
+- `openMainWindow` — `AppDelegate` → SwiftUI `openWindow`
+- `openWelcomeWindow` — same
+- `mainWindowWillClose` — `NSWindowDelegate` → tab persistence
+
+### Replace:
+
+- [ ] `lastWindowDidClose` — `WindowLifecycleMonitor` → `DatabaseManager`. Use a direct callback/delegate.
+- [ ] `sshTunnelDied` — `SSHTunnelManager` → `DatabaseManager`. Use a closure callback set at tunnel creation.
+- [ ] `connectionUpdated` — `ConnectionFormView` → `WelcomeWindowView`. Use `@Observable ConnectionStorage`.
+- [ ] `newConnection` — menu → welcome/content view. Use `@FocusedValue` or `@Environment(\.openWindow)`.
+
+---
+
+## Phase 8: Replace Deep-Link Notifications
+
+**Status:** Not started
+
+- [ ] `openSQLFiles` — `AppDelegate` → `MainContentCommandActions`. Keep notification (legitimate AppKit → SwiftUI bridge).
+- [ ] `switchSchemaFromURL` — `AppDelegate` → coordinator. Keep or use a coordinator lookup by connectionId.
+- [ ] `applyURLFilter` — `AppDelegate` → coordinator. Same.
+
+---
+
+## Priority Order
+
+1. **Phase 1** (dead code removal) — zero risk, immediate cleanup
+2. **Phase 3** (data refresh scoping) — fixes the actual sidebar bug, biggest architectural win
+3. **Phase 4** (sidebar actions via @FocusedValue) — clean menu routing
+4. **Phase 5** (structure view) — removes the most confusing notification routing
+5. **Phase 6** (editor/AI) — cleaner inter-panel communication
+6. **Phase 2** (settings) — partial, only SwiftUI consumers
+7. **Phase 7** (window lifecycle) — lower priority, partially legitimate
+8. **Phase 8** (deep-link) — mostly keep as-is
+
+## Metrics
+
+| Metric                                       | Before | Current | Target                                           |
+| -------------------------------------------- | ------ | ------- | ------------------------------------------------ |
+| Custom notification names                    | 62     | ~33     | ~15 (AppKit bridges + settings for AppKit views) |
+| Dead notifications                           | 11     | 0       | 0                                                |
+| Global broadcasts without connection scoping | 3      | 1       | 0                                                |
+| `userInfo` dictionary payloads               | ~8     | ~7      | 0 (typed APIs)                                   |


### PR DESCRIPTION
## Summary

- Give `MainContentCoordinator` a `weak var sidebarViewModel` reference, wired by `SidebarView` on appear
- Replace 10 `.refreshData` notification posts in `+Navigation.swift` with direct `reloadSidebar()` calls
- Replace 2 `.databaseDidConnect` abuse posts in `+SaveChanges.swift` and `+Discard.swift` with `reloadSidebar()`
- Remove `SidebarViewModel`'s `Publishers.Merge` subscription for `.databaseDidConnect`/`.refreshData`
- Chain `coordinator?.reloadSidebar()` into `handleRefreshData()` and `handleDatabaseDidConnect()` in `MainContentCommandActions` so menu/toolbar/import/DatabaseManager signals still reach the sidebar

Sidebar reloads are now per-window instead of global. Multi-window users no longer see every sidebar reload when any window triggers a refresh.

## Test plan

- [ ] Connect to database — sidebar loads tables
- [ ] Switch database/schema — sidebar reloads for current window only
- [ ] Cmd+R refresh — sidebar reloads + data grid re-queries
- [ ] Save table operations (truncate/drop) — sidebar reloads
- [ ] Discard changes — sidebar reloads
- [ ] Import data — sidebar reloads
- [ ] DDL changes (create table via query) — sidebar reloads
- [ ] Multi-window: refresh in window A does NOT reload sidebar in window B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sidebar refresh responsiveness by modernizing internal communication patterns, ensuring the sidebar synchronizes more reliably with database operations and state changes.

* **Documentation**
  * Added development documentation outlining the architecture improvements for the app's communication infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->