### PR TITLE
fix: resolve pgpass password app-side with original host

### DIFF
--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -337,9 +337,11 @@ enum DatabaseDriverFactory {
     private static func resolvePassword(for connection: DatabaseConnection) -> String {
         if connection.usePgpass {
             let pgpassHost = connection.additionalFields["pgpassOriginalHost"] ?? connection.host
+            let pgpassPort = connection.additionalFields["pgpassOriginalPort"]
+                .flatMap(Int.init) ?? connection.port
             return PgpassReader.resolve(
                 host: pgpassHost.isEmpty ? "localhost" : pgpassHost,
-                port: connection.port,
+                port: pgpassPort,
                 database: connection.database,
                 username: connection.username
             ) ?? ""

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -443,6 +443,7 @@ final class DatabaseManager {
         var effectiveFields = connection.additionalFields
         if connection.usePgpass {
             effectiveFields["pgpassOriginalHost"] = connection.host
+            effectiveFields["pgpassOriginalPort"] = String(connection.port)
         }
 
         return DatabaseConnection(


### PR DESCRIPTION
## Summary

Fixes #356

- Resolve `.pgpass` passwords app-side using `PgpassReader` instead of delegating to libpq's native pgpass handling, which may resolve hostnames to IPs before matching
- Preserve the original host in `additionalFields` before SSH tunnel rewrites it to `127.0.0.1`, so pgpass lookup uses the real server hostname

## Test plan

- [ ] Direct connection with hostname in `.pgpass` — should match and connect
- [ ] SSH tunnel connection with hostname in `.pgpass` — should match using original host, not `127.0.0.1`
- [ ] Wildcard `.pgpass` entries (`*`) — should still match
- [ ] No matching `.pgpass` entry — should fail with auth error
- [ ] Pgpass disabled (toggle off) — password from Keychain, no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pgpass file support for password resolution using connection parameters.
  * Improved credential lookup to honor the original host and port (defaults host to "localhost" when empty).
  * Ensures resolved credentials are applied when found and gracefully falls back to an empty password otherwise.
  * Preserves connection metadata when pgpass-based resolution is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->