### PR TITLE
feat: add Cmd+/Cmd- editor font zoom

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -393,6 +393,18 @@ struct AppMenuCommands: Commands {
             }
             .optionalKeyboardShortcut(shortcut(for: .closeResultTab))
             .disabled(!appState.isConnected)
+
+            Divider()
+
+            Button("Zoom In") {
+                ThemeEngine.shared.adjustEditorFontSize(by: 1)
+            }
+            .keyboardShortcut("=", modifiers: .command)
+
+            Button("Zoom Out") {
+                ThemeEngine.shared.adjustEditorFontSize(by: -1)
+            }
+            .keyboardShortcut("-", modifiers: .command)
         }
 
         // Tab navigation shortcuts — native macOS window tabs

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -199,6 +199,18 @@ internal final class ThemeEngine {
         availableThemes = ThemeStorage.loadAllThemes()
     }
 
+    // MARK: - Editor Font Size Zoom
+
+    func adjustEditorFontSize(by delta: Int) {
+        var theme = activeTheme
+        let newSize = max(9, min(24, theme.fonts.editorFontSize + delta))
+        guard newSize != theme.fonts.editorFontSize else { return }
+        theme.fonts.editorFontSize = newSize
+        activeTheme = theme
+        editorFonts = EditorFontCache(from: theme.fonts)
+        notifyThemeDidChange()
+    }
+
     // MARK: - Font Cache Reload (accessibility)
 
     func reloadFontCaches() {

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -190,6 +190,13 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Next Result | `Cmd+Opt+]` |
 | Close Result Tab | `Cmd+Shift+W` |
 
+### Editor Zoom
+
+| Action | Shortcut |
+|--------|----------|
+| Zoom In | `Cmd+=` |
+| Zoom Out | `Cmd+-` |
+
 ### AI
 
 | Action | Shortcut | Description |


### PR DESCRIPTION
## Summary
- Added `Cmd+=` (Zoom In) and `Cmd+-` (Zoom Out) shortcuts in the View menu
- `ThemeEngine.adjustEditorFontSize(by:)` adjusts the editor font size in-memory (session-only, not persisted to disk), clamps to 9-24pt, and rebuilds the editor font cache
- Updated keyboard shortcuts docs

## Test plan
- [ ] Press Cmd+= multiple times — editor font grows, caps at 24pt
- [ ] Press Cmd+- multiple times — editor font shrinks, caps at 9pt
- [ ] Quit and reopen — font size resets to theme default (session-only zoom)
- [ ] Verify data grid font is NOT affected (only editor zoom)