### PR TITLE
fix: remove auto-install plugin on database type selection

### DIFF
--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -1111,11 +1111,15 @@ struct ConnectionFormView: View {
             } catch {
                 await MainActor.run {
                     isTesting = false
-                    AlertHelper.showErrorSheet(
-                        title: String(localized: "Connection Test Failed"),
-                        message: error.localizedDescription,
-                        window: window
-                    )
+                    if case PluginError.pluginNotInstalled = error {
+                        pluginInstallConnection = testConn
+                    } else {
+                        AlertHelper.showErrorSheet(
+                            title: String(localized: "Connection Test Failed"),
+                            message: error.localizedDescription,
+                            window: window
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #296

## Summary
- Remove automatic plugin download when selecting a database type in the connection form picker. Previously, just clicking on a database type (e.g., Oracle, ClickHouse) would immediately start downloading and installing the plugin without user consent — problematic for accidental clicks.
- Remove `installPluginForType()` method, `isInstallingPlugin`/`pluginInstallProgress` state, and the "Installing plugin..." progress indicator in the footer.
- Plugin installation now only happens at connect time via `PluginInstallModifier`, which shows a confirmation dialog first ("Would you like to download it from the plugin marketplace?").
- The download icon (arrow.down.circle) still appears next to uninstalled types in the picker as a visual hint.

## Test plan
- [ ] Open connection form, switch between database types including uninstalled ones (Oracle, ClickHouse, DuckDB) — verify no automatic download starts
- [ ] Verify the download icon still shows next to uninstalled types in the picker
- [ ] Click Connect/Test with an uninstalled plugin — verify the install prompt appears
- [ ] Verify Test and Save buttons are not incorrectly disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed plugin installation progress indicator from the connection form interface.
  * Plugin installation no longer occurs automatically when changing database types.
  * Updated connection test and save functionality to handle plugin-related errors through a revised flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->