### PR TITLE
fix: add logging to silent try?/catch blocks in critical paths

### DIFF
--- a/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import os
 import TableProPluginKit
 
 /// Provides cached database schema information for autocomplete
 actor SQLSchemaProvider {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SQLSchemaProvider")
     // MARK: - Properties
 
     private var tables: [TableInfo] = []
@@ -74,6 +76,7 @@ actor SQLSchemaProvider {
             evictIfNeeded()
             return columns
         } catch {
+            Self.logger.debug("Column fetch failed for autocomplete: \(error.localizedDescription)")
             return []
         }
     }

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -272,7 +272,8 @@ extension DatabaseDriver {
                 let columns = try await fetchColumns(table: table.name)
                 result[table.name] = columns
             } catch {
-                // Skip tables whose columns can't be fetched
+                Logger(subsystem: "com.TablePro", category: "DatabaseDriver")
+                    .debug("Skipping columns for table '\(table.name)': \(error.localizedDescription)")
             }
         }
         return result

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -616,6 +616,7 @@ final class DatabaseManager {
                     _ = try await mainDriver.execute(query: "SELECT 1")
                     return true
                 } catch {
+                    Self.logger.debug("Ping failed: \(error.localizedDescription)")
                     return false
                 }
             },
@@ -632,6 +633,7 @@ final class DatabaseManager {
                     }
                     return true
                 } catch {
+                    Self.logger.debug("Reconnect failed: \(error.localizedDescription)")
                     return false
                 }
             },

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -929,7 +929,11 @@ final class PluginManager {
             }
             Self.logger.warning("Plugin '\(existingEntry.id)' exists but driver not registered, reinstalling")
             if existingEntry.source == .userInstalled {
-                try? uninstallPlugin(id: existingEntry.id)
+                do {
+                    try uninstallPlugin(id: existingEntry.id)
+                } catch {
+                    Self.logger.warning("Failed to uninstall plugin '\(existingEntry.id)' before reinstall: \(error.localizedDescription)")
+                }
             }
         }
 

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -180,7 +180,11 @@ final class ExportService {
                 progress: progress
             )
         } catch {
-            try? FileManager.default.removeItem(at: url)
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch {
+                Self.logger.warning("Failed to clean up export file: \(error.localizedDescription)")
+            }
             state.errorMessage = error.localizedDescription
             throw error
         }
@@ -260,7 +264,11 @@ final class ExportService {
                 progress: progress
             )
         } catch {
-            try? FileManager.default.removeItem(at: url)
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch {
+                Self.logger.warning("Failed to clean up export file: \(error.localizedDescription)")
+            }
             state.errorMessage = error.localizedDescription
             throw error
         }


### PR DESCRIPTION
## Summary

7 silent `try?` or empty `catch` blocks in critical paths now log errors via `os.Logger` instead of silently discarding them:

| File | Site | Logger |
|------|------|--------|
| PluginManager.swift | Plugin uninstall before reinstall | `warning` |
| ExportService.swift (2 sites) | Partial export file cleanup | `warning` |
| DatabaseDriver.swift | Per-table column fetch for autocomplete | `debug` |
| DatabaseManager.swift (2 sites) | Health check ping + reconnect | `debug` |
| SQLSchemaProvider.swift | Column fetch for autocomplete | `debug` |

Control flow is unchanged — errors are logged but behavior stays the same (skip, return false, return empty).

## Test plan

- [ ] Build succeeds
- [ ] Connect to database → check Console.app for `DatabaseManager` debug logs during reconnect
- [ ] Export with invalid path → check for `ExportService` warning log
- [ ] Autocomplete on table with access issues → check for `DatabaseDriver` debug log