### PR TITLE
fix: preserve pgpass setting when loading existing connections

### DIFF
--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -161,15 +161,15 @@ struct ConnectionFormView: View { // swiftlint:disable:this type_body_length
         .onChange(of: type) { _, newType in
             if hasLoadedData {
                 port = String(newType.defaultPort)
+                additionalFieldValues = [:]
+                for field in PluginManager.shared.additionalConnectionFields(for: newType) {
+                    if let defaultValue = field.defaultValue {
+                        additionalFieldValues[field.id] = defaultValue
+                    }
+                }
             }
             if !visibleTabs.contains(selectedTab) {
                 selectedTab = .general
-            }
-            additionalFieldValues = [:]
-            for field in PluginManager.shared.additionalConnectionFields(for: newType) {
-                if let defaultValue = field.defaultValue {
-                    additionalFieldValues[field.id] = defaultValue
-                }
             }
         }
         .pluginInstallPrompt(connection: $pluginInstallConnection) { connection in


### PR DESCRIPTION
## Summary
- Fixed `onChange(of: type)` unconditionally resetting `additionalFieldValues` during initial load, which wiped the persisted `usePgpass` setting when editing an existing PostgreSQL connection
- Moved the reset inside the `hasLoadedData` guard so it only runs when the user manually changes the database type, not during initial form population


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where connection form fields would not properly reinitialize when changing connection types, ensuring all settings are correctly updated for the newly selected type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->