### PR TITLE
perf: skip column width calculation when saved layout exists

### DIFF
--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -373,6 +373,7 @@ struct DataGridView: NSViewRepresentable {
                     tableView.removeTableColumn(column)
                 }
 
+                let willRestoreWidths = !columnLayout.columnWidths.isEmpty
                 for (index, columnName) in rowProvider.columns.enumerated() {
                     let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("col_\(index)"))
                     column.title = columnName
@@ -384,11 +385,15 @@ struct DataGridView: NSViewRepresentable {
                     column.headerCell.setAccessibilityLabel(
                         String(localized: "Column: \(columnName)")
                     )
-                    column.width = coordinator.cellFactory.calculateOptimalColumnWidth(
-                        for: columnName,
-                        columnIndex: index,
-                        rowProvider: rowProvider
-                    )
+                    if willRestoreWidths {
+                        column.width = columnLayout.columnWidths[columnName] ?? 100
+                    } else {
+                        column.width = coordinator.cellFactory.calculateOptimalColumnWidth(
+                            for: columnName,
+                            columnIndex: index,
+                            rowProvider: rowProvider
+                        )
+                    }
                     column.minWidth = 30
                     column.resizingMask = .userResizingMask
                     column.isEditable = isEditable
@@ -397,6 +402,7 @@ struct DataGridView: NSViewRepresentable {
                 }
             } else {
                 // Same column count — lightweight in-place update (avoids remove/add overhead)
+                let hasSavedWidths = !columnLayout.columnWidths.isEmpty
                 for column in tableView.tableColumns where column.identifier.rawValue != "__rowNumber__" {
                     guard let colIndex = Self.columnIndex(from: column.identifier),
                           colIndex < rowProvider.columns.count else { continue }
@@ -407,11 +413,13 @@ struct DataGridView: NSViewRepresentable {
                             ?? rowProvider.columnTypes[colIndex].displayName
                         column.headerToolTip = "\(columnName) (\(typeName))"
                     }
-                    column.width = coordinator.cellFactory.calculateOptimalColumnWidth(
-                        for: columnName,
-                        columnIndex: colIndex,
-                        rowProvider: rowProvider
-                    )
+                    if !hasSavedWidths {
+                        column.width = coordinator.cellFactory.calculateOptimalColumnWidth(
+                            for: columnName,
+                            columnIndex: colIndex,
+                            rowProvider: rowProvider
+                        )
+                    }
                     column.isEditable = isEditable
                 }
             }


### PR DESCRIPTION
## Summary
- `calculateOptimalColumnWidth()` samples 30 rows per column to estimate width. During column rebuild, this ran for EVERY column even when the user had saved column widths that would immediately overwrite the calculated values.
- Now skips the calculation when `columnLayout.columnWidths` is non-empty, using saved widths directly. For a 50-column table, this eliminates 50 x 30 = 1,500 cell reads on every column rebuild.
- Applies to both full rebuild (columns changed) and in-place update (initial data load) paths.

## Test plan
- [ ] Open a table for the first time (no saved layout) — columns auto-size correctly
- [ ] Resize a column, switch tabs and back — verify saved width is preserved (no flash of auto-sized width)
- [ ] Open a table with saved layout — should load noticeably faster for wide tables (50+ columns)
- [ ] Delete saved layout (clear column widths) — verify auto-sizing kicks back in