### PR TITLE
feat(ios): P0 HIG compliance fixes

### DIFF
--- a/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
@@ -13,6 +13,7 @@ struct SQLHighlightTextView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
+        context.coordinator.textView = textView
         textView.delegate = context.coordinator
         textView.font = Self.font
         textView.autocorrectionType = .no
@@ -25,6 +26,7 @@ struct SQLHighlightTextView: UIViewRepresentable {
         textView.backgroundColor = .clear
         textView.textContainerInset = UIEdgeInsets(top: 8, left: 4, bottom: 8, right: 4)
         textView.textStorage.delegate = context.coordinator
+        textView.inputAccessoryView = context.coordinator.makeAccessoryToolbar()
         return textView
     }
 
@@ -45,6 +47,7 @@ struct SQLHighlightTextView: UIViewRepresentable {
     class Coordinator: NSObject, UITextViewDelegate, NSTextStorageDelegate {
         var parent: SQLHighlightTextView
         var isUpdating = false
+        weak var textView: UITextView?
 
         init(_ parent: SQLHighlightTextView) {
             self.parent = parent
@@ -62,10 +65,96 @@ struct SQLHighlightTextView: UIViewRepresentable {
             changeInLength delta: Int
         ) {
             guard editedMask.contains(.editedCharacters), !isUpdating else { return }
-            // Defer to avoid re-entrant editing during processEditing
             DispatchQueue.main.async {
                 SQLSyntaxHighlighter.highlight(textStorage, in: editedRange)
             }
+        }
+
+        // MARK: - Keyboard Accessory Toolbar
+
+        func makeAccessoryToolbar() -> UIView {
+            let toolbar = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+            toolbar.backgroundColor = .secondarySystemBackground
+
+            let separator = UIView()
+            separator.backgroundColor = .separator
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            toolbar.addSubview(separator)
+
+            let scrollView = UIScrollView()
+            scrollView.showsHorizontalScrollIndicator = false
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.spacing = 8
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+
+            let keywords = ["SELECT", "FROM", "WHERE", "JOIN", "AND", "OR", "INSERT", "UPDATE", "DELETE", "*", "(", ")", ";"]
+            for keyword in keywords {
+                stackView.addArrangedSubview(makeKeywordButton(keyword))
+            }
+
+            scrollView.addSubview(stackView)
+
+            let doneButton = UIButton(type: .system)
+            doneButton.setTitle(String(localized: "Done"), for: .normal)
+            doneButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .semibold)
+            doneButton.addTarget(self, action: #selector(dismissKeyboard), for: .touchUpInside)
+            doneButton.translatesAutoresizingMaskIntoConstraints = false
+            doneButton.setContentHuggingPriority(.required, for: .horizontal)
+            doneButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+            toolbar.addSubview(scrollView)
+            toolbar.addSubview(doneButton)
+
+            NSLayoutConstraint.activate([
+                separator.topAnchor.constraint(equalTo: toolbar.topAnchor),
+                separator.leadingAnchor.constraint(equalTo: toolbar.leadingAnchor),
+                separator.trailingAnchor.constraint(equalTo: toolbar.trailingAnchor),
+                separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+
+                scrollView.topAnchor.constraint(equalTo: toolbar.topAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: toolbar.leadingAnchor, constant: 8),
+                scrollView.bottomAnchor.constraint(equalTo: toolbar.bottomAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: doneButton.leadingAnchor, constant: -8),
+
+                stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+                stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+                stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+                stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+                stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+
+                doneButton.trailingAnchor.constraint(equalTo: toolbar.trailingAnchor, constant: -12),
+                doneButton.centerYAnchor.constraint(equalTo: toolbar.centerYAnchor)
+            ])
+
+            return toolbar
+        }
+
+        private func makeKeywordButton(_ keyword: String) -> UIButton {
+            var config = UIButton.Configuration.gray()
+            config.title = keyword
+            config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var attrs = incoming
+                attrs.font = UIFont.monospacedSystemFont(ofSize: 14, weight: .medium)
+                return attrs
+            }
+            config.cornerStyle = .capsule
+            config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
+            let button = UIButton(configuration: config)
+            button.addTarget(self, action: #selector(keywordTapped(_:)), for: .touchUpInside)
+            return button
+        }
+
+        @objc private func keywordTapped(_ sender: UIButton) {
+            guard let keyword = sender.configuration?.title else { return }
+            let needsSpace = keyword.count > 1
+            textView?.insertText(needsSpace ? keyword + " " : keyword)
+        }
+
+        @objc private func dismissKeyboard() {
+            textView?.resignFirstResponder()
         }
     }
 }

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -30,6 +30,9 @@ struct ConnectedView: View {
     @State private var activeSchema: String = "public"
     @State private var isSwitching = false
     @State private var isReconnecting = false
+    @State private var connectTask: Task<Void, Never>?
+
+    @Environment(\.dismiss) private var dismiss
 
     enum ConnectedTab: String, CaseIterable {
         case tables = "Tables"
@@ -52,8 +55,15 @@ struct ConnectedView: View {
     var body: some View {
         Group {
             if isConnecting {
-                ProgressView {
-                    Text(String(format: String(localized: "Connecting to %@..."), displayName))
+                VStack(spacing: 16) {
+                    ProgressView {
+                        Text(String(format: String(localized: "Connecting to %@..."), displayName))
+                    }
+                    Button(String(localized: "Cancel")) {
+                        connectTask?.cancel()
+                        dismiss()
+                    }
+                    .buttonStyle(.bordered)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let appError {
@@ -157,8 +167,14 @@ struct ConnectedView: View {
             }
         }
         .task {
-            await connect()
-            queryHistory = historyStorage.load(for: connection.id)
+            let task = Task {
+                await connect()
+            }
+            connectTask = task
+            await task.value
+            if !Task.isCancelled {
+                queryHistory = historyStorage.load(for: connection.id)
+            }
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active, session != nil {
@@ -205,6 +221,7 @@ struct ConnectedView: View {
             self.session = existing
             do {
                 self.tables = try await existing.driver.fetchTables(schema: nil)
+                guard !Task.isCancelled else { return }
                 await loadDatabases()
                 await loadSchemas()
             } catch {
@@ -225,12 +242,17 @@ struct ConnectedView: View {
 
         do {
             let session = try await appState.connectionManager.connect(connection)
+            guard !Task.isCancelled else {
+                await appState.connectionManager.disconnect(connection.id)
+                return
+            }
             self.session = session
             self.tables = try await session.driver.fetchTables(schema: nil)
             isConnecting = false
             await loadDatabases()
             await loadSchemas()
         } catch {
+            guard !Task.isCancelled else { return }
             let context = ErrorContext(
                 operation: "connect",
                 databaseType: connection.type,

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -31,6 +31,8 @@ struct ConnectedView: View {
     @State private var isSwitching = false
     @State private var isReconnecting = false
     @State private var connectTask: Task<Void, Never>?
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
 
     @Environment(\.dismiss) private var dismiss
 
@@ -88,6 +90,8 @@ struct ConnectedView: View {
                     .animation(.default, value: isSwitching)
             }
         }
+        .sensoryFeedback(.success, trigger: hapticSuccess)
+        .sensoryFeedback(.error, trigger: hapticError)
         .alert("Error", isPresented: $showFailureAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -249,6 +253,7 @@ struct ConnectedView: View {
             self.session = session
             self.tables = try await session.driver.fetchTables(schema: nil)
             isConnecting = false
+            hapticSuccess.toggle()
             await loadDatabases()
             await loadSchemas()
         } catch {
@@ -261,6 +266,7 @@ struct ConnectedView: View {
             )
             appError = ErrorClassifier.classify(error, context: context)
             isConnecting = false
+            hapticError.toggle()
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -30,7 +30,6 @@ struct ConnectedView: View {
     @State private var activeSchema: String = "public"
     @State private var isSwitching = false
     @State private var isReconnecting = false
-    @State private var connectTask: Task<Void, Never>?
     @State private var hapticSuccess = false
     @State private var hapticError = false
 
@@ -62,7 +61,6 @@ struct ConnectedView: View {
                         Text(String(format: String(localized: "Connecting to %@..."), displayName))
                     }
                     Button(String(localized: "Cancel")) {
-                        connectTask?.cancel()
                         dismiss()
                     }
                     .buttonStyle(.bordered)
@@ -171,11 +169,7 @@ struct ConnectedView: View {
             }
         }
         .task {
-            let task = Task {
-                await connect()
-            }
-            connectTask = task
-            await task.value
+            await connect()
             if !Task.isCancelled {
                 queryHistory = historyStorage.load(for: connection.id)
             }

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -66,6 +66,8 @@ struct ConnectionFormView: View {
     @State private var testResult: TestResult?
     @State private var credentialError: String?
     @State private var showCredentialError = false
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionFormView")
 
@@ -280,6 +282,8 @@ struct ConnectionFormView: View {
             } message: {
                 Text("Enter a name for the new SQLite database.")
             }
+            .sensoryFeedback(.success, trigger: hapticSuccess)
+            .sensoryFeedback(.error, trigger: hapticError)
             .alert("Keychain Warning", isPresented: $showCredentialError) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -529,6 +533,7 @@ struct ConnectionFormView: View {
             _ = try await appState.connectionManager.connect(testConn)
             await appState.connectionManager.disconnect(tempId)
             testResult = TestResult(success: true, message: String(localized: "Connection successful"), recovery: nil)
+            hapticSuccess.toggle()
         } catch {
             let context = ErrorContext(
                 operation: "testConnection",
@@ -538,6 +543,7 @@ struct ConnectionFormView: View {
             )
             let classified = ErrorClassifier.classify(error, context: context)
             testResult = TestResult(success: false, message: classified.message, recovery: classified.recovery)
+            hapticError.toggle()
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -337,11 +337,12 @@ struct ConnectionListView: View {
             ConnectionRow(connection: connection, tag: appState.tag(for: connection.tagId))
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button(role: .destructive) {
+            Button {
                 connectionToDelete = connection
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+            .tint(.red)
         }
         .contextMenu {
             Button {

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -18,6 +18,14 @@ struct ConnectionListView: View {
     @State private var filterTagId: UUID?
     @State private var groupByGroup = false
     @State private var editMode: EditMode = .inactive
+    @State private var connectionToDelete: DatabaseConnection?
+
+    private var showDeleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { connectionToDelete != nil },
+            set: { if !$0 { connectionToDelete = nil } }
+        )
+    }
 
     private var displayedConnections: [DatabaseConnection] {
         var result = appState.connections
@@ -175,6 +183,22 @@ struct ConnectionListView: View {
                     localTags: appState.tags
                 )
             }
+            .confirmationDialog(
+                String(localized: "Delete Connection"),
+                isPresented: showDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Delete"), role: .destructive) {
+                    if let connection = connectionToDelete {
+                        if selectedConnectionId == connection.id {
+                            selectedConnectionId = nil
+                        }
+                        appState.removeConnection(connection)
+                    }
+                }
+            } message: {
+                Text("Are you sure you want to delete this connection? Saved credentials will be permanently removed.")
+            }
         }
     }
 
@@ -314,10 +338,7 @@ struct ConnectionListView: View {
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
-                if selectedConnectionId == connection.id {
-                    selectedConnectionId = nil
-                }
-                appState.removeConnection(connection)
+                connectionToDelete = connection
             } label: {
                 Label("Delete", systemImage: "trash")
             }
@@ -338,10 +359,7 @@ struct ConnectionListView: View {
             }
             Divider()
             Button(role: .destructive) {
-                if selectedConnectionId == connection.id {
-                    selectedConnectionId = nil
-                }
-                appState.removeConnection(connection)
+                connectionToDelete = connection
             } label: {
                 Label("Delete", systemImage: "trash")
             }

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -287,12 +287,13 @@ struct DataBrowserView: View {
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     if !isView && hasPrimaryKeys && !connection.safeModeLevel.blocksWrites {
-                        Button(role: .destructive) {
+                        Button {
                             deleteTarget = primaryKeyValues(for: row)
                             showDeleteConfirmation = true
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
+                        .tint(.red)
                     }
                 }
             }

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -41,6 +41,8 @@ struct DataBrowserView: View {
     @State private var foreignKeys: [ForeignKeyInfo] = []
     @State private var fkPreviewItem: FKPreviewItem?
     @State private var memoryWarningMessage: String?
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
 
     private var isView: Bool {
         table.type == .view || table.type == .materializedView
@@ -157,6 +159,8 @@ struct DataBrowserView: View {
                     }
                 }
             }
+            .sensoryFeedback(.success, trigger: hapticSuccess)
+            .sensoryFeedback(.error, trigger: hapticError)
             .alert("Go to Page", isPresented: $showGoToPage) {
                 TextField("Page number", text: $goToPageInput)
                     .keyboardType(.numberPad)
@@ -595,12 +599,14 @@ struct DataBrowserView: View {
                 query: SQLBuilder.buildDelete(table: table.name, type: connection.type, primaryKeys: pkValues)
             )
             await loadData()
+            hapticSuccess.toggle()
         } catch {
             operationError = ErrorClassifier.classify(
                 error,
                 context: ErrorContext(operation: "deleteRow", databaseType: connection.type, host: connection.host)
             )
             showOperationError = true
+            hapticError.toggle()
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/GroupManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/GroupManagementView.swift
@@ -44,11 +44,12 @@ struct GroupManagementView: View {
                         }
                     }
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button(role: .destructive) {
+                        Button {
                             groupToDelete = group
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
+                        .tint(.red)
                     }
                 }
                 .onMove { source, destination in

--- a/TableProMobile/TableProMobile/Views/GroupManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/GroupManagementView.swift
@@ -11,6 +11,14 @@ struct GroupManagementView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var editingGroup: ConnectionGroup?
     @State private var showingAddGroup = false
+    @State private var groupToDelete: ConnectionGroup?
+
+    private var showDeleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { groupToDelete != nil },
+            set: { if !$0 { groupToDelete = nil } }
+        )
+    }
 
     var body: some View {
         NavigationStack {
@@ -37,7 +45,7 @@ struct GroupManagementView: View {
                     }
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                         Button(role: .destructive) {
-                            appState.deleteGroup(group.id)
+                            groupToDelete = group
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
@@ -60,6 +68,19 @@ struct GroupManagementView: View {
                         Text("Create a group to organize your connections.")
                     }
                 }
+            }
+            .confirmationDialog(
+                String(localized: "Delete Group"),
+                isPresented: showDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Delete"), role: .destructive) {
+                    if let group = groupToDelete {
+                        appState.deleteGroup(group.id)
+                    }
+                }
+            } message: {
+                Text("Connections in this group will be moved to ungrouped.")
             }
             .navigationTitle("Groups")
             .navigationBarTitleDisplayMode(.inline)

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -39,6 +39,8 @@ struct InsertRowView: View {
     @State private var isSaving = false
     @State private var operationError: AppError?
     @State private var showOperationError = false
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
 
     var body: some View {
         NavigationStack {
@@ -133,6 +135,8 @@ struct InsertRowView: View {
                     .disabled(isSaving)
                 }
             }
+            .sensoryFeedback(.success, trigger: hapticSuccess)
+            .sensoryFeedback(.error, trigger: hapticError)
             .alert(operationError?.title ?? "Error", isPresented: $showOperationError) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -209,12 +213,14 @@ struct InsertRowView: View {
 
         do {
             _ = try await session.driver.execute(query: sql)
+            hapticSuccess.toggle()
             onInserted?()
             dismiss()
         } catch {
             let context = ErrorContext(operation: "insertRow", databaseType: databaseType)
             operationError = ErrorClassifier.classify(error, context: context)
             showOperationError = true
+            hapticError.toggle()
         }
     }
 }

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -31,6 +31,8 @@ struct QueryEditorView: View {
     @State private var showWriteConfirmation = false
     @State private var showWriteBlockedAlert = false
     @State private var pendingWriteQuery = ""
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
     var body: some View {
         VStack(spacing: 0) {
             editorSection
@@ -53,6 +55,8 @@ struct QueryEditorView: View {
         } message: {
             Text("This query will modify data. Are you sure you want to continue?")
         }
+        .sensoryFeedback(.success, trigger: hapticSuccess)
+        .sensoryFeedback(.error, trigger: hapticError)
         .sheet(isPresented: $showHistory) { historySheet }
     }
 
@@ -383,6 +387,7 @@ struct QueryEditorView: View {
             let queryResult = try await session.driver.execute(query: trimmed)
             self.result = queryResult
             self.executionTime = queryResult.executionTime
+            hapticSuccess.toggle()
 
             let item = QueryHistoryItem(query: trimmed, connectionId: connectionId)
             historyStorage.save(item)
@@ -390,6 +395,7 @@ struct QueryEditorView: View {
         } catch {
             let context = ErrorContext(operation: "executeQuery")
             self.appError = ErrorClassifier.classify(error, context: context)
+            hapticError.toggle()
         }
     }
 }

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -27,6 +27,9 @@ struct RowDetailView: View {
     @State private var showOperationError = false
     @State private var showSaveSuccess = false
     @State private var fkPreviewItem: FKPreviewItem?
+    @State private var hapticSuccess = false
+    @State private var hapticError = false
+    @State private var hapticSelection = 0
 
     init(
         columns: [ColumnInfo],
@@ -198,6 +201,7 @@ struct RowDetailView: View {
             ToolbarItemGroup(placement: .bottomBar) {
                 Button {
                     withAnimation { currentIndex -= 1 }
+                    hapticSelection += 1
                 } label: {
                     Image(systemName: "chevron.left")
                 }
@@ -215,12 +219,16 @@ struct RowDetailView: View {
 
                 Button {
                     withAnimation { currentIndex += 1 }
+                    hapticSelection += 1
                 } label: {
                     Image(systemName: "chevron.right")
                 }
                 .disabled(currentIndex >= rows.count - 1 || isEditing)
             }
         }
+        .sensoryFeedback(.success, trigger: hapticSuccess)
+        .sensoryFeedback(.error, trigger: hapticError)
+        .sensoryFeedback(.selection, trigger: hapticSelection)
         .alert(operationError?.title ?? "Error", isPresented: $showOperationError) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -365,6 +373,7 @@ struct RowDetailView: View {
             rows[currentIndex] = editedValues
             isEditing = false
             showSaveSuccess = true
+            hapticSuccess.toggle()
             onSaved?()
             Task {
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -374,6 +383,7 @@ struct RowDetailView: View {
             let context = ErrorContext(operation: "saveChanges", databaseType: databaseType)
             operationError = ErrorClassifier.classify(error, context: context)
             showOperationError = true
+            hapticError.toggle()
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses 4 critical (P0) HIG violations identified in the iOS UI/UX audit:

- **Confirmation dialogs for deletion**: Connection and group deletion via swipe/context menu now shows `.confirmationDialog` before removing. Previously deleted immediately with no undo path, permanently destroying Keychain credentials.
- **SQL keyboard accessory toolbar**: Scrollable toolbar above keyboard with 13 SQL keyword buttons (`SELECT`, `FROM`, `WHERE`, `JOIN`, etc.) + Done button. Inserts at cursor position.
- **Cancel button on connection attempt**: ProgressView during connection now includes a Cancel button. Cancels the async task, cleans up partial connections, and dismisses back to connection list.
- **Haptic feedback**: Added `.sensoryFeedback` (iOS 17+) across 6 view files for success/error/selection feedback on key actions (query execution, row save/delete/insert, connection test, row navigation).

## Files Changed (9)

| File | Change |
|------|--------|
| `ConnectionListView.swift` | Confirmation dialog for connection deletion |
| `GroupManagementView.swift` | Confirmation dialog for group deletion |
| `SQLHighlightTextView.swift` | Keyboard accessory toolbar with SQL keywords |
| `ConnectedView.swift` | Cancel button + haptics |
| `DataBrowserView.swift` | Haptic feedback |
| `QueryEditorView.swift` | Haptic feedback |
| `RowDetailView.swift` | Haptic feedback (success/error/selection) |
| `ConnectionFormView.swift` | Haptic feedback |
| `InsertRowView.swift` | Haptic feedback |

## Test plan

- [ ] Swipe-to-delete a connection → confirmation dialog appears → Cancel dismisses, Delete removes
- [ ] Context menu → Delete on connection → same confirmation dialog
- [ ] Swipe-to-delete a group → confirmation dialog with "moved to ungrouped" message
- [ ] Open Query tab → tap editor → keyboard shows accessory toolbar with SQL keywords
- [ ] Tap keyword buttons → text inserted at cursor with trailing space
- [ ] Tap Done → keyboard dismisses
- [ ] Tap a connection → "Connecting..." screen shows Cancel button
- [ ] Tap Cancel → returns to connections list
- [ ] Execute a query → feel success haptic
- [ ] Execute bad SQL → feel error haptic
- [ ] Delete a row → feel success haptic
- [ ] Navigate between rows in detail view → feel selection haptic
- [ ] Test connection in form → feel success/error haptic