### PR TITLE
fix: log rollback errors and use O(1) string length

### DIFF
--- a/TablePro/Core/Database/DatabaseManager+Schema.swift
+++ b/TablePro/Core/Database/DatabaseManager+Schema.swift
@@ -73,8 +73,11 @@ extension DatabaseManager {
                 // Post notification to refresh UI
                 NotificationCenter.default.post(name: .refreshData, object: nil)
             } catch {
-                // Rollback on error
-                try? await driver.rollbackTransaction()
+                do {
+                    try await driver.rollbackTransaction()
+                } catch {
+                    Self.logger.error("Rollback failed after schema change error: \(error.localizedDescription)")
+                }
                 throw DatabaseError.queryFailed("Schema change failed: \(error.localizedDescription)")
             }
         }

--- a/TablePro/Views/Editor/EditorEventRouter.swift
+++ b/TablePro/Views/Editor/EditorEventRouter.swift
@@ -76,6 +76,8 @@ internal final class EditorEventRouter {
                 guard var ref = self.editors[key], !ref.needsFirstResponderCheck else { return }
                 ref.needsFirstResponderCheck = true
                 self.editors[key] = ref
+                // Deferred to next run loop iteration to coalesce multiple
+                // didUpdateNotification fires into one checkFirstResponderChange() call.
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     self.editors[key]?.needsFirstResponderCheck = false

--- a/TablePro/Views/Filter/CompletionTextField.swift
+++ b/TablePro/Views/Filter/CompletionTextField.swift
@@ -72,8 +72,9 @@ struct CompletionTextField: NSViewRepresentable {
         func controlTextDidChange(_ notification: Notification) {
             guard let textField = notification.object as? NSTextField else { return }
             let newValue = textField.stringValue
-            let grew = newValue.count > previousTextLength
-            previousTextLength = newValue.count
+            let newLength = (newValue as NSString).length
+            let grew = newLength > previousTextLength
+            previousTextLength = newLength
             text.wrappedValue = newValue
 
             if grew, !newValue.isEmpty,


### PR DESCRIPTION
## Summary
- **DatabaseManager+Schema.swift**: `try?` on `rollbackTransaction()` now wrapped in do/catch with `logger.error` so rollback failures are visible instead of silently swallowed
- **CompletionTextField.swift**: `string.count` (O(n) in Swift) replaced with `(string as NSString).length` (O(1))
- **EditorEventRouter.swift**: Added clarifying comment on why `DispatchQueue.main.async` inside `MainActor.assumeIsolated` is intentional (coalesces rapid `didUpdateNotification` fires)

## Test plan
- [ ] Build succeeds
- [ ] Filter text field autocomplete still works correctly
- [ ] SQL editor cursor/first-responder behavior unchanged