### PR TITLE
fix: smooth sync icon animation and remove connect hint

### DIFF
--- a/TablePro/Views/Components/SyncStatusIndicator.swift
+++ b/TablePro/Views/Components/SyncStatusIndicator.swift
@@ -19,10 +19,14 @@ struct SyncStatusIndicator: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: iconName)
+                        .contentTransition(.symbolEffect(.replace))
+                        .symbolEffect(.pulse, isActive: syncCoordinator.syncStatus.isSyncing)
                     Text(statusLabel)
+                        .contentTransition(.numericText())
                 }
                 .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
                 .foregroundStyle(foregroundStyle)
+                .animation(.default, value: syncCoordinator.syncStatus)
             }
             .buttonStyle(.plain)
             .help(helpText)

--- a/TablePro/Views/Connection/WelcomeLeftPanel.swift
+++ b/TablePro/Views/Connection/WelcomeLeftPanel.swift
@@ -73,13 +73,11 @@ struct WelcomeLeftPanel: View {
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 12) {
                     SyncStatusIndicator()
-                    KeyboardHint(keys: "↵", label: "Connect")
                     KeyboardHint(keys: "⌘N", label: "New")
                     KeyboardHint(keys: "⌘,", label: "Settings")
                 }
                 HStack(spacing: 8) {
                     SyncStatusIndicator()
-                    KeyboardHint(keys: "↵", label: "Connect")
                     KeyboardHint(keys: "⌘N", label: "New")
                     KeyboardHint(keys: "⌘,", label: nil)
                 }


### PR DESCRIPTION
## Summary

- Fix sync icon glitching during active sync (Closes #555)
- Add `.symbolEffect(.pulse, isActive:)` for smooth pulsing animation while syncing
- Add `.contentTransition(.symbolEffect(.replace))` for smooth icon cross-fade between states
- Add `.contentTransition(.numericText())` for smooth text label transitions
- Coordinate all transitions with `.animation(.default, value:)`
- Remove "↵ Connect" keyboard hint from welcome panel footer

## Test plan

- [ ] Open TablePro → Welcome window → trigger iCloud sync
- [ ] Verify icon pulses smoothly during sync, no layout jumps
- [ ] Verify smooth transition when sync completes (icon + text)
- [ ] Verify "Connect" shortcut hint is no longer shown in footer