### PR TITLE
fix: welcome window UX polish

### DIFF
--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -681,11 +681,16 @@ struct WelcomeWindowView: View {
                 Button {
                     moveConnections(targets, toGroup: group.id)
                 } label: {
-                    if !group.color.isDefault {
-                        Label(group.name, systemImage: "circle.fill")
-                            .foregroundStyle(group.color.color)
-                    } else {
+                    HStack {
+                        if !group.color.isDefault {
+                            Image(systemName: "circle.fill")
+                                .foregroundStyle(group.color.color)
+                        }
                         Text(group.name)
+                        if currentGroupId == group.id {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
                     }
                 }
                 .disabled(currentGroupId == group.id)


### PR DESCRIPTION
## Summary

Five UX fixes for the welcome window connection list to match native macOS conventions:

- **Escape clears search**: Pressing Escape in the search field clears text and moves focus to the connection list (matches Finder, Xcode, Spotlight)
- **Initial focus on open**: Search field auto-focuses when the welcome window opens (no click required before keyboard works)
- **Cmd+A select all**: Selects all visible connections. Escape on the list deselects all.
- **↵ Connect hint in footer**: The most important shortcut was missing from the keyboard hints
- **Group color in Move to Group menu**: Replaced `Circle().fill(color)` (not rendered by NSMenu) with `Label(name, systemImage: "circle.fill")` which renders correctly

## Test plan

- [ ] Open welcome window → search field is focused
- [ ] Type search text → press Escape → text clears, focus moves to list
- [ ] Click a connection → press Cmd+A → all visible connections selected
- [ ] Press Escape on list → selection clears
- [ ] Footer shows "↵ Connect" hint
- [ ] Right-click → Move to Group → group colors visible in submenu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search field auto-focuses on view load for quicker typing.
  * Keyboard shortcuts: Enter to connect; Escape clears search and moves focus to the connection list; Escape also clears selection when rows are selected; Command+A selects all visible connections.

* **Style**
  * Refined group list visuals for clearer color indicators and selection display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->