### PR TITLE
fix: enable Globe+F (fn+F) fullscreen shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Globe+F (fn+F) fullscreen shortcut not working in SwiftUI lifecycle app
+
 ## [0.26.0] - 2026-03-29
 
 ### Added

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -140,7 +140,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         fullscreenKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             guard mods == [.control, .command],
-                  event.keyCode == 3 else { return event }
+                  event.keyCode == KeyCode.f.rawValue else { return event }
             NSApp.keyWindow?.toggleFullScreen(nil)
             return nil
         }


### PR DESCRIPTION
## Summary
- SwiftUI lifecycle apps don't create a real NSMenuItem for "Enter Full Screen" — the `fn F` shortcut shown in the View menu is a visual hint only, with no key equivalent binding
- macOS maps Globe+F (fn+F) to ⌃⌘F at the system level, but without a real menu item, the keystroke has no target
- Install a local event monitor in `AppDelegate` that catches ⌃⌘F and calls `toggleFullScreen(nil)` on the key window

## Investigation
- Debug dump of View menu confirmed "Enter Full Screen" does not exist as a real NSMenuItem
- Verified no existing code (VimKeyInterceptor, EditorEventRouter, InlineSuggestionManager) intercepts ⌃⌘F
- Tested removing Toggle Filters (Cmd+F) shortcut — fn+F still didn't work, ruling out subset modifier matching
- Tested explicitly setting `.fullScreenPrimary` on main windows — didn't trigger macOS to create a real menu item

## Test plan
- [ ] Press fn+F (Globe+F) → enters fullscreen
- [ ] Press fn+F again → exits fullscreen
- [ ] Verify Cmd+F still toggles filters
- [ ] Verify Option+click green button still works
- [ ] Verify View menu → "Enter Full Screen" click still works