### PR TITLE
feat(ios): P1 HIG compliance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full-text search across all columns in iOS data browser
 - iPad keyboard shortcuts (Cmd+N new connection, Cmd+Return execute query, Cmd+1/2 switch tabs) and trackpad hover effects on list rows
 - Server Dashboard with active sessions, server metrics, and slow query monitoring (PostgreSQL, MySQL, MSSQL, ClickHouse, DuckDB, SQLite)
+- Handoff support for cross-device continuity between iOS and macOS
 
 ## [0.30.1] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Full-text search across all columns in iOS data browser
+- iPad keyboard shortcuts (Cmd+N new connection, Cmd+Return execute query, Cmd+1/2 switch tabs) and trackpad hover effects on list rows
 - Server Dashboard with active sessions, server metrics, and slow query monitoring (PostgreSQL, MySQL, MSSQL, ClickHouse, DuckDB, SQLite)
 
 ## [0.30.1] - 2026-04-10

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -537,6 +537,13 @@
 			);
 			target = 5AB9F3D82F7C1C12001F3337 /* TableProMobile */;
 		};
+		5AB9F3DC2F7C1C13001F3337 /* Exceptions for "TableProMobile" folder in "TableProMobile" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 5AB9F3D82F7C1C12001F3337 /* TableProMobile */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -551,6 +558,9 @@
 		};
 		5AB9F3DB2F7C1C12001F3337 /* TableProMobile */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				5AB9F3DC2F7C1C13001F3337 /* Exceptions for "TableProMobile" folder in "TableProMobile" target */,
+			);
 			path = TableProMobile;
 			sourceTree = "<group>";
 		};

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -1973,6 +1973,7 @@
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TableProMobile/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TablePro;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -2015,6 +2016,7 @@
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TableProMobile/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TablePro;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";

--- a/TableProMobile/TableProMobile/Info.plist
+++ b/TableProMobile/TableProMobile/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>com.TablePro.viewConnection</string>
+		<string>com.TablePro.viewTable</string>
+	</array>
+</dict>
+</plist>

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -37,6 +37,16 @@ struct TableProMobileApp: App {
                       let uuid = UUID(uuidString: identifier) else { return }
                 appState.pendingConnectionId = uuid
             }
