### PR TITLE
fix: always show safe mode badge including silent level

### DIFF
--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -213,9 +213,7 @@ final class ConnectionToolbarState {
             parts.append(String(localized: "Replication lag: \(lag)s"))
         }
 
-        if safeModeLevel != .silent {
-            parts.append(safeModeLevel.displayName)
-        }
+        parts.append(safeModeLevel.displayName)
 
         return parts.joined(separator: " • ")
     }

--- a/TablePro/Views/Toolbar/ConnectionStatusView.swift
+++ b/TablePro/Views/Toolbar/ConnectionStatusView.swift
@@ -73,13 +73,11 @@ struct ConnectionStatusView: View {
                 .font(.system(size: 13))
                 .foregroundStyle(ThemeEngine.shared.colors.toolbar.secondaryTextSwiftUI)
                 .overlay(alignment: .bottomTrailing) {
-                    if safeModeLevel != .silent {
-                        Image(systemName: safeModeLevel.iconName)
-                            .font(.system(size: 7, weight: .bold))
-                            .foregroundStyle(safeModeLevel.badgeColor)
-                            .offset(x: 3, y: 2)
-                            .help(safeModeLevel.displayName)
-                    }
+                    Image(systemName: safeModeLevel.iconName)
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundStyle(safeModeLevel.badgeColor)
+                        .offset(x: 3, y: 2)
+                        .help(safeModeLevel.displayName)
                 }
 
             Text(databaseName)

--- a/TablePro/Views/Toolbar/SafeModeBadgeView.swift
+++ b/TablePro/Views/Toolbar/SafeModeBadgeView.swift
@@ -10,36 +10,34 @@ struct SafeModeBadgeView: View {
     @State private var showPopover = false
 
     var body: some View {
-        if safeModeLevel != .silent {
-            Button {
-                showPopover.toggle()
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: safeModeLevel.iconName)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(safeModeLevel.badgeColor)
-                }
+        Button {
+            showPopover.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: safeModeLevel.iconName)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(safeModeLevel.badgeColor)
             }
-            .buttonStyle(.plain)
-            .help(String(localized: "Safe Mode: \(safeModeLevel.displayName)"))
-            .popover(isPresented: $showPopover) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Safe Mode")
-                        .font(.headline)
-                        .padding(.bottom, 4)
+        }
+        .buttonStyle(.plain)
+        .help(String(localized: "Safe Mode: \(safeModeLevel.displayName)"))
+        .popover(isPresented: $showPopover) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Safe Mode")
+                    .font(.headline)
+                    .padding(.bottom, 4)
 
-                    Picker("", selection: $safeModeLevel) {
-                        ForEach(SafeModeLevel.allCases) { level in
-                            Label(level.displayName, systemImage: level.iconName)
-                                .tag(level)
-                        }
+                Picker("", selection: $safeModeLevel) {
+                    ForEach(SafeModeLevel.allCases) { level in
+                        Label(level.displayName, systemImage: level.iconName)
+                            .tag(level)
                     }
-                    .pickerStyle(.radioGroup)
-                    .labelsHidden()
                 }
-                .padding()
-                .frame(width: 200)
+                .pickerStyle(.radioGroup)
+                .labelsHidden()
             }
+            .padding()
+            .frame(width: 200)
         }
     }
 }
@@ -48,6 +46,7 @@ struct SafeModeBadgeView: View {
 
 #Preview("Safe Mode Badges") {
     VStack(spacing: 12) {
+        SafeModeBadgeView(safeModeLevel: .constant(.silent))
         SafeModeBadgeView(safeModeLevel: .constant(.alert))
         SafeModeBadgeView(safeModeLevel: .constant(.safeMode))
         SafeModeBadgeView(safeModeLevel: .constant(.readOnly))


### PR DESCRIPTION
Remove conditional rendering of safe mode badge. The silent level should be displayed alongside other safe mode levels to ensure consistent UI and make the safe mode state always visible to users, even when set to silent.

Closes #358 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Safe mode status indicator now always displays consistently, even when in silent mode, ensuring users can always see the current safe mode status without requiring additional interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->