### PR TITLE
fix: connection list mismatch after iCloud sync

### DIFF
--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -50,16 +50,20 @@ final class ConnectionStorage {
 
     /// Save all connections
     func saveConnections(_ connections: [DatabaseConnection]) {
-        cachedConnections = connections
-
         let storedConnections = connections.map { StoredConnection(from: $0) }
 
         do {
             let data = try encoder.encode(storedConnections)
             defaults.set(data, forKey: connectionsKey)
+            cachedConnections = nil
         } catch {
             Self.logger.error("Failed to save connections: \(error)")
         }
+    }
+
+    /// Invalidate the in-memory cache so the next load reads fresh from UserDefaults.
+    func invalidateCache() {
+        cachedConnections = nil
     }
 
     /// Add a new connection

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -379,6 +379,9 @@ final class SyncCoordinator {
     private func applyRemoteChanges(_ result: PullResult) {
         let settings = AppSettingsStorage.shared.loadSync()
 
+        // Invalidate caches before applying remote data to ensure fresh reads
+        ConnectionStorage.shared.invalidateCache()
+
         // Suppress change tracking during remote apply to avoid sync loops
         changeTracker.isSuppressed = true
         defer {


### PR DESCRIPTION
Closes #516

## Problem
Welcome window shows different connections from the connection menu after iCloud sync. Duplicating a connection makes all connections appear.

## Root Cause
`ConnectionStorage.saveConnections()` set `cachedConnections = connections` BEFORE writing to UserDefaults. If encoding failed or a race occurred, cache diverged from disk. All 11 consumers read stale cache.

## Fix
- Clear cache AFTER successful write (matches `GroupStorage`/`TagStorage` pattern)
- Add `invalidateCache()` method
- Call `invalidateCache()` before applying remote sync changes

## Test plan
- [ ] Enable iCloud Sync, add connection on device A → appears on device B
- [ ] Delete connection on device A → disappears on device B
- [ ] Dock menu matches welcome window connection list
- [ ] Connection switcher (Cmd+K) matches welcome window