### PR TITLE
fix: resolve SSH tunnel failures with config profiles (#672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- SSH Tunnel not working when `~/.ssh/config` uses `Include` directives (#672)
-- SSH tunnel cleanup not firing for profile-based connections
-- SSH config tokens (`%d`, `%h`, `%u`, `%r`) not expanded in `IdentityFile` paths
-- Multi-word `Host` entries in SSH config causing connection failures
-- SSH handshake error messages showing numeric codes instead of diagnostics
+- SSH Tunnel not working with `~/.ssh/config` profiles (#672): added `Include` directive support, SSH token expansion (`%d`, `%h`, `%u`, `%r`), multi-word `Host` filtering, and detailed handshake error messages
 
 ## [0.30.1] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handoff support for cross-device continuity between iOS and macOS
 - State restoration across app lifecycle on iOS (selected connection, active tab, query text, database/schema selection)
 
+### Fixed
+
+- SSH Tunnel not working when `~/.ssh/config` uses `Include` directives (#672)
+- SSH tunnel cleanup not firing for profile-based connections
+- SSH config tokens (`%d`, `%h`, `%u`, `%r`) not expanded in `IdentityFile` paths
+- Multi-word `Host` entries in SSH config causing connection failures
+- SSH handshake error messages showing numeric codes instead of diagnostics
+
 ## [0.30.1] - 2026-04-10
 
 ### Added

--- a/TablePro/Core/Database/DatabaseManager+Queries.swift
+++ b/TablePro/Core/Database/DatabaseManager+Queries.swift
@@ -78,9 +78,9 @@ extension DatabaseManager {
             sshPasswordOverride: sshPassword
         )
 
-        // Resolve effective SSH config once for cleanup (profile takes priority over inline)
-        let sshProfile = connection.sshProfileId.flatMap { SSHProfileStorage.shared.profile(for: $0) }
-        let sshEnabled = connection.effectiveSSHConfig(profile: sshProfile).enabled
+        // Detect whether buildEffectiveConnection created a tunnel by checking
+        // if the returned connection was redirected to localhost (tunnel endpoint)
+        let tunnelWasCreated = testConnection.host == "127.0.0.1" && testConnection.port != connection.port
 
         let result: Bool
         do {
@@ -90,7 +90,7 @@ extension DatabaseManager {
             )
             result = try await driver.testConnection()
         } catch {
-            if sshEnabled {
+            if tunnelWasCreated {
                 do {
                     try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
                 } catch {
@@ -100,7 +100,7 @@ extension DatabaseManager {
             throw error
         }
 
-        if sshEnabled {
+        if tunnelWasCreated {
             do {
                 try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
             } catch {

--- a/TablePro/Core/Database/DatabaseManager+Queries.swift
+++ b/TablePro/Core/Database/DatabaseManager+Queries.swift
@@ -78,6 +78,10 @@ extension DatabaseManager {
             sshPasswordOverride: sshPassword
         )
 
+        // Resolve effective SSH config once for cleanup (profile takes priority over inline)
+        let sshProfile = connection.sshProfileId.flatMap { SSHProfileStorage.shared.profile(for: $0) }
+        let sshEnabled = connection.effectiveSSHConfig(profile: sshProfile).enabled
+
         let result: Bool
         do {
             let driver = try DatabaseDriverFactory.createDriver(
@@ -86,7 +90,7 @@ extension DatabaseManager {
             )
             result = try await driver.testConnection()
         } catch {
-            if connection.sshConfig.enabled {
+            if sshEnabled {
                 do {
                     try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
                 } catch {
@@ -96,7 +100,7 @@ extension DatabaseManager {
             throw error
         }
 
-        if connection.sshConfig.enabled {
+        if sshEnabled {
             do {
                 try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
             } catch {

--- a/TablePro/Core/Database/DatabaseManager+SSH.swift
+++ b/TablePro/Core/Database/DatabaseManager+SSH.swift
@@ -24,34 +24,24 @@ extension DatabaseManager {
         for connection: DatabaseConnection,
         sshPasswordOverride: String? = nil
     ) async throws -> DatabaseConnection {
-        // Resolve SSH configuration: profile takes priority over inline
-        let profile = connection.sshProfileId.flatMap { SSHProfileStorage.shared.profile(for: $0) }
-        let sshConfig = connection.effectiveSSHConfig(profile: profile)
-        let isProfile = connection.sshProfileId != nil && profile != nil
-
-        if let profileId = connection.sshProfileId, profile == nil {
-            Self.logger.warning(
-                "SSH profile \(profileId) not found for connection '\(connection.name)' — falling back to inline SSH config"
-            )
-        }
-
-        let secretOwnerId = (isProfile ? connection.sshProfileId : nil) ?? connection.id
-
-        guard sshConfig.enabled else {
-            return connection
-        }
+        let sshConfig = connection.resolvedSSHConfig
+        guard sshConfig.enabled else { return connection }
 
         let storedSshPassword: String?
         let keyPassphrase: String?
         let totpSecret: String?
-        if isProfile {
-            storedSshPassword = SSHProfileStorage.shared.loadSSHPassword(for: secretOwnerId)
-            keyPassphrase = SSHProfileStorage.shared.loadKeyPassphrase(for: secretOwnerId)
-            totpSecret = SSHProfileStorage.shared.loadTOTPSecret(for: secretOwnerId)
-        } else {
-            storedSshPassword = ConnectionStorage.shared.loadSSHPassword(for: secretOwnerId)
-            keyPassphrase = ConnectionStorage.shared.loadKeyPassphrase(for: secretOwnerId)
-            totpSecret = ConnectionStorage.shared.loadTOTPSecret(for: secretOwnerId)
+
+        switch connection.sshTunnelMode {
+        case .disabled:
+            return connection
+        case .profile(let profileId, _):
+            storedSshPassword = SSHProfileStorage.shared.loadSSHPassword(for: profileId)
+            keyPassphrase = SSHProfileStorage.shared.loadKeyPassphrase(for: profileId)
+            totpSecret = SSHProfileStorage.shared.loadTOTPSecret(for: profileId)
+        case .inline:
+            storedSshPassword = ConnectionStorage.shared.loadSSHPassword(for: connection.id)
+            keyPassphrase = ConnectionStorage.shared.loadKeyPassphrase(for: connection.id)
+            totpSecret = ConnectionStorage.shared.loadTOTPSecret(for: connection.id)
         }
 
         let sshPassword = sshPasswordOverride ?? storedSshPassword

--- a/TablePro/Core/Database/DatabaseManager+SSH.swift
+++ b/TablePro/Core/Database/DatabaseManager+SSH.swift
@@ -28,6 +28,13 @@ extension DatabaseManager {
         let profile = connection.sshProfileId.flatMap { SSHProfileStorage.shared.profile(for: $0) }
         let sshConfig = connection.effectiveSSHConfig(profile: profile)
         let isProfile = connection.sshProfileId != nil && profile != nil
+
+        if let profileId = connection.sshProfileId, profile == nil {
+            Self.logger.warning(
+                "SSH profile \(profileId) not found for connection '\(connection.name)' — falling back to inline SSH config"
+            )
+        }
+
         let secretOwnerId = (isProfile ? connection.sshProfileId : nil) ?? connection.id
 
         guard sshConfig.enabled else {

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -92,7 +92,7 @@ extension DatabaseManager {
             )
         } catch {
             // Close tunnel if SSH was established
-            if connection.sshConfig.enabled {
+            if connection.resolvedSSHConfig.enabled {
                 Task {
                     do {
                         try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
@@ -157,7 +157,7 @@ extension DatabaseManager {
             }
         } catch {
             // Close tunnel if connection failed
-            if connection.sshConfig.enabled {
+            if connection.resolvedSSHConfig.enabled {
                 Task {
                     do {
                         try await SSHTunnelManager.shared.closeTunnel(connectionId: connection.id)
@@ -243,7 +243,7 @@ extension DatabaseManager {
         guard let session = activeSessions[sessionId] else { return }
 
         // Close SSH tunnel if exists
-        if session.connection.sshConfig.enabled {
+        if session.connection.resolvedSSHConfig.enabled {
             do {
                 try await SSHTunnelManager.shared.closeTunnel(connectionId: session.connection.id)
             } catch {

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -403,8 +403,12 @@ internal enum LibSSH2TunnelFactory {
 
         let rc = libssh2_session_handshake(session, socketFD)
         if rc != 0 {
+            var msgPtr: UnsafeMutablePointer<CChar>?
+            var msgLen: Int32 = 0
+            libssh2_session_last_error(session, &msgPtr, &msgLen, 0)
+            let detail = msgPtr.map { String(cString: $0) } ?? "Unknown error"
             libssh2_session_free(session)
-            throw SSHTunnelError.tunnelCreationFailed("SSH handshake failed (error \(rc))")
+            throw SSHTunnelError.tunnelCreationFailed("SSH handshake failed: \(detail)")
         }
 
         return session

--- a/TablePro/Core/SSH/SSHConfigParser.swift
+++ b/TablePro/Core/SSH/SSHConfigParser.swift
@@ -80,20 +80,13 @@ final class SSHConfigParser {
         return parseContent(content, visitedPaths: &visitedPaths, depth: depth)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private static func parseContent(
         _ content: String,
         visitedPaths: inout Set<String>,
         depth: Int
     ) -> [SSHConfigEntry] {
         var entries: [SSHConfigEntry] = []
-        var currentHost: String?
-        var currentHostname: String?
-        var currentPort: Int?
-        var currentUser: String?
-        var currentIdentityFile: String?
-        var currentIdentityAgent: String?
-        var currentProxyJump: String?
+        var pending = PendingEntry()
 
         let lines = content.components(separatedBy: .newlines)
 
@@ -114,88 +107,30 @@ final class SSHConfigParser {
 
             switch key {
             case "host":
-                // Save previous entry if exists
-                if let host = currentHost {
-                    // Skip wildcard patterns and multi-word hosts
-                    if !host.contains("*") && !host.contains("?") && !host.contains(" ") {
-                        entries.append(
-                            SSHConfigEntry(
-                                host: host,
-                                hostname: currentHostname,
-                                port: currentPort,
-                                user: currentUser,
-                                identityFile: currentIdentityFile.map {
-                                    SSHPathUtilities.expandSSHTokens(
-                                        $0, hostname: currentHostname, remoteUser: currentUser)
-                                },
-                                identityAgent: currentIdentityAgent.map {
-                                    SSHPathUtilities.expandSSHTokens(
-                                        $0, hostname: currentHostname, remoteUser: currentUser)
-                                },
-                                proxyJump: currentProxyJump
-                            ))
-                    }
-                }
-
-                // Start new entry
-                currentHost = value
-                currentHostname = nil
-                currentPort = nil
-                currentUser = nil
-                currentIdentityFile = nil
-                currentIdentityAgent = nil
-                currentProxyJump = nil
+                pending.flush(into: &entries)
+                pending.host = value
 
             case "hostname":
-                currentHostname = value
+                pending.hostname = value
 
             case "port":
-                currentPort = Int(value)
+                pending.port = Int(value)
 
             case "user":
-                currentUser = value
+                pending.user = value
 
             case "identityfile":
-                currentIdentityFile = value
+                pending.identityFile = value
 
             case "identityagent":
-                currentIdentityAgent = value
+                pending.identityAgent = value
 
             case "proxyjump":
-                currentProxyJump = value
+                pending.proxyJump = value
 
             case "include":
-                // Flush current pending entry before processing includes
-                if let host = currentHost {
-                    if !host.contains("*") && !host.contains("?") && !host.contains(" ") {
-                        entries.append(
-                            SSHConfigEntry(
-                                host: host,
-                                hostname: currentHostname,
-                                port: currentPort,
-                                user: currentUser,
-                                identityFile: currentIdentityFile.map {
-                                    SSHPathUtilities.expandSSHTokens(
-                                        $0, hostname: currentHostname, remoteUser: currentUser)
-                                },
-                                identityAgent: currentIdentityAgent.map {
-                                    SSHPathUtilities.expandSSHTokens(
-                                        $0, hostname: currentHostname, remoteUser: currentUser)
-                                },
-                                proxyJump: currentProxyJump
-                            ))
-                    }
-                    currentHost = nil
-                    currentHostname = nil
-                    currentPort = nil
-                    currentUser = nil
-                    currentIdentityFile = nil
-                    currentIdentityAgent = nil
-                    currentProxyJump = nil
-                }
-
-                let includePaths = resolveIncludePaths(value)
-                for includePath in includePaths {
+                pending.flush(into: &entries)
+                for includePath in resolveIncludePaths(value) {
                     let includedEntries = parseFile(
                         path: includePath,
                         visitedPaths: &visitedPaths,
@@ -210,26 +145,47 @@ final class SSHConfigParser {
         }
 
         // Don't forget the last entry
-        if let host = currentHost, !host.contains("*"), !host.contains("?"), !host.contains(" ") {
+        pending.flush(into: &entries)
+
+        return entries
+    }
+
+    // MARK: - Pending Entry State
+
+    /// Accumulates directives for the current Host stanza during parsing.
+    private struct PendingEntry {
+        var host: String?
+        var hostname: String?
+        var port: Int?
+        var user: String?
+        var identityFile: String?
+        var identityAgent: String?
+        var proxyJump: String?
+
+        /// Flush the pending entry into the entries array and reset state.
+        /// Skips wildcard patterns (`*`, `?`) and multi-word hosts.
+        mutating func flush(into entries: inout [SSHConfigEntry]) {
+            defer { self = PendingEntry() }
+
+            guard let host, !host.contains("*"), !host.contains("?"), !host.contains(" ") else {
+                return
+            }
+
             entries.append(
                 SSHConfigEntry(
                     host: host,
-                    hostname: currentHostname,
-                    port: currentPort,
-                    user: currentUser,
-                    identityFile: currentIdentityFile.map {
-                        SSHPathUtilities.expandSSHTokens(
-                            $0, hostname: currentHostname, remoteUser: currentUser)
+                    hostname: hostname,
+                    port: port,
+                    user: user,
+                    identityFile: identityFile.map {
+                        SSHPathUtilities.expandSSHTokens($0, hostname: hostname, remoteUser: user)
                     },
-                    identityAgent: currentIdentityAgent.map {
-                        SSHPathUtilities.expandSSHTokens(
-                            $0, hostname: currentHostname, remoteUser: currentUser)
+                    identityAgent: identityAgent.map {
+                        SSHPathUtilities.expandSSHTokens($0, hostname: hostname, remoteUser: user)
                     },
-                    proxyJump: currentProxyJump
+                    proxyJump: proxyJump
                 ))
         }
-
-        return entries
     }
 
     /// Expand a glob pattern to matching file paths using POSIX glob(3).

--- a/TablePro/Core/SSH/SSHConfigParser.swift
+++ b/TablePro/Core/SSH/SSHConfigParser.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 /// Represents a parsed entry from ~/.ssh/config
 struct SSHConfigEntry: Identifiable, Hashable {
@@ -29,6 +30,9 @@ struct SSHConfigEntry: Identifiable, Hashable {
 
 /// Parser for SSH config file (~/.ssh/config)
 final class SSHConfigParser {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SSHConfigParser")
+    private static let maxIncludeDepth = 10
+
     /// Default SSH config file path
     static let defaultConfigPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".ssh/config").path(percentEncoded: false)
@@ -37,17 +41,51 @@ final class SSHConfigParser {
     /// - Parameter path: Path to the SSH config file (defaults to ~/.ssh/config)
     /// - Returns: Array of SSHConfigEntry
     static func parse(path: String = defaultConfigPath) -> [SSHConfigEntry] {
-        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
-            return []
-        }
-
-        return parseContent(content)
+        var visitedPaths = Set<String>()
+        return parseFile(path: path, visitedPaths: &visitedPaths, depth: 0)
     }
 
     /// Parse SSH config content string
     /// - Parameter content: The content of the SSH config file
     /// - Returns: Array of SSHConfigEntry
     static func parseContent(_ content: String) -> [SSHConfigEntry] {
+        var visited = Set<String>()
+        return parseContent(content, visitedPaths: &visited, depth: 0)
+    }
+
+    /// Parse SSH config file with Include support.
+    private static func parseFile(
+        path: String,
+        visitedPaths: inout Set<String>,
+        depth: Int
+    ) -> [SSHConfigEntry] {
+        guard depth <= maxIncludeDepth else {
+            logger.warning("SSH config Include depth exceeded at: \(path)")
+            return []
+        }
+
+        let canonicalPath = (path as NSString).standardizingPath
+
+        guard !visitedPaths.contains(canonicalPath) else {
+            logger.warning("SSH config circular Include detected: \(path)")
+            return []
+        }
+
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+
+        visitedPaths.insert(canonicalPath)
+
+        return parseContent(content, visitedPaths: &visitedPaths, depth: depth)
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    private static func parseContent(
+        _ content: String,
+        visitedPaths: inout Set<String>,
+        depth: Int
+    ) -> [SSHConfigEntry] {
         var entries: [SSHConfigEntry] = []
         var currentHost: String?
         var currentHostname: String?
@@ -78,16 +116,22 @@ final class SSHConfigParser {
             case "host":
                 // Save previous entry if exists
                 if let host = currentHost {
-                    // Skip wildcard patterns like "*"
-                    if !host.contains("*") && !host.contains("?") {
+                    // Skip wildcard patterns and multi-word hosts
+                    if !host.contains("*") && !host.contains("?") && !host.contains(" ") {
                         entries.append(
                             SSHConfigEntry(
                                 host: host,
                                 hostname: currentHostname,
                                 port: currentPort,
                                 user: currentUser,
-                                identityFile: currentIdentityFile.map(SSHPathUtilities.expandTilde),
-                                identityAgent: currentIdentityAgent.map(SSHPathUtilities.expandTilde),
+                                identityFile: currentIdentityFile.map {
+                                    SSHPathUtilities.expandSSHTokens(
+                                        $0, hostname: currentHostname, remoteUser: currentUser)
+                                },
+                                identityAgent: currentIdentityAgent.map {
+                                    SSHPathUtilities.expandSSHTokens(
+                                        $0, hostname: currentHostname, remoteUser: currentUser)
+                                },
                                 proxyJump: currentProxyJump
                             ))
                     }
@@ -120,26 +164,108 @@ final class SSHConfigParser {
             case "proxyjump":
                 currentProxyJump = value
 
+            case "include":
+                // Flush current pending entry before processing includes
+                if let host = currentHost {
+                    if !host.contains("*") && !host.contains("?") && !host.contains(" ") {
+                        entries.append(
+                            SSHConfigEntry(
+                                host: host,
+                                hostname: currentHostname,
+                                port: currentPort,
+                                user: currentUser,
+                                identityFile: currentIdentityFile.map {
+                                    SSHPathUtilities.expandSSHTokens(
+                                        $0, hostname: currentHostname, remoteUser: currentUser)
+                                },
+                                identityAgent: currentIdentityAgent.map {
+                                    SSHPathUtilities.expandSSHTokens(
+                                        $0, hostname: currentHostname, remoteUser: currentUser)
+                                },
+                                proxyJump: currentProxyJump
+                            ))
+                    }
+                    currentHost = nil
+                    currentHostname = nil
+                    currentPort = nil
+                    currentUser = nil
+                    currentIdentityFile = nil
+                    currentIdentityAgent = nil
+                    currentProxyJump = nil
+                }
+
+                let includePaths = resolveIncludePaths(value)
+                for includePath in includePaths {
+                    let includedEntries = parseFile(
+                        path: includePath,
+                        visitedPaths: &visitedPaths,
+                        depth: depth + 1
+                    )
+                    entries.append(contentsOf: includedEntries)
+                }
+
             default:
                 break  // Ignore other directives
             }
         }
 
         // Don't forget the last entry
-        if let host = currentHost, !host.contains("*"), !host.contains("?") {
+        if let host = currentHost, !host.contains("*"), !host.contains("?"), !host.contains(" ") {
             entries.append(
                 SSHConfigEntry(
                     host: host,
                     hostname: currentHostname,
                     port: currentPort,
                     user: currentUser,
-                    identityFile: currentIdentityFile.map(SSHPathUtilities.expandTilde),
-                    identityAgent: currentIdentityAgent.map(SSHPathUtilities.expandTilde),
+                    identityFile: currentIdentityFile.map {
+                        SSHPathUtilities.expandSSHTokens(
+                            $0, hostname: currentHostname, remoteUser: currentUser)
+                    },
+                    identityAgent: currentIdentityAgent.map {
+                        SSHPathUtilities.expandSSHTokens(
+                            $0, hostname: currentHostname, remoteUser: currentUser)
+                    },
                     proxyJump: currentProxyJump
                 ))
         }
 
         return entries
+    }
+
+    /// Expand a glob pattern to matching file paths using POSIX glob(3).
+    private static func globPaths(_ pattern: String) -> [String] {
+        var gt = glob_t()
+        defer { globfree(&gt) }
+
+        guard glob(pattern, GLOB_TILDE | GLOB_BRACE, nil, &gt) == 0 else {
+            return []
+        }
+
+        var paths: [String] = []
+        for i in 0..<Int(gt.gl_matchc) {
+            if let cStr = gt.gl_pathv[i] {
+                paths.append(String(cString: cStr))
+            }
+        }
+        return paths.sorted()
+    }
+
+    /// Resolve an Include directive value to actual file paths.
+    /// Relative paths are resolved against ~/.ssh/ per OpenSSH convention.
+    private static func resolveIncludePaths(_ value: String) -> [String] {
+        let expanded = SSHPathUtilities.expandTilde(value)
+
+        // Relative paths resolve against ~/.ssh/ per OpenSSH convention
+        let resolved: String
+        if expanded.hasPrefix("/") {
+            resolved = expanded
+        } else {
+            let sshDir = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".ssh").path(percentEncoded: false)
+            resolved = (sshDir as NSString).appendingPathComponent(expanded)
+        }
+
+        return globPaths(resolved)
     }
 
     /// Find a specific entry by host name

--- a/TablePro/Core/SSH/SSHPathUtilities.swift
+++ b/TablePro/Core/SSH/SSHPathUtilities.swift
@@ -20,4 +20,34 @@ enum SSHPathUtilities {
         }
         return path
     }
+
+    /// Expand SSH config tokens and tilde in a path.
+    /// Supports: %d (user home directory), %h (hostname), %u (local username),
+    /// %r (remote username), %% (literal %). See ssh_config(5) TOKENS section.
+    static func expandSSHTokens(
+        _ path: String,
+        hostname: String? = nil,
+        remoteUser: String? = nil
+    ) -> String {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+            .path(percentEncoded: false)
+        let localUser = NSUserName()
+
+        // Protect literal %% from token expansion
+        let sentinel = "\u{FFFF}"
+        var result = path.replacingOccurrences(of: "%%", with: sentinel)
+
+        result = result.replacingOccurrences(of: "%d", with: homeDir)
+        if let hostname {
+            result = result.replacingOccurrences(of: "%h", with: hostname)
+        }
+        result = result.replacingOccurrences(of: "%u", with: localUser)
+        if let remoteUser {
+            result = result.replacingOccurrences(of: "%r", with: remoteUser)
+        }
+
+        result = result.replacingOccurrences(of: sentinel, with: "%")
+
+        return expandTilde(result)
+    }
 }

--- a/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
@@ -23,7 +23,7 @@ struct ConnectionURLFormatter {
             return formatDuckDB(connection.database)
         }
 
-        let ssh = connection.effectiveSSHConfig(profile: sshProfile)
+        let ssh = connection.resolvedSSHConfig
         if ssh.enabled {
             return formatSSH(connection, sshConfig: ssh, scheme: scheme, password: password)
         }

--- a/TablePro/Models/Connection/DatabaseConnection+SSH.swift
+++ b/TablePro/Models/Connection/DatabaseConnection+SSH.swift
@@ -4,9 +4,20 @@
 //
 
 extension DatabaseConnection {
+    /// The resolved SSH configuration, derived from `sshTunnelMode`.
+    var resolvedSSHConfig: SSHConfiguration {
+        switch sshTunnelMode {
+        case .disabled:
+            return SSHConfiguration()
+        case .inline(let config):
+            return config
+        case .profile(_, let snapshot):
+            return snapshot
+        }
+    }
+
     /// Resolves the effective SSH configuration for this connection.
-    /// When an SSH profile is referenced and provided, uses the profile's config.
-    /// Otherwise falls back to the inline `sshConfig`.
+    @available(*, deprecated, message: "Use resolvedSSHConfig")
     func effectiveSSHConfig(profile: SSHProfile?) -> SSHConfiguration {
         if sshProfileId != nil, let profile {
             return profile.toSSHConfiguration()

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -180,6 +180,7 @@ struct DatabaseConnection: Identifiable, Hashable {
     var tagId: UUID?
     var groupId: UUID?
     var sshProfileId: UUID?
+    var sshTunnelMode: SSHTunnelMode
     var safeModeLevel: SafeModeLevel
     var aiPolicy: AIConnectionPolicy?
     var additionalFields: [String: String] = [:]
@@ -256,6 +257,7 @@ struct DatabaseConnection: Identifiable, Hashable {
         tagId: UUID? = nil,
         groupId: UUID? = nil,
         sshProfileId: UUID? = nil,
+        sshTunnelMode: SSHTunnelMode = .disabled,
         safeModeLevel: SafeModeLevel = .silent,
         aiPolicy: AIConnectionPolicy? = nil,
         mongoAuthSource: String? = nil,
@@ -285,6 +287,21 @@ struct DatabaseConnection: Identifiable, Hashable {
         self.groupId = groupId
         self.sshProfileId = sshProfileId
         self.safeModeLevel = safeModeLevel
+
+        // Auto-derive sshTunnelMode from legacy fields if not explicitly set
+        if sshTunnelMode == .disabled {
+            if let profileId = sshProfileId {
+                var snapshot = sshConfig
+                snapshot.enabled = true
+                self.sshTunnelMode = .profile(id: profileId, snapshot: snapshot)
+            } else if sshConfig.enabled {
+                self.sshTunnelMode = .inline(sshConfig)
+            } else {
+                self.sshTunnelMode = .disabled
+            }
+        } else {
+            self.sshTunnelMode = sshTunnelMode
+        }
         self.aiPolicy = aiPolicy
         self.redisDatabase = redisDatabase
         self.startupCommands = startupCommands
@@ -319,7 +336,76 @@ extension DatabaseConnection {
 
 // MARK: - Codable Conformance
 
-extension DatabaseConnection: Codable {}
+extension DatabaseConnection: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, name, host, port, database, username, type
+        case sshConfig, sslConfig, color, tagId, groupId, sshProfileId
+        case sshTunnelMode, safeModeLevel, aiPolicy, additionalFields
+        case redisDatabase, startupCommands, sortOrder
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        host = try container.decodeIfPresent(String.self, forKey: .host) ?? "localhost"
+        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? 3_306
+        database = try container.decodeIfPresent(String.self, forKey: .database) ?? ""
+        username = try container.decodeIfPresent(String.self, forKey: .username) ?? "root"
+        type = try container.decodeIfPresent(DatabaseType.self, forKey: .type) ?? .mysql
+        sshConfig = try container.decodeIfPresent(SSHConfiguration.self, forKey: .sshConfig) ?? SSHConfiguration()
+        sslConfig = try container.decodeIfPresent(SSLConfiguration.self, forKey: .sslConfig) ?? SSLConfiguration()
+        color = try container.decodeIfPresent(ConnectionColor.self, forKey: .color) ?? .none
+        tagId = try container.decodeIfPresent(UUID.self, forKey: .tagId)
+        groupId = try container.decodeIfPresent(UUID.self, forKey: .groupId)
+        sshProfileId = try container.decodeIfPresent(UUID.self, forKey: .sshProfileId)
+        safeModeLevel = try container.decodeIfPresent(SafeModeLevel.self, forKey: .safeModeLevel) ?? .silent
+        aiPolicy = try container.decodeIfPresent(AIConnectionPolicy.self, forKey: .aiPolicy)
+        additionalFields = try container.decodeIfPresent([String: String].self, forKey: .additionalFields) ?? [:]
+        redisDatabase = try container.decodeIfPresent(Int.self, forKey: .redisDatabase)
+        startupCommands = try container.decodeIfPresent(String.self, forKey: .startupCommands)
+        sortOrder = try container.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
+
+        // Migrate from legacy fields if sshTunnelMode is not present
+        if let tunnelMode = try container.decodeIfPresent(SSHTunnelMode.self, forKey: .sshTunnelMode) {
+            sshTunnelMode = tunnelMode
+        } else {
+            if let profileId = sshProfileId {
+                var snapshot = sshConfig
+                snapshot.enabled = true
+                sshTunnelMode = .profile(id: profileId, snapshot: snapshot)
+            } else if sshConfig.enabled {
+                sshTunnelMode = .inline(sshConfig)
+            } else {
+                sshTunnelMode = .disabled
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(host, forKey: .host)
+        try container.encode(port, forKey: .port)
+        try container.encode(database, forKey: .database)
+        try container.encode(username, forKey: .username)
+        try container.encode(type, forKey: .type)
+        try container.encode(sshConfig, forKey: .sshConfig)
+        try container.encode(sslConfig, forKey: .sslConfig)
+        try container.encode(color, forKey: .color)
+        try container.encodeIfPresent(tagId, forKey: .tagId)
+        try container.encodeIfPresent(groupId, forKey: .groupId)
+        try container.encodeIfPresent(sshProfileId, forKey: .sshProfileId)
+        try container.encode(sshTunnelMode, forKey: .sshTunnelMode)
+        try container.encode(safeModeLevel, forKey: .safeModeLevel)
+        try container.encodeIfPresent(aiPolicy, forKey: .aiPolicy)
+        try container.encode(additionalFields, forKey: .additionalFields)
+        try container.encodeIfPresent(redisDatabase, forKey: .redisDatabase)
+        try container.encodeIfPresent(startupCommands, forKey: .startupCommands)
+        try container.encode(sortOrder, forKey: .sortOrder)
+    }
+}
 
 // MARK: - String Helpers
 

--- a/TablePro/Models/Connection/SSHTunnelFormState.swift
+++ b/TablePro/Models/Connection/SSHTunnelFormState.swift
@@ -1,0 +1,161 @@
+//
+//  SSHTunnelFormState.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Encapsulates all SSH tunnel UI state for the connection form.
+/// Replaces the 23 scattered @State variables in ConnectionFormView.
+struct SSHTunnelFormState {
+    // Mode
+    var enabled: Bool = false
+    var profileId: UUID?
+    var profiles: [SSHProfile] = []
+
+    // Sheet presentation
+    var showingCreateProfile: Bool = false
+    var editingProfile: SSHProfile?
+    var showingSaveAsProfile: Bool = false
+
+    // Inline config fields
+    var host: String = ""
+    var port: String = "22"
+    var username: String = ""
+    var password: String = ""
+    var authMethod: SSHAuthMethod = .password
+    var privateKeyPath: String = ""
+    var agentSocketOption: SSHAgentSocketOption = .systemDefault
+    var customAgentSocketPath: String = ""
+    var keyPassphrase: String = ""
+    var configEntries: [SSHConfigEntry] = []
+    var selectedConfigHost: String = ""
+    var jumpHosts: [SSHJumpHost] = []
+    var totpMode: TOTPMode = .none
+    var totpSecret: String = ""
+    var totpAlgorithm: TOTPAlgorithm = .sha1
+    var totpDigits: Int = 6
+    var totpPeriod: Int = 30
+
+    // MARK: - Computed Properties
+
+    var selectedProfile: SSHProfile? {
+        guard let id = profileId else { return nil }
+        return profiles.first { $0.id == id }
+    }
+
+    var resolvedAgentSocketPath: String {
+        agentSocketOption.resolvedPath(customPath: customAgentSocketPath)
+    }
+
+    // MARK: - Build Methods
+
+    func buildInlineConfig() -> SSHConfiguration {
+        SSHConfiguration(
+            enabled: enabled,
+            host: host,
+            port: Int(port) ?? 22,
+            username: username,
+            authMethod: authMethod,
+            privateKeyPath: privateKeyPath,
+            useSSHConfig: !selectedConfigHost.isEmpty,
+            agentSocketPath: resolvedAgentSocketPath,
+            jumpHosts: jumpHosts,
+            totpMode: totpMode,
+            totpAlgorithm: totpAlgorithm,
+            totpDigits: totpDigits,
+            totpPeriod: totpPeriod
+        )
+    }
+
+    func buildSSHConfig() -> SSHConfiguration {
+        if let profileId, let profile = profiles.first(where: { $0.id == profileId }) {
+            return profile.toSSHConfiguration()
+        }
+        return buildInlineConfig()
+    }
+
+    // MARK: - Load Methods
+
+    mutating func load(from connection: DatabaseConnection) {
+        profileId = connection.sshProfileId
+        enabled = connection.sshConfig.enabled
+        populateFields(from: connection.sshConfig)
+    }
+
+    @MainActor
+    mutating func loadSecrets(connectionId: UUID, storage: ConnectionStorage) {
+        if let savedPassword = storage.loadSSHPassword(for: connectionId) {
+            password = savedPassword
+        }
+        if let savedPassphrase = storage.loadKeyPassphrase(for: connectionId) {
+            keyPassphrase = savedPassphrase
+        }
+        if let savedTOTPSecret = storage.loadTOTPSecret(for: connectionId) {
+            totpSecret = savedTOTPSecret
+        }
+    }
+
+    // MARK: - Mutation Methods
+
+    mutating func disable() {
+        enabled = false
+        profileId = nil
+        host = ""
+        port = "22"
+        username = ""
+        password = ""
+        authMethod = .password
+        privateKeyPath = ""
+        agentSocketOption = .systemDefault
+        customAgentSocketPath = ""
+        keyPassphrase = ""
+        selectedConfigHost = ""
+        jumpHosts = []
+        totpMode = .none
+        totpSecret = ""
+        totpAlgorithm = .sha1
+        totpDigits = 6
+        totpPeriod = 30
+    }
+
+    mutating func switchToInline(fromProfile profile: SSHProfile) {
+        profileId = nil
+        host = profile.host
+        port = String(profile.port)
+        username = profile.username
+        authMethod = profile.authMethod
+        privateKeyPath = profile.privateKeyPath
+        applyAgentSocketPath(profile.agentSocketPath)
+        jumpHosts = profile.jumpHosts
+        totpMode = profile.totpMode
+        totpAlgorithm = profile.totpAlgorithm
+        totpDigits = profile.totpDigits
+        totpPeriod = profile.totpPeriod
+    }
+
+    mutating func populateFields(from config: SSHConfiguration) {
+        host = config.host
+        port = String(config.port)
+        username = config.username
+        authMethod = config.authMethod
+        privateKeyPath = config.privateKeyPath
+        applyAgentSocketPath(config.agentSocketPath)
+        jumpHosts = config.jumpHosts
+        totpMode = config.totpMode
+        totpAlgorithm = config.totpAlgorithm
+        totpDigits = config.totpDigits
+        totpPeriod = config.totpPeriod
+    }
+
+    mutating func applyAgentSocketPath(_ socketPath: String) {
+        let option = SSHAgentSocketOption(socketPath: socketPath)
+        agentSocketOption = option
+
+        if option == .custom {
+            customAgentSocketPath = socketPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            customAgentSocketPath = ""
+        }
+    }
+}

--- a/TablePro/Models/Connection/SSHTunnelFormState.swift
+++ b/TablePro/Models/Connection/SSHTunnelFormState.swift
@@ -78,22 +78,43 @@ struct SSHTunnelFormState {
     // MARK: - Load Methods
 
     mutating func load(from connection: DatabaseConnection) {
-        profileId = connection.sshProfileId
-        enabled = connection.sshConfig.enabled
-        populateFields(from: connection.sshConfig)
+        switch connection.sshTunnelMode {
+        case .disabled:
+            enabled = false
+            profileId = nil
+        case .inline(let config):
+            enabled = true
+            profileId = nil
+            populateFields(from: config)
+        case .profile(let id, let snapshot):
+            enabled = true
+            profileId = id
+            populateFields(from: snapshot)
+        }
     }
 
     @MainActor
     mutating func loadSecrets(connectionId: UUID, storage: ConnectionStorage) {
-        if let savedPassword = storage.loadSSHPassword(for: connectionId) {
-            password = savedPassword
+        if case .profile(let profileId, _) = buildTunnelMode() {
+            // Profile-mode: load secrets from profile keychain namespace
+            password = SSHProfileStorage.shared.loadSSHPassword(for: profileId) ?? ""
+            keyPassphrase = SSHProfileStorage.shared.loadKeyPassphrase(for: profileId) ?? ""
+            totpSecret = SSHProfileStorage.shared.loadTOTPSecret(for: profileId) ?? ""
+        } else {
+            // Inline/disabled: load from connection keychain namespace
+            password = storage.loadSSHPassword(for: connectionId) ?? ""
+            keyPassphrase = storage.loadKeyPassphrase(for: connectionId) ?? ""
+            totpSecret = storage.loadTOTPSecret(for: connectionId) ?? ""
         }
-        if let savedPassphrase = storage.loadKeyPassphrase(for: connectionId) {
-            keyPassphrase = savedPassphrase
+    }
+
+    /// Build the SSHTunnelMode for saving to the connection.
+    func buildTunnelMode() -> SSHTunnelMode {
+        guard enabled else { return .disabled }
+        if let profileId, let profile = profiles.first(where: { $0.id == profileId }) {
+            return .profile(id: profileId, snapshot: profile.toSSHConfiguration())
         }
-        if let savedTOTPSecret = storage.loadTOTPSecret(for: connectionId) {
-            totpSecret = savedTOTPSecret
-        }
+        return .inline(buildInlineConfig())
     }
 
     // MARK: - Mutation Methods
@@ -146,6 +167,13 @@ struct SSHTunnelFormState {
         totpAlgorithm = config.totpAlgorithm
         totpDigits = config.totpDigits
         totpPeriod = config.totpPeriod
+
+        // Restore config host picker state if a config entry was used
+        if config.useSSHConfig {
+            selectedConfigHost = configEntries.first { $0.hostname == config.host || $0.host == config.host }?.host ?? ""
+        } else {
+            selectedConfigHost = ""
+        }
     }
 
     mutating func applyAgentSocketPath(_ socketPath: String) {

--- a/TablePro/Models/Connection/SSHTunnelMode.swift
+++ b/TablePro/Models/Connection/SSHTunnelMode.swift
@@ -1,0 +1,60 @@
+//
+//  SSHTunnelMode.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Single source of truth for how a connection handles SSH tunneling.
+enum SSHTunnelMode: Hashable, Sendable {
+    case disabled
+    case inline(SSHConfiguration)
+    case profile(id: UUID, snapshot: SSHConfiguration)
+}
+
+// MARK: - Codable
+
+extension SSHTunnelMode: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case profileId
+        case config
+    }
+
+    private enum Mode: String, Codable {
+        case disabled
+        case inline
+        case profile
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let mode = try container.decode(Mode.self, forKey: .mode)
+        switch mode {
+        case .disabled:
+            self = .disabled
+        case .inline:
+            let config = try container.decode(SSHConfiguration.self, forKey: .config)
+            self = .inline(config)
+        case .profile:
+            let profileId = try container.decode(UUID.self, forKey: .profileId)
+            let config = try container.decode(SSHConfiguration.self, forKey: .config)
+            self = .profile(id: profileId, snapshot: config)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .disabled:
+            try container.encode(Mode.disabled, forKey: .mode)
+        case .inline(let config):
+            try container.encode(Mode.inline, forKey: .mode)
+            try container.encode(config, forKey: .config)
+        case .profile(let profileId, let snapshot):
+            try container.encode(Mode.profile, forKey: .mode)
+            try container.encode(profileId, forKey: .profileId)
+            try container.encode(snapshot, forKey: .config)
+        }
+    }
+}

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -77,11 +77,11 @@ extension ConnectionFormView {
         .onChange(of: password) { _, _ in testSucceeded = false }
         .onChange(of: database) { _, _ in testSucceeded = false }
         .onChange(of: type) { _, _ in testSucceeded = false }
-        .onChange(of: sshEnabled) { _, _ in testSucceeded = false }
-        .onChange(of: sshHost) { _, _ in testSucceeded = false }
-        .onChange(of: sshPort) { _, _ in testSucceeded = false }
-        .onChange(of: sshUsername) { _, _ in testSucceeded = false }
-        .onChange(of: sshAuthMethod) { _, _ in testSucceeded = false }
+        .onChange(of: sshState.enabled) { _, _ in testSucceeded = false }
+        .onChange(of: sshState.host) { _, _ in testSucceeded = false }
+        .onChange(of: sshState.port) { _, _ in testSucceeded = false }
+        .onChange(of: sshState.username) { _, _ in testSucceeded = false }
+        .onChange(of: sshState.authMethod) { _, _ in testSucceeded = false }
         .onChange(of: sslMode) { _, _ in testSucceeded = false }
     }
 

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -102,7 +102,9 @@ extension ConnectionFormView {
 
             // Load SSH configuration
             sshProfileId = existing.sshProfileId
-            sshEnabled = existing.sshConfig.enabled
+            let profile = existing.sshProfileId.flatMap { id in sshProfiles.first { $0.id == id } }
+            let effectiveSSH = existing.effectiveSSHConfig(profile: profile)
+            sshEnabled = effectiveSSH.enabled
 
             sshHost = existing.sshConfig.host
             sshPort = String(existing.sshConfig.port)

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -196,6 +196,7 @@ extension ConnectionFormView {
             finalAdditionalFields.removeValue(forKey: field.id)
         }
 
+        let sshTunnelMode = sshState.buildTunnelMode()
         let connectionToSave = DatabaseConnection(
             id: finalId,
             name: name,
@@ -210,6 +211,7 @@ extension ConnectionFormView {
             tagId: selectedTagId,
             groupId: selectedGroupId,
             sshProfileId: sshState.enabled ? sshState.profileId : nil,
+            sshTunnelMode: sshTunnelMode,
             safeModeLevel: safeModeLevel,
             aiPolicy: aiPolicy,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
@@ -361,6 +363,7 @@ extension ConnectionFormView {
             finalAdditionalFields.removeValue(forKey: "preConnectScript")
         }
 
+        let testTunnelMode = sshState.buildTunnelMode()
         let testConn = DatabaseConnection(
             name: name,
             host: finalHost,
@@ -374,6 +377,7 @@ extension ConnectionFormView {
             tagId: selectedTagId,
             groupId: selectedGroupId,
             sshProfileId: sshState.enabled ? sshState.profileId : nil,
+            sshTunnelMode: testTunnelMode,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
             startupCommands: startupCommands.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil : startupCommands,

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -181,7 +181,8 @@ extension ConnectionFormView {
 
     func saveConnection() {
         let sshConfig: SSHConfiguration
-        if let profileId = sshProfileId,
+        if sshEnabled,
+           let profileId = sshProfileId,
            let profile = sshProfiles.first(where: { $0.id == profileId })
         {
             sshConfig = profile.toSSHConfiguration()
@@ -252,7 +253,7 @@ extension ConnectionFormView {
             color: connectionColor,
             tagId: selectedTagId,
             groupId: selectedGroupId,
-            sshProfileId: sshProfileId,
+            sshProfileId: sshEnabled ? sshProfileId : nil,
             safeModeLevel: safeModeLevel,
             aiPolicy: aiPolicy,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
@@ -382,7 +383,8 @@ extension ConnectionFormView {
         let window = NSApp.keyWindow
 
         let sshConfig: SSHConfiguration
-        if let profileId = sshProfileId,
+        if sshEnabled,
+           let profileId = sshProfileId,
            let profile = sshProfiles.first(where: { $0.id == profileId })
         {
             sshConfig = profile.toSSHConfiguration()
@@ -438,7 +440,7 @@ extension ConnectionFormView {
             color: connectionColor,
             tagId: selectedTagId,
             groupId: selectedGroupId,
-            sshProfileId: sshProfileId,
+            sshProfileId: sshEnabled ? sshProfileId : nil,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
             startupCommands: startupCommands.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil : startupCommands,

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -52,13 +52,14 @@ extension ConnectionFormView {
                 basicValid = basicValid && hasAccessKey && hasSecret
             }
         }
-        if sshEnabled && sshProfileId == nil {
-            let sshPortValid = sshPort.isEmpty || (Int(sshPort).map { (1...65_535).contains($0) } ?? false)
-            let sshValid = !sshHost.isEmpty && !sshUsername.isEmpty && sshPortValid
+        if sshState.enabled && sshState.profileId == nil {
+            let sshPortValid = sshState.port.isEmpty
+                || (Int(sshState.port).map { (1...65_535).contains($0) } ?? false)
+            let sshValid = !sshState.host.isEmpty && !sshState.username.isEmpty && sshPortValid
             let authValid =
-                sshAuthMethod == .password || sshAuthMethod == .sshAgent
-                || sshAuthMethod == .keyboardInteractive || !sshPrivateKeyPath.isEmpty
-            let jumpValid = jumpHosts.allSatisfy(\.isValid)
+                sshState.authMethod == .password || sshState.authMethod == .sshAgent
+                || sshState.authMethod == .keyboardInteractive || !sshState.privateKeyPath.isEmpty
+            let jumpValid = sshState.jumpHosts.allSatisfy(\.isValid)
             return basicValid && sshValid && authValid && jumpValid
         }
         return basicValid
@@ -88,7 +89,7 @@ extension ConnectionFormView {
     }
 
     func loadConnectionData() {
-        sshProfiles = SSHProfileStorage.shared.loadProfiles()
+        sshState.profiles = SSHProfileStorage.shared.loadProfiles()
         if let id = connectionId,
             let existing = storage.loadConnections().first(where: { $0.id == id })
         {
@@ -101,22 +102,8 @@ extension ConnectionFormView {
             type = existing.type
 
             // Load SSH configuration
-            sshProfileId = existing.sshProfileId
-            let profile = existing.sshProfileId.flatMap { id in sshProfiles.first { $0.id == id } }
-            let effectiveSSH = existing.effectiveSSHConfig(profile: profile)
-            sshEnabled = effectiveSSH.enabled
-
-            sshHost = existing.sshConfig.host
-            sshPort = String(existing.sshConfig.port)
-            sshUsername = existing.sshConfig.username
-            sshAuthMethod = existing.sshConfig.authMethod
-            sshPrivateKeyPath = existing.sshConfig.privateKeyPath
-            applySSHAgentSocketPath(existing.sshConfig.agentSocketPath)
-            jumpHosts = existing.sshConfig.jumpHosts
-            totpMode = existing.sshConfig.totpMode
-            totpAlgorithm = existing.sshConfig.totpAlgorithm
-            totpDigits = existing.sshConfig.totpDigits
-            totpPeriod = existing.sshConfig.totpPeriod
+            sshState.load(from: existing)
+            sshState.loadSecrets(connectionId: existing.id, storage: storage)
 
             // Load SSL configuration
             sslMode = existing.sslConfig.mode
@@ -160,18 +147,9 @@ extension ConnectionFormView {
             startupCommands = existing.startupCommands ?? ""
             preConnectScript = existing.preConnectScript ?? ""
 
-            // Load passwords from Keychain
-            if let savedSSHPassword = storage.loadSSHPassword(for: existing.id) {
-                sshPassword = savedSSHPassword
-            }
-            if let savedPassphrase = storage.loadKeyPassphrase(for: existing.id) {
-                keyPassphrase = savedPassphrase
-            }
+            // Load connection password from Keychain
             if let savedPassword = storage.loadPassword(for: existing.id) {
                 password = savedPassword
-            }
-            if let savedTOTPSecret = storage.loadTOTPSecret(for: existing.id) {
-                totpSecret = savedTOTPSecret
             }
         }
         Task { @MainActor in
@@ -180,29 +158,7 @@ extension ConnectionFormView {
     }
 
     func saveConnection() {
-        let sshConfig: SSHConfiguration
-        if sshEnabled,
-           let profileId = sshProfileId,
-           let profile = sshProfiles.first(where: { $0.id == profileId })
-        {
-            sshConfig = profile.toSSHConfiguration()
-        } else {
-            sshConfig = SSHConfiguration(
-                enabled: sshEnabled,
-                host: sshHost,
-                port: Int(sshPort) ?? 22,
-                username: sshUsername,
-                authMethod: sshAuthMethod,
-                privateKeyPath: sshPrivateKeyPath,
-                useSSHConfig: !selectedSSHConfigHost.isEmpty,
-                agentSocketPath: resolvedSSHAgentSocketPath,
-                jumpHosts: jumpHosts,
-                totpMode: totpMode,
-                totpAlgorithm: totpAlgorithm,
-                totpDigits: totpDigits,
-                totpPeriod: totpPeriod
-            )
-        }
+        let sshConfig = sshState.buildSSHConfig()
 
         let sslConfig = SSLConfiguration(
             mode: sslMode,
@@ -253,7 +209,7 @@ extension ConnectionFormView {
             color: connectionColor,
             tagId: selectedTagId,
             groupId: selectedGroupId,
-            sshProfileId: sshEnabled ? sshProfileId : nil,
+            sshProfileId: sshState.enabled ? sshState.profileId : nil,
             safeModeLevel: safeModeLevel,
             aiPolicy: aiPolicy,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
@@ -269,22 +225,21 @@ extension ConnectionFormView {
             storage.savePassword(password, for: connectionToSave.id)
         }
         // Only save SSH secrets per-connection when using inline config (not a profile)
-        if sshEnabled && sshProfileId == nil {
-            if (sshAuthMethod == .password || sshAuthMethod == .keyboardInteractive)
-                && !sshPassword.isEmpty
+        if sshState.enabled && sshState.profileId == nil {
+            if (sshState.authMethod == .password || sshState.authMethod == .keyboardInteractive)
+                && !sshState.password.isEmpty
             {
-                storage.saveSSHPassword(sshPassword, for: connectionToSave.id)
+                storage.saveSSHPassword(sshState.password, for: connectionToSave.id)
             }
-            if sshAuthMethod == .privateKey && !keyPassphrase.isEmpty {
-                storage.saveKeyPassphrase(keyPassphrase, for: connectionToSave.id)
+            if sshState.authMethod == .privateKey && !sshState.keyPassphrase.isEmpty {
+                storage.saveKeyPassphrase(sshState.keyPassphrase, for: connectionToSave.id)
             }
-            if totpMode == .autoGenerate && !totpSecret.isEmpty {
-                storage.saveTOTPSecret(totpSecret, for: connectionToSave.id)
+            if sshState.totpMode == .autoGenerate && !sshState.totpSecret.isEmpty {
+                storage.saveTOTPSecret(sshState.totpSecret, for: connectionToSave.id)
             } else {
                 storage.deleteTOTPSecret(for: connectionToSave.id)
             }
         } else {
-            // Clean up stale per-connection SSH secrets when using a profile or SSH disabled
             storage.deleteSSHPassword(for: connectionToSave.id)
             storage.deleteKeyPassphrase(for: connectionToSave.id)
             storage.deleteTOTPSecret(for: connectionToSave.id)
@@ -382,29 +337,7 @@ extension ConnectionFormView {
         testSucceeded = false
         let window = NSApp.keyWindow
 
-        let sshConfig: SSHConfiguration
-        if sshEnabled,
-           let profileId = sshProfileId,
-           let profile = sshProfiles.first(where: { $0.id == profileId })
-        {
-            sshConfig = profile.toSSHConfiguration()
-        } else {
-            sshConfig = SSHConfiguration(
-                enabled: sshEnabled,
-                host: sshHost,
-                port: Int(sshPort) ?? 22,
-                username: sshUsername,
-                authMethod: sshAuthMethod,
-                privateKeyPath: sshPrivateKeyPath,
-                useSSHConfig: !selectedSSHConfigHost.isEmpty,
-                agentSocketPath: resolvedSSHAgentSocketPath,
-                jumpHosts: jumpHosts,
-                totpMode: totpMode,
-                totpAlgorithm: totpAlgorithm,
-                totpDigits: totpDigits,
-                totpPeriod: totpPeriod
-            )
-        }
+        let sshConfig = sshState.buildSSHConfig()
 
         let sslConfig = SSLConfiguration(
             mode: sslMode,
@@ -440,7 +373,7 @@ extension ConnectionFormView {
             color: connectionColor,
             tagId: selectedTagId,
             groupId: selectedGroupId,
-            sshProfileId: sshEnabled ? sshProfileId : nil,
+            sshProfileId: sshState.enabled ? sshState.profileId : nil,
             redisDatabase: additionalFieldValues["redisDatabase"].map { Int($0) ?? 0 },
             startupCommands: startupCommands.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil : startupCommands,
@@ -454,17 +387,17 @@ extension ConnectionFormView {
                     ConnectionStorage.shared.savePassword(password, for: testConn.id)
                 }
                 // Only write inline SSH secrets when not using a profile
-                if sshEnabled && sshProfileId == nil {
-                    if (sshAuthMethod == .password || sshAuthMethod == .keyboardInteractive)
-                        && !sshPassword.isEmpty
+                if sshState.enabled && sshState.profileId == nil {
+                    if (sshState.authMethod == .password || sshState.authMethod == .keyboardInteractive)
+                        && !sshState.password.isEmpty
                     {
-                        ConnectionStorage.shared.saveSSHPassword(sshPassword, for: testConn.id)
+                        ConnectionStorage.shared.saveSSHPassword(sshState.password, for: testConn.id)
                     }
-                    if sshAuthMethod == .privateKey && !keyPassphrase.isEmpty {
-                        ConnectionStorage.shared.saveKeyPassphrase(keyPassphrase, for: testConn.id)
+                    if sshState.authMethod == .privateKey && !sshState.keyPassphrase.isEmpty {
+                        ConnectionStorage.shared.saveKeyPassphrase(sshState.keyPassphrase, for: testConn.id)
                     }
-                    if totpMode == .autoGenerate && !totpSecret.isEmpty {
-                        ConnectionStorage.shared.saveTOTPSecret(totpSecret, for: testConn.id)
+                    if sshState.totpMode == .autoGenerate && !sshState.totpSecret.isEmpty {
+                        ConnectionStorage.shared.saveTOTPSecret(sshState.totpSecret, for: testConn.id)
                     }
                 }
 
@@ -478,7 +411,7 @@ extension ConnectionFormView {
                     }
                 }
 
-                let sshPasswordForTest = sshProfileId == nil ? sshPassword : nil
+                let sshPasswordForTest = sshState.profileId == nil ? sshState.password : nil
                 let isApiOnly = PluginManager.shared.connectionMode(for: type) == .apiOnly
                 let testPwOverride: String? = promptForPassword
                     ? (password.isEmpty
@@ -582,16 +515,16 @@ extension ConnectionFormView {
             password = parsed.password
             sslMode = parsed.sslMode ?? .disabled
             if let sshHostValue = parsed.sshHost {
-                sshEnabled = true
-                sshHost = sshHostValue
-                sshPort = parsed.sshPort.map(String.init) ?? "22"
-                sshUsername = parsed.sshUsername ?? ""
+                sshState.enabled = true
+                sshState.host = sshHostValue
+                sshState.port = parsed.sshPort.map(String.init) ?? "22"
+                sshState.username = parsed.sshUsername ?? ""
                 if parsed.usePrivateKey == true {
-                    sshAuthMethod = .privateKey
+                    sshState.authMethod = .privateKey
                 }
                 if parsed.useSSHAgent == true {
-                    sshAuthMethod = .sshAgent
-                    applySSHAgentSocketPath(parsed.agentSocket ?? "")
+                    sshState.authMethod = .sshAgent
+                    sshState.applyAgentSocketPath(parsed.agentSocket ?? "")
                 }
             }
             // Clear stale MongoDB fields before applying new import
@@ -650,7 +583,7 @@ extension ConnectionFormView {
     func loadSSHConfig() {
         Task {
             let entries = await Task.detached { SSHConfigParser.parse() }.value
-            sshConfigEntries = entries
+            sshState.configEntries = entries
         }
     }
 }
@@ -659,14 +592,7 @@ extension ConnectionFormView {
 
 extension ConnectionFormView {
     func applySSHAgentSocketPath(_ socketPath: String) {
-        let option = SSHAgentSocketOption(socketPath: socketPath)
-        sshAgentSocketOption = option
-
-        if option == .custom {
-            customSSHAgentSocketPath = socketPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        } else {
-            customSSHAgentSocketPath = ""
-        }
+        sshState.applyAgentSocketPath(socketPath)
     }
 }
 

--- a/TablePro/Views/Connection/ConnectionFormView.swift
+++ b/TablePro/Views/Connection/ConnectionFormView.swift
@@ -69,29 +69,7 @@ struct ConnectionFormView: View {
     @State var hasLoadedData = false
 
     // SSH Configuration
-    @State var sshProfileId: UUID?
-    @State var sshProfiles: [SSHProfile] = []
-    @State var showingCreateProfile = false
-    @State var editingProfile: SSHProfile?
-    @State var showingSaveAsProfile = false
-    @State var sshEnabled: Bool = false
-    @State var sshHost: String = ""
-    @State var sshPort: String = "22"
-    @State var sshUsername: String = ""
-    @State var sshPassword: String = ""
-    @State var sshAuthMethod: SSHAuthMethod = .password
-    @State var sshPrivateKeyPath: String = ""
-    @State var sshAgentSocketOption: SSHAgentSocketOption = .systemDefault
-    @State var customSSHAgentSocketPath: String = ""
-    @State var keyPassphrase: String = ""
-    @State var sshConfigEntries: [SSHConfigEntry] = []
-    @State var selectedSSHConfigHost: String = ""
-    @State var jumpHosts: [SSHJumpHost] = []
-    @State var totpMode: TOTPMode = .none
-    @State var totpSecret: String = ""
-    @State var totpAlgorithm: TOTPAlgorithm = .sha1
-    @State var totpDigits: Int = 6
-    @State var totpPeriod: Int = 30
+    @State var sshState = SSHTunnelFormState()
 
     // SSL Configuration
     @State var sslMode: SSLMode = .disabled
@@ -218,7 +196,7 @@ struct ConnectionFormView: View {
     }
 
     var resolvedSSHAgentSocketPath: String {
-        sshAgentSocketOption.resolvedPath(customPath: customSSHAgentSocketPath)
+        sshState.resolvedAgentSocketPath
     }
 
     // MARK: - Tab Form Content
@@ -230,29 +208,7 @@ struct ConnectionFormView: View {
             generalForm
         case .ssh:
             ConnectionSSHTunnelView(
-                sshEnabled: $sshEnabled,
-                sshProfileId: $sshProfileId,
-                sshProfiles: $sshProfiles,
-                showingCreateProfile: $showingCreateProfile,
-                editingProfile: $editingProfile,
-                showingSaveAsProfile: $showingSaveAsProfile,
-                sshHost: $sshHost,
-                sshPort: $sshPort,
-                sshUsername: $sshUsername,
-                sshPassword: $sshPassword,
-                sshAuthMethod: $sshAuthMethod,
-                sshPrivateKeyPath: $sshPrivateKeyPath,
-                sshAgentSocketOption: $sshAgentSocketOption,
-                customSSHAgentSocketPath: $customSSHAgentSocketPath,
-                keyPassphrase: $keyPassphrase,
-                sshConfigEntries: $sshConfigEntries,
-                selectedSSHConfigHost: $selectedSSHConfigHost,
-                jumpHosts: $jumpHosts,
-                totpMode: $totpMode,
-                totpSecret: $totpSecret,
-                totpAlgorithm: $totpAlgorithm,
-                totpDigits: $totpDigits,
-                totpPeriod: $totpPeriod,
+                sshState: $sshState,
                 databaseType: type
             )
         case .ssl:

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -38,6 +38,11 @@ struct ConnectionSSHTunnelView: View {
         Form {
             Section {
                 Toggle(String(localized: "Enable SSH Tunnel"), isOn: $sshEnabled)
+                    .onChange(of: sshEnabled) {
+                        if !sshEnabled {
+                            sshProfileId = nil
+                        }
+                    }
             }
 
             if sshEnabled {

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -8,49 +8,27 @@
 import SwiftUI
 
 struct ConnectionSSHTunnelView: View {
-    @Binding var sshEnabled: Bool
-    @Binding var sshProfileId: UUID?
-    @Binding var sshProfiles: [SSHProfile]
-    @Binding var showingCreateProfile: Bool
-    @Binding var editingProfile: SSHProfile?
-    @Binding var showingSaveAsProfile: Bool
-    @Binding var sshHost: String
-    @Binding var sshPort: String
-    @Binding var sshUsername: String
-    @Binding var sshPassword: String
-    @Binding var sshAuthMethod: SSHAuthMethod
-    @Binding var sshPrivateKeyPath: String
-    @Binding var sshAgentSocketOption: SSHAgentSocketOption
-    @Binding var customSSHAgentSocketPath: String
-    @Binding var keyPassphrase: String
-    @Binding var sshConfigEntries: [SSHConfigEntry]
-    @Binding var selectedSSHConfigHost: String
-    @Binding var jumpHosts: [SSHJumpHost]
-    @Binding var totpMode: TOTPMode
-    @Binding var totpSecret: String
-    @Binding var totpAlgorithm: TOTPAlgorithm
-    @Binding var totpDigits: Int
-    @Binding var totpPeriod: Int
+    @Binding var sshState: SSHTunnelFormState
 
     let databaseType: DatabaseType
 
     var body: some View {
         Form {
             Section {
-                Toggle(String(localized: "Enable SSH Tunnel"), isOn: $sshEnabled)
-                    .onChange(of: sshEnabled) {
-                        if !sshEnabled {
-                            sshProfileId = nil
+                Toggle(String(localized: "Enable SSH Tunnel"), isOn: $sshState.enabled)
+                    .onChange(of: sshState.enabled) {
+                        if !sshState.enabled {
+                            sshState.disable()
                         }
                     }
             }
 
-            if sshEnabled {
+            if sshState.enabled {
                 sshProfileSection
 
-                if let profile = selectedSSHProfile {
+                if let profile = sshState.selectedProfile {
                     sshProfileSummarySection(profile)
-                } else if sshProfileId != nil {
+                } else if sshState.profileId != nil {
                     Section {
                         HStack {
                             Image(systemName: "exclamationmark.triangle.fill")
@@ -58,7 +36,7 @@ struct ConnectionSSHTunnelView: View {
                             Text("Selected SSH profile no longer exists.")
                         }
                         Button("Switch to Inline Configuration") {
-                            sshProfileId = nil
+                            sshState.profileId = nil
                         }
                     }
                 } else {
@@ -74,89 +52,84 @@ struct ConnectionSSHTunnelView: View {
 
     private var sshProfileSection: some View {
         Section(String(localized: "SSH Profile")) {
-            Picker(String(localized: "Profile"), selection: $sshProfileId) {
+            Picker(String(localized: "Profile"), selection: $sshState.profileId) {
                 Text("Inline Configuration").tag(UUID?.none)
-                ForEach(sshProfiles) { profile in
+                ForEach(sshState.profiles) { profile in
                     Text("\(profile.name) (\(profile.username)@\(profile.host))").tag(UUID?.some(profile.id))
                 }
             }
 
             HStack(spacing: 12) {
                 Button("Create New Profile...") {
-                    showingCreateProfile = true
+                    sshState.showingCreateProfile = true
                 }
 
-                if sshProfileId != nil {
+                if sshState.profileId != nil {
                     Button("Edit Profile...") {
-                        if let profileId = sshProfileId {
-                            editingProfile = SSHProfileStorage.shared.profile(for: profileId)
+                        if let profileId = sshState.profileId {
+                            sshState.editingProfile = SSHProfileStorage.shared.profile(for: profileId)
                         }
                     }
                 }
 
-                if sshProfileId == nil && sshEnabled && !sshHost.isEmpty {
+                if sshState.profileId == nil && sshState.enabled && !sshState.host.isEmpty {
                     Button("Save Current as Profile...") {
-                        showingSaveAsProfile = true
+                        sshState.showingSaveAsProfile = true
                     }
                 }
             }
             .controlSize(.small)
         }
-        .sheet(isPresented: $showingCreateProfile) {
+        .sheet(isPresented: $sshState.showingCreateProfile) {
             SSHProfileEditorView(existingProfile: nil, onSave: { _ in
                 reloadProfiles()
             })
         }
-        .sheet(item: $editingProfile) { profile in
+        .sheet(item: $sshState.editingProfile) { profile in
             SSHProfileEditorView(existingProfile: profile, onSave: { _ in
                 reloadProfiles()
             }, onDelete: {
                 reloadProfiles()
             })
         }
-        .sheet(isPresented: $showingSaveAsProfile) {
+        .sheet(isPresented: $sshState.showingSaveAsProfile) {
             SSHProfileEditorView(
                 existingProfile: buildProfileFromInlineConfig(),
-                initialPassword: sshPassword,
-                initialKeyPassphrase: keyPassphrase,
-                initialTOTPSecret: totpSecret,
+                initialPassword: sshState.password,
+                initialKeyPassphrase: sshState.keyPassphrase,
+                initialTOTPSecret: sshState.totpSecret,
                 onSave: { savedProfile in
-                    sshProfileId = savedProfile.id
+                    sshState.profileId = savedProfile.id
                     reloadProfiles()
                 }
             )
         }
     }
 
-    private var selectedSSHProfile: SSHProfile? {
-        guard let id = sshProfileId else { return nil }
-        return sshProfiles.first { $0.id == id }
-    }
-
     private func reloadProfiles() {
-        sshProfiles = SSHProfileStorage.shared.loadProfiles()
-        if let id = sshProfileId,
+        sshState.profiles = SSHProfileStorage.shared.loadProfiles()
+        if let id = sshState.profileId,
            !SSHProfileStorage.shared.lastLoadFailed,
-           !sshProfiles.contains(where: { $0.id == id }) {
-            sshProfileId = nil
+           !sshState.profiles.contains(where: { $0.id == id }) {
+            sshState.profileId = nil
         }
     }
 
     private func buildProfileFromInlineConfig() -> SSHProfile {
         SSHProfile(
             name: "",
-            host: sshHost,
-            port: Int(sshPort) ?? 22,
-            username: sshUsername,
-            authMethod: sshAuthMethod,
-            privateKeyPath: sshPrivateKeyPath,
-            useSSHConfig: !selectedSSHConfigHost.isEmpty,
-            agentSocketPath: sshAgentSocketOption.resolvedPath(customPath: customSSHAgentSocketPath),
-            jumpHosts: jumpHosts,
-            totpMode: totpMode,
-            totpAlgorithm: totpAlgorithm,
-            totpDigits: totpDigits,
-            totpPeriod: totpPeriod
+            host: sshState.host,
+            port: Int(sshState.port) ?? 22,
+            username: sshState.username,
+            authMethod: sshState.authMethod,
+            privateKeyPath: sshState.privateKeyPath,
+            useSSHConfig: !sshState.selectedConfigHost.isEmpty,
+            agentSocketPath: sshState.resolvedAgentSocketPath,
+            jumpHosts: sshState.jumpHosts,
+            totpMode: sshState.totpMode,
+            totpAlgorithm: sshState.totpAlgorithm,
+            totpDigits: sshState.totpDigits,
+            totpPeriod: sshState.totpPeriod
         )
     }
 
@@ -180,86 +153,90 @@ struct ConnectionSSHTunnelView: View {
     private var sshInlineFields: some View {
         Group {
             Section(String(localized: "Server")) {
-                if !sshConfigEntries.isEmpty {
-                    Picker(String(localized: "Config Host"), selection: $selectedSSHConfigHost) {
+                if !sshState.configEntries.isEmpty {
+                    Picker(String(localized: "Config Host"), selection: $sshState.selectedConfigHost) {
                         Text(String(localized: "Manual")).tag("")
-                        ForEach(sshConfigEntries) { entry in
+                        ForEach(sshState.configEntries) { entry in
                             Text(entry.displayName).tag(entry.host)
                         }
                     }
-                    .onChange(of: selectedSSHConfigHost) {
-                        applySSHConfigEntry(selectedSSHConfigHost)
+                    .onChange(of: sshState.selectedConfigHost) {
+                        applySSHConfigEntry(sshState.selectedConfigHost)
                     }
                 }
-                if selectedSSHConfigHost.isEmpty || sshConfigEntries.isEmpty {
-                    TextField(String(localized: "SSH Host"), text: $sshHost, prompt: Text("ssh.example.com"))
+                if sshState.selectedConfigHost.isEmpty || sshState.configEntries.isEmpty {
+                    TextField(String(localized: "SSH Host"), text: $sshState.host, prompt: Text("ssh.example.com"))
                 }
-                TextField(String(localized: "SSH Port"), text: $sshPort, prompt: Text("22"))
-                TextField(String(localized: "SSH User"), text: $sshUsername, prompt: Text("username"))
+                TextField(String(localized: "SSH Port"), text: $sshState.port, prompt: Text("22"))
+                TextField(String(localized: "SSH User"), text: $sshState.username, prompt: Text("username"))
             }
 
             Section(String(localized: "Authentication")) {
-                Picker(String(localized: "Method"), selection: $sshAuthMethod) {
+                Picker(String(localized: "Method"), selection: $sshState.authMethod) {
                     ForEach(SSHAuthMethod.allCases) { method in
                         Text(method.rawValue).tag(method)
                     }
                 }
-                if sshAuthMethod == .password {
-                    SecureField(String(localized: "Password"), text: $sshPassword)
-                } else if sshAuthMethod == .sshAgent {
-                    Picker("Agent Socket", selection: $sshAgentSocketOption) {
+                if sshState.authMethod == .password {
+                    SecureField(String(localized: "Password"), text: $sshState.password)
+                } else if sshState.authMethod == .sshAgent {
+                    Picker("Agent Socket", selection: $sshState.agentSocketOption) {
                         ForEach(SSHAgentSocketOption.allCases) { option in
                             Text(option.displayName).tag(option)
                         }
                     }
-                    if sshAgentSocketOption == .custom {
-                        TextField("Custom Path", text: $customSSHAgentSocketPath, prompt: Text("/path/to/agent.sock"))
+                    if sshState.agentSocketOption == .custom {
+                        TextField(
+                            "Custom Path",
+                            text: $sshState.customAgentSocketPath,
+                            prompt: Text("/path/to/agent.sock")
+                        )
                     }
                     Text("Keys are provided by the SSH agent (e.g. 1Password, ssh-agent).")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                } else if sshAuthMethod == .keyboardInteractive {
-                    SecureField(String(localized: "Password"), text: $sshPassword)
+                } else if sshState.authMethod == .keyboardInteractive {
+                    SecureField(String(localized: "Password"), text: $sshState.password)
                     Text(String(localized: "Password is sent via keyboard-interactive challenge-response."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
                     LabeledContent(String(localized: "Key File")) {
                         HStack {
-                            TextField("", text: $sshPrivateKeyPath, prompt: Text("~/.ssh/id_rsa"))
+                            TextField("", text: $sshState.privateKeyPath, prompt: Text("~/.ssh/id_rsa"))
                             Button(String(localized: "Browse")) { browseForPrivateKey() }
                                 .controlSize(.small)
                         }
                     }
-                    SecureField(String(localized: "Passphrase"), text: $keyPassphrase)
+                    SecureField(String(localized: "Passphrase"), text: $sshState.keyPassphrase)
                 }
             }
 
-            if sshAuthMethod == .keyboardInteractive || sshAuthMethod == .password {
+            if sshState.authMethod == .keyboardInteractive || sshState.authMethod == .password {
                 Section(String(localized: "Two-Factor Authentication")) {
-                    Picker(String(localized: "TOTP"), selection: $totpMode) {
+                    Picker(String(localized: "TOTP"), selection: $sshState.totpMode) {
                         ForEach(TOTPMode.allCases) { mode in
                             Text(mode.displayName).tag(mode)
                         }
                     }
 
-                    if totpMode == .autoGenerate {
-                        SecureField(String(localized: "TOTP Secret"), text: $totpSecret)
+                    if sshState.totpMode == .autoGenerate {
+                        SecureField(String(localized: "TOTP Secret"), text: $sshState.totpSecret)
                             .help(String(localized: "Base32-encoded secret from your authenticator setup"))
-                        Picker(String(localized: "Algorithm"), selection: $totpAlgorithm) {
+                        Picker(String(localized: "Algorithm"), selection: $sshState.totpAlgorithm) {
                             ForEach(TOTPAlgorithm.allCases) { algo in
                                 Text(algo.rawValue).tag(algo)
                             }
                         }
-                        Picker(String(localized: "Digits"), selection: $totpDigits) {
+                        Picker(String(localized: "Digits"), selection: $sshState.totpDigits) {
                             Text("6").tag(6)
                             Text("8").tag(8)
                         }
-                        Picker(String(localized: "Period"), selection: $totpPeriod) {
+                        Picker(String(localized: "Period"), selection: $sshState.totpPeriod) {
                             Text("30s").tag(30)
                             Text("60s").tag(60)
                         }
-                    } else if totpMode == .promptAtConnect {
+                    } else if sshState.totpMode == .promptAtConnect {
                         Text(String(localized: "You will be prompted for a verification code each time you connect."))
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -269,10 +246,14 @@ struct ConnectionSSHTunnelView: View {
 
             Section {
                 DisclosureGroup(String(localized: "Jump Hosts")) {
-                    ForEach(jumpHosts) { jumpHost in
-                        let jumpHostBinding = $jumpHosts.element(jumpHost)
+                    ForEach(sshState.jumpHosts) { jumpHost in
+                        let jumpHostBinding = $sshState.jumpHosts.element(jumpHost)
                         DisclosureGroup {
-                            TextField(String(localized: "Host"), text: jumpHostBinding.host, prompt: Text("bastion.example.com"))
+                            TextField(
+                                String(localized: "Host"),
+                                text: jumpHostBinding.host,
+                                prompt: Text("bastion.example.com")
+                            )
                             HStack {
                                 TextField(
                                     String(localized: "Port"),
@@ -283,7 +264,11 @@ struct ConnectionSSHTunnelView: View {
                                     prompt: Text("22")
                                 )
                                 .frame(width: 80)
-                                TextField(String(localized: "Username"), text: jumpHostBinding.username, prompt: Text("admin"))
+                                TextField(
+                                    String(localized: "Username"),
+                                    text: jumpHostBinding.username,
+                                    prompt: Text("admin")
+                                )
                             }
                             Picker(String(localized: "Auth"), selection: jumpHostBinding.authMethod) {
                                 ForEach(SSHJumpAuthMethod.allCases) { method in
@@ -293,7 +278,11 @@ struct ConnectionSSHTunnelView: View {
                             if jumpHost.authMethod == .privateKey {
                                 LabeledContent(String(localized: "Key File")) {
                                     HStack {
-                                        TextField("", text: jumpHostBinding.privateKeyPath, prompt: Text("~/.ssh/id_rsa"))
+                                        TextField(
+                                            "",
+                                            text: jumpHostBinding.privateKeyPath,
+                                            prompt: Text("~/.ssh/id_rsa")
+                                        )
                                         Button(String(localized: "Browse")) {
                                             browseForJumpHostKey(jumpHost: jumpHostBinding)
                                         }
@@ -312,7 +301,7 @@ struct ConnectionSSHTunnelView: View {
                                 Spacer()
                                 Button {
                                     let idToRemove = jumpHost.id
-                                    withAnimation { jumpHosts.removeAll { $0.id == idToRemove } }
+                                    withAnimation { sshState.jumpHosts.removeAll { $0.id == idToRemove } }
                                 } label: {
                                     Image(systemName: "minus.circle.fill")
                                         .frame(width: 24, height: 24)
@@ -324,18 +313,20 @@ struct ConnectionSSHTunnelView: View {
                         }
                     }
                     .onMove { indices, destination in
-                        jumpHosts.move(fromOffsets: indices, toOffset: destination)
+                        sshState.jumpHosts.move(fromOffsets: indices, toOffset: destination)
                     }
 
                     Button {
-                        jumpHosts.append(SSHJumpHost())
+                        sshState.jumpHosts.append(SSHJumpHost())
                     } label: {
                         Label(String(localized: "Add Jump Host"), systemImage: "plus")
                     }
 
-                    Text("Jump hosts are connected in order before reaching the SSH server above. Only key and agent auth are supported for jumps.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Text(
+                        "Jump hosts are connected in order before reaching the SSH server above. Only key and agent auth are supported for jumps."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
             }
         }
@@ -354,7 +345,7 @@ struct ConnectionSSHTunnelView: View {
 
         panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
-                sshPrivateKeyPath = url.path(percentEncoded: false)
+                sshState.privateKeyPath = url.path(percentEncoded: false)
             }
         }
     }
@@ -376,37 +367,26 @@ struct ConnectionSSHTunnelView: View {
     }
 
     private func applySSHConfigEntry(_ host: String) {
-        guard let entry = sshConfigEntries.first(where: { $0.host == host }) else {
+        guard let entry = sshState.configEntries.first(where: { $0.host == host }) else {
             return
         }
 
-        sshHost = entry.hostname ?? entry.host
+        sshState.host = entry.hostname ?? entry.host
         if let port = entry.port {
-            sshPort = String(port)
+            sshState.port = String(port)
         }
         if let user = entry.user {
-            sshUsername = user
+            sshState.username = user
         }
         if let agentPath = entry.identityAgent {
-            applySSHAgentSocketPath(agentPath)
-            sshAuthMethod = .sshAgent
+            sshState.applyAgentSocketPath(agentPath)
+            sshState.authMethod = .sshAgent
         } else if let keyPath = entry.identityFile {
-            sshPrivateKeyPath = keyPath
-            sshAuthMethod = .privateKey
+            sshState.privateKeyPath = keyPath
+            sshState.authMethod = .privateKey
         }
         if let proxyJump = entry.proxyJump {
-            jumpHosts = SSHConfigParser.parseProxyJump(proxyJump)
-        }
-    }
-
-    private func applySSHAgentSocketPath(_ socketPath: String) {
-        let option = SSHAgentSocketOption(socketPath: socketPath)
-        sshAgentSocketOption = option
-
-        if option == .custom {
-            customSSHAgentSocketPath = socketPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        } else {
-            customSSHAgentSocketPath = ""
+            sshState.jumpHosts = SSHConfigParser.parseProxyJump(proxyJump)
         }
     }
 }

--- a/TablePro/Views/Connection/WelcomeConnectionRow.swift
+++ b/TablePro/Views/Connection/WelcomeConnectionRow.swift
@@ -61,7 +61,7 @@ struct WelcomeConnectionRow: View {
     }
 
     private var connectionSubtitle: String {
-        let ssh = connection.effectiveSSHConfig(profile: sshProfile)
+        let ssh = connection.resolvedSSHConfig
         if ssh.enabled {
             return "SSH : \(ssh.username)@\(ssh.host)"
         }

--- a/TableProTests/Core/SSH/SSHConfigParserTests.swift
+++ b/TableProTests/Core/SSH/SSHConfigParserTests.swift
@@ -444,4 +444,233 @@ struct SSHConfigParserTests {
         #expect(jumpHosts[0].host == "fe80::1")
         #expect(jumpHosts[0].port == 22)
     }
+
+    // MARK: - Multi-Word Host Filtering
+
+    @Test("Multi-word Host entries are filtered out")
+    func testMultiWordHostFiltered() {
+        let content = """
+        Host prod dev staging
+            HostName example.com
+            User admin
+
+        Host single-host
+            HostName single.com
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+        #expect(result[0].host == "single-host")
+        #expect(result[0].hostname == "single.com")
+    }
+
+    @Test("Multi-word Host as last entry is filtered out")
+    func testMultiWordHostAsLastEntryFiltered() {
+        let content = """
+        Host valid-host
+            HostName valid.com
+
+        Host prod staging
+            HostName multi.com
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+        #expect(result[0].host == "valid-host")
+    }
+
+    // MARK: - SSH Token Expansion
+
+    @Test("SSH tokens in IdentityFile are expanded")
+    func testSSHTokensInIdentityFile() {
+        let content = """
+        Host myserver
+            HostName example.com
+            User admin
+            IdentityFile %d/.ssh/custom_key
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+
+        let homeDir = NSHomeDirectory()
+        #expect(result[0].identityFile == "\(homeDir)/.ssh/custom_key")
+    }
+
+    @Test("SSH %h token expands to hostname")
+    func testSSHHostnameTokenExpansion() {
+        let content = """
+        Host myserver
+            HostName example.com
+            User admin
+            IdentityFile ~/.ssh/%h_key
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+
+        let homeDir = NSHomeDirectory()
+        #expect(result[0].identityFile == "\(homeDir)/.ssh/example.com_key")
+    }
+
+    @Test("SSH %u token expands to local username")
+    func testSSHLocalUserTokenExpansion() {
+        let content = """
+        Host myserver
+            HostName example.com
+            IdentityFile ~/.ssh/%u_key
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+
+        let homeDir = NSHomeDirectory()
+        let localUser = NSUserName()
+        #expect(result[0].identityFile == "\(homeDir)/.ssh/\(localUser)_key")
+    }
+
+    @Test("SSH %r token expands to remote username")
+    func testSSHRemoteUserTokenExpansion() {
+        let content = """
+        Host myserver
+            HostName example.com
+            User deploy
+            IdentityFile ~/.ssh/%r_key
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+
+        let homeDir = NSHomeDirectory()
+        #expect(result[0].identityFile == "\(homeDir)/.ssh/deploy_key")
+    }
+
+    @Test("SSH %% literal percent is preserved")
+    func testSSHLiteralPercentExpansion() {
+        let content = """
+        Host myserver
+            HostName example.com
+            IdentityFile /keys/%%backup%%/id_rsa
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+        #expect(result[0].identityFile == "/keys/%backup%/id_rsa")
+    }
+
+    // MARK: - Include Directive (parseContent — No Filesystem)
+
+    @Test("Include directive in parseContent is no-op without filesystem")
+    func testIncludeInParseContentNoOp() {
+        let content = """
+        Include config.d/*
+
+        Host myserver
+            HostName example.com
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 1)
+        #expect(result[0].host == "myserver")
+    }
+
+    @Test("Include between Host blocks flushes pending entry")
+    func testIncludeFlushesCurrentHost() {
+        let content = """
+        Host first
+            HostName first.com
+            User admin
+
+        Include nonexistent.conf
+
+        Host second
+            HostName second.com
+        """
+
+        let result = SSHConfigParser.parseContent(content)
+        #expect(result.count == 2)
+        #expect(result[0].host == "first")
+        #expect(result[0].hostname == "first.com")
+        #expect(result[1].host == "second")
+    }
+
+    // MARK: - Include Directive (parse — With Filesystem)
+
+    @Test("Include directive resolves files from filesystem")
+    func testIncludeWithFilesystem() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-ssh-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let includedContent = """
+        Host included-server
+            HostName included.example.com
+            User deploy
+        """
+        let includedFile = tempDir.appendingPathComponent("extra.conf")
+        try includedContent.write(to: includedFile, atomically: true, encoding: .utf8)
+
+        let mainContent = """
+        Include \(includedFile.path(percentEncoded: false))
+
+        Host main-server
+            HostName main.example.com
+        """
+        let mainFile = tempDir.appendingPathComponent("config")
+        try mainContent.write(to: mainFile, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parse(path: mainFile.path(percentEncoded: false))
+        #expect(result.count == 2)
+        #expect(result[0].host == "included-server")
+        #expect(result[0].hostname == "included.example.com")
+        #expect(result[0].user == "deploy")
+        #expect(result[1].host == "main-server")
+    }
+
+    @Test("Include with glob pattern resolves multiple files")
+    func testIncludeGlobPattern() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-ssh-test-\(UUID().uuidString)")
+        let configDir = tempDir.appendingPathComponent("config.d")
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try "Host alpha\n    HostName alpha.com".write(
+            to: configDir.appendingPathComponent("a.conf"), atomically: true, encoding: .utf8)
+        try "Host beta\n    HostName beta.com".write(
+            to: configDir.appendingPathComponent("b.conf"), atomically: true, encoding: .utf8)
+
+        let mainContent = "Include \(configDir.path(percentEncoded: false))/*"
+        let mainFile = tempDir.appendingPathComponent("config")
+        try mainContent.write(to: mainFile, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parse(path: mainFile.path(percentEncoded: false))
+        #expect(result.count == 2)
+        let hosts = result.map(\.host).sorted()
+        #expect(hosts == ["alpha", "beta"])
+    }
+
+    @Test("Circular Include does not cause infinite loop")
+    func testCircularIncludeProtection() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-ssh-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileA = tempDir.appendingPathComponent("a.conf")
+        let fileB = tempDir.appendingPathComponent("b.conf")
+
+        try "Include \(fileB.path(percentEncoded: false))\n\nHost from-a\n    HostName a.com".write(
+            to: fileA, atomically: true, encoding: .utf8)
+        try "Include \(fileA.path(percentEncoded: false))\n\nHost from-b\n    HostName b.com".write(
+            to: fileB, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parse(path: fileA.path(percentEncoded: false))
+        // Should include entries from both files without infinite loop
+        // fileA includes fileB → parses "from-b", then fileB tries to include fileA → skipped (visited)
+        #expect(result.count == 2)
+        let hosts = result.map(\.host).sorted()
+        #expect(hosts == ["from-a", "from-b"])
+    }
 }

--- a/TableProTests/Core/SSH/SSHPathUtilitiesTests.swift
+++ b/TableProTests/Core/SSH/SSHPathUtilitiesTests.swift
@@ -1,0 +1,96 @@
+//
+//  SSHPathUtilitiesTests.swift
+//  TableProTests
+//
+//  Tests for SSH path utilities and token expansion
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SSH Path Utilities")
+struct SSHPathUtilitiesTests {
+    @Test("expandTilde expands ~/")
+    func testExpandTilde() {
+        let result = SSHPathUtilities.expandTilde("~/.ssh/id_rsa")
+        let homeDir = NSHomeDirectory()
+        #expect(result == "\(homeDir)/.ssh/id_rsa")
+    }
+
+    @Test("expandTilde returns absolute paths unchanged")
+    func testExpandTildeAbsolutePath() {
+        let result = SSHPathUtilities.expandTilde("/etc/ssh/id_rsa")
+        #expect(result == "/etc/ssh/id_rsa")
+    }
+
+    @Test("expandSSHTokens expands %d to home directory")
+    func testExpandTokenD() {
+        let homeDir = NSHomeDirectory()
+        let result = SSHPathUtilities.expandSSHTokens("%d/.ssh/key")
+        #expect(result == "\(homeDir)/.ssh/key")
+    }
+
+    @Test("expandSSHTokens expands %h to hostname")
+    func testExpandTokenH() {
+        let result = SSHPathUtilities.expandSSHTokens(
+            "/keys/%h/id_rsa",
+            hostname: "example.com"
+        )
+        #expect(result == "/keys/example.com/id_rsa")
+    }
+
+    @Test("expandSSHTokens expands %u to local username")
+    func testExpandTokenU() {
+        let localUser = NSUserName()
+        let result = SSHPathUtilities.expandSSHTokens("/keys/%u/id_rsa")
+        #expect(result == "/keys/\(localUser)/id_rsa")
+    }
+
+    @Test("expandSSHTokens expands %r to remote username")
+    func testExpandTokenR() {
+        let result = SSHPathUtilities.expandSSHTokens(
+            "/keys/%r/id_rsa",
+            remoteUser: "deploy"
+        )
+        #expect(result == "/keys/deploy/id_rsa")
+    }
+
+    @Test("expandSSHTokens preserves %% as literal percent")
+    func testExpandLiteralPercent() {
+        let result = SSHPathUtilities.expandSSHTokens("/keys/%%backup/id_rsa")
+        #expect(result == "/keys/%backup/id_rsa")
+    }
+
+    @Test("expandSSHTokens combines multiple tokens")
+    func testExpandMultipleTokens() {
+        let homeDir = NSHomeDirectory()
+        let localUser = NSUserName()
+        let result = SSHPathUtilities.expandSSHTokens(
+            "%d/.ssh/%h_%r_%%key",
+            hostname: "example.com",
+            remoteUser: "admin"
+        )
+        #expect(result == "\(homeDir)/.ssh/example.com_admin_%key")
+        _ = localUser  // %u not used in this test
+    }
+
+    @Test("expandSSHTokens leaves %h unexpanded when hostname is nil")
+    func testUnexpandedTokenH() {
+        let result = SSHPathUtilities.expandSSHTokens("/keys/%h/id_rsa")
+        #expect(result == "/keys/%h/id_rsa")
+    }
+
+    @Test("expandSSHTokens leaves %r unexpanded when remoteUser is nil")
+    func testUnexpandedTokenR() {
+        let result = SSHPathUtilities.expandSSHTokens("/keys/%r/id_rsa")
+        #expect(result == "/keys/%r/id_rsa")
+    }
+
+    @Test("expandSSHTokens also expands tilde")
+    func testExpandTokensWithTilde() {
+        let homeDir = NSHomeDirectory()
+        let result = SSHPathUtilities.expandSSHTokens("~/.ssh/id_rsa")
+        #expect(result == "\(homeDir)/.ssh/id_rsa")
+    }
+}

--- a/TableProTests/Core/SSH/SSHPathUtilitiesTests.swift
+++ b/TableProTests/Core/SSH/SSHPathUtilitiesTests.swift
@@ -62,17 +62,16 @@ struct SSHPathUtilitiesTests {
         #expect(result == "/keys/%backup/id_rsa")
     }
 
-    @Test("expandSSHTokens combines multiple tokens")
+    @Test("expandSSHTokens combines all tokens in a single path")
     func testExpandMultipleTokens() {
         let homeDir = NSHomeDirectory()
         let localUser = NSUserName()
         let result = SSHPathUtilities.expandSSHTokens(
-            "%d/.ssh/%h_%r_%%key",
+            "%d/.ssh/%u_%h_%r_%%key",
             hostname: "example.com",
             remoteUser: "admin"
         )
-        #expect(result == "\(homeDir)/.ssh/example.com_admin_%key")
-        _ = localUser  // %u not used in this test
+        #expect(result == "\(homeDir)/.ssh/\(localUser)_example.com_admin_%key")
     }
 
     @Test("expandSSHTokens leaves %h unexpanded when hostname is nil")


### PR DESCRIPTION
## Summary

- **Support `Include` directive** in SSH config parser — hosts defined in included files (e.g., `~/.ssh/config.d/*`, OrbStack, Lima) now appear in the Config Host picker. Recursive parsing with glob patterns, circular include protection, and depth limiting.
- **Fix tunnel cleanup for profile-based connections** — cleanup now uses `effectiveSSHConfig(profile:)` instead of reading inline `sshConfig.enabled`, preventing port leaks when SSH profiles are used.
- **Expand SSH config tokens** (`%d`, `%h`, `%u`, `%r`, `%%`) in `IdentityFile`/`IdentityAgent` paths — previously stored literally, causing "file not found" errors.
- **Filter multi-word `Host` entries** — entries like `Host prod dev staging` are now excluded from the picker to prevent DNS resolution failures.
- **Improve SSH handshake error messages** — now shows detailed libssh2 error strings instead of numeric codes.
- **Log warning when SSH profile lookup fails** — helps diagnose silent fallback to inline config.

Closes #672

## Test plan

- [ ] Verify `~/.ssh/config` with `Include config.d/*` shows hosts from included files in Config Host picker
- [ ] Verify SSH Profile-based connections create and clean up tunnels correctly
- [ ] Verify `IdentityFile %d/.ssh/key` resolves to correct path
- [ ] Verify multi-word `Host prod staging` entries don't appear in picker
- [ ] Verify SSH handshake failure shows descriptive error message
- [ ] Run `SSHConfigParserTests` and `SSHPathUtilitiesTests` (26 new test cases)