### PR TITLE
Bundle RedisDriver plugin and fix installed plugin version display

### DIFF
--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		5ACE00012F4F000000000006 /* CodeEditTextView in Frameworks */ = {isa = PBXBuildFile; productRef = 5ACE00012F4F000000000007 /* CodeEditTextView */; };
 		5ACE00012F4F00000000000A /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 5ACE00012F4F000000000009 /* Sparkle */; };
 		5ACE00012F4F00000000000D /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5ACE00012F4F00000000000C /* MarkdownUI */; };
+		5A867000D00000000 /* RedisDriver.tableplugin in Copy Plug-Ins */ = {isa = PBXBuildFile; fileRef = 5A867000100000000 /* RedisDriver.tableplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5ADDB00000000000000000D0 /* DynamoDBDriverPlugin.tableplugin in Copy Plug-Ins */ = {isa = PBXBuildFile; fileRef = 5ADDB00300000000000000A0 /* DynamoDBDriverPlugin.tableplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5ADDB00100000000000000A1 /* DynamoDBConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADDB00200000000000000A1 /* DynamoDBConnection.swift */; };
 		5ADDB00100000000000000A2 /* DynamoDBItemFlattener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADDB00200000000000000A2 /* DynamoDBItemFlattener.swift */; };
@@ -133,6 +134,13 @@
 			remoteGlobalIDString = 5A1091C62EF17EDC0055EA7C;
 			remoteInfo = TablePro;
 		};
+		5A867000B00000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5A1091BF2EF17EDC0055EA7C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5A867000000000000;
+			remoteInfo = RedisDriver;
+		};
 		5ADDB00000000000000000C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5A1091BF2EF17EDC0055EA7C /* Project object */;
@@ -156,6 +164,7 @@
 				5A86B000D00000000 /* JSONExport.tableplugin in Copy Plug-Ins */,
 				5A86C000D00000000 /* SQLExport.tableplugin in Copy Plug-Ins */,
 				5ADDB00000000000000000D0 /* DynamoDBDriverPlugin.tableplugin in Copy Plug-Ins */,
+				5A867000D00000000 /* RedisDriver.tableplugin in Copy Plug-Ins */,
 			);
 			name = "Copy Plug-Ins";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -830,6 +839,7 @@
 				5A86B000C00000000 /* PBXTargetDependency */,
 				5A86C000C00000000 /* PBXTargetDependency */,
 				5ADDB00000000000000000C1 /* PBXTargetDependency */,
+				5A867000C00000000 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				5A1091C92EF17EDC0055EA7C /* TablePro */,
@@ -1765,6 +1775,11 @@
 			isa = PBXTargetDependency;
 			target = 5A86B000000000000 /* JSONExport */;
 			targetProxy = 5A86B000B00000000 /* PBXContainerItemProxy */;
