### PR TITLE
fix: replace NSLog with os.Logger, use O(1) string length, fix localization

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -218,7 +218,7 @@ struct AppMenuCommands: Commands {
                 actions?.previewSQL()
             } label: {
                 if let dbType = appState.currentDatabaseType {
-                    Text("Preview \(PluginManager.shared.queryLanguageName(for: dbType))")
+                    Text(String(format: String(localized: "Preview %@"), PluginManager.shared.queryLanguageName(for: dbType)))
                 } else {
                     Text("Preview SQL")
                 }

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Observation
+import os
 import SwiftUI
 
 // MARK: - TableFetcher Protocol
@@ -15,6 +16,8 @@ import SwiftUI
 protocol TableFetcher: Sendable {
     func fetchTables(force: Bool) async throws -> [TableInfo]
 }
+
+private let sidebarLogger = Logger(subsystem: "com.TablePro", category: "SidebarViewModel")
 
 /// Production implementation that uses DatabaseManager, with optional schema provider cache
 struct LiveTableFetcher: TableFetcher {
@@ -36,12 +39,12 @@ struct LiveTableFetcher: TableFetcher {
             }
         }
         guard let driver = await DatabaseManager.shared.driver(for: connectionId) else {
-            NSLog("[LiveTableFetcher] driver is nil for connectionId: %@", connectionId.uuidString)
+            sidebarLogger.warning("Driver is nil for connection \(connectionId)")
             return []
         }
         let fetched = try await driver.fetchTables()
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-        NSLog("[LiveTableFetcher] fetched %d tables", fetched.count)
+        sidebarLogger.debug("Fetched \(fetched.count) tables")
         if let provider = schemaProvider {
             await provider.updateTables(fetched)
         }
@@ -155,14 +158,14 @@ final class SidebarViewModel {
 
     func onAppear() {
         guard tables.isEmpty else {
-            NSLog("[SidebarVM] onAppear: tables not empty (%d), skipping", tables.count)
+            sidebarLogger.debug("onAppear: tables not empty (\(self.tables.count)), skipping")
             return
         }
         if DatabaseManager.shared.driver(for: connectionId) != nil {
-            NSLog("[SidebarVM] onAppear: driver found, loading tables")
+            sidebarLogger.debug("onAppear: loading tables")
             loadTables()
         } else {
-            NSLog("[SidebarVM] onAppear: driver is nil for %@", connectionId.uuidString)
+            sidebarLogger.warning("onAppear: driver is nil for \(self.connectionId)")
         }
     }
 

--- a/TablePro/Views/Filter/CompletionTextField.swift
+++ b/TablePro/Views/Filter/CompletionTextField.swift
@@ -96,7 +96,7 @@ struct CompletionTextField: NSViewRepresentable {
             if commandSelector == #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)) {
                 textView.insertNewlineIgnoringFieldEditor(nil)
                 text.wrappedValue = textView.string
-                previousTextLength = textView.string.count
+                previousTextLength = (textView.string as NSString).length
                 return true
             }
             return false


### PR DESCRIPTION
## Summary

3 quick-win code quality fixes from the audit:

- **NSLog → os.Logger** — 5 `NSLog` calls in `SidebarViewModel` replaced with `os.Logger` using the `SidebarViewModel` category. NSLog bypasses OSLog privacy, is slower, and violates project policy.
- **O(1) string length** — `string.count` (O(n)) replaced with `(string as NSString).length` (O(1)) in `CompletionTextField`.
- **Localization fix** — `Text("Preview \(name)")` creates a dynamic `LocalizedStringKey` that never matches the strings catalog. Fixed with `String(format: String(localized: "Preview %@"), name)`.

## Test plan

- [ ] Sidebar loads tables → check Console.app for `SidebarViewModel` category logs
- [ ] Filter field with autocomplete → works correctly
- [ ] View menu > Preview SQL → shows correct label (e.g., "Preview MQL" for MongoDB)