### PR TITLE
perf: move file I/O off main thread for themes, AI chat, and SSH config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix potential hang when coordinator deallocates during save
 - Fix Cmd+W save not persisting data grid changes (sidebar edits intercepted save path)
+- Move theme loading, AI chat history, and SSH config parsing off the main thread
 
 ## [0.27.5] - 2026-04-06
 

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -108,18 +108,20 @@ internal final class ThemeEngine {
     // MARK: - Init
 
     private init() {
-        let allThemes = ThemeStorage.loadAllThemes()
-        // Start with the default theme; AppSettingsManager.init() will call
-        // updateAppearanceAndTheme() to activate the correct preferred theme.
         let theme = ThemeDefinition.default
 
         self.activeTheme = theme
         self.colors = ResolvedThemeColors(from: theme)
         self.editorFonts = EditorFontCache(from: theme.fonts)
         self.dataGridFonts = DataGridFontCacheResolved(from: theme.fonts)
-        self.availableThemes = allThemes
+        self.availableThemes = [theme]
 
         observeAccessibilityChanges()
+
+        Task {
+            let themes = await Task.detached { ThemeStorage.loadAllThemes() }.value
+            self.availableThemes = themes
+        }
     }
 
     // MARK: - Theme Lifecycle
@@ -214,7 +216,10 @@ internal final class ThemeEngine {
     }
 
     func reloadAvailableThemes() {
-        availableThemes = ThemeStorage.loadAllThemes()
+        Task {
+            let themes = await Task.detached { ThemeStorage.loadAllThemes() }.value
+            self.availableThemes = themes
+        }
     }
 
     // MARK: - Editor Font Size Zoom

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -209,11 +209,14 @@ final class AIChatViewModel {
 
     /// Load saved conversations from disk
     func loadConversations() {
-        conversations = chatStorage.loadAll()
-        // Restore most recent conversation if available
-        if let mostRecent = conversations.first {
-            activeConversationID = mostRecent.id
-            messages = mostRecent.messages
+        let storage = chatStorage
+        Task {
+            let loaded = await Task.detached { storage.loadAll() }.value
+            conversations = loaded
+            if let mostRecent = loaded.first {
+                activeConversationID = mostRecent.id
+                messages = mostRecent.messages
+            }
         }
     }
 

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -1271,7 +1271,10 @@ private extension ConnectionFormView {
     }
 
     func loadSSHConfig() {
-        sshConfigEntries = SSHConfigParser.parse()
+        Task {
+            let entries = await Task.detached { SSHConfigParser.parse() }.value
+            sshConfigEntries = entries
+        }
     }
 }
 

--- a/TablePro/Views/Connection/SSHProfileEditorView.swift
+++ b/TablePro/Views/Connection/SSHProfileEditorView.swift
@@ -95,8 +95,11 @@ struct SSHProfileEditorView: View {
         }
         .frame(minWidth: 480, minHeight: 500)
         .onAppear {
-            sshConfigEntries = SSHConfigParser.parse()
             loadExistingProfile()
+        }
+        .task {
+            let entries = await Task.detached { SSHConfigParser.parse() }.value
+            sshConfigEntries = entries
         }
         .onChange(of: host) { _, _ in testSucceeded = false }
         .onChange(of: port) { _, _ in testSucceeded = false }


### PR DESCRIPTION
## Summary

Moves 4 synchronous file I/O operations off the main thread to prevent UI jank:

- **ThemeEngine.init()** — Theme directory scan + JSON decode loop now runs on `Task.detached`, default theme displayed immediately
- **ThemeEngine.reloadAvailableThemes()** — Same async pattern for theme save/delete/import
- **AIChatViewModel.loadConversations()** — All conversation JSON files loaded on background thread
- **SSHConfigParser.parse()** — `~/.ssh/config` read moved to `Task.detached` in ConnectionFormView and `.task` in SSHProfileEditorView

## Test plan

- [ ] App launch — themes available in settings (may briefly show only default)
- [ ] Settings > Themes > Import/Export/Delete — theme list refreshes correctly
- [ ] AI Chat panel — conversations load and most recent is restored
- [ ] New Connection > SSH tab — SSH config hosts populate in dropdown
- [ ] SSH Profile editor — SSH config hosts populate in dropdown