### PR TITLE
fix: accept SQLAlchemy-style connection URLs with driver hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Space key toggles FK preview popover on selected cell, rebindable in Settings > Keyboard (#648)
 
+### Fixed
+
+- Accept SQLAlchemy-style connection URLs with driver hints (e.g., `postgresql+psycopg://`) (#642)
+
 ## [0.29.0] - 2026-04-09
 
 ### Added

--- a/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
@@ -88,6 +88,9 @@ struct ConnectionURLParser {
         if scheme.hasSuffix("+ssh") {
             isSSH = true
             scheme = String(scheme.dropLast(4))
+        } else if let plusIdx = scheme.lastIndex(of: "+"),
+                  !scheme.hasSuffix("+srv") {
+            scheme = String(scheme[scheme.startIndex..<plusIdx])
         }
 
         let dbType: DatabaseType

--- a/TableProTests/Core/Utilities/DatabaseURLSchemeTests.swift
+++ b/TableProTests/Core/Utilities/DatabaseURLSchemeTests.swift
@@ -246,4 +246,54 @@ struct DatabaseURLSchemeTests {
         }
         #expect(parsed.type == .postgresql)
     }
+
+    // MARK: - Driver Hint Stripping
+
+    @Test("PostgreSQL+psycopg scheme strips driver hint")
+    func postgresqlPsycopgScheme() {
+        let result = ConnectionURLParser.parse("postgresql+psycopg://user:pass@localhost:5432/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.host == "localhost")
+        #expect(parsed.database == "mydb")
+    }
+
+    @Test("PostgreSQL+asyncpg scheme strips driver hint")
+    func postgresqlAsyncpgScheme() {
+        let result = ConnectionURLParser.parse("postgresql+asyncpg://user:pass@localhost/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+    }
+
+    @Test("MySQL+pymysql scheme strips driver hint")
+    func mysqlPymysqlScheme() {
+        let result = ConnectionURLParser.parse("mysql+pymysql://user:pass@localhost:3306/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .mysql)
+    }
+
+    @Test("MongoDB+srv scheme preserved (not stripped)")
+    func mongodbSrvPreserved() {
+        let result = ConnectionURLParser.parse("mongodb+srv://user:pass@cluster.example.com/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .mongodb)
+    }
+
+    @Test("PostgreSQL+ssh still enables SSH mode")
+    func postgresqlSshStillWorks() {
+        let result = ConnectionURLParser.parse("postgresql+ssh://user:pass@localhost/mydb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .postgresql)
+        #expect(parsed.isSSH == true)
+    }
 }


### PR DESCRIPTION
## Summary

- Strip driver hint suffixes (e.g., `+psycopg`, `+asyncpg`, `+pymysql`) from connection URL schemes before matching database type
- `postgresql+psycopg://...` now parses as PostgreSQL, `mysql+pymysql://...` as MySQL, etc.
- Preserves `+ssh` (SSH tunneling) and `+srv` (MongoDB SRV) behavior

Closes #642

## Test plan

- [ ] Paste `postgresql+psycopg://user:pass@localhost:5432/mydb` → parses as PostgreSQL
- [ ] Paste `postgresql+asyncpg://user:pass@localhost:5432/mydb` → parses as PostgreSQL
- [ ] Paste `mysql+pymysql://user:pass@localhost:3306/mydb` → parses as MySQL
- [ ] Paste `mongodb+srv://user:pass@cluster.example.com/mydb` → still parses as MongoDB (not stripped)
- [ ] Paste `postgresql+ssh://user:pass@localhost/mydb` → still enables SSH mode
- [ ] Existing URLs without driver hints continue to work unchanged