### PR TITLE
fix: remove redundant async dispatch, guard switchDatabase result

### DIFF
--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -184,8 +184,12 @@ final class DatabaseManager {
                     if resolvedConnection.database.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                        let adapter = driver as? PluginDriverAdapter,
                        let savedDb = AppSettingsStorage.shared.loadLastDatabase(for: connection.id) {
-                        try? await adapter.switchDatabase(to: savedDb)
-                        activeSessions[connection.id]?.currentDatabase = savedDb
+                        do {
+                            try await adapter.switchDatabase(to: savedDb)
+                            activeSessions[connection.id]?.currentDatabase = savedDb
+                        } catch {
+                            Self.logger.warning("Failed to restore saved database '\(savedDb, privacy: .public)' for \(connection.id): \(error.localizedDescription, privacy: .public)")
+                        }
                     }
                 case .selectDatabaseFromConnectionField(let fieldId):
                     // Select database from a connection field (e.g. Redis database index).

--- a/TablePro/Models/UI/RightPanelState.swift
+++ b/TablePro/Models/UI/RightPanelState.swift
@@ -24,10 +24,8 @@ import os
     var isPresented: Bool {
         didSet {
             guard !isSyncing else { return }
-            DispatchQueue.main.async { [self] in
-                UserDefaults.standard.set(self.isPresented, forKey: Self.isPresentedKey)
-                NotificationCenter.default.post(name: Self.isPresentedChangedNotification, object: self)
-            }
+            UserDefaults.standard.set(isPresented, forKey: Self.isPresentedKey)
+            NotificationCenter.default.post(name: Self.isPresentedChangedNotification, object: self)
         }
     }
 


### PR DESCRIPTION
## Summary
- **RightPanelState.isPresented didSet** — removed redundant `DispatchQueue.main.async { [self] in ... }`. The didSet already runs on `@MainActor`, so the async dispatch was unnecessary and created a brief strong self-capture.
- **DatabaseManager.switchDatabase** — replaced `try?` with `do/catch`. Previously, if restoring the saved database failed, `currentDatabase` was set to the saved value anyway, making the UI show a database the connection wasn't actually on. Now only updates `currentDatabase` on success and logs the failure.

## Test plan
- [ ] Toggle right panel open/close — verify state persists across app launches
- [ ] Connect to MSSQL with a saved last-database — verify database restores correctly
- [ ] Connect to MSSQL with a deleted/renamed saved database — verify graceful fallback (default database shown, warning logged)