### PR TITLE
fix: add SQLite schema versioning for future migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when closing window during SSH tunnel connection (use-after-free in libssh2)
 - Fix potential deadlock in SSH host key verification prompts (semaphore → async/await)
 - Fix data race in ConnectionStorage, GroupStorage, and TagStorage (added @MainActor isolation)
+- Add schema versioning to SQLite databases (query history, favorites) for future migrations
 
 ### Added
 

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -150,7 +150,41 @@ final class QueryHistoryStorage {
         execute("PRAGMA synchronous=NORMAL;")
 
         createTables()
+        migrateIfNeeded()
     }
+
+    // MARK: - Schema Migration
+
+    private func migrateIfNeeded() {
+        let currentVersion = getUserVersion()
+
+        // Future migrations go here:
+        // if currentVersion < 2 {
+        //     execute("ALTER TABLE history ADD COLUMN new_col TEXT;")
+        // }
+
+        let targetVersion: Int32 = 1
+        if currentVersion < targetVersion {
+            setUserVersion(targetVersion)
+        }
+    }
+
+    private func getUserVersion() -> Int32 {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, "PRAGMA user_version", -1, &statement, nil) == SQLITE_OK,
+              sqlite3_step(statement) == SQLITE_ROW
+        else {
+            return 0
+        }
+        return sqlite3_column_int(statement, 0)
+    }
+
+    private func setUserVersion(_ version: Int32) {
+        execute("PRAGMA user_version = \(version);")
+    }
+
+    // MARK: - Table Creation
 
     private func createTables() {
         // History table

--- a/TablePro/Core/Storage/SQLFavoriteStorage.swift
+++ b/TablePro/Core/Storage/SQLFavoriteStorage.swift
@@ -109,7 +109,41 @@ internal final class SQLFavoriteStorage {
         execute("PRAGMA synchronous=NORMAL;")
 
         createTables()
+        migrateIfNeeded()
     }
+
+    // MARK: - Schema Migration
+
+    private func migrateIfNeeded() {
+        let currentVersion = getUserVersion()
+
+        // Future migrations go here:
+        // if currentVersion < 2 {
+        //     execute("ALTER TABLE favorites ADD COLUMN new_col TEXT;")
+        // }
+
+        let targetVersion: Int32 = 1
+        if currentVersion < targetVersion {
+            setUserVersion(targetVersion)
+        }
+    }
+
+    private func getUserVersion() -> Int32 {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, "PRAGMA user_version", -1, &statement, nil) == SQLITE_OK,
+              sqlite3_step(statement) == SQLITE_ROW
+        else {
+            return 0
+        }
+        return sqlite3_column_int(statement, 0)
+    }
+
+    private func setUserVersion(_ version: Int32) {
+        execute("PRAGMA user_version = \(version);")
+    }
+
+    // MARK: - Table Creation
 
     private func createTables() {
         let favoritesTable = """


### PR DESCRIPTION
## Summary

Adds `PRAGMA user_version`-based schema migration infrastructure to both SQLite databases (`query_history.db` and `sql_favorites.db`).

Both databases currently use `CREATE TABLE IF NOT EXISTS` with no version tracking. If a future release needs to add a column, existing users would silently keep the old schema. This PR sets the foundation so future schema changes can use `ALTER TABLE ... ADD COLUMN` migrations gated by version checks.

**Changes:**
- `QueryHistoryStorage.swift` — Added `migrateIfNeeded()`, `getUserVersion()`, `setUserVersion()`. Current schema set to version 1.
- `SQLFavoriteStorage.swift` — Same three methods added. Current schema set to version 1.

No schema changes are made — this just stamps the current schema as version 1 so future migrations have a baseline.

Addresses audit item C5.

## Test plan

- [ ] Fresh launch: `sqlite3 ~/Library/Application\ Support/TablePro/query_history.db "PRAGMA user_version;"` returns `1`
- [ ] Fresh launch: `sqlite3 ~/Library/Application\ Support/TablePro/sql_favorites.db "PRAGMA user_version;"` returns `1`
- [ ] Query history works normally (execute queries, search history)
- [ ] SQL favorites work normally (create/edit/delete favorites and folders)
- [ ] Existing tests pass