### PR TITLE
fix: use correct error message when user-installed plugin is outdated

### DIFF
--- a/TablePro/Core/Plugins/PluginError.swift
+++ b/TablePro/Core/Plugins/PluginError.swift
@@ -10,6 +10,7 @@ enum PluginError: LocalizedError {
     case signatureInvalid(detail: String)
     case checksumMismatch
     case incompatibleVersion(required: Int, current: Int)
+    case pluginOutdated(pluginVersion: Int, requiredVersion: Int)
     case cannotUninstallBuiltIn
     case notFound
     case noCompatibleBinary
@@ -31,6 +32,8 @@ enum PluginError: LocalizedError {
             return String(localized: "Plugin checksum does not match expected value")
         case .incompatibleVersion(let required, let current):
             return String(localized: "Plugin requires PluginKit version \(required), but app provides version \(current)")
+        case .pluginOutdated(let pluginVersion, let requiredVersion):
+            return String(localized: "Plugin was built with PluginKit version \(pluginVersion), but version \(requiredVersion) is required. Please update the plugin.")
         case .cannotUninstallBuiltIn:
             return String(localized: "Built-in plugins cannot be uninstalled")
         case .notFound:

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -182,7 +182,7 @@ final class PluginManager {
 
             if entry.source == .userInstalled {
                 if pluginKitVersion < currentPluginKitVersion {
-                    logger.error("User plugin \(entry.url.lastPathComponent) has outdated PluginKit v\(pluginKitVersion)")
+                    logger.error("User plugin \(entry.url.lastPathComponent) was built with PluginKit v\(pluginKitVersion), but v\(currentPluginKitVersion) is required")
                     continue
                 }
             }
@@ -383,9 +383,9 @@ final class PluginManager {
             // have stale witness tables — accessing protocol properties crashes with
             // EXC_BAD_ACCESS. Reject them before loading the bundle.
             if pluginKitVersion < Self.currentPluginKitVersion {
-                throw PluginError.incompatibleVersion(
-                    required: Self.currentPluginKitVersion,
-                    current: pluginKitVersion
+                throw PluginError.pluginOutdated(
+                    pluginVersion: pluginKitVersion,
+                    requiredVersion: Self.currentPluginKitVersion
                 )
             }
             try verifyCodeSignature(bundle: bundle)
@@ -419,9 +419,9 @@ final class PluginManager {
 
         if source == .userInstalled {
             if pluginKitVersion < Self.currentPluginKitVersion {
-                throw PluginError.incompatibleVersion(
-                    required: Self.currentPluginKitVersion,
-                    current: pluginKitVersion
+                throw PluginError.pluginOutdated(
+                    pluginVersion: pluginKitVersion,
+                    requiredVersion: Self.currentPluginKitVersion
                 )
             }
             try verifyCodeSignature(bundle: bundle)

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -9394,9 +9394,6 @@
         }
       }
     },
-    "DataGridView placeholder for: %@" : {
-
-    },
     "Date format:" : {
       "localizations" : {
         "tr" : {
@@ -14166,9 +14163,6 @@
           }
         }
       }
-    },
-    "Fix with AI" : {
-
     },
     "Focus Border" : {
       "localizations" : {
@@ -25646,6 +25640,9 @@
         }
       }
     },
+    "Results" : {
+
+    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -26102,9 +26099,6 @@
           }
         }
       }
-    },
-    "Run a query to see results" : {
-
     },
     "Run in New Tab" : {
       "localizations" : {
@@ -32301,6 +32295,9 @@
       }
     },
     "Toggle Results" : {
+
+    },
+    "Toggle Results (⌘⌥R)" : {
 
     },
     "Toggle Table Browser" : {


### PR DESCRIPTION
## Summary
- When a user-installed plugin has a lower PluginKit version than the app requires, the error message was misleading — it said "Plugin requires PluginKit version 3, but app provides version 2" when the reality was the opposite (app requires v3, plugin was built with v2)
- Added a dedicated `pluginOutdated` error case with a clear message: "Plugin was built with PluginKit version X, but version Y is required. Please update the plugin."
- Updated 3 call sites in `PluginManager` (2 throws + 1 log message) to use the new error case

## Test plan
- [ ] Install a plugin built with an older PluginKit version and verify the new error message appears correctly
- [ ] Verify plugins with matching PluginKit versions still load normally
- [ ] Verify plugins with a *newer* PluginKit version than the app still show the original `incompatibleVersion` message