### PR TITLE
refactor: replace structure view notifications with direct coordinator calls

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -454,14 +454,12 @@ extension Notification.Name {
     // Multi-listener broadcasts (Sidebar + Coordinator + StructureView)
     static let refreshData = Notification.Name("refreshData")
 
-    // Data operations (still posted by DataGrid / context menus / StructureView subscribers)
+    // Data operations (still posted by DataGrid / context menus)
     static let deleteSelectedRows = Notification.Name("deleteSelectedRows")
     static let addNewRow = Notification.Name("addNewRow")
     static let duplicateRow = Notification.Name("duplicateRow")
     static let copySelectedRows = Notification.Name("copySelectedRows")
     static let pasteRows = Notification.Name("pasteRows")
-    static let undoChange = Notification.Name("undoChange")
-    static let redoChange = Notification.Name("redoChange")
 
     // Tab operations
     static let newQueryTab = Notification.Name("newQueryTab")
@@ -469,10 +467,8 @@ extension Notification.Name {
     // Sidebar operations (still posted by SidebarView / ConnectionStatusView)
     static let openDatabaseSwitcher = Notification.Name("openDatabaseSwitcher")
 
-    // Structure view operations (still posted by QueryEditorView)
+    // Query editor operations
     static let explainQuery = Notification.Name("explainQuery")
-    static let saveStructureChanges = Notification.Name("saveStructureChanges")
-    static let previewStructureSQL = Notification.Name("previewStructureSQL")
 
     // File opening notifications
     static let openSQLFiles = Notification.Name("openSQLFiles")

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -249,7 +249,7 @@ struct MainEditorContentView: View {
     private func resultsSection(tab: QueryTab) -> some View {
         VStack(spacing: 0) {
             if tab.showStructure, let tableName = tab.tableName {
-                TableStructureView(tableName: tableName, connection: connection, toolbarState: coordinator.toolbarState)
+                TableStructureView(tableName: tableName, connection: connection, toolbarState: coordinator.toolbarState, coordinator: coordinator)
                     .id(tableName)
                     .frame(maxHeight: .infinity)
             } else if let explainText = tab.explainText {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SQLPreview.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SQLPreview.swift
@@ -17,8 +17,8 @@ extension MainContentCoordinator {
         tableOperationOptions: [String: TableOperationOptions]
     ) {
         if tabManager.selectedTab?.showStructure == true {
-            // Structure view handles its own preview via notification
-            NotificationCenter.default.post(name: .previewStructureSQL, object: nil)
+            // Structure view handles its own preview via direct call
+            structureActions?.previewSQL?()
         } else {
             generatePreviewSQL(
                 pendingTruncates: pendingTruncates,

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -240,7 +240,7 @@ final class MainContentCommandActions {
 
     func copySelectedRows() {
         if coordinator?.tabManager.selectedTab?.showStructure == true {
-            NotificationCenter.default.post(name: .copySelectedRows, object: nil)
+            coordinator?.structureActions?.copyRows?()
         } else {
             let indices = selectedRowIndices.wrappedValue
             coordinator?.copySelectedRowsToClipboard(indices: indices)
@@ -254,7 +254,7 @@ final class MainContentCommandActions {
 
     func pasteRows() {
         if coordinator?.tabManager.selectedTab?.showStructure == true {
-            NotificationCenter.default.post(name: .pasteRows, object: nil)
+            coordinator?.structureActions?.pasteRows?()
         } else {
             var indices = selectedRowIndices.wrappedValue
             var cell = editingCell.wrappedValue
@@ -339,9 +339,9 @@ final class MainContentCommandActions {
             return
         }
 
-        // Structure view saves are notification-based
+        // Structure view saves via direct coordinator call
         if coordinator.tabManager.selectedTab?.showStructure == true {
-            NotificationCenter.default.post(name: .saveStructureChanges, object: nil)
+            coordinator.structureActions?.saveChanges?()
             performClose()
             return
         }
@@ -408,8 +408,7 @@ final class MainContentCommandActions {
     func saveChanges() {
         // Check if we're in structure view mode
         if coordinator?.tabManager.selectedTab?.showStructure == true {
-            // Post notification for structure view to handle
-            NotificationCenter.default.post(name: .saveStructureChanges, object: nil)
+            coordinator?.structureActions?.saveChanges?()
         } else if rightPanelState.editState.hasEdits {
             // Save sidebar edits if the right panel has pending changes
             rightPanelState.onSave?()
@@ -473,7 +472,7 @@ final class MainContentCommandActions {
 
     func undoChange() {
         if coordinator?.tabManager.selectedTab?.showStructure == true {
-            NotificationCenter.default.post(name: .undoChange, object: nil)
+            coordinator?.structureActions?.undo?()
         } else {
             var indices = selectedRowIndices.wrappedValue
             coordinator?.undoLastChange(selectedRowIndices: &indices)
@@ -483,7 +482,7 @@ final class MainContentCommandActions {
 
     func redoChange() {
         if coordinator?.tabManager.selectedTab?.showStructure == true {
-            NotificationCenter.default.post(name: .redoChange, object: nil)
+            coordinator?.structureActions?.redo?()
         } else {
             coordinator?.redoLastChange()
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -64,6 +64,9 @@ final class MainContentCoordinator {
     /// Direct reference to sidebar viewmodel — eliminates global notification broadcasts
     weak var sidebarViewModel: SidebarViewModel?
 
+    /// Direct reference to structure view actions — eliminates notification broadcasts
+    weak var structureActions: StructureViewActionHandler?
+
     // MARK: - Published State
 
     var schemaProvider: SQLSchemaProvider

--- a/TablePro/Views/Structure/StructureViewActionHandler.swift
+++ b/TablePro/Views/Structure/StructureViewActionHandler.swift
@@ -1,0 +1,21 @@
+//
+//  StructureViewActionHandler.swift
+//  TablePro
+//
+//  Action handler for structure view — allows coordinator to call
+//  structure-view actions directly instead of broadcasting notifications.
+//
+
+import Foundation
+
+/// Provides direct action dispatch from coordinator to structure view,
+/// replacing notification-based communication.
+@MainActor
+final class StructureViewActionHandler {
+    var saveChanges: (() -> Void)?
+    var previewSQL: (() -> Void)?
+    var copyRows: (() -> Void)?
+    var pasteRows: (() -> Void)?
+    var undo: (() -> Void)?
+    var redo: (() -> Void)?
+}

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -18,6 +18,7 @@ struct TableStructureView: View {
     let tableName: String
     let connection: DatabaseConnection
     let toolbarState: ConnectionToolbarState
+    let coordinator: MainContentCoordinator?
 
     @State private var selectedTab: StructureTab = .columns
     @State private var columns: [ColumnInfo] = []
@@ -41,11 +42,13 @@ struct TableStructureView: View {
     @State private var sortState = SortState()
     @State private var editingCell: CellPosition?
     @State private var structureColumnLayout = ColumnLayoutState()
+    @State private var actionHandler = StructureViewActionHandler()
 
-    init(tableName: String, connection: DatabaseConnection, toolbarState: ConnectionToolbarState) {
+    init(tableName: String, connection: DatabaseConnection, toolbarState: ConnectionToolbarState, coordinator: MainContentCoordinator?) {
         self.tableName = tableName
         self.connection = connection
         self.toolbarState = toolbarState
+        self.coordinator = coordinator
 
         // Initialize wrappedChangeManager using the StateObject's wrappedValue
         let manager = StructureChangeManager()
@@ -71,51 +74,30 @@ struct TableStructureView: View {
             AppState.shared.isCurrentTabEditable = (selectedTab != .ddl)
             AppState.shared.hasRowSelection = !selectedRows.isEmpty
             AppState.shared.hasStructureChanges = structureChangeManager.hasChanges
+
+            // Wire action handler for direct coordinator calls
+            actionHandler.saveChanges = {
+                if self.structureChangeManager.hasChanges && self.selectedTab != .ddl {
+                    Task { await self.executeSchemaChanges() }
+                }
+            }
+            actionHandler.previewSQL = { self.generateStructurePreviewSQL() }
+            actionHandler.copyRows = { self.handleCopyRows(self.selectedRows) }
+            actionHandler.pasteRows = { self.handlePaste() }
+            actionHandler.undo = { self.handleUndo() }
+            actionHandler.redo = { self.handleRedo() }
+            coordinator?.structureActions = actionHandler
         }
         .onDisappear {
             AppState.shared.isCurrentTabEditable = false
             AppState.shared.hasRowSelection = false
             AppState.shared.hasStructureChanges = false
+            coordinator?.structureActions = nil
         }
         .onChange(of: structureChangeManager.hasChanges) { _, newValue in
             AppState.shared.hasStructureChanges = newValue
         }
         .onReceive(NotificationCenter.default.publisher(for: .refreshData), perform: onRefreshData)
-        .onReceive(
-            Publishers.Merge(
-                NotificationCenter.default.publisher(for: .saveStructureChanges),
-                NotificationCenter.default.publisher(for: .previewStructureSQL)
-            )
-            .debounce(for: .milliseconds(50), scheduler: RunLoop.main)
-        ) { notification in
-            if notification.name == .saveStructureChanges {
-                if structureChangeManager.hasChanges && selectedTab != .ddl {
-                    Task {
-                        await executeSchemaChanges()
-                    }
-                }
-            } else {
-                generateStructurePreviewSQL()
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .copySelectedRows)) { _ in
-            handleCopyRows(selectedRows)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .pasteRows)) { _ in
-            handlePaste()
-        }
-        .onReceive(
-            Publishers.Merge(
-                NotificationCenter.default.publisher(for: .undoChange),
-                NotificationCenter.default.publisher(for: .redoChange)
-            )
-        ) { notification in
-            if notification.name == .undoChange {
-                handleUndo()
-            } else {
-                handleRedo()
-            }
-        }
     }
 
     // MARK: - Toolbar
@@ -895,7 +877,8 @@ struct TableStructureView: View {
             username: "root",
             type: .mysql
         ),
-        toolbarState: ConnectionToolbarState()
+        toolbarState: ConnectionToolbarState(),
+        coordinator: nil
     )
     .frame(width: 800, height: 600)
 }

--- a/docs/development/notification-refactor.md
+++ b/docs/development/notification-refactor.md
@@ -106,63 +106,50 @@ Gave the coordinator a direct `weak var sidebarViewModel` reference, replacing 1
 
 ---
 
-## Phase 4: Replace Sidebar Action Notifications with `@FocusedValue`
+## Phase 4: Replace Sidebar Action Notifications with Direct Calls
 
-**Status:** Not started
+**Status:** Done (PR [#286](https://github.com/datlechin/TablePro/pull/286))
 
-Menu items post global notifications to reach the sidebar. These should use `@FocusedValue` to call the active window's sidebar directly.
+Replaced 9 sidebar action notifications with direct coordinator calls and `@FocusedValue` routing. Context menu actions call coordinator directly. Menu bar uses `actions?.copyTableNames()` and `actions?.truncateTables()` via `@FocusedValue`.
 
-- [ ] `copyTableNames` — menu → `SidebarViewModel.copySelectedTableNames()`
-- [ ] `truncateTables` — menu → `SidebarViewModel.batchToggleTruncate()`
-- [ ] `clearSelection` — menu → `SidebarViewModel.selectedTables.removeAll()`
-- [ ] `showAllTables` — menu → coordinator action
-- [ ] `showTableStructure` — sidebar context menu → coordinator
-- [ ] `editViewDefinition` — sidebar context menu → coordinator
-- [ ] `createView` — sidebar context menu → coordinator
-- [ ] `exportTables` — sidebar context menu → coordinator
-- [ ] `importTables` — sidebar context menu → coordinator
+- [x] `copyTableNames` — menu → `actions?.copyTableNames()` → `coordinator.sidebarViewModel.copySelectedTableNames()`
+- [x] `truncateTables` — menu → `actions?.truncateTables()` → `coordinator.sidebarViewModel.batchToggleTruncate()`
+- [x] `clearSelection` — dead (no sender), removed both subscribers
+- [x] `showAllTables` — `SidebarView` calls `coordinator?.showAllTablesMetadata()` directly
+- [x] `showTableStructure` — context menu → `coordinator?.openTableTab(_, showStructure:)`
+- [x] `editViewDefinition` — context menu → `coordinator?.editViewDefinition(_:)`
+- [x] `createView` — context menu → `coordinator?.createView()`
+- [x] `exportTables` — context menu → `coordinator?.openExportDialog()`
+- [x] `importTables` — context menu → `coordinator?.openImportDialog()`
 
-### Pattern:
-
-```swift
-// Define focused value
-struct SidebarActionsKey: FocusedValueKey {
-    typealias Value = SidebarViewModel
-}
-
-extension FocusedValues {
-    var sidebarActions: SidebarViewModel? { ... }
-}
-
-// In SidebarView
-.focusedValue(\.sidebarActions, viewModel)
-
-// In menu
-Button("Copy Table Names") {
-    focusedSidebarActions?.copySelectedTableNames()
-}
-```
+Also extracted `createView()`, `editViewDefinition(_:)`, `openExportDialog()`, `openImportDialog()` from `MainContentCommandActions` into `MainContentCoordinator+SidebarActions.swift`. Removed all notification infrastructure from `SidebarViewModel` (`import Combine`, `cancellables`, `setupNotifications()`).
 
 ---
 
 ## Phase 5: Replace Structure View Notifications with Coordinator Pattern
 
-**Status:** Not started
+**Status:** Done
 
-`MainContentCommandActions` routes commands to `TableStructureView` via notifications because the structure view is deeply embedded and not directly accessible.
+Created `StructureViewActionHandler` class with closure properties for each action. `TableStructureView` wires closures in `.onAppear` and registers handler with coordinator. Senders call `coordinator.structureActions?.method?()` instead of posting notifications.
 
-### Notifications to replace:
+### Notifications replaced:
 
-- [ ] `copySelectedRows` (structure path)
-- [ ] `pasteRows` (structure path)
-- [ ] `undoChange` (structure path)
-- [ ] `redoChange` (structure path)
-- [ ] `saveStructureChanges`
-- [ ] `previewStructureSQL`
+- [x] `copySelectedRows` (structure path) — now `structureActions?.copyRows?()`
+- [x] `pasteRows` (structure path) — now `structureActions?.pasteRows?()`
+- [x] `undoChange` — removed notification name, now `structureActions?.undo?()`
+- [x] `redoChange` — removed notification name, now `structureActions?.redo?()`
+- [x] `saveStructureChanges` — removed notification name, now `structureActions?.saveChanges?()`
+- [x] `previewStructureSQL` — removed notification name, now `structureActions?.previewSQL?()`
 
-### Strategy:
+### Files changed:
 
-Create a `StructureViewActions` protocol/class that `TableStructureView` registers with the coordinator. The coordinator calls methods directly instead of broadcasting.
+- **New:** `Views/Structure/StructureViewActionHandler.swift` — action handler class
+- **Modified:** `MainContentCoordinator.swift` — added `weak var structureActions`
+- **Modified:** `TableStructureView.swift` — wire closures on appear, removed 6 `.onReceive` handlers
+- **Modified:** `MainEditorContentView.swift` — pass coordinator to `TableStructureView`
+- **Modified:** `MainContentCommandActions.swift` — 6 notification posts → direct calls
+- **Modified:** `MainContentCoordinator+SQLPreview.swift` — notification post → direct call
+- **Modified:** `TableProApp.swift` — removed 4 notification name definitions
 
 ---
 


### PR DESCRIPTION
## Summary

- Created `StructureViewActionHandler` class with 6 closure properties (`saveChanges`, `previewSQL`, `copyRows`, `pasteRows`, `undo`, `redo`) that `TableStructureView` wires on `.onAppear` and registers with `MainContentCoordinator`
- Replaced 6 notification posts in `MainContentCommandActions` and `MainContentCoordinator+SQLPreview` with direct `coordinator.structureActions?.method?()` calls
- Removed 4 notification name definitions (`undoChange`, `redoChange`, `saveStructureChanges`, `previewStructureSQL`) from `TableProApp.swift`
- Kept `copySelectedRows` and `pasteRows` notification names (still used by data grid path)

## Test plan

- [ ] Open table structure view → Cmd+Z (undo) works
- [ ] Open table structure view → Cmd+Shift+Z (redo) works
- [ ] Open table structure view → Cmd+C copies selected structure rows
- [ ] Open table structure view → Cmd+V pastes structure rows
- [ ] Open table structure view → Cmd+S saves schema changes
- [ ] Open table structure view → Preview SQL shows review popover
- [ ] Data grid copy/paste still works (unaffected)
- [ ] Close tab with unsaved structure changes → save dialog works
- [ ] Multi-window: structure actions affect only current window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal communication architecture by replacing notification-based messaging with direct coordinator calls for structure view operations, improving code clarity and maintainability.

* **Documentation**
  * Updated development guides to reflect changes to the notification refactor phases and new action handler pattern implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->