### PR TITLE
fix: Sort table list by name in MongoDb, BigQuery, DynamoDB, MySql.

### DIFF
--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -394,7 +394,7 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
                 tableType = "TABLE"
             }
             return PluginTableInfo(name: entry.tableReference.tableId, type: tableType)
-        }
+        }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
@@ -280,9 +280,10 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
             } while lastEvaluated != nil
 
             Self.logger.debug("fetchTables found \(allTableNames.count) tables")
-            return allTableNames.map { name in
-                PluginTableInfo(name: name, type: "TABLE")
-            }
+            return allTableNames.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+                .map { name in
+                    PluginTableInfo(name: name, type: "TABLE")
+                }
         } catch {
             Self.logger.error("fetchTables error: \(error.localizedDescription)")
             throw error

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -194,7 +194,8 @@ final class MongoDBPluginDriver: PluginDatabaseDriver {
         }
 
         let collections = try await conn.listCollections(database: currentDb)
-        return collections.map { PluginTableInfo(name: $0, type: "table", rowCount: nil) }
+        return collections.sorted(by: { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+            .map { PluginTableInfo(name: $0, type: "table", rowCount: nil) }
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -177,12 +177,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let result = try await execute(query: "SHOW FULL TABLES")
 
-        return result.rows.compactMap { row in
+        return result.rows.compactMap { row -> PluginTableInfo? in
             guard let name = row[safe: 0] ?? nil else { return nil }
             let typeStr = (row[safe: 1] ?? nil) ?? "BASE TABLE"
             let type = typeStr.contains("VIEW") ? "VIEW" : "TABLE"
             return PluginTableInfo(name: name, type: type)
-        }
+        }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {


### PR DESCRIPTION
The table list should be sorted to improve readability and make searching easier.

Example: Table list with MongoDB driver
<img width="271" height="476" alt="image" src="https://github.com/user-attachments/assets/47a49458-a45f-4730-85a7-d0710af38150" />
