### PR TITLE
fix: resolve 4 critical AI bugs

### DIFF
--- a/TablePro/Core/AI/InlineSuggestionManager.swift
+++ b/TablePro/Core/AI/InlineSuggestionManager.swift
@@ -188,6 +188,7 @@ final class InlineSuggestionManager {
 
         currentTask = Task { [weak self] in
             guard let self else { return }
+            self.suggestionOffset = cursorOffset
 
             do {
                 let suggestion = try await self.fetchSuggestion(textBefore: textBefore, fullQuery: fullText)
@@ -198,7 +199,6 @@ final class InlineSuggestionManager {
                 guard !cleaned.isEmpty else { return }
 
                 self.currentSuggestion = cleaned
-                self.suggestionOffset = cursorOffset
                 self.showGhostText(cleaned, at: cursorOffset)
             } catch {
                 if !Task.isCancelled {
@@ -386,18 +386,15 @@ final class InlineSuggestionManager {
 
                 switch event.keyCode {
                 case 48: // Tab — accept suggestion
-                    Task { @MainActor [weak self] in
-                        self?.acceptSuggestion()
-                    }
+                    self.acceptSuggestion()
                     return nil
 
                 case 53: // Escape — dismiss suggestion
-                    Task { @MainActor [weak self] in
-                        self?.dismissSuggestion()
-                    }
+                    self.dismissSuggestion()
                     return nil
 
                 default:
+                    // Deferred: must return the event to AppKit first, then dismiss
                     Task { @MainActor [weak self] in
                         self?.dismissSuggestion()
                     }

--- a/TablePro/Core/Storage/AIChatStorage.swift
+++ b/TablePro/Core/Storage/AIChatStorage.swift
@@ -9,7 +9,7 @@ import Foundation
 import os
 
 /// Manages persistent storage of AI chat conversations as individual JSON files
-final class AIChatStorage {
+actor AIChatStorage {
     static let shared = AIChatStorage()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "AIChatStorage")
@@ -40,11 +40,17 @@ final class AIChatStorage {
             Self.logger.error("Application Support directory unavailable, falling back to temporary directory")
             appSupport = FileManager.default.temporaryDirectory
         }
-        directory = appSupport
+        let dir = appSupport
             .appendingPathComponent("TablePro", isDirectory: true)
             .appendingPathComponent("ai_chats", isDirectory: true)
+        directory = dir
 
-        createDirectoryIfNeeded()
+        // Create directory inline since actor init is nonisolated
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            Self.logger.error("Failed to create ai_chats directory: \(error.localizedDescription)")
+        }
     }
 
     // MARK: - Public Methods
@@ -103,25 +109,17 @@ final class AIChatStorage {
     /// Delete all conversations
     func deleteAll() {
         do {
-            if FileManager.default.fileExists(atPath: directory.path) {
-                try FileManager.default.removeItem(at: directory)
-                createDirectoryIfNeeded()
+            let files = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: .skipsHiddenFiles
+            )
+            for file in files where file.pathExtension == "json" {
+                try FileManager.default.removeItem(at: file)
             }
         } catch {
             Self.logger.error("Failed to delete all conversations: \(error.localizedDescription)")
         }
     }
 
-    // MARK: - Private
-
-    private func createDirectoryIfNeeded() {
-        do {
-            try FileManager.default.createDirectory(
-                at: directory,
-                withIntermediateDirectories: true
-            )
-        } catch {
-            Self.logger.error("Failed to create ai_chats directory: \(error.localizedDescription)")
-        }
-    }
 }

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -150,7 +150,7 @@ final class AIChatViewModel {
     /// Clear all recent conversations
     func clearConversation() {
         cancelStream()
-        chatStorage.deleteAll()
+        Task { await chatStorage.deleteAll() }
         conversations.removeAll()
         messages.removeAll()
         activeConversationID = nil
@@ -209,9 +209,8 @@ final class AIChatViewModel {
 
     /// Load saved conversations from disk
     func loadConversations() {
-        let storage = chatStorage
         Task {
-            let loaded = await Task.detached { storage.loadAll() }.value
+            let loaded = await chatStorage.loadAll()
             conversations = loaded
             if let mostRecent = loaded.first {
                 activeConversationID = mostRecent.id
@@ -263,7 +262,7 @@ final class AIChatViewModel {
 
     /// Delete a conversation
     func deleteConversation(_ id: UUID) {
-        chatStorage.delete(id)
+        Task { await chatStorage.delete(id) }
         conversations.removeAll { $0.id == id }
         if activeConversationID == id {
             activeConversationID = nil
@@ -282,7 +281,7 @@ final class AIChatViewModel {
             conversation.updatedAt = Date()
             conversation.updateTitle()
             conversation.connectionName = connection?.name
-            chatStorage.save(conversation)
+            Task { await chatStorage.save(conversation) }
 
             if let index = conversations.firstIndex(where: { $0.id == existingID }) {
                 conversations[index] = conversation
@@ -294,7 +293,7 @@ final class AIChatViewModel {
                 connectionName: connection?.name
             )
             conversation.updateTitle()
-            chatStorage.save(conversation)
+            Task { await chatStorage.save(conversation) }
             activeConversationID = conversation.id
             conversations.insert(conversation, at: 0)
         }
@@ -306,6 +305,10 @@ final class AIChatViewModel {
     private func trimMessagesIfNeeded() {
         if messages.count > Self.maxMessageCount {
             messages.removeFirst(messages.count - Self.maxMessageCount)
+        }
+        // Ensure conversation starts with a user message (required by some providers)
+        while messages.first?.role == .assistant {
+            messages.removeFirst()
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 4 ship-blocking bugs found during AI system audit:

- **B1 — Ghost text at wrong offset**: Inline suggestion ghost text rendered at position 0 (or previous suggestion's offset) during progressive streaming. `suggestionOffset` was set *after* `fetchSuggestion()` returned, but `showGhostText` was called *during* streaming using the stale value. Fix: set offset before the await.
- **B2 — Tab key race condition**: Pressing Tab to accept a suggestion did nothing because `acceptSuggestion()` was deferred via `Task { @MainActor }` to the next runloop tick, but `handleTextChange()` fired synchronously first and cleared `currentSuggestion`. Fix: call `acceptSuggestion()` synchronously (already inside `MainActor.assumeIsolated`).
- **B3 — Trim breaks Anthropic API**: `trimMessagesIfNeeded()` could leave the conversation starting with an assistant message after removing oldest messages, causing Anthropic API 400 errors ("messages must start with user role"). Fix: drop leading assistant messages after trim.
- **B4 — Storage thread safety**: `AIChatStorage` was a plain `final class` with no isolation. `loadAll()` ran on a detached thread while `save()`/`delete()` ran on MainActor — concurrent file I/O on the same directory. Fix: convert to `actor`, update all callers to `await`, rewrite `deleteAll()` to enumerate files instead of removing the directory.

## Test plan

- [ ] Build succeeds with no new warnings
- [ ] Enable inline suggestions, type SQL — ghost text appears at cursor position (not at line start)
- [ ] Wait for ghost text, press Tab — suggestion inserts correctly
- [ ] Send 200+ messages in AI chat — no API errors from role ordering
- [ ] Open AI chat and send messages rapidly during app startup — no crashes or data loss