### PR TITLE
fix: correct header install path in build-libmongoc.sh

### DIFF
--- a/scripts/build-libmongoc.sh
+++ b/scripts/build-libmongoc.sh
@@ -139,7 +139,7 @@ install_libs() {
 install_headers() {
     local arch=$1
     local prefix="$BUILD_DIR/install-mongoc-$arch"
-    local dest="$PROJECT_DIR/TablePro/Core/Database/CLibMongoc/include"
+    local dest="$PROJECT_DIR/Plugins/MongoDBDriverPlugin/CLibMongoc/include"
 
     echo "📦 Installing libmongoc headers..."
 
@@ -176,7 +176,7 @@ build_for_arch() {
     build_mongoc "$arch"
     install_libs "$arch"
     # Install headers once (they're arch-independent)
-    if [ ! -f "$PROJECT_DIR/TablePro/Core/Database/CLibMongoc/include/mongoc/mongoc.h" ]; then
+    if [ ! -f "$PROJECT_DIR/Plugins/MongoDBDriverPlugin/CLibMongoc/include/mongoc/mongoc.h" ]; then
         install_headers "$arch"
     fi
 }


### PR DESCRIPTION
## Summary

- `build-libmongoc.sh` installed headers to `TablePro/Core/Database/CLibMongoc/include/` but the MongoDB plugin reads them from `Plugins/MongoDBDriverPlugin/CLibMongoc/include/`
- Fixed the install path so future rebuilds update the correct headers

## Test plan

- [x] `grep` confirms both occurrences updated
- [ ] Run `./scripts/build-libmongoc.sh arm64` — headers install to correct location