+		};
+		5A867000C00000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5A867000000000000 /* RedisDriver */;
+			targetProxy = 5A867000B00000000 /* PBXContainerItemProxy */;
 		};
 		5A86C000C00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -61,6 +61,49 @@ final class PluginManager {
 
     private init() {}
 
+    // MARK: - Registry Metadata
+
+    private struct RegistryMetadata: Codable {
+        let version: String
+        let pluginId: String
+    }
+
+    nonisolated private static func metadataURL(for pluginURL: URL) -> URL {
+        pluginURL.deletingLastPathComponent()
+            .appendingPathComponent(pluginURL.lastPathComponent + ".metadata.json")
+    }
+
+    nonisolated private static func readRegistryVersion(for pluginURL: URL) -> String? {
+        let url = metadataURL(for: pluginURL)
+        guard let data = try? Data(contentsOf: url),
+              let metadata = try? JSONDecoder().decode(RegistryMetadata.self, from: data) else {
+            return nil
+        }
+        return metadata.version
+    }
+
+    func updatePluginVersion(id: String, version: String) {
+        if let index = plugins.firstIndex(where: { $0.id == id }) {
+            plugins[index].version = version
+        }
+    }
+
+    func saveRegistryMetadata(version: String, pluginId: String, pluginURL: URL) {
+        let metadata = RegistryMetadata(version: version, pluginId: pluginId)
+        let url = Self.metadataURL(for: pluginURL)
+        do {
+            let data = try JSONEncoder().encode(metadata)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Self.logger.error("Failed to save registry metadata for \(pluginId): \(error.localizedDescription)")
+        }
+    }
+
+    private func removeRegistryMetadata(for pluginURL: URL) {
+        let url = Self.metadataURL(for: pluginURL)
+        try? FileManager.default.removeItem(at: url)
+    }
+
     private func migrateDisabledPluginsKey() {
         let defaults = UserDefaults.standard
         if let legacy = defaults.stringArray(forKey: Self.legacyDisabledPluginsKey) {
@@ -156,13 +199,14 @@ final class PluginManager {
             }
 
             let driverType = principalClass as? any DriverPlugin.Type
+            let version = readRegistryVersion(for: entry.url) ?? principalClass.pluginVersion
             let loaded = LoadedBundle(
                 url: entry.url,
                 source: entry.source,
                 bundle: bundle,
                 principalClassName: NSStringFromClass(principalClass),
                 pluginName: principalClass.pluginName,
-                pluginVersion: principalClass.pluginVersion,
+                pluginVersion: version,
                 pluginDescription: principalClass.pluginDescription,
                 capabilities: principalClass.capabilities,
                 databaseTypeId: driverType?.databaseTypeId,
@@ -359,13 +403,14 @@ final class PluginManager {
         let disabled = disabledPluginIds
 
         let driverType = principalClass as? any DriverPlugin.Type
+        let version = Self.readRegistryVersion(for: url) ?? principalClass.pluginVersion
         let entry = PluginEntry(
             id: bundleId,
             bundle: bundle,
             url: url,
             source: source,
             name: principalClass.pluginName,
-            version: principalClass.pluginVersion,
+            version: version,
             pluginDescription: principalClass.pluginDescription,
             capabilities: principalClass.capabilities,
             isEnabled: !disabled.contains(bundleId),
@@ -1008,6 +1053,8 @@ final class PluginManager {
         unregisterCapabilities(pluginId: id)
         entry.bundle.unload()
         plugins.remove(at: index)
+
+        removeRegistryMetadata(for: entry.url)
 
         let fm = FileManager.default
         if fm.fileExists(atPath: entry.url.path) {

--- a/TablePro/Core/Plugins/PluginModels.swift
+++ b/TablePro/Core/Plugins/PluginModels.swift
@@ -12,7 +12,7 @@ struct PluginEntry: Identifiable {
     let url: URL
     let source: PluginSource
     let name: String
-    let version: String
+    var version: String
     let pluginDescription: String
     let capabilities: [PluginCapability]
     var isEnabled: Bool

--- a/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
+++ b/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
@@ -68,6 +68,16 @@ extension PluginManager {
         // Move to our temp directory for installPlugin
         try FileManager.default.moveItem(at: tempDownloadURL, to: tempZipURL)
 
-        return try await installPlugin(from: tempZipURL)
+        var entry = try await installPlugin(from: tempZipURL)
+
+        saveRegistryMetadata(
+            version: registryPlugin.version,
+            pluginId: registryPlugin.id,
+            pluginURL: entry.url
+        )
+        entry.version = registryPlugin.version
+        updatePluginVersion(id: entry.id, version: registryPlugin.version)
+
+        return entry
     }
 }


### PR DESCRIPTION
## Summary

- **Bundle RedisDriver into the app** — added RedisDriver as a target dependency and to the "Copy Plug-Ins" build phase, so it ships as a built-in plugin (same as MySQL, PostgreSQL, SQLite, etc.). This eliminates the need to install it separately from the registry.
- **Fix installed plugin version display** — the Installed tab in plugin settings showed "1.0.0" for all plugins instead of the actual registry version (e.g., "1.0.4"). Now saves a `.metadata.json` sidecar file when installing from registry, and reads it back on load.

## Test plan

- [ ] Build and run TablePro — verify Redis appears in database list as a built-in plugin
- [ ] Connect to a Redis server — verify connection works
- [ ] Install a plugin from the registry — verify the Installed tab shows the correct version (not "1.0.0")
- [ ] Uninstall a registry plugin — verify the metadata file is cleaned up
- [ ] Relaunch the app — verify installed plugin versions persist correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin version tracking with persistent metadata storage to ensure accurate version information is maintained across installations and updates.
  * Enhanced plugin installation flow to properly capture and synchronize registry version data.

* **Chores**
  * Updated build configuration to include RedisDriver plugin in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->