### PR TITLE
fix: add @MainActor isolation to storage classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use sheet presentation for password and TOTP prompts instead of blocking modal dialogs
 - Fix localized strings with interpolation creating untranslatable dynamic keys
 - Fix crash when closing window during SSH tunnel connection (use-after-free in libssh2)
+- Fix data race in ConnectionStorage, GroupStorage, and TagStorage (added @MainActor isolation)
 
 ### Added
 

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -513,20 +513,18 @@ final class DatabaseManager {
             return connection
         }
 
-        // Load Keychain credentials off the main thread to avoid blocking UI
-        let (storedSshPassword, keyPassphrase, totpSecret) = await Task.detached {
-            if isProfile {
-                let pwd = SSHProfileStorage.shared.loadSSHPassword(for: secretOwnerId)
-                let phrase = SSHProfileStorage.shared.loadKeyPassphrase(for: secretOwnerId)
-                let totp = SSHProfileStorage.shared.loadTOTPSecret(for: secretOwnerId)
-                return (pwd, phrase, totp)
-            } else {
-                let pwd = ConnectionStorage.shared.loadSSHPassword(for: secretOwnerId)
-                let phrase = ConnectionStorage.shared.loadKeyPassphrase(for: secretOwnerId)
-                let totp = ConnectionStorage.shared.loadTOTPSecret(for: secretOwnerId)
-                return (pwd, phrase, totp)
-            }
-        }.value
+        let storedSshPassword: String?
+        let keyPassphrase: String?
+        let totpSecret: String?
+        if isProfile {
+            storedSshPassword = SSHProfileStorage.shared.loadSSHPassword(for: secretOwnerId)
+            keyPassphrase = SSHProfileStorage.shared.loadKeyPassphrase(for: secretOwnerId)
+            totpSecret = SSHProfileStorage.shared.loadTOTPSecret(for: secretOwnerId)
+        } else {
+            storedSshPassword = ConnectionStorage.shared.loadSSHPassword(for: secretOwnerId)
+            keyPassphrase = ConnectionStorage.shared.loadKeyPassphrase(for: secretOwnerId)
+            totpSecret = ConnectionStorage.shared.loadTOTPSecret(for: secretOwnerId)
+        }
 
         let sshPassword = sshPasswordOverride ?? storedSshPassword
 

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -10,6 +10,7 @@ import os
 import TableProPluginKit
 
 /// Service for persisting database connections
+@MainActor
 final class ConnectionStorage {
     static let shared = ConnectionStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionStorage")
@@ -188,13 +189,6 @@ final class ConnectionStorage {
     }
 
     // MARK: - Keychain (Password Storage)
-
-    // Thread safety note (SVC-15): SecItemCopyMatching is synchronous but all call sites
-    // are already off the main thread:
-    //   - MySQLDriver.connect() / PostgreSQLDriver.connect() — non-@MainActor async funcs
-    //   - DatabaseManager — uses Task.detached for SSH/key passphrase loads
-    //   - ConnectionFormView — single-item lookup during form population (negligible latency)
-    // No async wrapper is needed; adding one would add complexity without measurable benefit.
 
     func savePassword(_ password: String, for connectionId: UUID) {
         let key = "com.TablePro.password.\(connectionId.uuidString)"

--- a/TablePro/Core/Storage/GroupStorage.swift
+++ b/TablePro/Core/Storage/GroupStorage.swift
@@ -7,6 +7,7 @@ import Foundation
 import os
 
 /// Service for persisting connection groups
+@MainActor
 final class GroupStorage {
     static let shared = GroupStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "GroupStorage")

--- a/TablePro/Core/Storage/TagStorage.swift
+++ b/TablePro/Core/Storage/TagStorage.swift
@@ -9,6 +9,7 @@ import Foundation
 import os
 
 /// Service for persisting the global tag library
+@MainActor
 final class TagStorage {
     static let shared = TagStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "TagStorage")

--- a/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+@MainActor
 struct ConnectionURLFormatter {
     static func format(
         _ connection: DatabaseConnection,

--- a/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
@@ -583,7 +583,7 @@ struct ConnectionURLParser {
         return bestColor
     }
 
-    internal static func tagId(fromEnvName name: String) -> UUID? {
+    @MainActor internal static func tagId(fromEnvName name: String) -> UUID? {
         let tags = TagStorage.shared.loadTags()
         return tags.first(where: { $0.name.lowercased() == name.lowercased() })?.id
     }


### PR DESCRIPTION
## Summary

- Added `@MainActor` to `ConnectionStorage`, `GroupStorage`, and `TagStorage` to prevent data races on their in-memory caches (`cachedConnections`, `cachedGroups`, `cachedTags`)
- Removed `Task.detached` in `DatabaseManager.buildEffectiveConnection()` that called `ConnectionStorage` Keychain methods from a background thread — Keychain lookups are sub-millisecond, no need to leave the main actor
- Added `@MainActor` to `ConnectionURLFormatter` and `ConnectionURLParser.tagId(fromEnvName:)` to satisfy compiler-enforced isolation (all callers are already `@MainActor`)
- Removed stale thread-safety comment that referenced the now-deleted `Task.detached` pattern

Addresses audit item C4.

## Test plan

- [ ] Connect to SSH database with password — credentials load correctly
- [ ] Connect to SSH database with key passphrase — passphrase loads correctly
- [ ] Connect to SSH database with TOTP — TOTP secret loads correctly
- [ ] Create/edit/delete connections — storage works normally
- [ ] Create/edit/delete groups — storage works normally
- [ ] Create/edit/delete tags — storage works normally
- [ ] Export connection URL from context menu — URL formats correctly
- [ ] Import connection from deep link URL — tag resolves correctly