### PR TITLE
fix: use dialect-aware identifier quoting in TableQueryBuilder

### DIFF
--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -15,12 +15,21 @@ struct TableQueryBuilder {
 
     private let databaseType: DatabaseType
     private var pluginDriver: (any PluginDatabaseDriver)?
+    private let dialectQuote: (String) -> String
 
     // MARK: - Initialization
 
-    init(databaseType: DatabaseType, pluginDriver: (any PluginDatabaseDriver)? = nil) {
+    init(
+        databaseType: DatabaseType,
+        pluginDriver: (any PluginDatabaseDriver)? = nil,
+        dialectQuote: ((String) -> String)? = nil
+    ) {
         self.databaseType = databaseType
         self.pluginDriver = pluginDriver
+        self.dialectQuote = dialectQuote ?? { name in
+            let escaped = name.replacingOccurrences(of: "\"", with: "\"\"")
+            return "\"\(escaped)\""
+        }
     }
 
     mutating func setPluginDriver(_ driver: (any PluginDatabaseDriver)?) {
@@ -31,8 +40,7 @@ struct TableQueryBuilder {
 
     private func quote(_ name: String) -> String {
         if let pluginDriver { return pluginDriver.quoteIdentifier(name) }
-        let escaped = name.replacingOccurrences(of: "\"", with: "\"\"")
-        return "\"\(escaped)\""
+        return dialectQuote(name)
     }
 
     // MARK: - Query Building

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -228,7 +228,12 @@ final class MainContentCoordinator {
         self.filterStateManager = filterStateManager
         self.columnVisibilityManager = columnVisibilityManager
         self.toolbarState = toolbarState
-        self.queryBuilder = TableQueryBuilder(databaseType: connection.type)
+        self.queryBuilder = TableQueryBuilder(
+            databaseType: connection.type,
+            dialectQuote: quoteIdentifierFromDialect(
+                PluginManager.shared.sqlDialect(for: connection.type)
+            )
+        )
         self.persistence = TabPersistenceCoordinator(connectionId: connection.id)
 
         self.schemaProvider = SchemaProviderRegistry.shared.getOrCreate(for: connection.id)


### PR DESCRIPTION
## Summary
- Fix identifier quoting inconsistency where opening a table used correct dialect quoting (e.g., backticks for MySQL) but refreshing fell back to hardcoded double-quotes
- Add `dialectQuote` closure to `TableQueryBuilder` so the fallback quote style matches the database dialect when `pluginDriver` is nil
- Affects MySQL/MariaDB, SQLite, and ClickHouse (all use backtick quoting); PostgreSQL/MSSQL/Oracle were unaffected

## Root Cause
`TableQueryBuilder.quote()` had a hardcoded double-quote fallback when `pluginDriver` was nil. For MySQL/MariaDB/SQLite/ClickHouse, `pluginDriver` is always nil (they don't implement `buildBrowseQuery`), so refresh queries used `"table"` instead of `` `table` ``.

Meanwhile, the initial table open path (`QueryTab.buildBaseTableQuery`) correctly used `quoteIdentifierFromDialect()` to get backtick quoting from the dialect.

## Test plan
- [ ] Open a MySQL/MariaDB table — verify query uses backticks
- [ ] Refresh the same table (Cmd+R) — verify query still uses backticks (not double-quotes)
- [ ] Repeat for SQLite and ClickHouse
- [ ] Verify PostgreSQL still uses double-quotes on both open and refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced identifier quoting to support database dialect-specific formatting, improving SQL compatibility across different database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->