### PR TITLE
fix: query tab title incorrectly shows table name after execution (#668)

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -161,7 +161,8 @@ extension MainContentView {
         } else {
             let langName = PluginManager.shared.queryLanguageName(for: connection.type)
             let queryLabel = "\(langName) Query"
-            windowTitle = selectedTab?.tableName
+            windowTitle = (selectedTab?.tabType == .table ? selectedTab?.tableName : nil)
+                ?? selectedTab?.title
                 ?? (tabManager.tabs.isEmpty ? connection.name : queryLabel)
         }
         viewWindow?.representedURL = selectedTab?.sourceFileURL


### PR DESCRIPTION
## Summary

Fix query tab's window title changing to the executed table name, which also breaks sidebar table navigation.

Closes #668

## Root Cause

`updateWindowTitleAndFileState()` used `selectedTab?.tableName` as the window title regardless of tab type. After `SELECT * FROM users`, `tableName = "users"` is set (needed for edit support), but the window title also became `"users"`.

This caused `openTableTab`'s window dedup check (`window.title == tableName`) to match the query tab, preventing new table tabs from opening.

## Fix

One line: guard `tableName` usage on `tabType == .table`. Query tabs use `tab.title` ("Query 1") as the window title.

```swift
// Before:
windowTitle = selectedTab?.tableName ?? ...

// After:
windowTitle = (selectedTab?.tabType == .table ? selectedTab?.tableName : nil)
    ?? selectedTab?.title ?? ...
```

## Test plan

- [ ] Execute `SELECT * FROM users` in query tab: window title stays "Query 1" (not "users")
- [ ] Click "users" in sidebar: opens new table tab (not switches to query tab)
- [ ] Open table tab for "users": window title shows "users"
- [ ] ER Diagram tab: window title shows "ER Diagram"
- [ ] Create Table tab: window title shows "Create Table"
- [ ] File-backed query: window title shows filename