### PR TITLE
fix: file picker appears behind connection form window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- File picker dialog appears behind the connection form window
+
 ### Added
 
 - iOS: connection groups and tags

--- a/TablePro/AppDelegate+WindowConfig.swift
+++ b/TablePro/AppDelegate+WindowConfig.swift
@@ -203,8 +203,6 @@ extension AppDelegate {
 
         window.collectionBehavior.remove(.fullScreenPrimary)
         window.collectionBehavior.insert(.fullScreenNone)
-
-        window.level = .floating
     }
 
     // MARK: - Welcome Window Suppression

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -1155,12 +1155,13 @@ struct ConnectionFormView: View {
     }
 
     private func browseForFile() {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.database, .data]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
 
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 database = url.path(percentEncoded: false)
             }

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -335,6 +335,7 @@ struct ConnectionSSHTunnelView: View {
     // MARK: - Helper Methods
 
     private func browseForPrivateKey() {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
@@ -342,7 +343,7 @@ struct ConnectionSSHTunnelView: View {
             ".ssh")
         panel.showsHiddenFiles = true
 
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 sshPrivateKeyPath = url.path(percentEncoded: false)
             }
@@ -350,6 +351,7 @@ struct ConnectionSSHTunnelView: View {
     }
 
     private func browseForJumpHostKey(jumpHost: Binding<SSHJumpHost>) {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
@@ -357,7 +359,7 @@ struct ConnectionSSHTunnelView: View {
             ".ssh")
         panel.showsHiddenFiles = true
 
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 jumpHost.wrappedValue.privateKeyPath = url.path(percentEncoded: false)
             }

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -76,13 +76,14 @@ struct ConnectionSSLView: View {
     }
 
     private func browseForCertificate(binding: Binding<String>) {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.allowedContentTypes = [.data]
         panel.showsHiddenFiles = true
 
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 binding.wrappedValue = url.path(percentEncoded: false)
             }

--- a/TablePro/Views/Connection/SSHProfileEditorView.swift
+++ b/TablePro/Views/Connection/SSHProfileEditorView.swift
@@ -510,12 +510,13 @@ struct SSHProfileEditorView: View {
     }
 
     private func browseForPrivateKey() {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
         panel.showsHiddenFiles = true
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 privateKeyPath = url.path(percentEncoded: false)
             }
@@ -523,12 +524,13 @@ struct SSHProfileEditorView: View {
     }
 
     private func browseForJumpHostKey(jumpHost: Binding<SSHJumpHost>) {
+        guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
         panel.showsHiddenFiles = true
-        panel.begin { response in
+        panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
                 jumpHost.wrappedValue.privateKeyPath = url.path(percentEncoded: false)
             }


### PR DESCRIPTION
## Summary

- Removed `window.level = .floating` from the connection form window. `.floating` is designed for utility/inspector panels (Xcode inspector, Photoshop palettes), not form dialogs. This caused `NSOpenPanel` (which opens at `.normal` level) to appear behind the connection form.
- Converted all `NSOpenPanel` calls in connection form views from `panel.begin { }` to `panel.beginSheetModal(for:)` — the standard macOS pattern for file dialogs in form windows. The picker now slides down as a sheet attached to the form.

Closes #587

## Test plan

- [ ] Open New Connection → select SQLite → click Browse → verify file picker appears as a sheet on the connection form
- [ ] Open New Connection → enable SSL → click Browse for CA/Client cert/key → verify file picker appears as a sheet
- [ ] Open New Connection → enable SSH → click Browse for private key → verify file picker appears as a sheet
- [ ] Open New Connection → SSH → add jump host → click Browse for jump host key → verify file picker appears as a sheet
- [ ] Open SSH Profile Editor → click Browse for private key → verify file picker appears as a sheet
- [ ] Verify the connection form window no longer floats above all other app windows