### PR TITLE
fix: MSSQL login fails with "Unable to determine initial language" (#661)

### DIFF
--- a/Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h
+++ b/Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h
@@ -44,12 +44,17 @@ typedef struct loginrec LOGINREC;
 #define SYBDATETIMN     111
 #define SYBUNIQUE       36
 
-// Login property constants for dbsetlname() — values verified against FreeTDS 1.4 sybdb.h
-#define DBSETHOST   1
-#define DBSETUSER   2
-#define DBSETPWD    3
-#define DBSETAPP    5   // 4 is unused; real FreeTDS DBSETAPP = 5
-#define DBSETCHARSET 7  // Client charset for dbsetlname() — controls string encoding
+// Login property constants for dbsetlname() — values from FreeTDS master/include/sybdb.h
+#define DBSETHOST       1
+#define DBSETUSER       2
+#define DBSETPWD        3
+#define DBSETAPP        5
+#define DBSETBCP        6
+#define DBSETNATLANG    7
+#define DBSETCHARSET    10
+#define DBSETPACKET     11
+#define DBSETENCRYPT    12
+#define DBSETDBNAME     14
 
 // Convenience macros (match FreeTDS sybdb.h)
 #define DBSETLHOST(x, y)    dbsetlname((x), (y), DBSETHOST)

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -196,6 +196,7 @@ private final class FreeTDSConnection: @unchecked Sendable {
         _ = dbsetlname(login, user, Int32(DBSETUSER))
         _ = dbsetlname(login, password, Int32(DBSETPWD))
         _ = dbsetlname(login, "TablePro", Int32(DBSETAPP))
+        _ = dbsetlname(login, "us_english", Int32(DBSETNATLANG))
         _ = dbsetlname(login, "UTF-8", Int32(DBSETCHARSET))
         _ = dbsetlversion(login, UInt8(DBVERSION_74))
 


### PR DESCRIPTION
## Summary

Fix MSSQL connection failing with "Login failed for user 'sa'" when SQL Server requires language in the TDS login packet (common with Docker images).

Closes #661

## Root Cause

The C bridge header (`CFreeTDS/include/sybdb.h`) had **wrong constant values** for `dbsetlname()`:

| Constant | Our value (wrong) | Real FreeTDS |
|----------|-------------------|-------------|
| `DBSETCHARSET` | 7 | **10** |
| `DBSETNATLANG` | (missing) | **7** |

So `dbsetlname(login, "UTF-8", 7)` was actually setting the **language** to "UTF-8" (not charset), causing SQL Server error state 17: "Unable to determine the initial language and date format."

## Fix

1. Corrected all constants in `sybdb.h` to match FreeTDS `master/include/sybdb.h`
2. Added `DBSETNATLANG=7` with `"us_english"` to the login packet
3. `DBSETCHARSET=10` now correctly sets UTF-8 charset

## Test plan

- [x] Docker MSSQL 2022: connection succeeds (was failing with state 17)
- [ ] Verify existing MSSQL connections still work
- [ ] Verify charset handling (special characters in queries/results)