### PR TITLE
fix: sort table list at app layer for all databases

### DIFF
--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -40,6 +40,7 @@ struct LiveTableFetcher: TableFetcher {
             return []
         }
         let fetched = try await driver.fetchTables()
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         NSLog("[LiveTableFetcher] fetched %d tables", fetched.count)
         if let provider = schemaProvider {
             await provider.updateTables(fetched)


### PR DESCRIPTION
## Summary

- Sort table list alphabetically in `LiveTableFetcher` using `localizedCaseInsensitiveCompare`
- This covers **all** database types uniformly (MySQL, PostgreSQL, SQLite, MongoDB, BigQuery, DynamoDB, ClickHouse, Redis, Oracle, DuckDB, Cassandra, Etcd, CloudflareD1, MSSQL)
- Supersedes #554 which added per-plugin sorting in only 4 plugins

Single-line change in `SidebarViewModel.swift` — sorts `driver.fetchTables()` results before caching.

## Test plan

- [ ] Connect to any database → verify sidebar table list is alphabetically sorted
- [ ] Test with mixed case names (e.g., `Users`, `accounts`, `Orders`) → verify case-insensitive sorting