### PR TITLE
fix: clear filter state when no tab is selected after close

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -125,6 +125,7 @@ extension MainContentCoordinator {
             toolbarState.isTableTab = false
             toolbarState.isResultsCollapsed = false
             AppState.shared.isTableTab = false
+            filterStateManager.clearAll()
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix stale filter pane persisting after FK navigation tab is closed
- When `handleTabChange` transitions to no tab (`newTabId == nil`), `filterStateManager.clearAll()` was never called, leaving `isVisible = true` and stale FK filters on the coordinator-level state
- Opening a new table after this would show the filter pane with the old FK filter

Root cause: `FilterStateManager.isVisible` is coordinator-level (not per-tab). `setFKFilter()` sets `isVisible = true`, but the nil-tab branch in `handleTabChange` never reset it.

## Test plan

- [ ] Open a table with FK columns
- [ ] Cmd+Enter on FK cell → click "Open {table}" → filter pane opens with FK filter
- [ ] Close the FK-navigated tab (Cmd+W)
- [ ] Open any other table → filter pane should be closed, no stale filters