### PR TITLE
fix: prevent infinite alert loop when table tab query fails

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -392,6 +392,7 @@ extension MainContentCoordinator {
             var errTab = tabManager.tabs[idx]
             errTab.errorMessage = error.localizedDescription
             errTab.isExecuting = false
+            errTab.lastExecutedAt = Date()
             tabManager.tabs[idx] = errTab
         }
         toolbarState.setExecuting(false)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -108,6 +108,7 @@ extension MainContentCoordinator {
             let needsLazyQuery = newTab.tabType == .table
                 && (newTab.resultRows.isEmpty || isEvicted)
                 && (newTab.lastExecutedAt == nil || isEvicted)
+                && newTab.errorMessage == nil
                 && !newTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
             if needsLazyQuery {

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -326,6 +326,7 @@ struct MainContentView: View {
                     tab.tabType == .table
                         && (tab.resultRows.isEmpty || tab.rowBuffer.isEvicted)
                         && (tab.lastExecutedAt == nil || tab.rowBuffer.isEvicted)
+                        && tab.errorMessage == nil
                         && !tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 } ?? false
             if needsLazyLoad && !hasPendingEdits && isConnected {


### PR DESCRIPTION
## Summary
- When a table tab query fails (e.g., opening `pg_stat_statements_info` in the `extensions` schema), the "Query Execution Failed" alert shows in an infinite loop — clicking OK immediately re-triggers the alert
- Root cause: `handleQueryExecutionError` never set `lastExecutedAt` on the tab. Dismissing the NSAlert sheet posts `NSWindow.didBecomeKeyNotification`, which re-evaluates the lazy-load predicate. Since `lastExecutedAt == nil` and `resultRows.isEmpty`, the predicate passes and `runQuery()` fires again
- Set `lastExecutedAt = Date()` in the error handler so the tab is marked as "already attempted"
- Added `errorMessage == nil` guard to both lazy-load predicates (`didBecomeKeyNotification` handler and `handleTabChange`) as defense-in-depth

## Test plan
- [ ] Open a table that will fail (e.g., `pg_stat_statements_info` in `extensions` schema on a PostgreSQL server without `shared_preload_libraries` configured)
- [ ] Verify the error alert shows **once** and does not reappear after clicking OK
- [ ] Switch away from and back to the failed tab — verify no re-trigger
- [ ] Open a normal table tab — verify it still auto-executes correctly
- [ ] Restore tabs from persistence with a previously-failed tab — verify no loop