### PR TITLE
Fix installed plugin version display

### DIFF
--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -61,6 +61,49 @@ final class PluginManager {
 
     private init() {}
 
+    // MARK: - Registry Metadata
+
+    private struct RegistryMetadata: Codable {
+        let version: String
+        let pluginId: String
+    }
+
+    nonisolated private static func metadataURL(for pluginURL: URL) -> URL {
+        pluginURL.deletingLastPathComponent()
+            .appendingPathComponent(pluginURL.lastPathComponent + ".metadata.json")
+    }
+
+    nonisolated private static func readRegistryVersion(for pluginURL: URL) -> String? {
+        let url = metadataURL(for: pluginURL)
+        guard let data = try? Data(contentsOf: url),
+              let metadata = try? JSONDecoder().decode(RegistryMetadata.self, from: data) else {
+            return nil
+        }
+        return metadata.version
+    }
+
+    func saveRegistryMetadata(version: String, pluginId: String, pluginURL: URL) {
+        let metadata = RegistryMetadata(version: version, pluginId: pluginId)
+        let url = Self.metadataURL(for: pluginURL)
+        do {
+            let data = try JSONEncoder().encode(metadata)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Self.logger.error("Failed to save registry metadata for \(pluginId): \(error.localizedDescription)")
+        }
+    }
+
+    func updatePluginVersion(id: String, version: String) {
+        if let index = plugins.firstIndex(where: { $0.id == id }) {
+            plugins[index].version = version
+        }
+    }
+
+    private func removeRegistryMetadata(for pluginURL: URL) {
+        let url = Self.metadataURL(for: pluginURL)
+        try? FileManager.default.removeItem(at: url)
+    }
+
     private func migrateDisabledPluginsKey() {
         let defaults = UserDefaults.standard
         if let legacy = defaults.stringArray(forKey: Self.legacyDisabledPluginsKey) {
@@ -156,13 +199,14 @@ final class PluginManager {
             }
 
             let driverType = principalClass as? any DriverPlugin.Type
+            let version = readRegistryVersion(for: entry.url) ?? principalClass.pluginVersion
             let loaded = LoadedBundle(
                 url: entry.url,
                 source: entry.source,
                 bundle: bundle,
                 principalClassName: NSStringFromClass(principalClass),
                 pluginName: principalClass.pluginName,
-                pluginVersion: principalClass.pluginVersion,
+                pluginVersion: version,
                 pluginDescription: principalClass.pluginDescription,
                 capabilities: principalClass.capabilities,
                 databaseTypeId: driverType?.databaseTypeId,
@@ -359,13 +403,14 @@ final class PluginManager {
         let disabled = disabledPluginIds
 
         let driverType = principalClass as? any DriverPlugin.Type
+        let version = Self.readRegistryVersion(for: url) ?? principalClass.pluginVersion
         let entry = PluginEntry(
             id: bundleId,
             bundle: bundle,
             url: url,
             source: source,
             name: principalClass.pluginName,
-            version: principalClass.pluginVersion,
+            version: version,
             pluginDescription: principalClass.pluginDescription,
             capabilities: principalClass.capabilities,
             isEnabled: !disabled.contains(bundleId),
@@ -1008,6 +1053,8 @@ final class PluginManager {
         unregisterCapabilities(pluginId: id)
         entry.bundle.unload()
         plugins.remove(at: index)
+
+        removeRegistryMetadata(for: entry.url)
 
         let fm = FileManager.default
         if fm.fileExists(atPath: entry.url.path) {

--- a/TablePro/Core/Plugins/PluginModels.swift
+++ b/TablePro/Core/Plugins/PluginModels.swift
@@ -12,7 +12,7 @@ struct PluginEntry: Identifiable {
     let url: URL
     let source: PluginSource
     let name: String
-    let version: String
+    var version: String
     let pluginDescription: String
     let capabilities: [PluginCapability]
     var isEnabled: Bool

--- a/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
+++ b/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
@@ -68,6 +68,16 @@ extension PluginManager {
         // Move to our temp directory for installPlugin
         try FileManager.default.moveItem(at: tempDownloadURL, to: tempZipURL)
 
-        return try await installPlugin(from: tempZipURL)
+        var entry = try await installPlugin(from: tempZipURL)
+
+        saveRegistryMetadata(
+            version: registryPlugin.version,
+            pluginId: registryPlugin.id,
+            pluginURL: entry.url
+        )
+        entry.version = registryPlugin.version
+        updatePluginVersion(id: entry.id, version: registryPlugin.version)
+
+        return entry
     }
 }


### PR DESCRIPTION
## Summary

- Installed plugins tab showed "1.0.0" for all plugins because version was read from `principalClass.pluginVersion` (hardcoded in plugin source)
- Now saves a `.metadata.json` sidecar file when installing from registry, containing the actual registry version
- On load, prefers the metadata version over the hardcoded one
- Metadata is cleaned up on uninstall

## Test plan

- [ ] Install a plugin from registry — verify Installed tab shows correct version (e.g., "1.0.6" not "1.0.0")
- [ ] Relaunch app — verify version persists
- [ ] Uninstall plugin — verify metadata file is removed
- [ ] Built-in plugins still show "1.0" (no metadata file, uses hardcoded version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins installed from the registry now automatically track and synchronize version information, ensuring accurate version management and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->