### PR TITLE
feat: support all monospaced fonts installed on the local system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix idle ping spin loop caused by exhausted AsyncStream iterator (#618)
 - Skip exact row count for large tables — use database statistics estimate (#519)
 
+### Changed
+
+- Theme font pickers now list installed monospaced fonts dynamically instead of a fixed built-in list
+
 ## [0.28.0] - 2026-04-07
 
 ### Added

--- a/TablePro/Models/Settings/EditorSettings.swift
+++ b/TablePro/Models/Settings/EditorSettings.swift
@@ -9,22 +9,14 @@ import Foundation
 internal struct FontFamilyOption: Equatable, Identifiable, Sendable {
     let id: String
     let displayName: String
-    let isRecommended: Bool
 }
 
 internal enum EditorFontResolver {
     static let systemMonoId = "System Mono"
 
-    private static let recommendedFamilies: Set<String> = [
-        "SF Mono",
-        "Menlo",
-        "Monaco",
-        "Courier New",
-    ]
-
-    static func availableMonospacedFamilies() -> [FontFamilyOption] {
+    static let availableMonospacedFamilies: [FontFamilyOption] = {
         var options: [FontFamilyOption] = [
-            FontFamilyOption(id: systemMonoId, displayName: systemMonoId, isRecommended: true)
+            FontFamilyOption(id: systemMonoId, displayName: systemMonoId)
         ]
 
         let familyNames = NSFontManager.shared.availableFontFamilies
@@ -37,17 +29,11 @@ internal enum EditorFontResolver {
         var seen: Set<String> = [systemMonoId]
         for family in familyNames where !seen.contains(family) {
             seen.insert(family)
-            options.append(
-                FontFamilyOption(
-                    id: family,
-                    displayName: family,
-                    isRecommended: recommendedFamilies.contains(family)
-                )
-            )
+            options.append(FontFamilyOption(id: family, displayName: family))
         }
 
         return options
-    }
+    }()
 
     static func resolve(familyId: String, size: CGFloat) -> NSFont {
         guard familyId != systemMonoId else {
@@ -66,11 +52,6 @@ internal enum EditorFontResolver {
     static func isAvailable(familyId: String) -> Bool {
         guard familyId != systemMonoId else { return true }
         return isMonospacedFamily(familyId)
-    }
-
-    static func displayName(for familyId: String) -> String {
-        guard !familyId.isEmpty else { return systemMonoId }
-        return familyId
     }
 
     private static func isMonospacedFamily(_ familyId: String) -> Bool {

--- a/TablePro/Models/Settings/EditorSettings.swift
+++ b/TablePro/Models/Settings/EditorSettings.swift
@@ -6,52 +6,77 @@
 import AppKit
 import Foundation
 
-/// Available monospace fonts for the SQL editor
-enum EditorFont: String, Codable, CaseIterable, Identifiable {
-    case systemMono = "System Mono"
-    case sfMono = "SF Mono"
-    case menlo = "Menlo"
-    case monaco = "Monaco"
-    case courierNew = "Courier New"
+internal struct FontFamilyOption: Equatable, Identifiable, Sendable {
+    let id: String
+    let displayName: String
+    let isRecommended: Bool
+}
 
-    var id: String { rawValue }
+internal enum EditorFontResolver {
+    static let systemMonoId = "System Mono"
 
-    var displayName: String { rawValue }
+    private static let recommendedFamilies: Set<String> = [
+        "SF Mono",
+        "Menlo",
+        "Monaco",
+        "Courier New",
+    ]
 
-    /// Get the actual NSFont for this option
-    func font(size: CGFloat) -> NSFont {
-        switch self {
-        case .systemMono:
-            return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-        case .sfMono:
-            return NSFont(name: "SFMono-Regular", size: size)
-                ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-        case .menlo:
-            return NSFont(name: "Menlo", size: size)
-                ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-        case .monaco:
-            return NSFont(name: "Monaco", size: size)
-                ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-        case .courierNew:
-            return NSFont(name: "Courier New", size: size)
-                ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    static func availableMonospacedFamilies() -> [FontFamilyOption] {
+        var options: [FontFamilyOption] = [
+            FontFamilyOption(id: systemMonoId, displayName: systemMonoId, isRecommended: true)
+        ]
+
+        let familyNames = NSFontManager.shared.availableFontFamilies
+            .filter { $0 != systemMonoId }
+            .filter(isMonospacedFamily)
+            .sorted { lhs, rhs in
+                lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+            }
+
+        var seen: Set<String> = [systemMonoId]
+        for family in familyNames where !seen.contains(family) {
+            seen.insert(family)
+            options.append(
+                FontFamilyOption(
+                    id: family,
+                    displayName: family,
+                    isRecommended: recommendedFamilies.contains(family)
+                )
+            )
         }
+
+        return options
     }
 
-    /// Check if this font is available on the system
-    var isAvailable: Bool {
-        switch self {
-        case .systemMono:
-            return true
-        case .sfMono:
-            return NSFont(name: "SFMono-Regular", size: 12) != nil
-        case .menlo:
-            return NSFont(name: "Menlo", size: 12) != nil
-        case .monaco:
-            return NSFont(name: "Monaco", size: 12) != nil
-        case .courierNew:
-            return NSFont(name: "Courier New", size: 12) != nil
+    static func resolve(familyId: String, size: CGFloat) -> NSFont {
+        guard familyId != systemMonoId else {
+            return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
         }
+
+        let descriptor = NSFontDescriptor(fontAttributes: [.family: familyId])
+        if let font = NSFont(descriptor: descriptor, size: size),
+           font.fontDescriptor.symbolicTraits.contains(.monoSpace) {
+            return font
+        }
+
+        return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    static func isAvailable(familyId: String) -> Bool {
+        guard familyId != systemMonoId else { return true }
+        return isMonospacedFamily(familyId)
+    }
+
+    static func displayName(for familyId: String) -> String {
+        guard !familyId.isEmpty else { return systemMonoId }
+        return familyId
+    }
+
+    private static func isMonospacedFamily(_ familyId: String) -> Bool {
+        let descriptor = NSFontDescriptor(fontAttributes: [.family: familyId])
+        guard let font = NSFont(descriptor: descriptor, size: 12) else { return false }
+        return font.fontDescriptor.symbolicTraits.contains(.monoSpace)
     }
 }
 

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -32,8 +32,7 @@ internal struct EditorFontCache {
         let scale = Self.computeAccessibilityScale()
         scaleFactor = scale
         let scaledSize = round(CGFloat(min(max(fonts.editorFontSize, 11), 18)) * scale)
-        font = EditorFont(rawValue: fonts.editorFontFamily)?.font(size: scaledSize)
-            ?? NSFont.monospacedSystemFont(ofSize: scaledSize, weight: .regular)
+        font = EditorFontResolver.resolve(familyId: fonts.editorFontFamily, size: scaledSize)
         let lineNumSize = max(round((scaledSize - 2)), 9)
         lineNumberFont = NSFont.monospacedSystemFont(ofSize: lineNumSize, weight: .regular)
     }
@@ -55,8 +54,7 @@ internal struct DataGridFontCacheResolved {
     init(from fonts: ThemeFonts) {
         let scale = EditorFontCache.computeAccessibilityScale()
         let scaledSize = round(CGFloat(min(max(fonts.dataGridFontSize, 10), 18)) * scale)
-        regular = EditorFont(rawValue: fonts.dataGridFontFamily)?.font(size: scaledSize)
-            ?? NSFont.monospacedSystemFont(ofSize: scaledSize, weight: .regular)
+        regular = EditorFontResolver.resolve(familyId: fonts.dataGridFontFamily, size: scaledSize)
         italic = regular.withTraits(.italic)
         medium = NSFontManager.shared.convert(regular, toHaveTrait: .boldFontMask)
         let rowNumSize = max(round(scaledSize - 1), 9)

--- a/TablePro/Views/Settings/Appearance/ThemeEditorFontsSection.swift
+++ b/TablePro/Views/Settings/Appearance/ThemeEditorFontsSection.swift
@@ -76,9 +76,10 @@ struct ThemeEditorFontsSection: View {
     private var previewSection: some View {
         Section(String(localized: "Preview")) {
             let fonts = currentThemeFonts
-            let editorFont = EditorFont(rawValue: fonts.editorFontFamily)?
-                .font(size: CGFloat(fonts.editorFontSize))
-                ?? NSFont.monospacedSystemFont(ofSize: CGFloat(fonts.editorFontSize), weight: .regular)
+            let editorFont = EditorFontResolver.resolve(
+                familyId: fonts.editorFontFamily,
+                size: CGFloat(fonts.editorFontSize)
+            )
 
             Text("SELECT * FROM users WHERE id = 42;")
                 .font(Font(editorFont))
@@ -97,8 +98,8 @@ struct ThemeEditorFontsSection: View {
             get: { selection },
             set: { onChange($0) }
         )) {
-            ForEach(EditorFont.allCases.filter(\.isAvailable)) { font in
-                Text(font.displayName).tag(font.rawValue)
+            ForEach(EditorFontResolver.availableMonospacedFamilies()) { font in
+                Text(font.displayName).tag(font.id)
             }
         }
     }

--- a/TablePro/Views/Settings/Appearance/ThemeEditorFontsSection.swift
+++ b/TablePro/Views/Settings/Appearance/ThemeEditorFontsSection.swift
@@ -98,7 +98,7 @@ struct ThemeEditorFontsSection: View {
             get: { selection },
             set: { onChange($0) }
         )) {
-            ForEach(EditorFontResolver.availableMonospacedFamilies()) { font in
+            ForEach(EditorFontResolver.availableMonospacedFamilies) { font in
                 Text(font.displayName).tag(font.id)
             }
         }

--- a/TableProTests/Theme/ThemeDefinitionTests.swift
+++ b/TableProTests/Theme/ThemeDefinitionTests.swift
@@ -6,13 +6,13 @@
 //  currentStatementHighlight field and Codable backward compatibility.
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import TablePro
 
 @Suite("Theme Definition")
 struct ThemeDefinitionTests {
-
     // MARK: - Default light theme
 
     @Test("Default light editor colors include currentStatementHighlight")
@@ -133,5 +133,72 @@ struct ThemeDefinitionTests {
         let decoded = try JSONDecoder().decode(EditorThemeColors.self, from: data)
 
         #expect(decoded.currentStatementHighlight == "#AABBCC")
+    }
+
+    // MARK: - Editor font resolver
+
+    @Test("Font resolver always exposes System Mono")
+    func resolverExposesSystemMono() {
+        let families = EditorFontResolver.availableMonospacedFamilies()
+        #expect(families.contains { $0.id == EditorFontResolver.systemMonoId })
+    }
+
+    @Test("System Mono is first in picker list")
+    func systemMonoFirst() {
+        let families = EditorFontResolver.availableMonospacedFamilies()
+        #expect(families.first?.id == EditorFontResolver.systemMonoId)
+    }
+
+    @Test("Editor font cache falls back for unknown font family")
+    func editorCacheFallsBackForUnknownFamily() {
+        let fonts = ThemeFonts(
+            editorFontFamily: "NoSuchFamily-XYZ",
+            editorFontSize: 13,
+            dataGridFontFamily: "System Mono",
+            dataGridFontSize: 13
+        )
+        let cache = EditorFontCache(from: fonts)
+        #expect(cache.font.pointSize > 0)
+    }
+
+    @Test("Data grid cache falls back for unknown font family")
+    func dataGridCacheFallsBackForUnknownFamily() {
+        let fonts = ThemeFonts(
+            editorFontFamily: "System Mono",
+            editorFontSize: 13,
+            dataGridFontFamily: "NoSuchFamily-XYZ",
+            dataGridFontSize: 13
+        )
+        let cache = DataGridFontCacheResolved(from: fonts)
+        #expect(cache.regular.pointSize > 0)
+        #expect(cache.monoCharWidth > 0)
+    }
+
+    @Test("Resolver list has unique IDs")
+    func resolverListHasUniqueIds() {
+        let ids = EditorFontResolver.availableMonospacedFamilies().map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("Unknown family reports unavailable")
+    func unknownFamilyUnavailable() {
+        #expect(EditorFontResolver.isAvailable(familyId: "NoSuchFamily-XYZ") == false)
+    }
+
+    @Test("ThemeFonts decode keeps legacy family strings")
+    func themeFontsDecodeKeepsLegacyStrings() throws {
+        let json = #"{"editorFontFamily":"Menlo","editorFontSize":13,"dataGridFontFamily":"Monaco","dataGridFontSize":13}"#
+        let decoded = try JSONDecoder().decode(ThemeFonts.self, from: Data(json.utf8))
+        #expect(decoded.editorFontFamily == "Menlo")
+        #expect(decoded.dataGridFontFamily == "Monaco")
+    }
+
+    @Test("All resolver font families are monospaced")
+    func allResolverFamiliesAreMonospaced() {
+        let families = EditorFontResolver.availableMonospacedFamilies()
+        for family in families where family.id != EditorFontResolver.systemMonoId {
+            let font = EditorFontResolver.resolve(familyId: family.id, size: 12)
+            #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
+        }
     }
 }

--- a/TableProTests/Theme/ThemeDefinitionTests.swift
+++ b/TableProTests/Theme/ThemeDefinitionTests.swift
@@ -139,13 +139,13 @@ struct ThemeDefinitionTests {
 
     @Test("Font resolver always exposes System Mono")
     func resolverExposesSystemMono() {
-        let families = EditorFontResolver.availableMonospacedFamilies()
+        let families = EditorFontResolver.availableMonospacedFamilies
         #expect(families.contains { $0.id == EditorFontResolver.systemMonoId })
     }
 
     @Test("System Mono is first in picker list")
     func systemMonoFirst() {
-        let families = EditorFontResolver.availableMonospacedFamilies()
+        let families = EditorFontResolver.availableMonospacedFamilies
         #expect(families.first?.id == EditorFontResolver.systemMonoId)
     }
 
@@ -176,7 +176,7 @@ struct ThemeDefinitionTests {
 
     @Test("Resolver list has unique IDs")
     func resolverListHasUniqueIds() {
-        let ids = EditorFontResolver.availableMonospacedFamilies().map(\.id)
+        let ids = EditorFontResolver.availableMonospacedFamilies.map(\.id)
         #expect(Set(ids).count == ids.count)
     }
 
@@ -195,7 +195,7 @@ struct ThemeDefinitionTests {
 
     @Test("All resolver font families are monospaced")
     func allResolverFamiliesAreMonospaced() {
-        let families = EditorFontResolver.availableMonospacedFamilies()
+        let families = EditorFontResolver.availableMonospacedFamilies
         for family in families where family.id != EditorFontResolver.systemMonoId {
             let font = EditorFontResolver.resolve(familyId: family.id, size: 12)
             #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))

--- a/docs/customization/appearance.mdx
+++ b/docs/customization/appearance.mdx
@@ -76,7 +76,7 @@ When you select a theme from the list, it becomes the preferred theme for that t
 
 ## Customizing Themes
 
-Select a theme and edit directly. Built-in themes auto-duplicate when you change colors or layout, preserving the original. Font changes apply without duplication.
+Select a theme and edit directly. Built-in themes auto-duplicate when you change colors or layout, preserving the original. Font changes apply without duplication, and font family pickers list installed monospaced fonts from your Mac.
 
 ## Import, Export & Registry
 
@@ -175,4 +175,3 @@ These appear on:
     alt="Database type colors"
   />
 </Frame>
-

--- a/docs/customization/editor-settings.mdx
+++ b/docs/customization/editor-settings.mdx
@@ -9,182 +9,184 @@ Configure the SQL editor in **Settings** > **Editor**.
 
 {/* Screenshot: Editor settings panel */}
 <Frame caption="Editor settings">
-  <img
-    className="block dark:hidden"
-    src="/images/settings-editor.png"
-    alt="Editor settings"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/settings-editor-dark.png"
-    alt="Editor settings"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/settings-editor.png"
+        alt="Editor settings"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/settings-editor-dark.png"
+        alt="Editor settings"
+    />
 </Frame>
 
 ## Font Settings
 
 ### Font Family
 
-Available monospace fonts:
+The font picker shows installed monospaced families on your Mac.
 
-| Font | Description |
-|------|-------------|
+Common options include:
+
+| Font            | Description                           |
+| --------------- | ------------------------------------- |
 | **System Mono** | macOS default monospace (recommended) |
-| **SF Mono** | San Francisco Mono |
-| **Menlo** | Classic macOS monospace |
-| **Monaco** | Traditional Mac programming font |
-| **Courier New** | Cross-platform standard |
+| **SF Mono**     | San Francisco Mono                    |
+| **Menlo**       | Classic macOS monospace               |
+| **Monaco**      | Traditional Mac programming font      |
+| **Courier New** | Cross-platform standard               |
 
 <Tip>
-**System Mono** automatically uses the best available system monospace font.
+    **System Mono** automatically uses the best available system monospace font.
 </Tip>
 
-If a selected font isn't available, TablePro falls back to System Mono.
+If a saved font is no longer available, TablePro falls back to System Mono.
 
 {/* Screenshot: Font family selector */}
 <Frame caption="Font family selector with available fonts">
-  <img
-    className="block dark:hidden"
-    src="/images/editor-font-family.png"
-    alt="Font family selector"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/editor-font-family-dark.png"
-    alt="Font family selector"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/editor-font-family.png"
+        alt="Font family selector"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/editor-font-family-dark.png"
+        alt="Font family selector"
+    />
 </Frame>
 
 ### Font Size
 
-| Setting | Range | Default |
-|---------|-------|---------|
-| Font Size | 11-18 pt | 13 pt |
+| Setting   | Range    | Default |
+| --------- | -------- | ------- |
+| Font Size | 11-18 pt | 13 pt   |
 
 {/* Screenshot: Editor with different font sizes */}
 <Frame caption="Font size comparison">
-  <img
-    className="block dark:hidden"
-    src="/images/font-size-comparison.png"
-    alt="Font sizes"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/font-size-comparison-dark.png"
-    alt="Font sizes"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/font-size-comparison.png"
+        alt="Font sizes"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/font-size-comparison-dark.png"
+        alt="Font sizes"
+    />
 </Frame>
 
 **Recommendations**:
 
-| Size | Best For |
-|------|----------|
+| Size     | Best For                        |
+| -------- | ------------------------------- |
 | 11-12 pt | Small screens, seeing more code |
-| 13-14 pt | Standard usage (default) |
-| 15-16 pt | Better readability |
-| 17-18 pt | Large screens, accessibility |
+| 13-14 pt | Standard usage (default)        |
+| 15-16 pt | Better readability              |
+| 17-18 pt | Large screens, accessibility    |
 
 ## Display Settings
 
 ### Line Numbers
 
-| Option | Description |
-|--------|-------------|
-| **On** | Show line numbers (default) |
-| **Off** | Hide for a minimal look |
+| Option  | Description                 |
+| ------- | --------------------------- |
+| **On**  | Show line numbers (default) |
+| **Off** | Hide for a minimal look     |
 
 {/* Screenshot: Editor with and without line numbers */}
 <Frame caption="Line numbers on/off">
-  <img
-    className="block dark:hidden"
-    src="/images/line-numbers.png"
-    alt="Line numbers"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/line-numbers-dark.png"
-    alt="Line numbers"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/line-numbers.png"
+        alt="Line numbers"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/line-numbers-dark.png"
+        alt="Line numbers"
+    />
 </Frame>
 
 ### Current Line Highlight
 
-| Option | Description |
-|--------|-------------|
-| **On** | Highlight the line with cursor (default) |
-| **Off** | No highlight |
+| Option  | Description                              |
+| ------- | ---------------------------------------- |
+| **On**  | Highlight the line with cursor (default) |
+| **Off** | No highlight                             |
 
 {/* Screenshot: Current line highlight */}
 <Frame caption="Current line highlighting in the editor">
-  <img
-    className="block dark:hidden"
-    src="/images/current-line-highlight.png"
-    alt="Current line highlighting"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/current-line-highlight-dark.png"
-    alt="Current line highlighting"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/current-line-highlight.png"
+        alt="Current line highlighting"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/current-line-highlight-dark.png"
+        alt="Current line highlighting"
+    />
 </Frame>
 
 ### Word Wrap
 
-| Option | Description |
-|--------|-------------|
+| Option  | Description                              |
+| ------- | ---------------------------------------- |
 | **Off** | Long lines scroll horizontally (default) |
-| **On** | Long lines wrap to next line |
+| **On**  | Long lines wrap to next line             |
 
 {/* Screenshot: Word wrap */}
 <Frame caption="Word wrap: wrapped vs horizontal scrolling">
-  <img
-    className="block dark:hidden"
-    src="/images/editor-word-wrap.png"
-    alt="Word wrap comparison"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/editor-word-wrap-dark.png"
-    alt="Word wrap comparison"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/editor-word-wrap.png"
+        alt="Word wrap comparison"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/editor-word-wrap-dark.png"
+        alt="Word wrap comparison"
+    />
 </Frame>
 
 ## Indentation Settings
 
 ### Tab Width
 
-| Setting | Options | Default |
-|---------|---------|---------|
-| Tab Width | 1-16 spaces | 4 |
+| Setting   | Options     | Default |
+| --------- | ----------- | ------- |
+| Tab Width | 1-16 spaces | 4       |
 
 Common choices:
 
-| Width | Usage |
-|-------|-------|
-| 2 spaces | Compact, JavaScript-style |
+| Width    | Usage                                 |
+| -------- | ------------------------------------- |
+| 2 spaces | Compact, JavaScript-style             |
 | 4 spaces | Standard SQL formatting (recommended) |
-| 8 spaces | Traditional Unix-style |
+| 8 spaces | Traditional Unix-style                |
 
 {/* Screenshot: Tab width setting */}
 <Frame caption="Tab width setting for indentation">
-  <img
-    className="block dark:hidden"
-    src="/images/editor-tab-width.png"
-    alt="Tab width setting"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/editor-tab-width-dark.png"
-    alt="Tab width setting"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/editor-tab-width.png"
+        alt="Tab width setting"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/editor-tab-width-dark.png"
+        alt="Tab width setting"
+    />
 </Frame>
 
 ### Auto Indent
 
-| Option | Description |
-|--------|-------------|
-| **On** | New lines match previous indentation (default) |
-| **Off** | New lines start at column 1 |
+| Option  | Description                                    |
+| ------- | ---------------------------------------------- |
+| **On**  | New lines match previous indentation (default) |
+| **Off** | New lines start at column 1                    |
 
 ```sql
 SELECT
@@ -195,16 +197,16 @@ SELECT
 
 {/* Screenshot: Auto-indent */}
 <Frame caption="Auto-indent after SQL clauses">
-  <img
-    className="block dark:hidden"
-    src="/images/editor-auto-indent.png"
-    alt="Auto-indent in editor"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/editor-auto-indent-dark.png"
-    alt="Auto-indent in editor"
-  />
+    <img
+        className="block dark:hidden"
+        src="/images/editor-auto-indent.png"
+        alt="Auto-indent in editor"
+    />
+    <img
+        className="hidden dark:block"
+        src="/images/editor-auto-indent-dark.png"
+        alt="Auto-indent in editor"
+    />
 </Frame>
 
 ## Editor Behavior
@@ -217,12 +219,12 @@ All editor settings apply immediately. No restart required.
 
 ## Keyboard Shortcuts
 
-| Action | Shortcut |
-|--------|----------|
-| Execute query | `Cmd+Enter` |
-| Undo | `Cmd+Z` |
-| Redo | `Cmd+Shift+Z` |
-| Find | `Cmd+F` |
-| Replace | `Cmd+Option+F` |
-| Select All | `Cmd+A` |
-| Go to Line | `Cmd+G` |
+| Action        | Shortcut       |
+| ------------- | -------------- |
+| Execute query | `Cmd+Enter`    |
+| Undo          | `Cmd+Z`        |
+| Redo          | `Cmd+Shift+Z`  |
+| Find          | `Cmd+F`        |
+| Replace       | `Cmd+Option+F` |
+| Select All    | `Cmd+A`        |
+| Go to Line    | `Cmd+G`        |

--- a/docs/customization/editor-settings.mdx
+++ b/docs/customization/editor-settings.mdx
@@ -9,16 +9,16 @@ Configure the SQL editor in **Settings** > **Editor**.
 
 {/* Screenshot: Editor settings panel */}
 <Frame caption="Editor settings">
-    <img
-        className="block dark:hidden"
-        src="/images/settings-editor.png"
-        alt="Editor settings"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/settings-editor-dark.png"
-        alt="Editor settings"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/settings-editor.png"
+    alt="Editor settings"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/settings-editor-dark.png"
+    alt="Editor settings"
+  />
 </Frame>
 
 ## Font Settings
@@ -27,166 +27,164 @@ Configure the SQL editor in **Settings** > **Editor**.
 
 The font picker shows installed monospaced families on your Mac.
 
-Common options include:
-
-| Font            | Description                           |
-| --------------- | ------------------------------------- |
+| Font | Description |
+|------|-------------|
 | **System Mono** | macOS default monospace (recommended) |
-| **SF Mono**     | San Francisco Mono                    |
-| **Menlo**       | Classic macOS monospace               |
-| **Monaco**      | Traditional Mac programming font      |
-| **Courier New** | Cross-platform standard               |
+| **SF Mono** | San Francisco Mono |
+| **Menlo** | Classic macOS monospace |
+| **Monaco** | Traditional Mac programming font |
+| **Courier New** | Cross-platform standard |
 
 <Tip>
-    **System Mono** automatically uses the best available system monospace font.
+**System Mono** automatically uses the best available system monospace font.
 </Tip>
 
 If a saved font is no longer available, TablePro falls back to System Mono.
 
 {/* Screenshot: Font family selector */}
 <Frame caption="Font family selector with available fonts">
-    <img
-        className="block dark:hidden"
-        src="/images/editor-font-family.png"
-        alt="Font family selector"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/editor-font-family-dark.png"
-        alt="Font family selector"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/editor-font-family.png"
+    alt="Font family selector"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/editor-font-family-dark.png"
+    alt="Font family selector"
+  />
 </Frame>
 
 ### Font Size
 
-| Setting   | Range    | Default |
-| --------- | -------- | ------- |
-| Font Size | 11-18 pt | 13 pt   |
+| Setting | Range | Default |
+|---------|-------|---------|
+| Font Size | 11-18 pt | 13 pt |
 
 {/* Screenshot: Editor with different font sizes */}
 <Frame caption="Font size comparison">
-    <img
-        className="block dark:hidden"
-        src="/images/font-size-comparison.png"
-        alt="Font sizes"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/font-size-comparison-dark.png"
-        alt="Font sizes"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/font-size-comparison.png"
+    alt="Font sizes"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/font-size-comparison-dark.png"
+    alt="Font sizes"
+  />
 </Frame>
 
 **Recommendations**:
 
-| Size     | Best For                        |
-| -------- | ------------------------------- |
+| Size | Best For |
+|------|----------|
 | 11-12 pt | Small screens, seeing more code |
-| 13-14 pt | Standard usage (default)        |
-| 15-16 pt | Better readability              |
-| 17-18 pt | Large screens, accessibility    |
+| 13-14 pt | Standard usage (default) |
+| 15-16 pt | Better readability |
+| 17-18 pt | Large screens, accessibility |
 
 ## Display Settings
 
 ### Line Numbers
 
-| Option  | Description                 |
-| ------- | --------------------------- |
-| **On**  | Show line numbers (default) |
-| **Off** | Hide for a minimal look     |
+| Option | Description |
+|--------|-------------|
+| **On** | Show line numbers (default) |
+| **Off** | Hide for a minimal look |
 
 {/* Screenshot: Editor with and without line numbers */}
 <Frame caption="Line numbers on/off">
-    <img
-        className="block dark:hidden"
-        src="/images/line-numbers.png"
-        alt="Line numbers"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/line-numbers-dark.png"
-        alt="Line numbers"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/line-numbers.png"
+    alt="Line numbers"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/line-numbers-dark.png"
+    alt="Line numbers"
+  />
 </Frame>
 
 ### Current Line Highlight
 
-| Option  | Description                              |
-| ------- | ---------------------------------------- |
-| **On**  | Highlight the line with cursor (default) |
-| **Off** | No highlight                             |
+| Option | Description |
+|--------|-------------|
+| **On** | Highlight the line with cursor (default) |
+| **Off** | No highlight |
 
 {/* Screenshot: Current line highlight */}
 <Frame caption="Current line highlighting in the editor">
-    <img
-        className="block dark:hidden"
-        src="/images/current-line-highlight.png"
-        alt="Current line highlighting"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/current-line-highlight-dark.png"
-        alt="Current line highlighting"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/current-line-highlight.png"
+    alt="Current line highlighting"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/current-line-highlight-dark.png"
+    alt="Current line highlighting"
+  />
 </Frame>
 
 ### Word Wrap
 
-| Option  | Description                              |
-| ------- | ---------------------------------------- |
+| Option | Description |
+|--------|-------------|
 | **Off** | Long lines scroll horizontally (default) |
-| **On**  | Long lines wrap to next line             |
+| **On** | Long lines wrap to next line |
 
 {/* Screenshot: Word wrap */}
 <Frame caption="Word wrap: wrapped vs horizontal scrolling">
-    <img
-        className="block dark:hidden"
-        src="/images/editor-word-wrap.png"
-        alt="Word wrap comparison"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/editor-word-wrap-dark.png"
-        alt="Word wrap comparison"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/editor-word-wrap.png"
+    alt="Word wrap comparison"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/editor-word-wrap-dark.png"
+    alt="Word wrap comparison"
+  />
 </Frame>
 
 ## Indentation Settings
 
 ### Tab Width
 
-| Setting   | Options     | Default |
-| --------- | ----------- | ------- |
-| Tab Width | 1-16 spaces | 4       |
+| Setting | Options | Default |
+|---------|---------|---------|
+| Tab Width | 1-16 spaces | 4 |
 
 Common choices:
 
-| Width    | Usage                                 |
-| -------- | ------------------------------------- |
-| 2 spaces | Compact, JavaScript-style             |
+| Width | Usage |
+|-------|-------|
+| 2 spaces | Compact, JavaScript-style |
 | 4 spaces | Standard SQL formatting (recommended) |
-| 8 spaces | Traditional Unix-style                |
+| 8 spaces | Traditional Unix-style |
 
 {/* Screenshot: Tab width setting */}
 <Frame caption="Tab width setting for indentation">
-    <img
-        className="block dark:hidden"
-        src="/images/editor-tab-width.png"
-        alt="Tab width setting"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/editor-tab-width-dark.png"
-        alt="Tab width setting"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/editor-tab-width.png"
+    alt="Tab width setting"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/editor-tab-width-dark.png"
+    alt="Tab width setting"
+  />
 </Frame>
 
 ### Auto Indent
 
-| Option  | Description                                    |
-| ------- | ---------------------------------------------- |
-| **On**  | New lines match previous indentation (default) |
-| **Off** | New lines start at column 1                    |
+| Option | Description |
+|--------|-------------|
+| **On** | New lines match previous indentation (default) |
+| **Off** | New lines start at column 1 |
 
 ```sql
 SELECT
@@ -197,16 +195,16 @@ SELECT
 
 {/* Screenshot: Auto-indent */}
 <Frame caption="Auto-indent after SQL clauses">
-    <img
-        className="block dark:hidden"
-        src="/images/editor-auto-indent.png"
-        alt="Auto-indent in editor"
-    />
-    <img
-        className="hidden dark:block"
-        src="/images/editor-auto-indent-dark.png"
-        alt="Auto-indent in editor"
-    />
+  <img
+    className="block dark:hidden"
+    src="/images/editor-auto-indent.png"
+    alt="Auto-indent in editor"
+  />
+  <img
+    className="hidden dark:block"
+    src="/images/editor-auto-indent-dark.png"
+    alt="Auto-indent in editor"
+  />
 </Frame>
 
 ## Editor Behavior
@@ -219,12 +217,12 @@ All editor settings apply immediately. No restart required.
 
 ## Keyboard Shortcuts
 
-| Action        | Shortcut       |
-| ------------- | -------------- |
-| Execute query | `Cmd+Enter`    |
-| Undo          | `Cmd+Z`        |
-| Redo          | `Cmd+Shift+Z`  |
-| Find          | `Cmd+F`        |
-| Replace       | `Cmd+Option+F` |
-| Select All    | `Cmd+A`        |
-| Go to Line    | `Cmd+G`        |
+| Action | Shortcut |
+|--------|----------|
+| Execute query | `Cmd+Enter` |
+| Undo | `Cmd+Z` |
+| Redo | `Cmd+Shift+Z` |
+| Find | `Cmd+F` |
+| Replace | `Cmd+Option+F` |
+| Select All | `Cmd+A` |
+| Go to Line | `Cmd+G` |

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -155,7 +155,7 @@ No personal information, queries, or database content is transmitted. Toggle off
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
-| **Font family** | System Mono | System Mono, SF Mono, Menlo, Monaco, Courier New | Monospace font for data grid cells |
+| **Font family** | System Mono | Installed monospaced fonts (dynamic list) | Monospace font for data grid cells |
 | **Font size** | 13 pt | 10-18 pt | Text size in data grid cells |
 
 Affects all data grid cells, including NULL placeholders and cell editing overlays. A live preview is shown in the settings panel.


### PR DESCRIPTION
## Problem

I wanted to use a monospaced font that *wasn't* one of the 4 default included ones (specifically JetBrains Mono) but was obviously unable to as the list was hardcoded.

## Solution

I replaced the hardcoded font option flow with a shared runtime resolver that discovers installed monospaced font families and uses them in both settings UI and runtime theme font resolution. The resolver keeps `System Mono` as a safe default and fallback when a saved font is unavailable. Theme storage remains string-based and backward-compatible, and docs/tests were updated to cover dynamic listing and fallback behavior.

This is my first contribution to this repo so if I'm missing anything, please let me know.