### PR TITLE
fix: horizontal scroll, Home/End keys, and line operations in SQL editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SQL editor not auto-focused on new tab and cursor missing after tab switch
 - Long lines not scrollable horizontally in the SQL editor
+- Home and End keys not moving cursor in the SQL editor (#448)
 - SSH profile lost after app restart when iCloud Sync enabled
 - MariaDB JSON columns showing as hex dumps instead of JSON text
 - MongoDB Atlas TLS certificate verification failure

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
@@ -5,8 +5,9 @@
 //  Created by Khan Winter on 10/14/23.
 //
 
-import CodeEditTextView
 import AppKit
+import Carbon.HIToolbox
+import CodeEditTextView
 
 extension TextViewController {
     override public func viewWillAppear() {
@@ -262,6 +263,12 @@ extension TextViewController {
             _ = self.textView.resignFirstResponder()
             self.findViewController?.showFindPanel()
             return nil
+        case ([commandKey, .shift], "D"):
+            duplicateLine()
+            return nil
+        case ([commandKey, .shift], "K"):
+            deleteLine()
+            return nil
         case (.init(rawValue: 0), "\u{1b}"): // Escape key
             if findViewController?.viewModel.isShowingFindPanel == true {
                 self.findViewController?.hideFindPanel()
@@ -278,6 +285,23 @@ extension TextViewController {
             jumpToDefinitionModel.performJump(at: cursor.range)
             return nil
         case (_, _):
+            // Handle key-code-based shortcuts (arrow keys don't have stable characters)
+            return handleKeyCodeCommand(event: event, modifierFlags: modifierFlags)
+        }
+    }
+
+    private func handleKeyCodeCommand(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) -> NSEvent? {
+        // Strip .numericPad — arrow keys include it on macOS
+        let flags = modifierFlags.subtracting(.numericPad)
+
+        switch (flags, Int(event.keyCode)) {
+        case (.option, kVK_UpArrow):
+            moveLinesUp()
+            return nil
+        case (.option, kVK_DownArrow):
+            moveLinesDown()
+            return nil
+        default:
             return event
         }
     }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+LineOperations.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+LineOperations.swift
@@ -1,0 +1,64 @@
+//
+//  TextViewController+LineOperations.swift
+//  CodeEditSourceEditor
+//
+//  Line-level editing operations: duplicate, delete.
+//
+
+import AppKit
+import CodeEditTextView
+
+extension TextViewController {
+    /// Duplicates the current line(s) below the selection (Cmd+D).
+    func duplicateLine() {
+        guard let selection = textView.selectionManager.textSelections.first else { return }
+        guard let lineIndexes = getOverlappingLines(for: selection.range),
+              let firstLine = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound),
+              let lastLine = textView.layoutManager.textLineForIndex(lineIndexes.upperBound) else {
+            return
+        }
+
+        let fullRange = NSRange(
+            location: firstLine.range.location,
+            length: lastLine.range.upperBound - firstLine.range.location
+        )
+        guard let text = textView.textStorage.substring(from: fullRange) else { return }
+
+        textView.undoManager?.beginUndoGrouping()
+
+        // If line includes trailing \n, insert the text as-is after the line.
+        // If no trailing \n (last line), prepend \n before inserting.
+        let insertText = text.hasSuffix("\n") ? text : "\n" + text
+        let insertionPoint = fullRange.upperBound
+        textView.replaceCharacters(in: NSRange(location: insertionPoint, length: 0), with: insertText)
+
+        let offset = selection.range.location - fullRange.location
+        let newLocation = insertionPoint + (text.hasSuffix("\n") ? 0 : 1) + offset
+        setCursorPositions([CursorPosition(range: NSRange(location: newLocation, length: 0))])
+
+        textView.undoManager?.endUndoGrouping()
+    }
+
+    /// Deletes the current line(s) (Cmd+Shift+K).
+    func deleteLine() {
+        guard let selection = textView.selectionManager.textSelections.first else { return }
+        guard let lineIndexes = getOverlappingLines(for: selection.range),
+              let firstLine = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound),
+              let lastLine = textView.layoutManager.textLineForIndex(lineIndexes.upperBound) else {
+            return
+        }
+
+        let fullRange = NSRange(
+            location: firstLine.range.location,
+            length: lastLine.range.upperBound - firstLine.range.location
+        )
+
+        textView.undoManager?.beginUndoGrouping()
+
+        textView.replaceCharacters(in: fullRange, with: "")
+        let newLocation = min(fullRange.location, textView.textStorage.length)
+        setCursorPositions([CursorPosition(range: NSRange(location: newLocation, length: 0))])
+
+        textView.undoManager?.endUndoGrouping()
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+MoveLines.swift
@@ -11,61 +11,100 @@ extension TextViewController {
     /// Moves the selected lines up by one line.
     public func moveLinesUp() {
         guard !cursorPositions.isEmpty else { return }
+        guard let selection = textView.selectionManager.textSelections.first,
+              let lineIndexes = getOverlappingLines(for: selection.range) else { return }
+        let firstIndex = lineIndexes.lowerBound
+        guard firstIndex > 0 else { return }
 
-        textView.undoManager?.beginUndoGrouping()
-
-        textView.editSelections { textView, selection in
-            guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
-            let lowerBound = lineIndexes.lowerBound
-            guard lowerBound > .zero,
-                  let prevLineInfo = textView.layoutManager.textLineForIndex(lowerBound - 1),
-                  let prevString = textView.textStorage.substring(from: prevLineInfo.range),
-                  let lastSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.upperBound) else {
-                return
-            }
-
-            textView.insertString(prevString, at: lastSelectedString.range.upperBound)
-            textView.replaceCharacters(in: [prevLineInfo.range], with: String())
-
-            let rangeToSelect = NSRange(
-                start: prevLineInfo.range.lowerBound,
-                end: lastSelectedString.range.location - prevLineInfo.range.length + lastSelectedString.range.length
-            )
-
-            setCursorPositions([CursorPosition(range: rangeToSelect)], scrollToVisible: true)
+        guard let prevLine = textView.layoutManager.textLineForIndex(firstIndex - 1),
+              let firstSelectedLine = textView.layoutManager.textLineForIndex(firstIndex),
+              let lastSelectedLine = textView.layoutManager.textLineForIndex(lineIndexes.upperBound) else {
+            return
         }
 
+        // Combined range: previous line + selected lines
+        let combinedRange = NSRange(
+            location: prevLine.range.location,
+            length: lastSelectedLine.range.upperBound - prevLine.range.location
+        )
+        guard let combinedText = textView.textStorage.substring(from: combinedRange) else { return }
+
+        // Split into previous line text and selected lines text (UTF-16 safe)
+        let selectedStart = firstSelectedLine.range.location - prevLine.range.location
+        let nsCombined = combinedText as NSString
+        let prevText = nsCombined.substring(to: selectedStart)
+        let selectedText = nsCombined.substring(from: selectedStart)
+
+        // Ensure both parts have proper newline handling
+        let newText: String
+        if selectedText.hasSuffix("\n") {
+            newText = selectedText + prevText
+        } else if prevText.hasSuffix("\n") {
+            // Selected text is last line (no trailing \n), prev has \n
+            newText = selectedText + "\n" + String(prevText.dropLast())
+        } else {
+            newText = selectedText + "\n" + prevText
+        }
+
+        textView.undoManager?.beginUndoGrouping()
+        textView.replaceCharacters(in: combinedRange, with: newText)
+
+        // Place cursor at the start of the moved line
+        setCursorPositions(
+            [CursorPosition(range: NSRange(location: prevLine.range.location, length: 0))],
+            scrollToVisible: true
+        )
         textView.undoManager?.endUndoGrouping()
     }
 
     /// Moves the selected lines down by one line.
     public func moveLinesDown() {
         guard !cursorPositions.isEmpty else { return }
+        guard let selection = textView.selectionManager.textSelections.first,
+              let lineIndexes = getOverlappingLines(for: selection.range) else { return }
+        let lastIndex = lineIndexes.upperBound
+        guard lastIndex + 1 < textView.layoutManager.lineCount else { return }
 
-        textView.undoManager?.beginUndoGrouping()
-
-        textView.editSelections { textView, selection in
-            guard let lineIndexes = getOverlappingLines(for: selection.range) else { return }
-            let totalLines = textView.layoutManager.lineCount
-            let upperBound = lineIndexes.upperBound
-            guard upperBound + 1 < totalLines,
-                  let nextLineInfo = textView.layoutManager.textLineForIndex(upperBound + 1),
-                  let nextString = textView.textStorage.substring(from: nextLineInfo.range),
-                  let firstSelectedString = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound) else {
-                return
-            }
-
-            textView.replaceCharacters(in: [nextLineInfo.range], with: String())
-            textView.insertString(nextString, at: firstSelectedString.range.lowerBound)
-
-            let rangeToSelect = NSRange(
-                start: firstSelectedString.range.location + nextLineInfo.range.length,
-                end: nextLineInfo.range.upperBound
-            )
-
-            setCursorPositions([CursorPosition(range: rangeToSelect)], scrollToVisible: true)
+        guard let firstSelectedLine = textView.layoutManager.textLineForIndex(lineIndexes.lowerBound),
+              let lastSelectedLine = textView.layoutManager.textLineForIndex(lastIndex),
+              let nextLine = textView.layoutManager.textLineForIndex(lastIndex + 1),
+              nextLine.range.length > 0 else {
+            return
         }
 
+        // Combined range: selected lines + next line
+        let combinedRange = NSRange(
+            location: firstSelectedLine.range.location,
+            length: nextLine.range.upperBound - firstSelectedLine.range.location
+        )
+        guard let combinedText = textView.textStorage.substring(from: combinedRange) else { return }
+
+        // Split into selected lines text and next line text (UTF-16 safe)
+        let selectedLength = lastSelectedLine.range.upperBound - firstSelectedLine.range.location
+        let nsCombined = combinedText as NSString
+        let selectedText = nsCombined.substring(to: selectedLength)
+        let nextText = nsCombined.substring(from: selectedLength)
+
+        // Ensure both parts have proper newline handling
+        let newText: String
+        if nextText.hasSuffix("\n") {
+            newText = nextText + selectedText
+        } else if selectedText.hasSuffix("\n") {
+            newText = nextText + "\n" + String(selectedText.dropLast())
+        } else {
+            newText = nextText + "\n" + selectedText
+        }
+
+        textView.undoManager?.beginUndoGrouping()
+        textView.replaceCharacters(in: combinedRange, with: newText)
+
+        // Place cursor at the start of the moved line in its new position
+        let nextLen = (nextText as NSString).length + (nextText.hasSuffix("\n") ? 0 : 1)
+        let newLocation = firstSelectedLine.range.location + nextLen
+        setCursorPositions(
+            [CursorPosition(range: NSRange(location: newLocation, length: 0))],
+            scrollToVisible: true
+        )
         textView.undoManager?.endUndoGrouping()
     }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+KeyDown.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+KeyDown.swift
@@ -17,12 +17,46 @@ extension TextView {
 
         NSCursor.setHiddenUntilMouseMoves(true)
 
+        // Handle Home/End explicitly — AppKit's default key bindings map these
+        // to scrollToBeginningOfDocument:/scrollToEndOfDocument: which only
+        // scroll without moving the cursor. We redirect to move actions instead.
+        if handleHomeEndKey(event) {
+            return
+        }
+
         if !(inputContext?.handleEvent(event) ?? false) {
             interpretKeyEvents([event])
         } else {
             // Not handled, ignore so we don't double trigger events.
             return
         }
+    }
+
+    /// Handles Home and End key combinations.
+    /// - Returns: `true` if the event was handled.
+    private func handleHomeEndKey(_ event: NSEvent) -> Bool {
+        let keyCode = Int(event.keyCode)
+        guard keyCode == kVK_Home || keyCode == kVK_End else { return false }
+
+        let shift = event.modifierFlags.contains(.shift)
+        let cmd = event.modifierFlags.contains(.command)
+
+        if keyCode == kVK_Home {
+            switch (cmd, shift) {
+            case (true, true): moveToBeginningOfDocumentAndModifySelection(self)
+            case (true, false): moveToBeginningOfDocument(self)
+            case (false, true): moveToLeftEndOfLineAndModifySelection(self)
+            case (false, false): moveToLeftEndOfLine(self)
+            }
+        } else {
+            switch (cmd, shift) {
+            case (true, true): moveToEndOfDocumentAndModifySelection(self)
+            case (true, false): moveToEndOfDocument(self)
+            case (false, true): moveToRightEndOfLineAndModifySelection(self)
+            case (false, false): moveToRightEndOfLine(self)
+            }
+        }
+        return true
     }
 
     override public func performKeyEquivalent(with event: NSEvent) -> Bool {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Move.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Move.swift
@@ -159,6 +159,32 @@ extension TextView {
         updateAfterMove()
     }
 
+    override public func moveToBeginningOfLine(_ sender: Any?) {
+        moveToLeftEndOfLine(sender)
+    }
+
+    override public func moveToEndOfLine(_ sender: Any?) {
+        moveToRightEndOfLine(sender)
+    }
+
+    override public func moveToBeginningOfLineAndModifySelection(_ sender: Any?) {
+        moveToLeftEndOfLineAndModifySelection(sender)
+    }
+
+    override public func moveToEndOfLineAndModifySelection(_ sender: Any?) {
+        moveToRightEndOfLineAndModifySelection(sender)
+    }
+
+    override public func centerSelectionInVisibleArea(_ sender: Any?) {
+        guard let scrollView,
+              let selection = selectionManager.textSelections.first,
+              let rect = layoutManager.rectForOffset(selection.range.location) else { return }
+        let visibleHeight = scrollView.contentView.bounds.height
+        let targetY = max(rect.midY - visibleHeight / 2, 0)
+        scrollView.contentView.scroll(to: NSPoint(x: scrollView.contentView.bounds.origin.x, y: targetY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
     override public func pageUp(_ sender: Any?) {
         enclosingScrollView?.pageUp(sender)
     }

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -328,11 +328,8 @@ final class SQLEditorCoordinator: TextViewCoordinator {
             queue: .main
         ) { [weak self, weak controller] _ in
             guard let self, let controller else { return }
-            DispatchQueue.main.async { [weak self, weak controller] in
-                guard let self, let controller else { return }
-                self.handleVimSettingsChange(controller: controller)
-                self.vimCursorManager?.updatePosition()
-            }
+            self.handleVimSettingsChange(controller: controller)
+            self.vimCursorManager?.updatePosition()
         }
     }
 

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -52,10 +52,13 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 
 | Action | Shortcut |
 |--------|----------|
-| Go to beginning | `Cmd+Up` |
-| Go to end | `Cmd+Down` |
+| Start of line | `Home` or `Cmd+Left` |
+| End of line | `End` or `Cmd+Right` |
+| Start of document | `Cmd+Home` or `Cmd+Up` |
+| End of document | `Cmd+End` or `Cmd+Down` |
 | Move line up | `Option+Up` |
 | Move line down | `Option+Down` |
+| Center cursor in view | `Ctrl+L` |
 
 ### Find and Replace
 


### PR DESCRIPTION
## Summary
- Fix horizontal scrolling for long lines (upstream bug in CodeEditTextView)
- Add Home/End key support with all modifier combinations (#448)
- Add duplicate line (Cmd+Shift+D), delete line (Cmd+Shift+K), move line up/down (Option+Up/Down)
- Fix move line up/down for last-line and emoji content edge cases

## Root Causes

**Horizontal scroll:** Variable shadowing bug in CodeEditTextView `layoutLine()` — `var maxFoundLineWidth = maxFoundLineWidth` shadowed the inout param, so `maxLineWidth` never updated. Also patched `styleTextView()` to respect `wrapLines`.

**Home/End:** AppKit maps Home/End to `scrollToBeginningOfDocument:/scrollToEndOfDocument:` which only scroll without moving cursor. CodeEditTextView didn't override these.

**Line operations:** `moveLinesUp()`/`moveLinesDown()` existed but were never wired to key bindings. Also had bugs with trailing-newline handling and UTF-16 string splitting.

## Changes
- **CodeEditTextView** (vendored): fix `maxFoundLineWidth` shadowing, add Home/End handling in `keyDown`, add `moveToBeginningOfLine`/`moveToEndOfLine`/`centerSelectionInVisibleArea` overrides
- **CodeEditSourceEditor**: patch `styleTextView()`/`styleScrollView()` for horizontal scroll, wire Cmd+Shift+D/K and Option+Up/Down in `handleCommand`, add `duplicateLine()`/`deleteLine()`, rewrite `moveLinesUp()`/`moveLinesDown()` with correct newline and UTF-16 handling
- **SQLEditorCoordinator**: remove fragile horizontal scroll workaround, fix redundant double dispatch in settings observer

## Test plan
- [ ] Type long line with word wrap off — horizontal scroll works
- [ ] Home/End moves to start/end of line
- [ ] Cmd+Home/End moves to start/end of document
- [ ] Shift variants extend selection
- [ ] Cmd+Shift+D duplicates current line
- [ ] Cmd+Shift+K deletes current line
- [ ] Option+Up/Down moves line up/down
- [ ] Move line works correctly on last line (no trailing newline)
- [ ] Undo works after all line operations