### PR TITLE
cleanup: remove all dead AppState.shared writes and delete AppState class

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -112,12 +112,6 @@ struct ContentView: View {
                                 payload: payload
                             )
                         }
-                        AppState.shared.isConnected = true
-                        AppState.shared.safeModeLevel = session.connection.safeModeLevel
-                        AppState.shared.editorLanguage = PluginManager.shared.editorLanguage(for: session.connection.type)
-                        AppState.shared.currentDatabaseType = session.connection.type
-                        AppState.shared.supportsDatabaseSwitching = PluginManager.shared.supportsDatabaseSwitching(
-                            for: session.connection.type)
                     }
                 } else {
                     currentSession = nil
@@ -151,25 +145,6 @@ struct ContentView: View {
                     }()
                 guard isOurWindow else { return }
 
-                if let session = DatabaseManager.shared.activeSessions[connectionId] {
-                    AppState.shared.isConnected = true
-                    AppState.shared.safeModeLevel = session.connection.safeModeLevel
-                    AppState.shared.editorLanguage = PluginManager.shared.editorLanguage(for: session.connection.type)
-                    AppState.shared.currentDatabaseType = session.connection.type
-                    AppState.shared.supportsDatabaseSwitching = PluginManager.shared.supportsDatabaseSwitching(
-                        for: session.connection.type)
-                } else {
-                    AppState.shared.isConnected = false
-                    AppState.shared.safeModeLevel = .silent
-                    AppState.shared.editorLanguage = .sql
-                    AppState.shared.currentDatabaseType = nil
-                    AppState.shared.supportsDatabaseSwitching = true
-                }
-            }
-            .onChange(of: sessionState?.toolbarState.safeModeLevel) { _, newLevel in
-                if let level = newLevel {
-                    AppState.shared.safeModeLevel = level
-                }
             }
     }
 
@@ -373,12 +348,6 @@ struct ContentView: View {
                 sessionState = nil
                 currentSession = nil
                 columnVisibility = .detailOnly
-                AppState.shared.isConnected = false
-                AppState.shared.safeModeLevel = .silent
-                AppState.shared.editorLanguage = .sql
-                AppState.shared.currentDatabaseType = nil
-                AppState.shared.supportsDatabaseSwitching = true
-
                 // Window cleanup is handled by windowWillClose (opens welcome)
                 // and windowDidBecomeKey (hides restored orphan windows).
                 // Do NOT close windows here — it triggers SwiftUI state
@@ -404,12 +373,6 @@ struct ContentView: View {
                 payload: payload
             )
         }
-        AppState.shared.isConnected = true
-        AppState.shared.safeModeLevel = newSession.connection.safeModeLevel
-        AppState.shared.editorLanguage = PluginManager.shared.editorLanguage(for: newSession.connection.type)
-        AppState.shared.currentDatabaseType = newSession.connection.type
-        AppState.shared.supportsDatabaseSwitching = PluginManager.shared.supportsDatabaseSwitching(
-            for: newSession.connection.type)
     }
 
     // MARK: - Actions

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -11,27 +11,6 @@ import Sparkle
 import SwiftUI
 import TableProPluginKit
 
