### PR TITLE
fix: refresh connection list after creating new connection

### DIFF
--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -927,6 +927,7 @@ struct ConnectionFormView: View {
             SyncChangeTracker.shared.markDirty(.connection, id: connectionToSave.id.uuidString)
             // Close and connect to database
             NSApplication.shared.closeWindows(withId: "connection-form")
+            NotificationCenter.default.post(name: .connectionUpdated, object: nil)
             connectToDatabase(connectionToSave)
         } else {
             if let index = savedConnections.firstIndex(where: { $0.id == connectionToSave.id }) {


### PR DESCRIPTION
## Summary

- New connections created via the connection form didn't appear in the Welcome screen list until app restart
- The edit branch posted `.connectionUpdated` notification but the create branch did not
- Added the missing notification post to match the edit path

## Test plan

- [ ] Open Welcome screen → New Connection → fill form → Create
- [ ] If connection fails, navigate back to Welcome — new connection should be visible in the list
- [ ] Edit an existing connection → Save → verify list still refreshes (regression check)