### PR TITLE
fix: batch CloudKit push to respect 400-item limit

### DIFF
--- a/TablePro/Core/Sync/CloudKitSyncEngine.swift
+++ b/TablePro/Core/Sync/CloudKitSyncEngine.swift
@@ -50,9 +50,35 @@ actor CloudKitSyncEngine {
 
     // MARK: - Push
 
+    /// CloudKit allows at most 400 items (saves + deletions) per modify operation
+    private static let maxBatchSize = 400
+
     func push(records: [CKRecord], deletions: [CKRecord.ID]) async throws {
         guard !records.isEmpty || !deletions.isEmpty else { return }
 
+        // Split into batches that fit within CloudKit's 400-item limit
+        var remainingSaves = records[...]
+        var remainingDeletions = deletions[...]
+
+        while !remainingSaves.isEmpty || !remainingDeletions.isEmpty {
+            let batchSaves: [CKRecord]
+            let batchDeletions: [CKRecord.ID]
+
+            let savesCount = min(remainingSaves.count, Self.maxBatchSize)
+            batchSaves = Array(remainingSaves.prefix(savesCount))
+            remainingSaves = remainingSaves.dropFirst(savesCount)
+
+            let deletionsCount = min(remainingDeletions.count, Self.maxBatchSize - savesCount)
+            batchDeletions = Array(remainingDeletions.prefix(deletionsCount))
+            remainingDeletions = remainingDeletions.dropFirst(deletionsCount)
+
+            try await pushBatch(records: batchSaves, deletions: batchDeletions)
+        }
+
+        Self.logger.info("Pushed \(records.count) records, \(deletions.count) deletions")
+    }
+
+    private func pushBatch(records: [CKRecord], deletions: [CKRecord.ID]) async throws {
         try await withRetry {
             let operation = CKModifyRecordsOperation(
                 recordsToSave: records,
@@ -83,8 +109,6 @@ actor CloudKitSyncEngine {
                 self.database.add(operation)
             }
         }
-
-        Self.logger.info("Pushed \(records.count) records, \(deletions.count) deletions")
     }
 
     // MARK: - Pull


### PR DESCRIPTION
## Summary
- CloudKit's `CKModifyRecordsOperation` has a 400-item (saves + deletions) limit per request
- When syncing >400 records (e.g., 520 connections/history items), the push fails with "Your request contains N items which is more than the maximum number of items in a single request (400)"
- Split push into batches of 400 items, filling saves first then deletions with remaining capacity

## Test plan
- [ ] Trigger a sync with >400 pending records and verify it completes without error
- [ ] Verify normal syncs (<400 items) still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CloudKit synchronization reliability and performance when syncing large numbers of items at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->