### PR TITLE
fix: resolve export dialog doing nothing on macOS Tahoe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix export dialog doing nothing on macOS Tahoe due to incorrect window reference for save panel (#654)
 - Fix column visibility popover and hex editor alignment — left-align per macOS HIG (#653)
 - Accept SQLAlchemy-style connection URLs with driver hints (#642)
 

--- a/TablePro/Models/Export/ExportModels.swift
+++ b/TablePro/Models/Export/ExportModels.swift
@@ -10,7 +10,7 @@ import TableProPluginKit
 
 /// Defines the export mode: either exporting database tables or in-memory query results.
 enum ExportMode {
-    case tables(connection: DatabaseConnection, preselectedTables: Set<String>)
+    case tables(connection: DatabaseConnection, preselectedTables: Set<String>, sidebarTables: [TableInfo] = [])
     case queryResults(connection: DatabaseConnection, rowBuffer: RowBuffer, suggestedFileName: String)
 }
 

--- a/TablePro/Models/Export/ExportModels.swift
+++ b/TablePro/Models/Export/ExportModels.swift
@@ -10,7 +10,7 @@ import TableProPluginKit
 
 /// Defines the export mode: either exporting database tables or in-memory query results.
 enum ExportMode {
-    case tables(connection: DatabaseConnection, preselectedTables: Set<String>, sidebarTables: [TableInfo] = [])
+    case tables(connection: DatabaseConnection, preselectedTables: Set<String>)
     case queryResults(connection: DatabaseConnection, rowBuffer: RowBuffer, suggestedFileName: String)
 }
 

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -16,6 +16,7 @@ import UniformTypeIdentifiers
 struct ExportDialog: View {
     @Binding var isPresented: Bool
     let mode: ExportMode
+    var sidebarTables: [TableInfo] = []
 
     // MARK: - State
 
@@ -41,7 +42,7 @@ struct ExportDialog: View {
 
     private var connection: DatabaseConnection {
         switch mode {
-        case .tables(let conn, _, _): return conn
+        case .tables(let conn, _): return conn
         case .queryResults(let conn, _, _): return conn
         }
     }
@@ -59,14 +60,7 @@ struct ExportDialog: View {
     }
 
     private var preselectedTables: Set<String> {
-        if case .tables(_, let tables, _) = mode {
-            return tables
-        }
-        return []
-    }
-
-    private var sidebarTables: [TableInfo] {
-        if case .tables(_, _, let tables) = mode {
+        if case .tables(_, let tables) = mode {
             return tables
         }
         return []
@@ -538,12 +532,17 @@ struct ExportDialog: View {
         )
         databaseItems = [item]
         isLoading = false
+    }
 
-        if preselectedTables.count == 1, let first = preselectedTables.first {
-            config.fileName = first
-        } else if !dbName.isEmpty {
-            config.fileName = dbName
+    /// Build a lookup of user-toggled selection state from current `databaseItems`.
+    private func currentSelectionState() -> [String: Bool] {
+        var state: [String: Bool] = [:]
+        for db in databaseItems {
+            for table in db.tables {
+                state["\(db.name).\(table.name)"] = table.isSelected
+            }
         }
+        return state
     }
 
     @MainActor
@@ -558,6 +557,9 @@ struct ExportDialog: View {
             return
         }
 
+        // Snapshot user-toggled selections before replacing items
+        let priorSelections = currentSelectionState()
+
         do {
             var items: [ExportDatabaseItem] = []
 
@@ -569,20 +571,23 @@ struct ExportDialog: View {
                 let defaultSchema = PluginManager.shared.defaultSchemaName(for: dbType)
                 for schema in schemas {
                     let tables = try await fetchTablesForSchema(schema, driver: driver)
+                    let isDefaultSchema = schema.caseInsensitiveCompare(defaultSchema) == .orderedSame
                     let tableItems = tables.map { table in
-                        ExportTableItem(
+                        let key = "\(schema).\(table.name)"
+                        let selected = priorSelections[key]
+                            ?? (isDefaultSchema && preselectedTables.contains(table.name))
+                        return ExportTableItem(
                             name: table.name,
                             databaseName: schema,
                             type: table.type,
-                            isSelected: schema.caseInsensitiveCompare(defaultSchema) == .orderedSame
-                                && preselectedTables.contains(table.name)
+                            isSelected: selected
                         )
                     }
                     if !tableItems.isEmpty {
                         items.append(ExportDatabaseItem(
                             name: schema,
                             tables: tableItems,
-                            isExpanded: schema.caseInsensitiveCompare(defaultSchema) == .orderedSame
+                            isExpanded: isDefaultSchema
                         ))
                     }
                 }
@@ -595,26 +600,31 @@ struct ExportDialog: View {
                 let fallbackName = PluginManager.shared.defaultGroupName(for: dbType)
                 let dbItem = try await buildFlatDatabaseItem(
                     driver: driver,
-                    name: connection.database.isEmpty ? fallbackName : connection.database
+                    name: connection.database.isEmpty ? fallbackName : connection.database,
+                    priorSelections: priorSelections
                 )
                 if let dbItem { items.append(dbItem) }
             case .byDatabase:
                 let databases = try await driver.fetchDatabases()
                 for dbName in databases {
                     let tables = try await fetchTablesForDatabase(dbName, driver: driver)
+                    let isCurrentDB = dbName == connection.database
                     let tableItems = tables.map { table in
-                        ExportTableItem(
+                        let key = "\(dbName).\(table.name)"
+                        let selected = priorSelections[key]
+                            ?? (isCurrentDB && preselectedTables.contains(table.name))
+                        return ExportTableItem(
                             name: table.name,
                             databaseName: dbName,
                             type: table.type,
-                            isSelected: dbName == connection.database && preselectedTables.contains(table.name)
+                            isSelected: selected
                         )
                     }
                     if !tableItems.isEmpty {
                         items.append(ExportDatabaseItem(
                             name: dbName,
                             tables: tableItems,
-                            isExpanded: dbName == connection.database
+                            isExpanded: isCurrentDB
                         ))
                     }
                 }
@@ -646,15 +656,18 @@ struct ExportDialog: View {
 
     private func buildFlatDatabaseItem(
         driver: DatabaseDriver,
-        name: String
+        name: String,
+        priorSelections: [String: Bool] = [:]
     ) async throws -> ExportDatabaseItem? {
         let tables = try await driver.fetchTables()
         let tableItems = tables.map { table in
-            ExportTableItem(
+            let key = "\(name).\(table.name)"
+            let selected = priorSelections[key] ?? preselectedTables.contains(table.name)
+            return ExportTableItem(
                 name: table.name,
                 databaseName: "",
                 type: table.type,
-                isSelected: preselectedTables.contains(table.name)
+                isSelected: selected
             )
         }
         guard !tableItems.isEmpty else { return nil }

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -41,7 +41,7 @@ struct ExportDialog: View {
 
     private var connection: DatabaseConnection {
         switch mode {
-        case .tables(let conn, _): return conn
+        case .tables(let conn, _, _): return conn
         case .queryResults(let conn, _, _): return conn
         }
     }
@@ -59,7 +59,14 @@ struct ExportDialog: View {
     }
 
     private var preselectedTables: Set<String> {
-        if case .tables(_, let tables) = mode {
+        if case .tables(_, let tables, _) = mode {
+            return tables
+        }
+        return []
+    }
+
+    private var sidebarTables: [TableInfo] {
+        if case .tables(_, _, let tables) = mode {
             return tables
         }
         return []
@@ -118,6 +125,7 @@ struct ExportDialog: View {
                 }
                 isLoading = false
             } else {
+                populateFromSidebarTables()
                 await loadDatabaseItems()
             }
         }
@@ -511,6 +519,33 @@ struct ExportDialog: View {
 
     // MARK: - Actions
 
+    /// Instantly populate the current database from sidebar tables (no network).
+    private func populateFromSidebarTables() {
+        guard !sidebarTables.isEmpty else { return }
+        let dbName = connection.database
+        let tableItems = sidebarTables.map { table in
+            ExportTableItem(
+                name: table.name,
+                databaseName: dbName,
+                type: table.type,
+                isSelected: preselectedTables.contains(table.name)
+            )
+        }
+        let item = ExportDatabaseItem(
+            name: dbName.isEmpty ? "Tables" : dbName,
+            tables: tableItems,
+            isExpanded: true
+        )
+        databaseItems = [item]
+        isLoading = false
+
+        if preselectedTables.count == 1, let first = preselectedTables.first {
+            config.fileName = first
+        } else if !dbName.isEmpty {
+            config.fileName = dbName
+        }
+    }
+
     @MainActor
     private func loadDatabaseItems() async {
         guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
@@ -714,17 +749,14 @@ struct ExportDialog: View {
             savePanel.message = String(format: String(localized: "Export %d table(s) to %@"), exportableCount, formatName)
         }
 
-        guard let keyWindow = NSApp.keyWindow else { return }
-        let window = keyWindow.sheetParent ?? keyWindow
-        savePanel.beginSheetModal(for: window) { response in
-            guard response == .OK, let url = savePanel.url else { return }
+        let response = savePanel.runModal()
+        guard response == .OK, let url = savePanel.url else { return }
 
-            Task {
-                if self.isQueryResultsMode {
-                    await self.startQueryResultsExport(to: url)
-                } else {
-                    await self.startExport(to: url)
-                }
+        Task {
+            if self.isQueryResultsMode {
+                await self.startQueryResultsExport(to: url)
+            } else {
+                await self.startExport(to: url)
             }
         }
     }

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -294,14 +294,11 @@ struct ImportDialog: View {
         panel.allowsMultipleSelection = false
         panel.message = "Select file to import"
 
-        guard let keyWindow = NSApp.keyWindow else { return }
-        let window = keyWindow.sheetParent ?? keyWindow
-        panel.beginSheetModal(for: window) { response in
-            guard response == .OK, let url = panel.url else { return }
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
 
-            self.loadFileTask = Task {
-                await self.loadFile(url)
-            }
+        self.loadFileTask = Task {
+            await self.loadFile(url)
         }
     }
 

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -163,9 +163,9 @@ struct MainContentView: View {
                 isPresented: dismissBinding,
                 mode: .tables(
                     connection: exportConnection,
-                    preselectedTables: Set(sidebarState.selectedTables.map(\.name)),
-                    sidebarTables: tables
-                )
+                    preselectedTables: Set(sidebarState.selectedTables.map(\.name))
+                ),
+                sidebarTables: tables
             )
         case .exportQueryResults:
             if let tab = coordinator.tabManager.selectedTab {

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -117,6 +117,16 @@ struct MainContentView: View {
 
     // MARK: - Sheet Content
 
+    /// Connection with the active database from the current session,
+    /// so export/import dialogs see the database the user actually switched to.
+    private var connectionWithCurrentDatabase: DatabaseConnection {
+        var conn = connection
+        if let currentDB = DatabaseManager.shared.session(for: connection.id)?.currentDatabase {
+            conn.database = currentDB
+        }
+        return conn
+    }
+
     /// Returns the appropriate sheet view for the given `ActiveSheet` case.
     /// Uses a dismissal binding that sets `coordinator.activeSheet = nil` when the
     /// child view sets `isPresented = false`.
@@ -148,11 +158,13 @@ struct MainContentView: View {
                 }
             )
         case .exportDialog:
+            let exportConnection = connectionWithCurrentDatabase
             ExportDialog(
                 isPresented: dismissBinding,
                 mode: .tables(
-                    connection: connection,
-                    preselectedTables: Set(sidebarState.selectedTables.map(\.name))
+                    connection: exportConnection,
+                    preselectedTables: Set(sidebarState.selectedTables.map(\.name)),
+                    sidebarTables: tables
                 )
             )
         case .exportQueryResults:
@@ -160,7 +172,7 @@ struct MainContentView: View {
                 ExportDialog(
                     isPresented: dismissBinding,
                     mode: .queryResults(
-                        connection: connection,
+                        connection: connectionWithCurrentDatabase,
                         rowBuffer: tab.rowBuffer,
                         suggestedFileName: tab.tableName ?? "query_results"
                     )


### PR DESCRIPTION
## Summary
- Fix export/import save panel not appearing on macOS Tahoe — `beginSheetModal(for:)` silently fails when the target window already has a sheet (the dialog itself). Replaced with `runModal()` which shows a standalone modal dialog.
- Fix export dialog using stale `connection.database` instead of the session's current database after user switches databases via the database switcher.
- Populate export dialog table list instantly from sidebar tables (no network round-trip), then refresh with full database list in background.

Closes #654

## Test plan
- [ ] Open a MySQL connection, press Shift+Cmd+E, select tables, click Export — verify NSSavePanel appears
- [ ] Switch database via database switcher, then export — verify correct database tables are shown and pre-selected
- [ ] Select tables in sidebar, right-click → Export — verify selected tables are checked in the dialog
- [ ] Verify export dialog table list appears instantly (no loading delay for current database)
- [ ] Test import dialog file browser also works (same `runModal()` fix)