### PR TITLE
feat: single-click favorite to insert query in editor

### DIFF
--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -81,6 +81,11 @@ internal struct FavoritesTabView: View {
             deleteSelectedFavorites()
         }
         .onChange(of: selectedFavoriteIds) { oldIds, newIds in
+            if newIds.isEmpty {
+                lastInsertedFavoriteId = nil
+                return
+            }
+
             let added = newIds.subtracting(oldIds)
             guard added.count == 1,
                   newIds.count == 1,
@@ -91,11 +96,6 @@ internal struct FavoritesTabView: View {
             if let favorite = allFavorites.first(where: { "fav-\($0.id)" == selectedId }) {
                 coordinator?.insertFavorite(favorite)
                 lastInsertedFavoriteId = selectedId
-            }
-        }
-        .onChange(of: selectedFavoriteIds) {
-            if selectedFavoriteIds.isEmpty {
-                lastInsertedFavoriteId = nil
             }
         }
     }


### PR DESCRIPTION
## Summary
- Single-clicking a favorite in the sidebar now inserts its SQL into the current editor tab (#415)
- Guards prevent triggering during multi-select (Cmd+click, Shift+click) so delete workflow is unaffected
- Selection highlight is preserved after insert; clicking a different favorite then returning re-triggers insert

## Test plan
- [ ] Single-click a favorite → query appears in editor
- [ ] Click the same favorite again → no duplicate insert
- [ ] Click a different favorite, then click the first again → inserts again
- [ ] Deselect (click empty area), then click the same favorite → inserts again
- [ ] Cmd+click multiple favorites → no insert triggered
- [ ] Delete key with multi-select → still works as before
- [ ] Double-click a favorite → still inserts (existing behavior)

Closes #415 (partial — favorites quick-open item)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed favorites sidebar selection so selecting a favorite reliably inserts it into the editor.
  * Prevented duplicate insertions by ensuring only newly selected favorites trigger insertion; selection clearing resets the tracking state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->