### PR TITLE
fix: auto-focus SQL editor on new tab and restore cursor on tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SQL editor not auto-focused on new tab and cursor missing after tab switch
 - SSH profile lost after app restart when iCloud Sync enabled
 - MariaDB JSON columns showing as hex dumps instead of JSON text
 - MongoDB Atlas TLS certificate verification failure

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -26,6 +26,7 @@ final class SQLEditorCoordinator: TextViewCoordinator {
     @ObservationIgnored private var contextMenu: AIEditorContextMenu?
     @ObservationIgnored private var inlineSuggestionManager: InlineSuggestionManager?
     @ObservationIgnored private var editorSettingsObserver: NSObjectProtocol?
+    @ObservationIgnored private var windowKeyObserver: NSObjectProtocol?
     /// Debounce work item for frame-change notification to avoid
     /// triggering syntax highlight viewport recalculation on every keystroke.
     @ObservationIgnored private var frameChangeWorkItem: DispatchWorkItem?
@@ -61,6 +62,9 @@ final class SQLEditorCoordinator: TextViewCoordinator {
         if let observer = editorSettingsObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = windowKeyObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
         frameChangeWorkItem?.cancel()
     }
 
@@ -68,6 +72,10 @@ final class SQLEditorCoordinator: TextViewCoordinator {
         if let observer = editorSettingsObserver {
             NotificationCenter.default.removeObserver(observer)
             editorSettingsObserver = nil
+        }
+        if let observer = windowKeyObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowKeyObserver = nil
         }
         frameChangeWorkItem?.cancel()
         frameChangeWorkItem = nil
@@ -89,6 +97,22 @@ final class SQLEditorCoordinator: TextViewCoordinator {
             self.installVimModeIfEnabled(controller: controller)
             if let textView = controller.textView {
                 EditorEventRouter.shared.register(self, textView: textView)
+
+                // Auto-focus: make the editor first responder, then ensure a
+                // cursor exists. Order matters — setCursorPositions calls
+                // updateSelectionViews which guards on isFirstResponder.
+                if let window = textView.window {
+                    window.makeFirstResponder(textView)
+                }
+                if controller.cursorPositions.isEmpty {
+                    controller.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 0))])
+                }
+
+                // Recreate cursor views when the window regains key status.
+                // resignKeyWindow() on the text view calls removeCursors() which
+                // destroys cursor subviews, but becomeKeyWindow() only resets the
+                // blink timer without recreating them.
+                self.installWindowKeyObserver(for: textView.window)
             }
         }
     }
@@ -277,6 +301,24 @@ final class SQLEditorCoordinator: TextViewCoordinator {
             vimKeyInterceptor?.editorDidBlur()
             inlineSuggestionManager?.editorDidBlur()
             vimCursorManager?.pauseBlink()
+        }
+    }
+
+    // MARK: - Window Key Observer
+
+    /// Observe when the editor's window regains key status (e.g. tab switch) and
+    /// recreate cursor views that were destroyed by resignKeyWindow → removeCursors.
+    private func installWindowKeyObserver(for window: NSWindow?) {
+        guard let window else { return }
+        windowKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak controller] _ in
+            guard let controller, !controller.cursorPositions.isEmpty else { return }
+            // At this point becomeKeyWindow → becomeFirstResponder has already run,
+            // so isFirstResponder is true and setCursorPositions will create cursor views.
+            controller.setCursorPositions(controller.cursorPositions)
         }
     }
 


### PR DESCRIPTION
## Summary
- Auto-focus the SQL editor when opening a new query tab so users can type immediately without clicking
- Restore cursor blink when switching between editor tabs

## Root Cause
- **No auto-focus:** `prepareCoordinator` never called `makeFirstResponder` on the editor's text view, and `SourceEditorState()` initializes with nil cursor positions — so even with focus, `insertText` had no insertion point
- **Missing cursor on tab switch:** `resignKeyWindow` calls `removeCursors()` destroying cursor subviews, but `becomeKeyWindow` only resets the blink timer without recreating them

## Changes
`SQLEditorCoordinator.swift`:
- In `prepareCoordinator`: call `makeFirstResponder` then `setCursorPositions` (order matters — cursor view creation guards on `isFirstResponder`)
- Add `NSWindow.didBecomeKeyNotification` observer to re-apply cursor positions when window regains key status

## Test plan
- [ ] Open a connection → first tab editor is auto-focused with blinking cursor, can type immediately
- [ ] Cmd+T to open second tab → editor is auto-focused
- [ ] Switch between tabs → cursor blinks correctly on each tab
- [ ] Typing works on all tabs without clicking first