### PR TITLE
fix: scroll data grid to top on page change

### DIFF
--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -394,6 +394,9 @@ struct QueryTab: Identifiable, Equatable {
     // Version counter incremented when FK/metadata arrives (Phase 2), used to invalidate caches
     var metadataVersion: Int
 
+    // Version counter incremented on pagination changes, used to scroll grid to top
+    var paginationVersion: Int
+
     /// Whether the editor content differs from the last saved/loaded file content.
     /// Returns false for tabs not backed by a file.
     /// Uses O(1) length pre-check to avoid O(n) string comparison on every keystroke.
@@ -441,6 +444,7 @@ struct QueryTab: Identifiable, Equatable {
         self.sourceFileURL = nil
         self.resultVersion = 0
         self.metadataVersion = 0
+        self.paginationVersion = 0
     }
 
     /// Initialize from persisted tab state (used when restoring tabs)
@@ -476,6 +480,7 @@ struct QueryTab: Identifiable, Equatable {
         self.sourceFileURL = persisted.sourceFileURL
         self.resultVersion = 0
         self.metadataVersion = 0
+        self.paginationVersion = 0
     }
 
     /// Build a clean base query for a table tab (no filters/sort).
@@ -554,6 +559,7 @@ struct QueryTab: Identifiable, Equatable {
             && lhs.errorMessage == rhs.errorMessage
             && lhs.executionTime == rhs.executionTime
             && lhs.resultVersion == rhs.resultVersion
+            && lhs.paginationVersion == rhs.paginationVersion
             && lhs.pagination == rhs.pagination
             && lhs.sortState == rhs.sortState
             && lhs.showStructure == rhs.showStructure

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -418,6 +418,7 @@ struct MainEditorContentView: View {
             changeManager: currentChangeManager,
             resultVersion: tab.resultVersion,
             metadataVersion: tab.metadataVersion,
+            paginationVersion: tab.paginationVersion,
             isEditable: tab.isEditable && !tab.isView && !coordinator.safeModeLevel.blocksAllWrites,
             onRefresh: onRefresh,
             onCellEdit: onCellEdit,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Pagination.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Pagination.swift
@@ -96,6 +96,7 @@ extension MainContentCoordinator {
             guard let idx = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
 
             mutate(&self.tabManager.tabs[idx].pagination)
+            self.tabManager.tabs[idx].paginationVersion += 1
             self.reloadCurrentPage()
         }
     }

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -29,6 +29,7 @@ struct DataGridIdentity: Equatable {
     let reloadVersion: Int
     let resultVersion: Int
     let metadataVersion: Int
+    let paginationVersion: Int
     let rowCount: Int
     let columnCount: Int
     let isEditable: Bool
@@ -41,6 +42,7 @@ struct DataGridView: NSViewRepresentable {
     var changeManager: AnyChangeManager
     var resultVersion: Int = 0
     var metadataVersion: Int = 0
+    var paginationVersion: Int = 0
     let isEditable: Bool
     var onRefresh: (() -> Void)?
     var onCellEdit: ((Int, Int, String?) -> Void)?
@@ -228,6 +230,7 @@ struct DataGridView: NSViewRepresentable {
             reloadVersion: changeManager.reloadVersion,
             resultVersion: resultVersion,
             metadataVersion: metadataVersion,
+            paginationVersion: paginationVersion,
             rowCount: rowProvider.totalRowCount,
             columnCount: rowProvider.columns.count,
             isEditable: isEditable,
@@ -355,12 +358,15 @@ struct DataGridView: NSViewRepresentable {
 
         syncSortDescriptors(tableView: tableView, coordinator: coordinator)
 
+        let paginationChanged = previousIdentity.map { $0.paginationVersion != paginationVersion } ?? false
+
         reloadAndSyncSelection(
             tableView: tableView,
             coordinator: coordinator,
             needsFullReload: needsFullReload,
             versionChanged: versionChanged,
-            metadataChanged: metadataChanged
+            metadataChanged: metadataChanged,
+            paginationChanged: paginationChanged
         )
     }
 
@@ -546,7 +552,8 @@ struct DataGridView: NSViewRepresentable {
         coordinator: TableViewCoordinator,
         needsFullReload: Bool,
         versionChanged: Bool,
-        metadataChanged: Bool = false
+        metadataChanged: Bool = false,
+        paginationChanged: Bool = false
     ) {
         if needsFullReload {
             tableView.reloadData()
@@ -590,6 +597,11 @@ struct DataGridView: NSViewRepresentable {
         }
 
         coordinator.lastReloadVersion = changeManager.reloadVersion
+
+        // Scroll to first row when page changes
+        if paginationChanged && tableView.numberOfRows > 0 {
+            tableView.scrollRowToVisible(0)
+        }
 
         // Sync selection
         let currentSelection = tableView.selectedRowIndexes


### PR DESCRIPTION
Closes #541 (scroll-to-top part)

## Summary
- Added `paginationVersion` counter to `QueryTab`, following the existing `resultVersion`/`metadataVersion` pattern
- Only pagination operations (next/prev/first/last page, page size change, offset change) increment this counter
- `DataGridView` detects the change via `DataGridIdentity` comparison and calls `NSTableView.scrollRowToVisible(0)`
- Cell edits, undo/redo, FK metadata updates, and refreshes do NOT trigger scroll

## Test plan
- [ ] Open a table with pagination enabled and many rows
- [ ] Scroll to the middle of page 1
- [ ] Click Next Page — grid scrolls to first row
- [ ] Click Previous Page — grid scrolls to first row
- [ ] Change page size — grid scrolls to first row
- [ ] Edit a cell and save — grid does NOT scroll
- [ ] Undo/Redo — grid does NOT scroll