-// MARK: - App State for Menu Commands
-
-@MainActor
-@Observable
-final class AppState {
-    static let shared = AppState()
-    var isConnected: Bool = false
-    var safeModeLevel: SafeModeLevel = .silent
-    var isReadOnly: Bool { safeModeLevel.blocksAllWrites }
-    var editorLanguage: EditorLanguage = .sql
-    var currentDatabaseType: DatabaseType?
-    var supportsDatabaseSwitching: Bool = true
-    var isCurrentTabEditable: Bool = false  // True when current tab is an editable table
-    var hasRowSelection: Bool = false  // True when rows are selected in data grid
-    var hasTableSelection: Bool = false  // True when tables are selected in sidebar
-    var isHistoryPanelVisible: Bool = false  // Global history panel visibility
-    var hasQueryText: Bool = false  // True when current editor has non-empty query
-    var hasStructureChanges: Bool = false  // True when structure view has pending schema changes
-    var isTableTab: Bool = false  // True when current tab is a table tab (not query)
-}
-
 // MARK: - Pasteboard Commands
 
 /// Custom Commands struct for pasteboard operations

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -257,9 +257,6 @@ struct MainEditorContentView: View {
                 else { return }
 
                 tabManager.tabs[index].query = newValue
-                AppState.shared.hasQueryText = !newValue.trimmingCharacters(
-                    in: .whitespacesAndNewlines
-                ).isEmpty
 
                 // Update window dirty indicator and toolbar for file-backed tabs
                 if tabManager.tabs[index].sourceFileURL != nil {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -87,9 +87,7 @@ extension MainContentCoordinator {
         // Update editable state for menu items
         if let tabIndex = tabManager.selectedTabIndex {
             let tab = tabManager.tabs[tabIndex]
-            AppState.shared.isCurrentTabEditable = tab.isEditable && !tab.isView && tab.tableName != nil
             toolbarState.isTableTab = tab.tabType == .table
-            AppState.shared.isTableTab = tab.tabType == .table
         }
 
         if needsQuery {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -96,9 +96,7 @@ extension MainContentCoordinator {
                 tabManager.tabs[tabIndex].isEditable = !isView
                 tabManager.tabs[tabIndex].schemaName = currentSchema
                 tabManager.tabs[tabIndex].pagination.reset()
-                AppState.shared.isCurrentTabEditable = !isView && tableName.isEmpty == false
                 toolbarState.isTableTab = true
-                AppState.shared.isTableTab = true
             }
             // In-place navigation needs selectRedisDatabaseAndQuery to ensure the correct
             // database is SELECTed and session state is updated before querying.
@@ -128,7 +126,6 @@ extension MainContentCoordinator {
                 if let tabIndex = tabManager.selectedTabIndex {
                     tabManager.tabs[tabIndex].pagination.reset()
                     toolbarState.isTableTab = true
-                AppState.shared.isTableTab = true
                 }
                 restoreColumnLayoutForTable(tableName)
                 restoreFiltersForTable(tableName)
@@ -209,9 +206,7 @@ extension MainContentCoordinator {
                 if let tabIndex = previewCoordinator.tabManager.selectedTabIndex {
                     previewCoordinator.tabManager.tabs[tabIndex].showStructure = showStructure
                     previewCoordinator.tabManager.tabs[tabIndex].pagination.reset()
-                    AppState.shared.isCurrentTabEditable = !isView && !tableName.isEmpty
                     previewCoordinator.toolbarState.isTableTab = true
-                    AppState.shared.isTableTab = true
                 }
                 preview.window.makeKeyAndOrderFront(nil)
                 previewCoordinator.restoreColumnLayoutForTable(tableName)
@@ -277,9 +272,7 @@ extension MainContentCoordinator {
             if let tabIndex = tabManager.selectedTabIndex {
                 tabManager.tabs[tabIndex].showStructure = showStructure
                 tabManager.tabs[tabIndex].pagination.reset()
-                AppState.shared.isCurrentTabEditable = !isView && !tableName.isEmpty
                 toolbarState.isTableTab = true
-                AppState.shared.isTableTab = true
             }
             restoreColumnLayoutForTable(tableName)
             restoreFiltersForTable(tableName)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -194,11 +194,6 @@ extension MainContentCoordinator {
             cachedTableColumnNames[cacheKey] = columns
         }
 
-        AppState.shared.isCurrentTabEditable = updatedTab.isEditable
-            && !updatedTab.isView && updatedTab.tableName != nil
-        toolbarState.isTableTab = updatedTab.tabType == .table
-        AppState.shared.isTableTab = updatedTab.tabType == .table
-
         let resolvedPK: String?
         if let pk = metadata?.primaryKeyColumn {
             resolvedPK = pk

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -49,10 +49,8 @@ extension MainContentCoordinator {
             columnVisibilityManager.restoreFromColumnLayout(newTab.columnLayout.hiddenColumns)
 
             selectedRowIndices = newTab.selectedRowIndices
-            AppState.shared.isCurrentTabEditable = newTab.isEditable && !newTab.isView && newTab.tableName != nil
             toolbarState.isTableTab = newTab.tabType == .table
             toolbarState.isResultsCollapsed = newTab.isResultsCollapsed
-            AppState.shared.isTableTab = newTab.tabType == .table
 
             // Configure change manager without triggering reload yet — we'll fire a single
             // reloadVersion bump below after everything is set up.
@@ -122,10 +120,8 @@ extension MainContentCoordinator {
                 changeManager.reloadVersion += 1
             }
         } else {
-            AppState.shared.isCurrentTabEditable = false
             toolbarState.isTableTab = false
             toolbarState.isResultsCollapsed = false
-            AppState.shared.isTableTab = false
             filterStateManager.clearAll()
         }
     }

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -96,14 +96,12 @@ extension MainContentView {
         let action = TableSelectionAction.resolve(oldTables: oldTables, newTables: newTables)
 
         guard case .navigate(let tableName, let isView) = action else {
-            AppState.shared.hasTableSelection = !newTables.isEmpty
             return
         }
 
         // Only navigate when this is the focused window.
         // Prevents feedback loops when shared sidebar state syncs across native tabs.
         guard isKeyWindow else {
-            AppState.shared.hasTableSelection = !newTables.isEmpty
             return
         }
 
@@ -120,7 +118,6 @@ extension MainContentView {
 
         switch result {
         case .skip:
-            AppState.shared.hasTableSelection = !newTables.isEmpty
             return
         case .openInPlace:
             selectedRowIndices = []
@@ -131,7 +128,6 @@ extension MainContentView {
             coordinator.openTableTab(tableName, isView: isView)
         }
 
-        AppState.shared.hasTableSelection = !newTables.isEmpty
     }
 
     /// Keep sidebar selection in sync with the current window's tab.

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -369,8 +369,6 @@ struct MainContentView: View {
                 }
             }
             .onChange(of: selectedRowIndices) { _, newIndices in
-                // Synchronous: cheap state updates that don't cascade
-                AppState.shared.hasRowSelection = !newIndices.isEmpty
                 if !newIndices.isEmpty,
                     AppSettingsManager.shared.dataGrid.autoShowInspector,
                     tabManager.selectedTab?.tabType == .table

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -95,8 +95,6 @@ extension TableStructureView {
     // MARK: - Lifecycle Callbacks
 
     func onSelectedTabChanged(_ new: StructureTab) {
-        AppState.shared.isCurrentTabEditable = (new != .ddl && new != .parts)
-
         Task {
             await loadTabDataIfNeeded(new)
         }

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -68,12 +68,7 @@ struct TableStructureView: View {
         .onChange(of: columns) { onColumnsChanged() }
         .onChange(of: indexes) { onIndexesChanged() }
         .onChange(of: foreignKeys) { onForeignKeysChanged() }
-        .onChange(of: selectedRows) { _, newSelection in
-            AppState.shared.hasRowSelection = !newSelection.isEmpty
-        }
         .onAppear {
-            AppState.shared.isCurrentTabEditable = (selectedTab != .ddl)
-            AppState.shared.hasRowSelection = !selectedRows.isEmpty
             coordinator?.toolbarState.hasStructureChanges = structureChangeManager.hasChanges
 
             // Wire action handler for direct coordinator calls
@@ -90,8 +85,6 @@ struct TableStructureView: View {
             coordinator?.structureActions = actionHandler
         }
         .onDisappear {
-            AppState.shared.isCurrentTabEditable = false
-            AppState.shared.hasRowSelection = false
             coordinator?.toolbarState.hasStructureChanges = false
             coordinator?.structureActions = nil
         }


### PR DESCRIPTION
## Summary

Removes all 51 dead `AppState.shared` write statements and deletes the `AppState` class definition. After PR #610 migrated all reads to `@FocusedValue`, these writes had zero readers.

**11 files, -94 lines:**
- `TableProApp.swift` — deleted `AppState` class (15 lines)
- `ContentView.swift` — removed 22 writes (connection state push on session/key window changes)
- `MainContentCoordinator+Navigation.swift` — removed 7 writes
- `MainContentView+EventHandlers.swift` — removed 4 writes
- `MainContentCoordinator+TabSwitch.swift` — removed 4 writes
- `TableStructureView.swift` — removed 4 writes
- `MainContentCoordinator+FKNavigation.swift` — removed 2 writes
- `MainContentCoordinator+QueryHelpers.swift` — removed 2 writes
- `MainContentView.swift` — removed 1 write
- `MainEditorContentView.swift` — removed 1 write
- `TableStructureView+DataLoading.swift` — removed 1 write

`grep -rn "AppState" TablePro/ --include='*.swift'` returns zero results.

## Test plan

- [ ] Build succeeds
- [ ] All menu items still enable/disable correctly
- [ ] Multi-window: menus reflect active window