### PR TITLE
fix(ios): P3 HIG polish — final batch

### DIFF
--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -91,6 +91,22 @@ struct ConnectedView: View {
                         }
                     }
                     .animation(.default, value: isSwitching)
+                    .overlay(alignment: .top) {
+                        if isReconnecting {
+                            HStack(spacing: 6) {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                Text(String(localized: "Reconnecting..."))
+                                    .font(.caption)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(.regularMaterial, in: Capsule())
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                            .padding(.top, 4)
+                        }
+                    }
+                    .animation(.default, value: isReconnecting)
             }
         }
         .sensoryFeedback(.success, trigger: hapticSuccess)

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -167,6 +167,7 @@ struct ConnectionFormView: View {
                             Text(level.displayName).tag(level)
                         }
                     }
+                    .pickerStyle(.menu)
                 }
 
                 if type == .sqlite {
@@ -379,6 +380,7 @@ struct ConnectionFormView: View {
                     Text("Password").tag(SSHConfiguration.SSHAuthMethod.password)
                     Text("Private Key").tag(SSHConfiguration.SSHAuthMethod.privateKey)
                 }
+                .pickerStyle(.segmented)
             }
 
             if sshAuthMethod == .password {

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -348,6 +348,14 @@ struct ConnectionListView: View {
             ConnectionRow(connection: connection, tag: appState.tag(for: connection.tagId))
         }
         .hoverEffect()
+        .swipeActions(edge: .leading) {
+            Button {
+                editingConnection = connection
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.blue)
+        }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button {
                 connectionToDelete = connection

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -888,7 +888,7 @@ private struct RowCard: View {
             ForEach(Array(detailPairs.enumerated()), id: \.offset) { _, pair in
                 HStack(spacing: 6) {
                     Text(pair.name)
-                        .font(.caption2)
+                        .font(.caption)
                         .foregroundStyle(.tertiary)
                     Text(verbatim: pair.value)
                         .font(.caption)

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -23,6 +23,7 @@ struct QueryEditorView: View {
     @State private var isExecuting = false
     @State private var executionTime: TimeInterval?
     @State private var executeTask: Task<Void, Never>?
+    @State private var executionStartTime: Date?
     @Binding var queryHistory: [QueryHistoryItem]
     let connectionId: UUID
     let historyStorage: QueryHistoryStorage
@@ -87,9 +88,16 @@ struct QueryEditorView: View {
             SQLHighlightTextView(text: $query)
                 .frame(minHeight: 80, maxHeight: result != nil || appError != nil ? 120 : 250)
 
-            if executionTime != nil || result != nil {
+            if isExecuting || executionTime != nil || result != nil {
                 HStack {
-                    if let time = executionTime {
+                    if isExecuting, let startTime = executionStartTime {
+                        TimelineView(.periodic(from: startTime, by: 0.1)) { context in
+                            let elapsed = context.date.timeIntervalSince(startTime)
+                            Label(String(format: "%.1fs", elapsed), systemImage: "clock")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if let time = executionTime {
                         Label(String(format: "%.1fms", time * 1000), systemImage: "clock")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
@@ -410,7 +418,11 @@ struct QueryEditorView: View {
 
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         isExecuting = true
-        defer { isExecuting = false }
+        executionStartTime = Date()
+        defer {
+            isExecuting = false
+            executionStartTime = nil
+        }
         appError = nil
         result = nil
 

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -31,6 +31,7 @@ struct QueryEditorView: View {
     @State private var showWriteConfirmation = false
     @State private var showWriteBlockedAlert = false
     @State private var pendingWriteQuery = ""
+    @State private var showClearConfirmation = false
     @State private var showShareSheet = false
     @State private var shareText = ""
     @State private var hapticSuccess = false
@@ -63,6 +64,20 @@ struct QueryEditorView: View {
             ActivityViewController(items: [shareText])
         }
         .sheet(isPresented: $showHistory) { historySheet }
+        .confirmationDialog(
+            String(localized: "Clear Query"),
+            isPresented: $showClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Clear"), role: .destructive) {
+                query = ""
+                result = nil
+                appError = nil
+                executionTime = nil
+            }
+        } message: {
+            Text("Query text and results will be cleared.")
+        }
     }
 
     // MARK: - Editor
@@ -290,10 +305,7 @@ struct QueryEditorView: View {
                 Divider()
 
                 Button(role: .destructive) {
-                    query = ""
-                    result = nil
-                    appError = nil
-                    executionTime = nil
+                    showClearConfirmation = true
                 } label: {
                     Label("Clear", systemImage: "trash")
                 }

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -247,9 +247,9 @@ struct RowDetailView: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: "arrow.right.circle.fill")
-                                        .font(.caption2)
+                                        .font(.footnote)
                                     Text("\(fk.referencedTable).\(fk.referencedColumn)")
-                                        .font(.caption2)
+                                        .font(.footnote)
                                 }
                                 .foregroundStyle(.blue)
                             }

--- a/TableProMobile/TableProMobile/Views/TagManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/TagManagementView.swift
@@ -31,7 +31,7 @@ struct TagManagementView: View {
 
                             if tag.isPreset {
                                 Image(systemName: "lock.fill")
-                                    .font(.caption2)
+                                    .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
 


### PR DESCRIPTION
## Summary

Final batch of nice-to-have polish from the iOS UI/UX audit (P3 priority). 8 files changed.

### Tiny Fixes
- **RowCard font bump**: Column labels from `.caption2` to `.caption` for better readability
- **Safe Mode picker**: Changed to `.menu` style (dropdown instead of nav push for 3 options)
- **SSH Auth picker**: Changed to `.segmented` style (ideal for 2-option binary choice)
- **Clear confirmation**: "Clear" in query editor overflow menu now shows confirmation dialog
- **Lock icon size**: Bumped from `.caption2` to `.caption` in Tags list
- **FK button size**: Bumped from `.caption2` to `.footnote` in Row Detail

### Small Features
- **Leading swipe on connections**: Swipe right → blue "Edit" action (uses existing edit sheet)
- **Live elapsed timer**: Shows running time during query execution via `TimelineView`, static time after completion
- **Reconnect indicator**: Subtle "Reconnecting..." capsule with spinner appears during reconnection

## Test plan

- [ ] RowCard column labels slightly larger
- [ ] Safe Mode picker shows as dropdown menu
- [ ] SSH Auth picker shows as segmented control
- [ ] Clear button → confirmation dialog before clearing
- [ ] Lock icon slightly larger in Tags
- [ ] FK button slightly larger in Row Detail
- [ ] Swipe right on connection → "Edit" action
- [ ] Run a query → live timer counts up during execution
- [ ] Kill network → app foregrounds → "Reconnecting..." pill appears