### PR TITLE
feat: add macOS Handoff support for cross-device continuity

### DIFF
--- a/TablePro/AppDelegate+FileOpen.swift
+++ b/TablePro/AppDelegate+FileOpen.swift
@@ -12,6 +12,58 @@ import SwiftUI
 private let fileOpenLogger = Logger(subsystem: "com.TablePro", category: "FileOpen")
 
 extension AppDelegate {
+    // MARK: - Handoff
+
+    func application(_ application: NSApplication, continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void) -> Bool {
+        handleHandoffActivity(userActivity)
+        return true
+    }
+
+    private func handleHandoffActivity(_ activity: NSUserActivity) {
+        guard let connectionIdString = activity.userInfo?["connectionId"] as? String,
+              let connectionId = UUID(uuidString: connectionIdString) else { return }
+
+        let connections = ConnectionStorage.shared.loadConnections()
+        guard let connection = connections.first(where: { $0.id == connectionId }) else {
+            fileOpenLogger.error("Handoff: no connection with ID '\(connectionIdString, privacy: .public)'")
+            return
+        }
+
+        let tableName = activity.userInfo?["tableName"] as? String
+
+        if DatabaseManager.shared.activeSessions[connectionId]?.driver != nil {
+            if let tableName {
+                let payload = EditorTabPayload(connectionId: connectionId, tabType: .table, tableName: tableName)
+                WindowOpener.shared.openNativeTab(payload)
+            } else {
+                for window in NSApp.windows where isMainWindow(window) {
+                    window.makeKeyAndOrderFront(nil)
+                    return
+                }
+            }
+            return
+        }
+
+        let initialPayload = EditorTabPayload(connectionId: connectionId)
+        WindowOpener.shared.openNativeTab(initialPayload)
+
+        Task { @MainActor in
+            do {
+                try await DatabaseManager.shared.connectToSession(connection)
+                for window in NSApp.windows where self.isWelcomeWindow(window) {
+                    window.close()
+                }
+                if let tableName {
+                    let payload = EditorTabPayload(connectionId: connectionId, tabType: .table, tableName: tableName)
+                    WindowOpener.shared.openNativeTab(payload)
+                }
+            } catch {
+                fileOpenLogger.error("Handoff connect failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
     // MARK: - URL Classification
 
     private func isDatabaseURL(_ url: URL) -> Bool {

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -204,6 +204,11 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>com.TablePro.viewConnection</string>
+		<string>com.TablePro.viewTable</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -292,6 +292,25 @@ struct MainContentView: View {
             .onChange(of: pendingChangeTrigger) {
                 updateToolbarPendingState()
             }
+            .userActivity("com.TablePro.viewConnection") { activity in
+                activity.title = connection.name.isEmpty
+                    ? connection.host
+                    : connection.name
+                activity.isEligibleForHandoff = true
+                activity.userInfo = ["connectionId": connection.id.uuidString]
+            }
+            .userActivity("com.TablePro.viewTable") { activity in
+                guard let tableName = tabManager.selectedTab?.tableName else {
+                    activity.invalidate()
+                    return
+                }
+                activity.title = tableName
+                activity.isEligibleForHandoff = true
+                activity.userInfo = [
+                    "connectionId": connection.id.uuidString,
+                    "tableName": tableName
+                ]
+            }
     }
 
     private var bodyContentCore: some View {


### PR DESCRIPTION
## Summary

Adds Handoff support to the macOS app, completing the bidirectional continuity started in #676 (iOS).

- **Receive Handoff from iOS**: When a user browses a connection/table on iPhone, the Mac Dock shows a Handoff icon. Clicking it opens the same connection (and optionally the same table) on Mac.
- **Advertise Handoff to iOS**: When browsing on Mac, the iPhone Lock Screen shows a Handoff icon to continue on iOS.

Follows the existing `connectViaDeeplink` pattern — Handoff is just another entry vector into the same connection-opening flow, resolving by UUID instead of name.

## Files Changed (3 code files)

| File | Change |
|------|--------|
| `Info.plist` | Declare `NSUserActivityTypes` for both activity types |
| `AppDelegate+FileOpen.swift` | `application(_:continue:restorationHandler:)` + `handleHandoffActivity()` |
| `MainContentView.swift` | `.userActivity` modifiers for `viewConnection` and `viewTable` |

## Test plan

- [ ] Open a connection on iOS → Mac Dock shows Handoff icon → click opens connection on Mac
- [ ] Browse a table on iOS → click Handoff → Mac opens that specific table
- [ ] If connection is already open on Mac → Handoff brings existing window to front
- [ ] Open a connection on Mac → iPhone Lock Screen shows Handoff icon
- [ ] Browse a table on Mac → Handoff updates to table-level activity
- [ ] Both devices: same Apple ID, same Wi-Fi, Bluetooth on