### PR TITLE
fix(ios): P2 HIG polish fixes

### DIFF
--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -9,6 +9,7 @@ import TableProSync
 
 struct ConnectionListView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showingAddConnection = false
     @State private var editingConnection: DatabaseConnection?
     @State private var selectedConnectionId: UUID?
@@ -133,6 +134,32 @@ struct ConnectionListView: View {
     }
 
     @ViewBuilder
+    private var connectionList: some View {
+        let list = List(selection: $selectedConnectionId) {
+            if groupByGroup {
+                groupedContent
+            } else {
+                ForEach(displayedConnections) { connection in
+                    connectionRow(connection)
+                }
+                .onMove { source, destination in
+                    var items = displayedConnections
+                    items.move(fromOffsets: source, toOffset: destination)
+                    for index in items.indices {
+                        items[index].sortOrder = index
+                    }
+                    appState.reorderConnections(items)
+                }
+            }
+        }
+        if sizeClass == .regular {
+            list.listStyle(.sidebar)
+        } else {
+            list.listStyle(.insetGrouped)
+        }
+    }
+
+    @ViewBuilder
     private var sidebar: some View {
         if appState.connections.isEmpty && !isSyncing {
             ContentUnavailableView {
@@ -149,24 +176,7 @@ struct ConnectionListView: View {
             ProgressView("Syncing from iCloud...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            List(selection: $selectedConnectionId) {
-                if groupByGroup {
-                    groupedContent
-                } else {
-                    ForEach(displayedConnections) { connection in
-                        connectionRow(connection)
-                    }
-                    .onMove { source, destination in
-                        var items = displayedConnections
-                        items.move(fromOffsets: source, toOffset: destination)
-                        for index in items.indices {
-                            items[index].sortOrder = index
-                        }
-                        appState.reorderConnections(items)
-                    }
-                }
-            }
-            .listStyle(.insetGrouped)
+            connectionList
             .overlay {
                 if !appState.connections.isEmpty && displayedConnections.isEmpty {
                     ContentUnavailableView(
@@ -403,12 +413,12 @@ private struct ConnectionRow: View {
             if let tag {
                 Text(tag.name)
                     .font(.caption)
-                    .foregroundStyle(ConnectionColorPicker.swiftUIColor(for: tag.color))
+                    .foregroundStyle(.white)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
                     .background(
                         Capsule()
-                            .fill(ConnectionColorPicker.swiftUIColor(for: tag.color).opacity(0.15))
+                            .fill(ConnectionColorPicker.swiftUIColor(for: tag.color))
                     )
             }
         }

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -204,6 +204,7 @@ struct DataBrowserView: View {
                 .navigationTitle(table.name)
                 .navigationBarTitleDisplayMode(.inline)
                 .searchable(text: $searchText, prompt: "Search all columns")
+                .textInputAutocapitalization(.never)
                 .onSubmit(of: .search) { applySearch() }
                 .onChange(of: searchText) { oldValue, newValue in
                     if newValue.isEmpty, !oldValue.isEmpty, hasActiveSearch {
@@ -696,6 +697,7 @@ private struct FilterSheetView: View {
 
     @State private var draft: [TableFilter] = []
     @State private var draftLogicMode: FilterLogicMode = .and
+    @State private var showClearConfirmation = false
 
     private var hasValidFilters: Bool {
         draft.contains { $0.isEnabled && $0.isValid }
@@ -763,10 +765,7 @@ private struct FilterSheetView: View {
                 if !draft.isEmpty {
                     Section {
                         Button("Clear All Filters", role: .destructive) {
-                            filters.removeAll()
-                            logicMode = .and
-                            onClear()
-                            dismiss()
+                            showClearConfirmation = true
                         }
                     }
                 }
@@ -790,6 +789,20 @@ private struct FilterSheetView: View {
             .onAppear {
                 draft = filters
                 draftLogicMode = logicMode
+            }
+            .confirmationDialog(
+                String(localized: "Clear All Filters"),
+                isPresented: $showClearConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "Clear All"), role: .destructive) {
+                    filters.removeAll()
+                    logicMode = .and
+                    onClear()
+                    dismiss()
+                }
+            } message: {
+                Text("All filter conditions will be removed.")
             }
         }
     }

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -113,6 +113,7 @@ struct InsertRowView: View {
                     }
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .formStyle(.grouped)
             .navigationTitle("Insert Row")
             .navigationBarTitleDisplayMode(.inline)

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -100,7 +100,7 @@ struct RowDetailView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .navigationTitle(String(format: String(localized: "Row %d of %d"), currentIndex + 1, rows.count))
+        .navigationTitle(table?.name ?? String(format: String(localized: "Row %d of %d"), currentIndex + 1, rows.count))
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/TableProMobile/TableProMobile/Views/StructureView.swift
+++ b/TableProMobile/TableProMobile/Views/StructureView.swift
@@ -29,37 +29,39 @@ struct StructureView: View {
     @State private var appError: AppError?
 
     var body: some View {
-        VStack(spacing: 0) {
+        Group {
+            if isLoading {
+                ProgressView("Loading structure...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let appError {
+                ErrorView(error: appError) {
+                    await loadStructure()
+                }
+            } else {
+                switch selectedTab {
+                case .columns:
+                    columnsTab
+                case .indexes:
+                    indexesTab
+                case .foreignKeys:
+                    foreignKeysTab
+                }
+            }
+        }
+        .safeAreaInset(edge: .top) {
             Picker("Section", selection: $selectedTab) {
                 ForEach(Tab.allCases, id: \.self) { tab in
                     Text(tab.rawValue).tag(tab)
                 }
             }
             .pickerStyle(.segmented)
-            .padding()
-
-            Group {
-                if isLoading {
-                    ProgressView("Loading structure...")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let appError {
-                    ErrorView(error: appError) {
-                        await loadStructure()
-                    }
-                } else {
-                    switch selectedTab {
-                    case .columns:
-                        columnsTab
-                    case .indexes:
-                        indexesTab
-                    case .foreignKeys:
-                        foreignKeysTab
-                    }
-                }
-            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(.bar)
         }
         .navigationTitle(table.name)
         .navigationBarTitleDisplayMode(.inline)
+        .refreshable { await loadStructure() }
         .task { await loadStructure() }
     }
 

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -101,6 +101,7 @@ struct TableListView: View {
         }
         .listStyle(.insetGrouped)
         .searchable(text: $searchText, prompt: "Search tables")
+        .textInputAutocapitalization(.never)
         .refreshable {
             await onRefresh?()
         }


### PR DESCRIPTION
## Summary

8 polish fixes from the iOS UI/UX audit (P2 priority):

1. **Search bar autocapitalization disabled** — DataBrowserView and TableListView search bars no longer auto-capitalize (database values are case-sensitive)
2. **StructureView segmented control** — Now uses `safeAreaInset` with `.background(.bar)`, matching ConnectedView's pattern
3. **StructureView pull-to-refresh** — Added `.refreshable` to reload table structure
4. **Clear All Filters confirmation** — "Clear All Filters" now shows a confirmation dialog before removing all filter conditions
5. **InsertRowView keyboard dismiss** — Added `.scrollDismissesKeyboard(.interactively)` so users can scroll to dismiss keyboard
6. **Row detail breadcrumb** — Navigation title now shows table name instead of "Row X of Y" (row position stays in bottom toolbar)
7. **Tag badge contrast** — Changed from colored text on light background to white text on solid colored background (WCAG compliant)
8. **iPad sidebar list style** — Connection list uses `.sidebar` style on iPad, `.insetGrouped` on iPhone

## Test plan

- [ ] Data browser search → keyboard does NOT auto-capitalize
- [ ] Table list search → keyboard does NOT auto-capitalize
- [ ] Structure view → segmented control has bar background, matches Tables/Query style
- [ ] Structure view → pull down to refresh reloads columns/indexes/FK
- [ ] Filter sheet → "Clear All Filters" shows confirmation dialog
- [ ] Insert row → scroll form to dismiss keyboard
- [ ] Row detail → title shows table name, "Row X of Y" in bottom bar
- [ ] Connection list → tag badges are white text on colored background
- [ ] iPad → connection list uses sidebar style