### PR TITLE
fix: resolve sidebar CancellationError and truncate long toolbar version

### DIFF
--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -195,6 +195,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             throw OracleError(message: detail)
         } catch let error as OracleError {
             throw error
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw OracleError(message: "Query execution failed: \(String(describing: error))")
         }

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -170,6 +170,7 @@ final class SidebarViewModel {
     // MARK: - Table Loading
 
     func loadTables(force: Bool = false) {
+        loadTask?.cancel()
         guard !isLoading else { return }
         isLoading = true
         errorMessage = nil
@@ -229,6 +230,8 @@ final class SidebarViewModel {
                     isRestoringSelection = false
                 }
             }
+            isLoading = false
+        } catch is CancellationError {
             isLoading = false
         } catch {
             errorMessage = error.localizedDescription

--- a/TablePro/Views/Toolbar/ConnectionStatusView.swift
+++ b/TablePro/Views/Toolbar/ConnectionStatusView.swift
@@ -42,6 +42,9 @@ struct ConnectionStatusView: View {
         Text(formattedDatabaseInfo)
             .font(.system(size: ThemeEngine.shared.activeTheme.typography.small, weight: .regular, design: .monospaced))
             .foregroundStyle(ThemeEngine.shared.colors.toolbar.secondaryTextSwiftUI)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: 280)
             .accessibilityLabel(
                 String(localized: "Database type: \(formattedDatabaseInfo)")
             )


### PR DESCRIPTION
## Summary

- Sidebar showed "Query execution failed: CancellationError()" on first Oracle connection due to a race condition between connection establishment and table loading
- Long database version strings (e.g., Oracle's full banner) overflowed the toolbar

### Changes

- **OracleConnection.swift**: Re-throw `CancellationError` instead of wrapping it as an `OracleError` with a user-visible message
- **SidebarViewModel.swift**: Handle `CancellationError` silently (not a user-facing error); cancel previous load task before starting a new one
- **ConnectionStatusView.swift**: Add `lineLimit(1)`, `truncationMode(.middle)`, and `frame(maxWidth: 280)` to the version text. Full string shown in tooltip on hover.

## Test plan

- [ ] Connect to Oracle 18c XE. Sidebar should not show CancellationError on first connect
- [ ] Oracle toolbar version truncates with "..." in the middle, full text in tooltip
- [ ] MySQL/PostgreSQL toolbar version unchanged (short enough to fit)
- [ ] Sidebar refresh still works