### PR TITLE
fix: resolve compiler warnings across 6 files

### DIFF
--- a/TablePro/Core/SSH/Auth/KeyboardInteractiveAuthenticator.swift
+++ b/TablePro/Core/SSH/Auth/KeyboardInteractiveAuthenticator.swift
@@ -54,12 +54,8 @@ private let kbdintCallback: @convention(c) (
         let prompt = prompts[i]
         let promptText: String
         if let textPtr = prompt.text, prompt.length > 0 {
-            promptText = String(
-                bytesNoCopy: UnsafeMutableRawPointer(mutating: textPtr),
-                length: Int(prompt.length),
-                encoding: .utf8,
-                freeWhenDone: false
-            ) ?? ""
+            let buffer = UnsafeBufferPointer(start: textPtr, count: Int(prompt.length))
+            promptText = String(decoding: buffer, as: UTF8.self)
         } else {
             promptText = ""
         }

--- a/TablePro/ViewModels/RedisKeyTreeViewModel.swift
+++ b/TablePro/ViewModels/RedisKeyTreeViewModel.swift
@@ -86,7 +86,7 @@ internal final class RedisKeyTreeViewModel {
                 .map { .key(name: $0.key, fullKey: $0.key, keyType: $0.type) }
         }
 
-        var root = TrieNode()
+        let root = TrieNode()
         for entry in keys {
             let parts = entry.key.components(separatedBy: separator)
             root.insert(parts: parts, fullKey: entry.key, keyType: entry.type)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -469,7 +469,7 @@ extension MainContentCoordinator {
                 sidebarState.redisKeyTreeViewModel = vm
             }
             Task {
-                await sidebarViewModel?.redisKeyTreeViewModel?.loadKeys(
+                await self.sidebarViewModel?.redisKeyTreeViewModel?.loadKeys(
                     connectionId: connId,
                     database: database,
                     separator: separator

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -230,7 +230,6 @@ struct MainContentView: View {
 
                 let capturedWindowId = windowId
                 let connectionId = connection.id
-                let connectionName = connection.name
                 Task { @MainActor in
                     // Grace period: SwiftUI fires onDisappear transiently during tab group
                     // merges/splits, then re-fires onAppear shortly after. The onAppear

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -33,7 +33,7 @@ extension TableViewCoordinator {
 
     func copyRows(at indices: Set<Int>) {
         let sortedIndices = indices.sorted()
-        let columnTypes = (rowProvider as? InMemoryRowProvider)?.columnTypes
+        let columnTypes = rowProvider.columnTypes
         var lines: [String] = []
 
         for index in sortedIndices {
@@ -48,7 +48,7 @@ extension TableViewCoordinator {
 
     func copyRowsWithHeaders(at indices: Set<Int>) {
         let sortedIndices = indices.sorted()
-        let columnTypes = (rowProvider as? InMemoryRowProvider)?.columnTypes
+        let columnTypes = rowProvider.columnTypes
         var lines: [String] = []
 
         // Add header row
@@ -102,8 +102,8 @@ extension TableViewCoordinator {
         guard columnIndex >= 0 && columnIndex < rowProvider.columns.count else { return }
 
         let value = rowProvider.value(atRow: rowIndex, column: columnIndex) ?? "NULL"
-        let columnTypes = (rowProvider as? InMemoryRowProvider)?.columnTypes
-        let columnType = columnTypes.flatMap { $0.indices.contains(columnIndex) ? $0[columnIndex] : nil }
+        let columnTypes = rowProvider.columnTypes
+        let columnType = columnTypes.indices.contains(columnIndex) ? columnTypes[columnIndex] : nil
         let copyValue = BlobFormattingService.shared.formatIfNeeded(value, columnType: columnType, for: .copy)
         ClipboardService.shared.writeText(copyValue)
     }
@@ -143,8 +143,7 @@ extension TableViewCoordinator {
     func copyRowsAsJson(at indices: Set<Int>) {
         let rows = indices.sorted().compactMap { rowProvider.rowValues(at: $0) }
         guard !rows.isEmpty else { return }
-        let columnTypes = (rowProvider as? InMemoryRowProvider)?.columnTypes
-            ?? Array(repeating: ColumnType.text(rawType: nil), count: rowProvider.columns.count)
+        let columnTypes = rowProvider.columnTypes
         let converter = JsonRowConverter(columns: rowProvider.columns, columnTypes: columnTypes)
         ClipboardService.shared.writeText(converter.generateJson(rows: rows))
     }

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -838,8 +838,10 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let self, let tableView = self.tableView else { return }
-            Self.updateVisibleCellFonts(tableView: tableView)
+            MainActor.assumeIsolated {
+                guard let self, let tableView = self.tableView else { return }
+                Self.updateVisibleCellFonts(tableView: tableView)
+            }
         }
     }
 
@@ -850,7 +852,9 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             object: connectionId,
             queue: .main
         ) { [weak self] _ in
-            self?.releaseData()
+            MainActor.assumeIsolated {
+                self?.releaseData()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace deprecated `String(bytesNoCopy:length:encoding:freeWhenDone:)` with `UnsafeBufferPointer` + `String(decoding:as:)` in SSH keyboard-interactive auth
- Change `var root` to `let root` in `RedisKeyTreeViewModel` (reference is never reassigned)
- Add explicit `self.` for `sidebarViewModel` in `MainContentCoordinator+Navigation` closure
- Remove unused `connectionName` variable in `MainContentView`
- Wrap main-actor-isolated calls in `MainActor.assumeIsolated` in `DataGridView` notification observers (already dispatched on `queue: .main`)
- Remove redundant `as? InMemoryRowProvider` casts in `DataGridView+RowActions` (type already known)

## Test plan

- [ ] Build succeeds with zero warnings
- [ ] SSH keyboard-interactive authentication still works
- [ ] Redis key tree loads correctly
- [ ] DataGrid row copy/paste operations unchanged