### PR TITLE
fix: bump PluginKit version to 3 to reject stale registry plugins

### DIFF
--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 </dict>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>TableProPluginKitVersion</key>
-    <integer>2</integer>
+    <integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 </dict>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -12,7 +12,7 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager()
-    static let currentPluginKitVersion = 2
+    static let currentPluginKitVersion = 3
     private static let disabledPluginsKey = "com.TablePro.disabledPlugins"
     private static let legacyDisabledPluginsKey = "disabledPlugins"
 


### PR DESCRIPTION
## Summary
- Bumps `currentPluginKitVersion` from 2 to 3 in `PluginManager.swift`
- Updates `TableProPluginKitVersion` from 2 to 3 in all 19 plugin `Info.plist` files

## Context
Fixes #443. Users with stale registry-installed plugins (e.g., MongoDBDriver compiled against PluginKit v2) crash on launch with `EXC_BAD_INSTRUCTION` because the `DriverPlugin` protocol ABI changed but the version was never bumped. The existing version guard now correctly rejects these stale plugins at discovery time instead of loading them and crashing.

## Test plan
- [ ] Build and launch with a stale v2 MongoDBDriver plugin in `~/Library/Application Support/TablePro/Plugins/` — should skip it with a log warning instead of crashing
- [ ] Verify all built-in plugins still load correctly
- [ ] Verify fresh registry plugin installs (rebuilt with v3) load correctly