+            .onContinueUserActivity("com.TablePro.viewConnection") { activity in
+                guard let connectionId = activity.userInfo?["connectionId"] as? String,
+                      let uuid = UUID(uuidString: connectionId) else { return }
+                appState.pendingConnectionId = uuid
+            }
+            .onContinueUserActivity("com.TablePro.viewTable") { activity in
+                guard let connectionId = activity.userInfo?["connectionId"] as? String,
+                      let uuid = UUID(uuidString: connectionId) else { return }
+                appState.pendingConnectionId = uuid
+            }
         }
         .onChange(of: scenePhase) { _, phase in
             switch phase {

--- a/TableProMobile/TableProMobile/Views/Components/ActivityViewController.swift
+++ b/TableProMobile/TableProMobile/Views/Components/ActivityViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ActivityViewController.swift
+//  TableProMobile
+//
+
+import SwiftUI
+import UIKit
+
+struct ActivityViewController: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -107,6 +107,14 @@ struct ConnectedView: View {
             .padding(.vertical, 8)
             .background(.bar)
         }
+        .background {
+            Button("") { selectedTab = .tables }
+                .keyboardShortcut("1", modifiers: .command)
+                .hidden()
+            Button("") { selectedTab = .query }
+                .keyboardShortcut("2", modifiers: .command)
+                .hidden()
+        }
         .toolbar {
             if connection.safeModeLevel != .off {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -72,6 +72,11 @@ struct ConnectedView: View {
                 }
             } else {
                 connectedContent
+                    .userActivity("com.TablePro.viewConnection") { activity in
+                        activity.title = connection.name.isEmpty ? connection.host : connection.name
+                        activity.isEligibleForHandoff = true
+                        activity.userInfo = ["connectionId": connection.id.uuidString]
+                    }
                     .allowsHitTesting(!isSwitching)
                     .overlay {
                         if isSwitching {

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -64,6 +64,7 @@ struct ConnectionListView: View {
                         } label: {
                             Image(systemName: "plus")
                         }
+                        .keyboardShortcut("n", modifiers: .command)
                     }
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
@@ -336,6 +337,7 @@ struct ConnectionListView: View {
         NavigationLink(value: connection.id) {
             ConnectionRow(connection: connection, tag: appState.tag(for: connection.tagId))
         }
+        .hoverEffect()
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button {
                 connectionToDelete = connection

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -259,6 +259,7 @@ struct DataBrowserView: View {
                         row: row
                     )
                 }
+                .hoverEffect()
                 .contextMenu {
                     Menu("Share Row") {
                         ForEach(ExportFormat.allCases) { format in

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -105,6 +105,14 @@ struct DataBrowserView: View {
 
     var body: some View {
         searchableContent
+            .userActivity("com.TablePro.viewTable") { activity in
+                activity.title = table.name
+                activity.isEligibleForHandoff = true
+                activity.userInfo = [
+                    "connectionId": connection.id.uuidString,
+                    "tableName": table.name
+                ]
+            }
             .toolbar { topToolbar }
             .toolbar(rows.isEmpty && !hasActiveSearch && !hasActiveFilters ? .hidden : .visible, for: .bottomBar)
             .toolbar { paginationToolbar }

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -43,6 +43,7 @@ struct DataBrowserView: View {
     @State private var memoryWarningMessage: String?
     @State private var hapticSuccess = false
     @State private var hapticError = false
+    @State private var showStructure = false
 
     private var isView: Bool {
         table.type == .view || table.type == .materializedView
@@ -161,6 +162,9 @@ struct DataBrowserView: View {
             }
             .sensoryFeedback(.success, trigger: hapticSuccess)
             .sensoryFeedback(.error, trigger: hapticError)
+            .navigationDestination(isPresented: $showStructure) {
+                StructureView(table: table, session: session, databaseType: connection.type)
+            }
             .alert("Go to Page", isPresented: $showGoToPage) {
                 TextField("Page number", text: $goToPageInput)
                     .keyboardType(.numberPad)
@@ -313,25 +317,6 @@ struct DataBrowserView: View {
     private var topToolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
             Menu {
-                ForEach(ExportFormat.allCases) { format in
-                    Button {
-                        let text = ClipboardExporter.exportRows(
-                            columns: columns, rows: rows,
-                            format: format, tableName: table.name
-                        )
-                        ClipboardExporter.copyToClipboard(text)
-                    } label: {
-                        Label(format.rawValue, systemImage: "doc.on.clipboard")
-                    }
-                }
-            } label: {
-                Image(systemName: "square.and.arrow.up")
-                    .accessibilityLabel(Text("Export"))
-            }
-            .disabled(rows.isEmpty)
-        }
-        ToolbarItem(placement: .topBarTrailing) {
-            Menu {
                 Picker("Sort By", selection: sortColumnBinding) {
                     Text("Default").tag(String?.none)
                     ForEach(columns, id: \.name) { col in
@@ -365,11 +350,26 @@ struct DataBrowserView: View {
             .badge(activeFilterCount)
         }
         ToolbarItem(placement: .topBarTrailing) {
-            NavigationLink {
-                StructureView(table: table, session: session, databaseType: connection.type)
+            Menu {
+                Button { showStructure = true } label: {
+                    Label("Table Structure", systemImage: "info.circle")
+                }
+                Divider()
+                Section("Export") {
+                    ForEach(ExportFormat.allCases) { format in
+                        Button {
+                            let text = ClipboardExporter.exportRows(
+                                columns: columns, rows: rows,
+                                format: format, tableName: table.name
+                            )
+                            ClipboardExporter.copyToClipboard(text)
+                        } label: {
+                            Label(format.rawValue, systemImage: "doc.on.clipboard")
+                        }
+                    }
+                }
             } label: {
-                Image(systemName: "info.circle")
-                    .accessibilityLabel(Text("Table Structure"))
+                Image(systemName: "ellipsis.circle")
             }
         }
         if !isView && !connection.safeModeLevel.blocksWrites {

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -41,6 +41,8 @@ struct DataBrowserView: View {
     @State private var foreignKeys: [ForeignKeyInfo] = []
     @State private var fkPreviewItem: FKPreviewItem?
     @State private var memoryWarningMessage: String?
+    @State private var showShareSheet = false
+    @State private var shareText = ""
     @State private var hapticSuccess = false
     @State private var hapticError = false
     @State private var showStructure = false
@@ -124,6 +126,9 @@ struct DataBrowserView: View {
                     session: session,
                     databaseType: connection.type
                 )
+            }
+            .sheet(isPresented: $showShareSheet) {
+                ActivityViewController(items: [shareText])
             }
             .confirmationDialog("Delete Row", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
                 Button("Delete", role: .destructive) {
@@ -255,6 +260,17 @@ struct DataBrowserView: View {
                     )
                 }
                 .contextMenu {
+                    Menu("Share Row") {
+                        ForEach(ExportFormat.allCases) { format in
+                            Button(format.rawValue) {
+                                shareText = ClipboardExporter.exportRow(
+                                    columns: columns, row: row,
+                                    format: format, tableName: table.name
+                                )
+                                showShareSheet = true
+                            }
+                        }
+                    }
                     Menu("Copy Row") {
                         ForEach(ExportFormat.allCases) { format in
                             Button(format.rawValue) {

--- a/TableProMobile/TableProMobile/Views/GroupManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/GroupManagementView.swift
@@ -86,8 +86,10 @@ struct GroupManagementView: View {
             .navigationTitle("Groups")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItemGroup(placement: .topBarTrailing) {
+                ToolbarItem(placement: .topBarLeading) {
                     EditButton()
+                }
+                ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
                         showingAddGroup = true
                     } label: {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -31,6 +31,8 @@ struct QueryEditorView: View {
     @State private var showWriteConfirmation = false
     @State private var showWriteBlockedAlert = false
     @State private var pendingWriteQuery = ""
+    @State private var showShareSheet = false
+    @State private var shareText = ""
     @State private var hapticSuccess = false
     @State private var hapticError = false
     var body: some View {
@@ -57,6 +59,9 @@ struct QueryEditorView: View {
         }
         .sensoryFeedback(.success, trigger: hapticSuccess)
         .sensoryFeedback(.error, trigger: hapticError)
+        .sheet(isPresented: $showShareSheet) {
+            ActivityViewController(items: [shareText])
+        }
         .sheet(isPresented: $showHistory) { historySheet }
     }
 
@@ -253,6 +258,19 @@ struct QueryEditorView: View {
                 }
 
                 if let result, !result.rows.isEmpty {
+                    Section("Share Results") {
+                        ForEach(ExportFormat.allCases) { format in
+                            Button {
+                                shareText = ClipboardExporter.exportRows(
+                                    columns: result.columns, rows: result.rows,
+                                    format: format
+                                )
+                                showShareSheet = true
+                            } label: {
+                                Label(format.rawValue, systemImage: "square.and.arrow.up")
+                            }
+                        }
+                    }
                     Section("Copy Results") {
                         ForEach(ExportFormat.allCases) { format in
                             Button {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -233,6 +233,7 @@ struct QueryEditorView: View {
                 Image(systemName: isExecuting ? "stop.fill" : "play.fill")
             }
             .disabled(!isExecuting && query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .keyboardShortcut(.return, modifiers: .command)
         }
 
         ToolbarItem(placement: .topBarTrailing) {

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -30,6 +30,8 @@ struct RowDetailView: View {
     @State private var hapticSuccess = false
     @State private var hapticError = false
     @State private var hapticSelection = 0
+    @State private var showShareSheet = false
+    @State private var shareText = ""
 
     init(
         columns: [ColumnInfo],
@@ -103,15 +105,30 @@ struct RowDetailView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
-                    ForEach(ExportFormat.allCases) { format in
-                        Button {
-                            let text = ClipboardExporter.exportRow(
-                                columns: columns, row: currentRow,
-                                format: format, tableName: table?.name
-                            )
-                            ClipboardExporter.copyToClipboard(text)
-                        } label: {
-                            Label(format.rawValue, systemImage: "doc.on.clipboard")
+                    Section("Share") {
+                        ForEach(ExportFormat.allCases) { format in
+                            Button {
+                                shareText = ClipboardExporter.exportRow(
+                                    columns: columns, row: currentRow,
+                                    format: format, tableName: table?.name
+                                )
+                                showShareSheet = true
+                            } label: {
+                                Label(format.rawValue, systemImage: "square.and.arrow.up")
+                            }
+                        }
+                    }
+                    Section("Copy to Clipboard") {
+                        ForEach(ExportFormat.allCases) { format in
+                            Button {
+                                let text = ClipboardExporter.exportRow(
+                                    columns: columns, row: currentRow,
+                                    format: format, tableName: table?.name
+                                )
+                                ClipboardExporter.copyToClipboard(text)
+                            } label: {
+                                Label(format.rawValue, systemImage: "doc.on.clipboard")
+                            }
                         }
                     }
                 } label: {
@@ -191,6 +208,9 @@ struct RowDetailView: View {
                 session: session,
                 databaseType: databaseType
             )
+        }
+        .sheet(isPresented: $showShareSheet) {
+            ActivityViewController(items: [shareText])
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -72,8 +72,134 @@ struct RowDetailView: View {
     }
 
     var body: some View {
+        Group {
+            if isEditing {
+                rowContent(at: currentIndex)
+            } else {
+                TabView(selection: $currentIndex) {
+                    ForEach(Array(rows.indices), id: \.self) { index in
+                        rowContent(at: index)
+                            .tag(index)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+            }
+        }
+        .onChange(of: currentIndex) {
+            hapticSelection += 1
+        }
+        .overlay(alignment: .bottom) {
+            if showSaveSuccess {
+                Label("Row updated", systemImage: "checkmark.circle.fill")
+                    .font(.subheadline)
+                    .padding()
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .navigationTitle(String(format: String(localized: "Row %d of %d"), currentIndex + 1, rows.count))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    ForEach(ExportFormat.allCases) { format in
+                        Button {
+                            let text = ClipboardExporter.exportRow(
+                                columns: columns, row: currentRow,
+                                format: format, tableName: table?.name
+                            )
+                            ClipboardExporter.copyToClipboard(text)
+                        } label: {
+                            Label(format.rawValue, systemImage: "doc.on.clipboard")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                if canEdit {
+                    if isEditing {
+                        Button {
+                            Task { await saveChanges() }
+                        } label: {
+                            if isSaving {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Text("Save")
+                            }
+                        }
+                        .disabled(isSaving)
+                    } else {
+                        Button("Edit") { startEditing() }
+                    }
+                }
+            }
+
+            if isEditing {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { cancelEditing() }
+                        .disabled(isSaving)
+                }
+            }
+
+            ToolbarItemGroup(placement: .bottomBar) {
+                Button {
+                    withAnimation { currentIndex -= 1 }
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .disabled(currentIndex <= 0 || isEditing)
+
+                Spacer()
+
+                Text("\(currentIndex + 1) of \(rows.count)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .fixedSize()
+
+                Spacer()
+
+                Button {
+                    withAnimation { currentIndex += 1 }
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
+                .disabled(currentIndex >= rows.count - 1 || isEditing)
+            }
+        }
+        .sensoryFeedback(.success, trigger: hapticSuccess)
+        .sensoryFeedback(.error, trigger: hapticError)
+        .sensoryFeedback(.selection, trigger: hapticSelection)
+        .alert(operationError?.title ?? "Error", isPresented: $showOperationError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            if let recovery = operationError?.recovery {
+                Text(verbatim: "\(operationError?.message ?? "") \(recovery)")
+            } else {
+                Text(operationError?.message ?? "")
+            }
+        }
+        .sheet(item: $fkPreviewItem) { item in
+            FKPreviewView(
+                fk: item.fk,
+                value: item.value,
+                session: session,
+                databaseType: databaseType
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func rowContent(at rowIndex: Int) -> some View {
+        let row = rowIndex >= 0 && rowIndex < rows.count ? rows[rowIndex] : []
+        let values = isEditing ? editedValues : row
         List {
-            ForEach(Array(zip(columns, isEditing ? editedValues : currentRow).enumerated()), id: \.offset) { index, pair in
+            ForEach(Array(zip(columns, values).enumerated()), id: \.offset) { index, pair in
                 let (column, value) = pair
                 let isPK = columnDetail(for: column.name)?.isPrimaryKey ?? column.isPrimaryKey
                 Section {
@@ -140,112 +266,6 @@ struct RowDetailView: View {
         }
         .listStyle(.insetGrouped)
         .scrollDismissesKeyboard(.interactively)
-        .overlay(alignment: .bottom) {
-            if showSaveSuccess {
-                Label("Row updated", systemImage: "checkmark.circle.fill")
-                    .font(.subheadline)
-                    .padding()
-                    .background(.regularMaterial, in: Capsule())
-                    .padding(.bottom)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-        }
-        .navigationTitle(String(format: String(localized: "Row %d of %d"), currentIndex + 1, rows.count))
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    ForEach(ExportFormat.allCases) { format in
-                        Button {
-                            let text = ClipboardExporter.exportRow(
-                                columns: columns, row: currentRow,
-                                format: format, tableName: table?.name
-                            )
-                            ClipboardExporter.copyToClipboard(text)
-                        } label: {
-                            Label(format.rawValue, systemImage: "doc.on.clipboard")
-                        }
-                    }
-                } label: {
-                    Image(systemName: "square.and.arrow.up")
-                }
-            }
-
-            ToolbarItem(placement: .primaryAction) {
-                if canEdit {
-                    if isEditing {
-                        Button {
-                            Task { await saveChanges() }
-                        } label: {
-                            if isSaving {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Text("Save")
-                            }
-                        }
-                        .disabled(isSaving)
-                    } else {
-                        Button("Edit") { startEditing() }
-                    }
-                }
-            }
-
-            if isEditing {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { cancelEditing() }
-                        .disabled(isSaving)
-                }
-            }
-
-            ToolbarItemGroup(placement: .bottomBar) {
-                Button {
-                    withAnimation { currentIndex -= 1 }
-                    hapticSelection += 1
-                } label: {
-                    Image(systemName: "chevron.left")
-                }
-                .disabled(currentIndex <= 0 || isEditing)
-
-                Spacer()
-
-                Text("\(currentIndex + 1) of \(rows.count)")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .fixedSize()
-
-                Spacer()
-
-                Button {
-                    withAnimation { currentIndex += 1 }
-                    hapticSelection += 1
-                } label: {
-                    Image(systemName: "chevron.right")
-                }
-                .disabled(currentIndex >= rows.count - 1 || isEditing)
-            }
-        }
-        .sensoryFeedback(.success, trigger: hapticSuccess)
-        .sensoryFeedback(.error, trigger: hapticError)
-        .sensoryFeedback(.selection, trigger: hapticSelection)
-        .alert(operationError?.title ?? "Error", isPresented: $showOperationError) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            if let recovery = operationError?.recovery {
-                Text(verbatim: "\(operationError?.message ?? "") \(recovery)")
-            } else {
-                Text(operationError?.message ?? "")
-            }
-        }
-        .sheet(item: $fkPreviewItem) { item in
-            FKPreviewView(
-                fk: item.fk,
-                value: item.value,
-                session: session,
-                databaseType: databaseType
-            )
-        }
     }
 
     private func editableField(index: Int, value: String?) -> some View {

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -165,7 +165,7 @@ struct RowDetailView: View {
 
             ToolbarItemGroup(placement: .bottomBar) {
                 Button {
-                    withAnimation { currentIndex -= 1 }
+                    currentIndex -= 1
                 } label: {
                     Image(systemName: "chevron.left")
                 }
@@ -182,7 +182,7 @@ struct RowDetailView: View {
                 Spacer()
 
                 Button {
-                    withAnimation { currentIndex += 1 }
+                    currentIndex += 1
                 } label: {
                     Image(systemName: "chevron.right")
                 }

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -131,7 +131,8 @@ struct TableListView: View {
                 if let table = tableToTruncate {
                     Task {
                         do {
-                            _ = try await session?.driver.execute(query: "TRUNCATE TABLE \"\(table.name)\"")
+                            let quoted = SQLBuilder.quoteIdentifier(table.name, for: connection.type)
+                            _ = try await session?.driver.execute(query: "TRUNCATE TABLE \(quoted)")
                             await onRefresh?()
                         } catch {
                             errorMessage = error.localizedDescription
@@ -154,7 +155,8 @@ struct TableListView: View {
                 if let table = tableToDrop {
                     Task {
                         do {
-                            _ = try await session?.driver.execute(query: "DROP TABLE \"\(table.name)\"")
+                            let quoted = SQLBuilder.quoteIdentifier(table.name, for: connection.type)
+                            _ = try await session?.driver.execute(query: "DROP TABLE \(quoted)")
                             await onRefresh?()
                         } catch {
                             errorMessage = error.localizedDescription

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -14,6 +14,24 @@ struct TableListView: View {
     var onRefresh: (() async -> Void)?
 
     @State private var searchText = ""
+    @State private var tableToTruncate: TableInfo?
+    @State private var tableToDrop: TableInfo?
+    @State private var errorMessage = ""
+    @State private var showError = false
+
+    private var showTruncateConfirmation: Binding<Bool> {
+        Binding(
+            get: { tableToTruncate != nil },
+            set: { if !$0 { tableToTruncate = nil } }
+        )
+    }
+
+    private var showDropConfirmation: Binding<Bool> {
+        Binding(
+            get: { tableToDrop != nil },
+            set: { if !$0 { tableToDrop = nil } }
+        )
+    }
 
     private var filteredTables: [TableInfo] {
         let filtered = searchText.isEmpty ? tables : tables.filter {
@@ -43,6 +61,30 @@ struct TableListView: View {
                     ForEach(items) { table in
                         NavigationLink(value: table) {
                             TableRow(table: table)
+                        }
+                        .contextMenu {
+                            Button {
+                                UIPasteboard.general.string = table.name
+                            } label: {
+                                Label("Copy Name", systemImage: "doc.on.doc")
+                            }
+
+                            let isView = table.type == .view || table.type == .materializedView
+                            if !isView && !connection.safeModeLevel.blocksWrites {
+                                Divider()
+
+                                Button(role: .destructive) {
+                                    tableToTruncate = table
+                                } label: {
+                                    Label("Truncate Table", systemImage: "trash.slash")
+                                }
+
+                                Button(role: .destructive) {
+                                    tableToDrop = table
+                                } label: {
+                                    Label("Drop Table", systemImage: "trash")
+                                }
+                            }
                         }
                     }
                 } header: {
@@ -78,6 +120,57 @@ struct TableListView: View {
             } else if filteredTables.isEmpty && !searchText.isEmpty {
                 ContentUnavailableView.search(text: searchText)
             }
+        }
+        .confirmationDialog(
+            String(localized: "Truncate Table"),
+            isPresented: showTruncateConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Truncate"), role: .destructive) {
+                if let table = tableToTruncate {
+                    Task {
+                        do {
+                            _ = try await session?.driver.execute(query: "TRUNCATE TABLE \"\(table.name)\"")
+                            await onRefresh?()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                            showError = true
+                        }
+                    }
+                }
+            }
+        } message: {
+            if let table = tableToTruncate {
+                Text("All data in \"\(table.name)\" will be permanently deleted.")
+            }
+        }
+        .confirmationDialog(
+            String(localized: "Drop Table"),
+            isPresented: showDropConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Drop"), role: .destructive) {
+                if let table = tableToDrop {
+                    Task {
+                        do {
+                            _ = try await session?.driver.execute(query: "DROP TABLE \"\(table.name)\"")
+                            await onRefresh?()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                            showError = true
+                        }
+                    }
+                }
+            }
+        } message: {
+            if let table = tableToDrop {
+                Text("The table \"\(table.name)\" and all its data will be permanently deleted.")
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
         }
     }
 }

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -86,6 +86,7 @@ struct TableListView: View {
                                 }
                             }
                         }
+                        .hoverEffect()
                     }
                 } header: {
                     HStack {


### PR DESCRIPTION
## Summary

Addresses 7 P1 (Important) HIG items from the iOS UI/UX audit (depends on #674):

- **Toolbar consolidation**: DataBrowserView toolbar reduced from 5 to 3 items. Export and Table Structure moved into overflow menu (ellipsis).
- **GroupManagement toolbar fix**: EditButton moved to leading position.
- **Table context menus**: Long-press on table rows shows Copy Name, Truncate Table, Drop Table (with confirmation dialogs, gated behind safe mode).
- **Share sheet support**: Export menus now have Share section (UIActivityViewController) alongside Copy to Clipboard.
- **Swipe-between-rows**: RowDetailView uses TabView page-style swiping. Disabled during edit mode.
- **iPad keyboard shortcuts**: Cmd+N (new connection), Cmd+Return (run query), Cmd+1/2 (switch tabs).
- **iPad hover effects**: `.hoverEffect()` on list rows for trackpad feedback.
- **Handoff support**: NSUserActivity for viewConnection/viewTable. Continue from iPhone to Mac.

## Test plan

- [ ] DataBrowserView: 3 toolbar icons (Sort, Filter, ellipsis menu with Structure + Export)
- [ ] Long-press table row -> context menu (Copy Name, Truncate, Drop)
- [ ] Export menu -> Share section opens system share sheet
- [ ] RowDetailView: swipe left/right between rows, disabled during edit
- [ ] GroupManagement: Edit on left, +/Done on right
- [ ] iPad: Cmd+N, Cmd+Return, Cmd+1/2 keyboard shortcuts
- [ ] iPad: hover effect on list rows with trackpad
- [ ] Handoff: NSUserActivity advertised when browsing tables