### PR TITLE
fix: replace fixed delays in deep link handling with event-driven waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Cmd+W save not persisting data grid changes
 - Show error feedback when connection fails from Connection Switcher
 - Move theme, AI chat, and SSH config file loading off the main thread
+- Replace fixed delays in deep link handling with event-driven waits
 
 ## [0.27.5] - 2026-04-06
 

--- a/TablePro/AppDelegate+ConnectionHandler.swift
+++ b/TablePro/AppDelegate+ConnectionHandler.swift
@@ -311,11 +311,8 @@ extension AppDelegate {
     }
 
     private func postSQLFilesWhenReady(urls: [URL]) {
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(100))
-            if !NSApp.windows.contains(where: { self?.isMainWindow($0) == true && $0.isKeyWindow }) {
-                connectionLogger.warning("postSQLFilesWhenReady: no key main window, posting anyway")
-            }
+        Task { @MainActor in
+            await waitForConnection(timeout: .seconds(3))
             NotificationCenter.default.post(name: .openSQLFiles, object: urls)
         }
     }
@@ -343,7 +340,7 @@ extension AppDelegate {
                     object: nil,
                     userInfo: ["connectionId": connectionId, "schema": schema]
                 )
-                try? await Task.sleep(for: .milliseconds(500))
+                await waitForNotification(.refreshData, timeout: .seconds(3))
             }
 
             if let tableName = parsed.tableName {
@@ -356,7 +353,7 @@ extension AppDelegate {
                 WindowOpener.shared.openNativeTab(payload)
 
                 if parsed.filterColumn != nil || parsed.filterCondition != nil {
-                    try? await Task.sleep(for: .milliseconds(300))
+                    await waitForNotification(.refreshData, timeout: .seconds(3))
                     NotificationCenter.default.post(
                         name: .applyURLFilter,
                         object: nil,
@@ -395,6 +392,33 @@ extension AppDelegate {
                 forName: .databaseDidConnect,
                 object: nil,
                 queue: .main
+            ) { _ in
+                timeoutTask.cancel()
+                resumeOnce()
+            }
+        }
+    }
+
+    private func waitForNotification(_ name: Notification.Name, timeout: Duration) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var didResume = false
+            var observer: NSObjectProtocol?
+
+            func resumeOnce() {
+                guard !didResume else { return }
+                didResume = true
+                if let obs = observer {
+                    NotificationCenter.default.removeObserver(obs)
+                }
+                continuation.resume()
+            }
+
+            let timeoutTask = Task { @MainActor in
+                try? await Task.sleep(for: timeout)
+                resumeOnce()
+            }
+            observer = NotificationCenter.default.addObserver(
+                forName: name, object: nil, queue: .main
             ) { _ in
                 timeoutTask.cancel()
                 resumeOnce()
@@ -443,7 +467,7 @@ extension AppDelegate {
         // User cancelled password prompt — no error dialog needed
         if error is CancellationError { return }
 
-        try? await Task.sleep(for: .milliseconds(200))
+        await Task.yield()
         AlertHelper.showErrorSheet(
             title: String(localized: "Connection Failed"),
             message: error.localizedDescription,


### PR DESCRIPTION
## Summary

Replaces 4 fixed `Task.sleep` delays in `AppDelegate+ConnectionHandler.swift` with event-driven alternatives:

| Site | Before | After |
|------|--------|-------|
| `postSQLFilesWhenReady` | 100ms sleep | `waitForConnection()` (existing helper) |
| Schema switch → open table | 500ms sleep | `waitForNotification(.refreshData)` |
| Open table → apply URL filter | 300ms sleep | `waitForNotification(.refreshData)` |
| Connection failure → error alert | 200ms sleep | `Task.yield()` (one run loop pass) |

Adds a reusable `waitForNotification(_:timeout:)` helper (same pattern as existing `waitForConnection`).

## Test plan

- [ ] Deep link: `tablepro://connect?type=mysql&host=localhost` → connects
- [ ] Deep link with schema: `&schema=public` → schema switches correctly
- [ ] Deep link with table: `&table=users` → table tab opens after schema switch
- [ ] Deep link with filter: `&filter_column=id&filter_value=1` → filter applies after table loads
- [ ] Connection failure → error alert appears promptly
- [ ] Open .sql file while connected → SQL tab opens in main window