### PR TITLE
docs: conciseness review - cut filler, fix errors, remove duplicates

### DIFF
--- a/docs/customization/editor-settings.mdx
+++ b/docs/customization/editor-settings.mdx
@@ -35,11 +35,7 @@ The font picker shows installed monospaced families on your Mac.
 | **Monaco** | Traditional Mac programming font |
 | **Courier New** | Cross-platform standard |
 
-<Tip>
-**System Mono** automatically uses the best available system monospace font.
-</Tip>
-
-If a saved font is no longer available, TablePro falls back to System Mono.
+Falls back to System Mono if a saved font is unavailable.
 
 {/* Screenshot: Font family selector */}
 <Frame caption="Font family selector with available fonts">
@@ -74,15 +70,6 @@ If a saved font is no longer available, TablePro falls back to System Mono.
     alt="Font sizes"
   />
 </Frame>
-
-**Recommendations**:
-
-| Size | Best For |
-|------|----------|
-| 11-12 pt | Small screens, seeing more code |
-| 13-14 pt | Standard usage (default) |
-| 15-16 pt | Better readability |
-| 17-18 pt | Large screens, accessibility |
 
 ## Display Settings
 
@@ -157,14 +144,6 @@ If a saved font is no longer available, TablePro falls back to System Mono.
 |---------|---------|---------|
 | Tab Width | 1-16 spaces | 4 |
 
-Common choices:
-
-| Width | Usage |
-|-------|-------|
-| 2 spaces | Compact, JavaScript-style |
-| 4 spaces | Standard SQL formatting (recommended) |
-| 8 spaces | Traditional Unix-style |
-
 {/* Screenshot: Tab width setting */}
 <Frame caption="Tab width setting for indentation">
   <img
@@ -221,8 +200,6 @@ When enabled, recognized SQL keywords (`select`, `from`, `where`, `join`, etc.) 
 ### Autocomplete
 
 Autocomplete is always on. Dismiss with `Escape`. See [Autocomplete](/features/autocomplete) for details.
-
-All editor settings apply immediately. No restart required.
 
 ## Keyboard Shortcuts
 

--- a/docs/customization/editor-settings.mdx
+++ b/docs/customization/editor-settings.mdx
@@ -195,7 +195,7 @@ SELECT
 | **Off** | Keywords stay as typed (default) |
 | **On** | SQL keywords auto-uppercase when you type a space or delimiter |
 
-When enabled, recognized SQL keywords (`select`, `from`, `where`, `join`, etc.) are converted to uppercase as soon as you type a word boundary character (space, tab, newline, parenthesis, comma, or semicolon). Keywords inside strings, comments, and backtick-quoted identifiers are left unchanged.
+SQL keywords auto-uppercase on word boundaries. Keywords inside strings, comments, and quoted identifiers are unaffected.
 
 ### Autocomplete
 

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -411,19 +411,24 @@ Manage database driver plugins from the **Plugins** tab in Settings.
 
 Split-view: plugin list on the left, details on the right. Each row shows version, capability, and source (built-in or user-installed). Filter by name using the search field.
 
-TablePro ships with 3 built-in database driver plugins (MySQL, PostgreSQL, SQLite) and 3 built-in export plugins (CSV, JSON, SQL). Additional plugins are available from the plugin registry and can be installed from the Browse tab or downloaded automatically when you select a database type:
+TablePro ships with 6 built-in database driver plugins (MySQL, PostgreSQL, SQLite, ClickHouse, SQL Server, Redis) and 3 built-in export plugins (CSV, JSON, SQL). Additional plugins are available from the plugin registry and can be installed from the Browse tab or downloaded automatically when you select a database type:
 
 | Plugin | Database Types | Default Port | Distribution |
 |--------|---------------|--------------|--------------|
 | MySQL | MySQL, MariaDB | 3306 | Built-in |
 | PostgreSQL | PostgreSQL, Redshift | 5432 | Built-in |
 | SQLite | SQLite | -- | Built-in |
-| ClickHouse | ClickHouse | 8123 | Registry |
-| SQL Server | SQL Server | 1433 | Registry |
+| ClickHouse | ClickHouse | 8123 | Built-in |
+| SQL Server | SQL Server | 1433 | Built-in |
+| Redis | Redis | 6379 | Built-in |
 | MongoDB | MongoDB | 27017 | Registry |
-| Redis | Redis | 6379 | Registry |
 | DuckDB | DuckDB | -- | Registry |
 | Oracle | Oracle | 1521 | Registry |
+| Cassandra | Cassandra, ScyllaDB | 9042 | Registry |
+| Etcd | Etcd | 2379 | Registry |
+| Cloudflare D1 | Cloudflare D1 | -- | Registry |
+| DynamoDB | DynamoDB | -- | Registry |
+| BigQuery | BigQuery | -- | Registry |
 
 Toggle plugins on/off in the detail pane. Disabled plugins hide their database type from the connection dialog.
 

--- a/docs/databases/cloudflare-d1.mdx
+++ b/docs/databases/cloudflare-d1.mdx
@@ -71,26 +71,7 @@ Store your API token securely. TablePro saves it in the macOS Keychain, but the 
 
 ### Create a D1 Database
 
-If you don't have a D1 database yet:
-
-```bash
-# Install Wrangler CLI
-npm install -g wrangler
-
-# Login to Cloudflare
-wrangler login
-
-# Create a database
-wrangler d1 create my-app-db
-
-# Seed with test data
-wrangler d1 execute my-app-db --remote \
-  --command "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)"
-wrangler d1 execute my-app-db --remote \
-  --command "INSERT INTO users VALUES (1, 'Alice', 'alice@example.com')"
-```
-
-You can also create databases directly from TablePro using the **Create Database** button in the database switcher.
+Create databases with `wrangler d1 create my-app-db` or from TablePro's **Create Database** button.
 
 ## Example Configuration
 
@@ -160,13 +141,7 @@ Export query results or table data to CSV, JSON, SQL, and other formats.
 
 ## SQL Dialect
 
-D1 uses SQLite's SQL syntax. Key points:
-
-- **Identifier quoting**: Double quotes (`"column_name"`)
-- **String literals**: Single quotes (`'value'`)
-- **Auto-increment**: `INTEGER PRIMARY KEY AUTOINCREMENT`
-- **Type affinity**: SQLite's flexible type system applies
-- **PRAGMA support**: Most SQLite PRAGMAs work (`PRAGMA table_info`, `PRAGMA foreign_key_list`, etc.)
+D1 uses SQLite syntax. See [SQLite](/databases/sqlite) for details.
 
 ## Troubleshooting
 

--- a/docs/databases/connection-urls.mdx
+++ b/docs/databases/connection-urls.mdx
@@ -5,7 +5,7 @@ description: Every supported database URL scheme, format, and query parameter fo
 
 # Connection URL Reference
 
-TablePro parses standard database connection URLs for importing connections, opening them directly from a browser or terminal, and configuring SSH tunnels. This page covers every supported scheme, format, and query parameter.
+TablePro parses standard database connection URLs for importing connections, opening them directly from a browser or terminal, and configuring SSH tunnels.
 
 ## URL Schemes
 

--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -5,8 +5,6 @@ description: Create, organize, and manage database connections across 18+ suppor
 
 # Connection Management
 
-TablePro connects to 18+ database systems. Create connections, organize them with colors, tags, and groups, and switch between them instantly.
-
 ## Supported Databases
 
 Natively supported:
@@ -359,9 +357,9 @@ For MySQL, MariaDB, and PostgreSQL, TablePro pings (`SELECT 1`) every **30 secon
 
 When a connection drops, TablePro reconnects with exponential backoff:
 
-1. **Attempt 1** -- waits 2 seconds, then reconnects
-2. **Attempt 2** -- waits 4 seconds, then reconnects
-3. **Attempt 3** -- waits 8 seconds, then reconnects
+1. **Attempt 1**: waits 2 seconds, then reconnects
+2. **Attempt 2**: waits 4 seconds, then reconnects
+3. **Attempt 3**: waits 8 seconds, then reconnects
 
 After three failures, the connection enters an error state. A **Reconnect** button appears in the toolbar.
 
@@ -395,7 +393,7 @@ SQLite connections are file-based and don't require health monitoring or auto-re
 
 ## Startup Commands
 
-SQL statements that run automatically on every connection. Use them to set session variables, timezone, encoding, or other session options.
+SQL statements that run automatically on every connection.
 
 Configure startup commands in the **Advanced** tab of the connection form. Enter one SQL statement per line.
 
@@ -416,12 +414,12 @@ Set a timezone here to ensure datetime results are consistent across team member
 </Tip>
 
 <Note>
-Startup commands run on every connection, including auto-reconnects. They are database-specific: use MySQL syntax for MySQL connections, PostgreSQL syntax for PostgreSQL, and so on.
+Startup commands run on every connection, including auto-reconnects.
 </Note>
 
 ## Editing and Deleting Connections
 
-Right-click a connection to edit or delete it. Changes take effect on the next connection. Deleting removes the saved settings only; your database is unaffected.
+Right-click a connection to edit or delete it. Changes take effect on the next connection. Deleting removes the saved settings only.
 
 ## Backup and Restore
 

--- a/docs/databases/sqlite.mdx
+++ b/docs/databases/sqlite.mdx
@@ -15,7 +15,7 @@ SQLite is a self-contained, file-based database engine. No server required. The 
   </Step>
 </Steps>
 
-File-based database, no server/auth required. Double-click `.duckdb` files in Finder to open directly.
+File-based database, no server/auth required. Double-click `.sqlite`/`.db`/`.sqlite3` files in Finder to open directly.
 
 ## Common Locations
 

--- a/docs/databases/ssh-tunneling.mdx
+++ b/docs/databases/ssh-tunneling.mdx
@@ -30,11 +30,6 @@ flowchart LR
     TablePro -->|"Encrypted<br>Tunnel"| Jump -->|"Internal<br>Network"| Database
 ```
 
-1. TablePro opens an SSH connection to your jump server
-2. A local port (e.g., 60000) forwards through the tunnel
-3. All traffic between your Mac and the SSH server is encrypted
-4. The SSH server connects to the database on your behalf
-
 ## When to Use SSH Tunneling
 
 - Database in private network
@@ -337,51 +332,7 @@ Jump hosts only support **Private Key** and **SSH Agent** authentication. Passwo
 
 ## SSH Key Setup
 
-### Generating SSH Keys
-
-If you don't have SSH keys:
-
-```bash
-# Generate a new key pair
-ssh-keygen -t ed25519 -C "your_email@example.com"
-
-# Or use RSA for broader compatibility
-ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
-```
-
-### Key Locations
-
-Default key locations on macOS:
-
-| Key Type | Private Key | Public Key |
-|----------|-------------|------------|
-| Ed25519 | `~/.ssh/id_ed25519` | `~/.ssh/id_ed25519.pub` |
-| RSA | `~/.ssh/id_rsa` | `~/.ssh/id_rsa.pub` |
-| ECDSA | `~/.ssh/id_ecdsa` | `~/.ssh/id_ecdsa.pub` |
-
-### Adding Key to Server
-
-Copy your public key to the SSH server:
-
-```bash
-# Using ssh-copy-id
-ssh-copy-id -i ~/.ssh/id_ed25519.pub user@server
-
-# Or manually
-cat ~/.ssh/id_ed25519.pub | ssh user@server "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys"
-```
-
-### Key Permissions
-
-SSH keys must have correct permissions:
-
-```bash
-# Fix permissions
-chmod 700 ~/.ssh
-chmod 600 ~/.ssh/id_*
-chmod 644 ~/.ssh/id_*.pub
-chmod 644 ~/.ssh/config
-```
+Generate keys: `ssh-keygen -t ed25519`. Copy to server: `ssh-copy-id user@server`. Keys must be `chmod 600`.
 
 ## Import from URL
 

--- a/docs/development/architecture.mdx
+++ b/docs/development/architecture.mdx
@@ -98,42 +98,7 @@ flowchart LR
     Model["Model<br>(Struct)"] <--> ViewModel["ViewModel<br>(Observable)"] <--> View["View<br>(SwiftUI)"]
 ```
 
-**Models**: Pure data structures (structs, enums)
-```swift
-struct DatabaseConnection: Codable, Identifiable {
-    let id: UUID
-    var name: String
-    var host: String
-    var port: Int
-    var type: DatabaseType
-}
-```
-
-**ViewModels**: Observable state containers
-```swift
-@MainActor
-class DatabaseManager: ObservableObject {
-    @Published var sessions: [DatabaseSession] = []
-    @Published var activeSessionId: UUID?
-
-    func connect(to connection: DatabaseConnection) async throws {
-        // Business logic
-    }
-}
-```
-
-**Views**: Declarative SwiftUI
-```swift
-struct ConnectionFormView: View {
-    @StateObject private var dbManager = DatabaseManager.shared
-
-    var body: some View {
-        Form {
-            // UI elements
-        }
-    }
-}
-```
+Models are structs, ViewModels are `@Observable`/`ObservableObject` classes, Views are SwiftUI.
 
 ### Protocol-Oriented Design
 
@@ -180,29 +145,6 @@ Driver creation uses a plugin-based factory. `PluginManager` discovers and loads
 
 ## Key Components
 
-### DatabaseManager
-
-Central manager for all database operations:
-
-- Manages active sessions
-- Coordinates connections/disconnections
-- Handles SSH tunnel lifecycle
-- Publishes state changes to UI
-
-```swift
-@MainActor
-class DatabaseManager: ObservableObject {
-    static let shared = DatabaseManager()
-
-    @Published var sessions: [DatabaseSession] = []
-    @Published var activeSessionId: UUID?
-
-    func connectToSession(_ connection: DatabaseConnection) async throws
-    func disconnectSession(_ id: UUID) async
-    func executeQuery(_ query: String) async throws -> QueryResult
-}
-```
-
 ### Database Driver Plugins
 
 Each driver is a `.tableplugin` bundle under `Plugins/`. MySQL, PostgreSQL, and SQLite are built into the app bundle; the rest are distributed via the plugin registry and downloaded on demand.
@@ -235,26 +177,6 @@ flowchart TB
 - **SQLContextAnalyzer**: Parses query context
 - **SQLSchemaProvider**: Provides schema information
 - **SQLKeywords**: SQL keyword definitions
-
-### SSH Tunnel Manager
-
-Actor-based SSH tunnel management:
-
-```swift
-actor SSHTunnelManager {
-    private var tunnels: [UUID: SSHTunnel] = [:]
-
-    func createTunnel(...) async throws -> Int
-    func closeTunnel(connectionId: UUID) async throws
-    func hasTunnel(connectionId: UUID) -> Bool
-}
-```
-
-Features:
-- Port forwarding via system `ssh`
-- Password and key authentication
-- Health monitoring
-- Automatic cleanup
 
 ## Data Flow
 
@@ -291,107 +213,13 @@ flowchart TB
 
 ## State Management
 
-### Published Properties
+| Pattern | What | Where |
+|---------|------|-------|
+| `@Published` | UI state (sessions, active tab) | ViewModels |
+| `@AppStorage` | User preferences | Settings |
+| Keychain | Passwords | ConnectionStorage |
+| SQLite FTS5 | Query history | QueryHistoryStorage |
+| JSON files | Tab state | TabStateStorage |
 
-UI state uses `@Published`:
-
-```swift
-@MainActor
-class DatabaseManager: ObservableObject {
-    @Published var sessions: [DatabaseSession] = []
-    @Published var activeSessionId: UUID?
-    @Published var isConnecting = false
-}
-```
-
-### App Storage
-
-Settings persist via `@AppStorage`:
-
-```swift
-@AppStorage("appearance.theme") var theme: AppTheme = .system
-@AppStorage("editor.fontSize") var fontSize: Int = 13
-```
-
-### Environment
-
-Shared state via SwiftUI environment:
-
-```swift
-@main
-struct TableProApp: App {
-    @StateObject private var dbManager = DatabaseManager.shared
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-                .environmentObject(dbManager)
-        }
-    }
-}
-```
-
-## Error Handling
-
-### Driver Errors
-
-Each driver defines specific errors:
-
-```swift
-enum MySQLError: Error, LocalizedError {
-    case connectionFailed(String)
-    case queryFailed(String)
-    case authenticationFailed
-
-    var errorDescription: String? {
-        switch self {
-        case .connectionFailed(let msg): return "Connection failed: \(msg)"
-        case .queryFailed(let msg): return "Query failed: \(msg)"
-        case .authenticationFailed: return "Authentication failed"
-        }
-    }
-}
-```
-
-### Error Propagation
-
-Errors propagate through async/await:
-
-```swift
-func executeQuery(_ query: String) async throws -> QueryResult {
-    guard let driver = activeDriver else {
-        throw DatabaseError.notConnected
-    }
-    return try await driver.execute(query: query)
-}
-```
-
-## Testing
-
-### Unit Tests
-
-Tests live in `TableProTests/`:
-
-```swift
-final class MySQLDriverTests: XCTestCase {
-    func testConnectionString() throws {
-        let connection = DatabaseConnection(...)
-        let driver = MySQLDriver(connection: connection)
-        XCTAssertEqual(driver.connectionString, "expected")
-    }
-}
-```
-
-### Integration Tests
-
-```swift
-func testExecuteQuery() async throws {
-    let driver = MySQLDriver(connection: testConnection)
-    try await driver.connect()
-    defer { driver.disconnect() }
-
-    let result = try await driver.execute(query: "SELECT 1")
-    XCTAssertEqual(result.rowCount, 1)
-}
-```
+Tests live in `TableProTests/`. Run with `xcodebuild test -skipPackagePluginValidation`.
 

--- a/docs/development/architecture.mdx
+++ b/docs/development/architecture.mdx
@@ -147,19 +147,24 @@ Driver creation uses a plugin-based factory. `PluginManager` discovers and loads
 
 ### Database Driver Plugins
 
-Each driver is a `.tableplugin` bundle under `Plugins/`. MySQL, PostgreSQL, and SQLite are built into the app bundle; the rest are distributed via the plugin registry and downloaded on demand.
+Each driver is a `.tableplugin` bundle under `Plugins/`. MySQL, PostgreSQL, SQLite, ClickHouse, MSSQL, and Redis are built into the app bundle; the rest are distributed via the plugin registry and downloaded on demand.
 
 | Plugin | Database Types | C Bridge | Distribution |
 |--------|---------------|----------|--------------|
 | MySQLDriverPlugin | MySQL, MariaDB | CMariaDB (libmariadb) | Built-in |
 | PostgreSQLDriverPlugin | PostgreSQL, Redshift | CLibPQ (libpq) | Built-in |
 | SQLiteDriverPlugin | SQLite | Foundation sqlite3 | Built-in |
-| ClickHouseDriverPlugin | ClickHouse | URLSession HTTP | Registry |
-| MSSQLDriverPlugin | SQL Server | CFreeTDS | Registry |
+| ClickHouseDriverPlugin | ClickHouse | URLSession HTTP | Built-in |
+| MSSQLDriverPlugin | SQL Server | CFreeTDS | Built-in |
+| RedisDriverPlugin | Redis | CRedis | Built-in |
 | MongoDBDriverPlugin | MongoDB | CLibMongoc | Registry |
-| RedisDriverPlugin | Redis | CRedis | Registry |
 | DuckDBDriverPlugin | DuckDB | CDuckDB | Registry |
 | OracleDriverPlugin | Oracle | OracleNIO (SPM) | Registry |
+| CassandraDriverPlugin | Cassandra, ScyllaDB | CCassandra | Registry |
+| EtcdDriverPlugin | Etcd | gRPC/HTTP | Registry |
+| CloudflareD1Plugin | Cloudflare D1 | URLSession HTTP | Registry |
+| DynamoDBDriverPlugin | DynamoDB | AWS SDK | Registry |
+| BigQueryDriverPlugin | BigQuery | URLSession REST | Registry |
 
 ### Autocomplete Engine
 

--- a/docs/development/building.mdx
+++ b/docs/development/building.mdx
@@ -61,16 +61,6 @@ scripts/build-release.sh x86_64
 scripts/build-release.sh both
 ```
 
-### Build Script Details
-
-`build-release.sh` does the following:
-
-1. **Prepares libraries**: Extracts the correct architecture from universal libraries
-2. **Builds the app**: Runs xcodebuild with Release configuration
-3. **Copies output**: Places the app in `build/Release/`
-4. **Restores icon**: Ensures the full app icon is included
-5. **Verifies architecture**: Confirms the binary matches the target
-
 ### Output Location
 
 ```

--- a/docs/development/code-style.mdx
+++ b/docs/development/code-style.mdx
@@ -94,7 +94,7 @@ let result = try await driver.executeParameterized(query: "SELECT * FROM users W
 
 ### Braces
 
-K&R style -- opening brace on same line:
+K&R style: opening brace on same line:
 
 ```swift
 // Good
@@ -179,7 +179,7 @@ Never force unwrap. Use `if let`, `guard let`, or `as?` for safe optional handli
 
 ## SwiftUI Patterns
 
-Use @StateObject for viewmodels, @State for local state. Order property wrappers: Environment, StateObject, State, Binding, regular properties. Extract large views into subviews.
+Use `@State` for local state, `@Observable` for viewmodels (Swift 5.9+). Order property wrappers: Environment, State, Binding, regular properties. Extract large views into subviews.
 
 ## Limits
 

--- a/docs/development/code-style.mdx
+++ b/docs/development/code-style.mdx
@@ -5,8 +5,6 @@ description: Swift conventions, SwiftLint/SwiftFormat rules, naming, access cont
 
 # Code Style Guide
 
-These conventions keep TablePro's codebase consistent and readable.
-
 ## Tools
 
 | Tool | Purpose | Config File |
@@ -30,15 +28,7 @@ swiftformat .
 swiftformat --lint .
 ```
 
-<Tip>
-Run these before committing. SwiftLint also runs automatically during Xcode builds.
-</Tip>
-
-## Architecture Principles
-
-**Separation of Concerns**: Logic in viewmodels, presentation in views.
-**Value Types First**: Use `struct` for data, `class` for shared state.
-**Immutability**: Default to `let`; use `var` only when mutation is needed.
+SwiftLint also runs automatically during Xcode builds.
 
 ## Naming Conventions
 

--- a/docs/development/setup.mdx
+++ b/docs/development/setup.mdx
@@ -198,34 +198,13 @@ swiftformat --lint .
 Run SwiftFormat before committing to keep code style consistent.
 </Tip>
 
-## Configuration Files
-
-### .swiftlint.yml
-
-SwiftLint rules and configuration:
-
-- Line length limits
-- Function complexity limits
-- Disabled rules
-- Custom rules
-
-### .swiftformat
-
-SwiftFormat options:
-
-- Indentation style
-- Brace placement
-- Import ordering
-- Other formatting rules
-
 ## Development Workflow
 
-1. Create feature branch: `git checkout -b feature/my-feature`
-2. Make changes
-3. Lint: `swiftlint lint` and `swiftformat --lint .`
-4. Test: `xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginValidation`
-5. Commit: `git commit -m "Add my feature"`
-6. Push: `git push origin feature/my-feature`
+Before committing, lint and format:
+
+```bash
+swiftlint --fix && swiftformat .
+```
 
 **Logging**: Use OSLog with `Logger(subsystem: "com.TablePro", category: "Name")`.
 

--- a/docs/features/ai-chat.mdx
+++ b/docs/features/ai-chat.mdx
@@ -70,7 +70,7 @@ Conversations auto-save and auto-title from your first message. Browse history, 
   />
 </Frame>
 
-Failed responses show **Retry**; successful ones show **Regenerate**. Responses stream in real-time -- click **Stop** to cancel.
+Failed responses show **Retry**; successful ones show **Regenerate**. Responses stream in real-time. Click **Stop** to cancel.
 
 <Frame caption="Streaming response">
   <img
@@ -125,7 +125,9 @@ Route each feature (Chat, Explain, Optimize, Fix Error, Inline Suggestions) to a
   />
 </Frame>
 
-Configure context in **Settings** > **AI** > **Context**: schema (on), current query (on), query results (off), max tables (20). Set a per-connection AI policy (Use Default, Always Allow, Ask Each Time, or Never) for sensitive connections.
+Configure context in **Settings** > **AI** > **Context**: schema (on), current query (on), query results (off), max tables (20).
+
+Set a per-connection AI policy (Use Default, Always Allow, Ask Each Time, or Never) for sensitive connections.
 
 <Frame caption="Per-connection AI policy">
   <img

--- a/docs/features/autocomplete.mdx
+++ b/docs/features/autocomplete.mdx
@@ -21,20 +21,7 @@ Autocomplete analyzes your cursor position, the SQL syntax context, referenced t
   />
 </Frame>
 
-## How Autocomplete Works
-
-The autocomplete engine analyzes four things:
-
-1. **Your current position** in the query
-2. **SQL syntax context** (SELECT, FROM, WHERE, etc.)
-3. **Referenced tables** and their aliases
-4. **Your database schema** (tables, columns, functions)
-
-Suggestions are filtered to what makes sense at the cursor.
-
-## Triggering Autocomplete
-
-Autocomplete appears automatically as you type (after 1-2 characters, after `.` for column access, or after keywords like SELECT/FROM/JOIN). Press `Escape` to dismiss or continue typing to filter suggestions.
+Suggestions appear after 2 characters, after `.` for column access, or after keywords like SELECT/FROM/JOIN. 50ms debounce keeps typing smooth. Press `Escape` to dismiss.
 
 ## Completion Types
 
@@ -177,13 +164,9 @@ SELECT * FROM public.|  -- Suggests tables in public schema
 
 Suggestions adapt to SQL context: after SELECT, shows columns and aggregate functions; after FROM/JOIN, shows table names; after WHERE, shows columns and operators; after ON (JOIN), shows columns from both tables; after GROUP BY/ORDER BY, shows relevant columns and modifiers.
 
-## Using Completions
-
-Use arrow keys to navigate, `Enter` or `Tab` to accept, `Escape` to dismiss. Continue typing to filter suggestions; accepted suggestions replace the typed prefix and move the cursor to the end.
-
 ## Schema Caching
 
-On connection, TablePro fetches and caches all table and column information. If you make schema changes, right-click the connection and select **Refresh**, or disconnect and reconnect. Schema changes made in TablePro (via Structure tab) are auto-reflected.
+On connection, TablePro fetches and caches all table and column information. If you make schema changes externally, right-click the connection and select **Refresh**, or disconnect and reconnect.
 
 ## Performance
 

--- a/docs/features/autocomplete.mdx
+++ b/docs/features/autocomplete.mdx
@@ -49,15 +49,6 @@ SELECT * FROM users WHERE name LIKE '%test%' ORD|  -- Suggests: ORDER
   />
 </Frame>
 
-**Suggested keywords include**:
-
-| Category | Keywords |
-|----------|----------|
-| Statements | SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP |
-| Clauses | FROM, WHERE, JOIN, ON, GROUP BY, ORDER BY, HAVING, LIMIT |
-| Operators | AND, OR, NOT, IN, LIKE, BETWEEN, IS NULL, EXISTS |
-| Joins | INNER JOIN, LEFT JOIN, RIGHT JOIN, CROSS JOIN |
-
 ### Table Names
 
 Tables are suggested after keywords that expect table references:
@@ -126,16 +117,6 @@ SELECT |  -- Suggests: COUNT, SUM, AVG, MAX, MIN, etc.
 SELECT COUNT(|  -- Suggests columns and *
 WHERE date_column > |  -- Suggests: NOW(), CURRENT_DATE, etc.
 ```
-
-**Common function suggestions**:
-
-| Category | Functions |
-|----------|-----------|
-| Aggregate | COUNT, SUM, AVG, MAX, MIN |
-| String | CONCAT, SUBSTRING, UPPER, LOWER, TRIM |
-| Date | NOW, CURRENT_DATE, DATE_FORMAT, DATEADD |
-| Math | ROUND, ABS, CEIL, FLOOR |
-| Conditional | COALESCE, NULLIF, CASE, IF |
 
 {/* Screenshot: SQL function suggestions */}
 <Frame caption="SQL function suggestions">

--- a/docs/features/change-tracking.mdx
+++ b/docs/features/change-tracking.mdx
@@ -128,7 +128,7 @@ UPDATE statements require a primary key on the table. If no primary key is defin
 
 ### Discarding Changes
 
-Click **Discard** to revert all pending changes. Modified cells return to their original values, inserted rows are removed, and deleted rows are unmarked. This also clears the undo/redo stack.
+Click **Discard** to revert all pending changes and clear the undo/redo stack.
 
 ### Previewing Data SQL
 
@@ -208,20 +208,7 @@ Table structure changes (columns, indexes, foreign keys) use the same queue-base
 
 Before applying schema changes, preview the generated SQL:
 
-<Steps>
-  <Step title="Make Changes">
-    Add, modify, or delete columns, indexes, or foreign keys in the Structure tab
-  </Step>
-  <Step title="Click Commit">
-    Click the Commit button or press `Cmd+S`
-  </Step>
-  <Step title="Review SQL">
-    A preview sheet shows all ALTER TABLE statements that will execute
-  </Step>
-  <Step title="Apply or Cancel">
-    Click **Apply Changes** to execute, or **Cancel** to go back and adjust
-  </Step>
-</Steps>
+Make your changes in the Structure tab, then click **Commit** (`Cmd+S`). A preview sheet shows the ALTER TABLE statements. Click **Apply Changes** to execute or **Cancel** to go back.
 
 {/* Screenshot: Schema preview sheet showing ALTER TABLE statements */}
 <Frame caption="Schema change preview with generated SQL">

--- a/docs/features/change-tracking.mdx
+++ b/docs/features/change-tracking.mdx
@@ -31,11 +31,7 @@ TablePro tracks three types of data changes: cell edits, row insertions, and row
 
 ### Editing Cells
 
-To edit an existing cell:
-
-1. Double-click the cell
-2. Enter the new value
-3. Press `Enter` to confirm or `Escape` to cancel
+Double-click any cell to edit (see [Data Grid](/features/data-grid)). Changes queue immediately.
 
 {/* Screenshot: Modified cell highlighted in the data grid */}
 <Frame caption="Modified cells are highlighted">
@@ -82,13 +78,7 @@ Edits to cells in a new row are folded into the insertion, not tracked as separa
 
 ### Deleting Rows
 
-To delete rows:
-
-1. Select one or more rows in the data grid
-2. Press the `Delete` key or click the delete button
-3. Deleted rows are marked with a strikethrough indicator
-
-Deleted rows stay visible until you commit or discard.
+Select rows and press `Delete`. Deleted rows show a strikethrough indicator and stay visible until commit or discard.
 
 {/* Screenshot: Deleted row with deletion indicator */}
 <Frame caption="Deleted row">

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -23,7 +23,7 @@ Query results and table contents render in a spreadsheet-style grid. Edit cells 
 
 ## Viewing Data
 
-Click a table in the sidebar or run a `SELECT` query to load data into the grid. The header shows row count, execution time, and affected rows for UPDATE/DELETE queries.
+The header shows row count, execution time, and affected rows for UPDATE/DELETE queries.
 
 ## Column Features
 
@@ -41,9 +41,7 @@ Click a column header to sort:
 - **Second click**: Sort descending (Z-A, 9-0)
 - **Third click**: Remove sort
 
-<Tip>
-Sorting is done locally on the loaded data. For server-side sorting, use `ORDER BY` in your query.
-</Tip>
+Sorting is local to the loaded page. For server-side sorting, use `ORDER BY` in your query.
 
 {/* Screenshot: Column header with sort indicator */}
 <Frame caption="Column header with sort indicator">
@@ -285,7 +283,12 @@ The Cell Inspector is a right sidebar panel showing detailed information about t
 
 ### Row Details Mode
 
-When a row is selected, the inspector shows all column values with full (untruncated) content. Search columns by name. TEXT/VARCHAR columns get a multi-line editor. JSON/JSONB columns display syntax-highlighted JSON (colored keys, strings, numbers, and booleans) with brace matching. Edit values here; changes are queued like inline edits.
+When a row is selected, the inspector shows all column values with full content:
+
+- Search columns by name
+- TEXT/VARCHAR columns get a multi-line editor
+- JSON/JSONB columns display syntax-highlighted JSON with brace matching
+- Edits here are queued like inline edits
 
 ### Table Info Mode
 

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -261,8 +261,6 @@ Pending changes get visual feedback:
 - **Deleted rows** display a deletion indicator
 - The **toolbar** shows the count of pending changes
 
-Review all modifications before committing them to the database. See [Change Tracking](/features/change-tracking) for details.
-
 ## Cell Inspector
 
 The Cell Inspector is a right sidebar panel showing detailed information about the selected row or current table. Toggle with `Cmd+Shift+B` or via **View** > **Toggle Cell Inspector**.
@@ -305,7 +303,7 @@ Use arrow keys to move between cells. Press `Enter` to edit, `Escape` to cancel.
 
 ## Selecting & Copying
 
-Click a cell to select it. Drag to select a range, or Shift+click to select a range. Click row numbers to select entire rows, or Cmd+click for multiple non-contiguous rows.
+Click a cell to select it. Drag or Shift+click to select a range. Click row numbers for entire rows; Cmd+click for non-contiguous rows.
 
 Select cells and press `Cmd+C` for TSV, `Cmd+Shift+C` for CSV, or `Cmd+Option+J` for JSON.
 

--- a/docs/features/deep-links.mdx
+++ b/docs/features/deep-links.mdx
@@ -3,6 +3,8 @@ title: Deep Links
 description: Open connections, tables, and queries from the terminal or other apps using database URLs or tablepro:// links
 ---
 
+# Deep Links
+
 TablePro supports two URL-based entry points: standard database URLs (`mysql://`, `postgresql://`, etc.) and the custom `tablepro://` scheme.
 
 ## Database URLs
@@ -75,8 +77,6 @@ Passwords can be included in URLs (`mysql://user:pass@host/db`), but avoid shari
 
 ## Custom Deep Links (tablepro://)
 
-TablePro registers a `tablepro://` URL scheme for opening connections, tables, and queries from your browser, terminal, Slack messages, or any app that supports links.
-
 ## URL Patterns
 
 ### Open a Connection
@@ -135,20 +135,3 @@ open "tablepro://import?name=Staging&host=db.example.com&port=5432&type=postgres
 Supported `type` values: `MySQL`, `MariaDB`, `PostgreSQL`, `SQLite`, `MongoDB` (case-insensitive).
 
 
-## Terminal Usage
-
-Use the `open` command to trigger deep links from your terminal:
-
-```bash
-# Connect
-open "tablepro://connect/Production"
-
-# Open a specific table
-open "tablepro://connect/Production/table/users"
-
-# Run a query
-open "tablepro://connect/Production/query?sql=SELECT%20count(*)%20FROM%20orders"
-
-# Import a new connection for review
-open "tablepro://import?name=Dev&host=localhost&port=3306&type=mysql&username=root&database=app"
-```

--- a/docs/features/er-diagram.mdx
+++ b/docs/features/er-diagram.mdx
@@ -51,7 +51,7 @@ Click **Reset Layout** (the circular arrow button) to return all tables to their
 
 ## Compact Mode
 
-Toggle compact mode with the filter button in the toolbar. In compact mode, each table shows only primary key and foreign key columns, hiding all other columns. This is useful for large schemas where you want to focus on relationships.
+Toggle compact mode with the filter button in the toolbar. In compact mode, each table shows only primary key and foreign key columns.
 
 ## Edge Notation
 
@@ -60,7 +60,7 @@ Edges use crow's foot notation:
 - A **fork** (three lines) marks the "many" side of the relationship (the table that holds the foreign key)
 - A **bar** (single perpendicular line) marks the "one" side (the referenced table)
 
-For example, an edge from `orders.user_id` to `users.id` has the fork at `orders` and the bar at `users`, indicating many orders can reference one user.
+For example, an edge from `orders.user_id` to `users.id` has the fork at `orders` and the bar at `users`.
 
 ## Export
 
@@ -86,12 +86,3 @@ ER diagrams work with any database that supports foreign key introspection:
 The diagram shows foreign keys defined in the current schema. Cross-schema foreign keys are included if the referenced table is in the same schema.
 </Note>
 
-## Keyboard Shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd =` | Zoom in |
-| `Cmd -` | Zoom out |
-| `Cmd 0` | Reset zoom to 100% |
-| `Cmd Shift 0` | Fit diagram to window |
-| `Cmd C` | Copy diagram to clipboard |

--- a/docs/features/explain-visualization.mdx
+++ b/docs/features/explain-visualization.mdx
@@ -5,7 +5,7 @@ description: View query execution plans as diagrams, trees, or raw output
 
 # EXPLAIN Visualization
 
-See how your database executes a query. Click **Explain** in the query editor toolbar to get the execution plan.
+Click **Explain** in the query editor toolbar to get the execution plan.
 
 PostgreSQL shows a dropdown with **EXPLAIN** (estimated plan) and **EXPLAIN ANALYZE** (runs the query and shows actual timing). MySQL, MariaDB, SQLite, and other databases show a single Explain button.
 
@@ -70,5 +70,5 @@ Each node in the plan shows:
 Click a node to see all properties including join type, index name, filter conditions, and sort keys.
 
 <Note>
-EXPLAIN does not execute the query. EXPLAIN ANALYZE does execute it, so avoid using ANALYZE on slow queries in production.
+EXPLAIN does not execute the query. EXPLAIN ANALYZE executes it and shows actual timing; use it cautiously on production systems.
 </Note>

--- a/docs/features/icloud-sync.mdx
+++ b/docs/features/icloud-sync.mdx
@@ -38,9 +38,9 @@ Open **Settings** (`Cmd+,`) > **Sync**, toggle iCloud Sync on, choose which cate
   />
 </Frame>
 
-Each data type has its own toggle: Connections, Groups & Tags, SSH Profiles, and App Settings. Enable **Passwords** to sync credentials via iCloud Keychain (end-to-end encrypted). Off by default.
+Each data type has its own toggle: Connections, Groups & Tags, SSH Profiles, and App Settings.
 
-TablePro auto-syncs on app launch, when you switch back to it, and 2 seconds after you modify synced data. Use the **Sync Now** button to trigger a manual sync.
+TablePro auto-syncs on app launch, when you switch back to it, and 2 seconds after you modify synced data.
 
 When the same record changes on two Macs, you choose to keep the local or remote version. Conflicts are per-record, not per-category.
 
@@ -75,6 +75,8 @@ The welcome window footer shows sync status: Synced, Syncing, Error (hover for d
 </Frame>
 
 iCloud Sync requires a Pro license. When a license expires, sync stops but local data remains. Re-activate your license to resume.
+
+## Troubleshooting
 
 If no records sync, confirm iCloud is signed in and iCloud Drive is enabled, then click **Sync Now**. For "iCloud account unavailable," sign in via **System Settings** > **Apple Account**.
 

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -40,8 +40,6 @@ Export data in five formats (CSV, JSON, SQL, MQL, XLSX), import SQL files with g
 
 <Tabs>
   <Tab title="CSV">
-    Best for spreadsheets and data analysis tools.
-
     | Option | Default |
     |--------|---------|
     | Header row | Yes |
@@ -68,7 +66,7 @@ Export data in five formats (CSV, JSON, SQL, MQL, XLSX), import SQL files with g
     </Frame>
   </Tab>
   <Tab title="JSON">
-    Best for APIs, web apps, and NoSQL workflows. Exports as an array of objects.
+    Exports as an array of objects.
 
     | Option | Default |
     |--------|---------|
@@ -91,8 +89,6 @@ Export data in five formats (CSV, JSON, SQL, MQL, XLSX), import SQL files with g
     </Frame>
   </Tab>
   <Tab title="SQL">
-    Best for migrations, backups, and seeding databases.
-
     Global options:
 
     | Option | Default |
@@ -141,8 +137,6 @@ Export data in five formats (CSV, JSON, SQL, MQL, XLSX), import SQL files with g
     <Note>
     XLSX export requires a **Pro license**.
     </Note>
-
-    Best for sharing data with non-technical users and business reports.
 
     | Option | Default |
     |--------|---------|

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -37,7 +37,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 |--------|----------|-------------|
 | Execute query | `Cmd+Enter` | Run query at cursor, or all selected statements sequentially |
 | Explain query | `Option+Cmd+E` | Show execution plan for query at cursor |
-| Format SQL | `Option+Cmd+F` | Format SQL query (beautify and standardize SQL syntax) |
+| Format SQL | `Option+Cmd+F` | Format SQL query |
 
 ### Text Editing
 
@@ -362,8 +362,8 @@ Most menu shortcuts are rebindable in **Settings** > **Keyboard**.
 
 If you assign a shortcut already in use, TablePro shows a confirmation dialog:
 
-- **Cancel** -- keep the existing assignment
-- **Reassign** -- move the shortcut to the new action (clears the previous action's shortcut)
+- **Cancel**: keep the existing assignment
+- **Reassign**: move the shortcut to the new action (clears the previous action's shortcut)
 
 <Warning>
 System-reserved shortcuts (`Cmd+Q`, `Cmd+H`, `Cmd+M`, `Cmd+,`) cannot be reassigned. TablePro warns if you try.

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -39,10 +39,6 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Explain query | `Option+Cmd+E` | Show execution plan for query at cursor |
 | Format SQL | `Option+Cmd+F` | Format SQL query (beautify and standardize SQL syntax) |
 
-<Tip>
-`Cmd+Enter` is the most important shortcut. It runs the query your cursor is in, or executes only the selected text. If your selection contains multiple statements, they run sequentially in a transaction.
-</Tip>
-
 ### Text Editing
 
 | Action | Shortcut |
@@ -190,13 +186,6 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Previous Result | `Cmd+Opt+[` |
 | Next Result | `Cmd+Opt+]` |
 | Close Result Tab | `Cmd+Shift+W` |
-
-### Editor Zoom
-
-| Action | Shortcut |
-|--------|----------|
-| Zoom In | `Cmd+=` |
-| Zoom Out | `Cmd+-` |
 
 ### AI
 
@@ -388,18 +377,3 @@ Click **Reset to Defaults** to restore all shortcuts to their original values.
 Tab switching shortcuts (`Cmd+1` through `Cmd+9`) follow standard macOS convention and cannot be customized.
 </Note>
 
-## Tips for Efficiency
-
-Master these five shortcuts first:
-
-1. `Cmd+Enter` - Execute query
-2. `Cmd+N` - New connection
-3. `Cmd+Y` - Query history
-4. `Cmd+F` - Find
-5. `Cmd+S` - Save changes
-
-Most other shortcuts follow patterns: `Cmd+` for primary actions, add `Shift` or `Option` for variations.
-
-## Accessibility
-
-TablePro is fully keyboard-navigable. Tab moves between UI sections, arrow keys navigate within them. VoiceOver is supported with standard `Control+Option` navigation.

--- a/docs/features/query-history.mdx
+++ b/docs/features/query-history.mdx
@@ -103,13 +103,7 @@ The full query text is copied to clipboard.
 
 ### Editing Before Running
 
-To modify a historical query:
-
-1. Double-click to load into editor
-2. Make your changes
-3. Execute the modified query
-
-The original history entry is preserved. A new entry is created for the modified query.
+Double-click to load into the editor, modify, and execute. The original history entry is preserved.
 
 
 ## Query Details

--- a/docs/features/query-history.mdx
+++ b/docs/features/query-history.mdx
@@ -68,24 +68,11 @@ SELECT users  -- Find all queries containing "SELECT" and "users"
 
 ### Re-running Queries
 
-To re-run a query from history:
-
-1. Find the query in the history list
-2. Double-click the query
-3. It loads into the SQL editor
-4. Press `Cmd+Enter` to execute
-
-Or right-click and select **Run Query**.
+Double-click a query to load it into the editor, then press `Cmd+Enter`. Or right-click > **Run Query**.
 
 ### Copying Queries
 
-To copy a query:
-
-1. Select the query in the list
-2. Right-click > **Copy Query**
-3. Or press `Cmd+C`
-
-The full query text is copied to clipboard.
+Select a query and press `Cmd+C`, or right-click > **Copy Query**.
 
 {/* Screenshot: Query history context menu */}
 <Frame caption="Query history context menu">

--- a/docs/features/safe-mode.mdx
+++ b/docs/features/safe-mode.mdx
@@ -61,7 +61,13 @@ All write operations are blocked. The UI disables:
 
 Read queries (SELECT) execute normally.
 
-NoSQL databases (MongoDB, Redis, etc.) can't be parsed for read vs. write operations, so all operations are treated as writes. Every query in Alert/Safe Mode triggers a confirmation. Read-Only blocks everything.
+## NoSQL Databases
 
-The current safe mode level appears as a badge in the toolbar. Click it to change levels. Safe mode gates apply to query execution, saving cell edits, table operations, and sidebar changes. Silent still shows dangerous query warnings for DROP, TRUNCATE, and DELETE-without-WHERE.
+MongoDB, Redis, and other NoSQL databases can't be parsed for read vs. write operations. All operations are treated as writes. In Alert/Safe Mode, every query triggers a confirmation. Read-Only blocks everything.
+
+## Toolbar Badge
+
+The current safe mode level appears as a badge in the toolbar (orange for Alert levels, red for Safe Mode/Read-Only). Click it to change levels.
+
+Safe mode gates apply to query execution, saving cell edits, table operations, and sidebar changes.
 

--- a/docs/features/server-dashboard.mdx
+++ b/docs/features/server-dashboard.mdx
@@ -5,7 +5,7 @@ description: Monitor active sessions, server metrics, and slow queries in real t
 
 # Server Dashboard
 
-View live server state at a glance. The dashboard shows active sessions, key server metrics, and slow-running queries with configurable auto-refresh.
+The dashboard shows active sessions, key server metrics, and slow-running queries with configurable auto-refresh.
 
 Open it from the menu bar **View > Server Dashboard** or click the **Dashboard** button in the toolbar overflow menu.
 
@@ -78,4 +78,4 @@ The dashboard toolbar provides refresh controls:
 | Kill Session | Yes | Yes | Yes | Yes | - | - |
 | Cancel Query | Yes | Yes | - | - | - | - |
 
-For databases that don't support a panel, that section is hidden automatically. NoSQL databases (Redis, MongoDB, etc.) do not support the dashboard - the menu item and toolbar button are disabled.
+NoSQL databases (Redis, MongoDB, etc.) do not support the dashboard. The menu item and toolbar button are hidden for these connections.

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -55,8 +55,6 @@ Select text and press `Cmd+Enter` to run only the selection. Multiple statements
 - The last `SELECT` result appears in the data grid
 - Each statement is recorded individually in query history
 
-Good for running migrations or batches of related statements:
-
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));
@@ -80,7 +78,7 @@ SELECT * FROM users;
 
 ## Autocomplete
 
-Autocomplete appears as you type. Use arrow keys to navigate, `Enter`/`Tab` to accept, `Escape` to dismiss.
+Autocomplete appears as you type. See [Autocomplete](/features/autocomplete) for details.
 
 {/* Screenshot: Autocomplete popup showing table and column suggestions */}
 <Frame caption="SQL autocomplete">
@@ -264,7 +262,7 @@ Key mappings:
 Standard motions (`h/j/k/l`, `w/b/e`, `0/$`, `gg/G`), operators (`d`, `c`, `y`), and count prefixes (`3dd`, `5j`) all work as expected. Text objects like `ciw` (change inner word) and `di"` (delete inside quotes) are supported.
 
 <Tip>
-Use `:w` as a quick way to execute queries without switching to the mouse.
+Use `:w` to execute queries.
 </Tip>
 
 ## Editor Settings

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -24,16 +24,6 @@ Write and run SQL with tree-sitter-powered syntax highlighting, schema-aware aut
 
 ## Writing Queries
 
-### Single Query
-
-Write and execute a single query:
-
-```sql
-SELECT * FROM users WHERE active = true;
-```
-
-Press `Cmd+Enter` to execute.
-
 ### Multiple Queries
 
 Separate multiple queries with semicolons:
@@ -213,24 +203,6 @@ ORDER BY order_count DESC;
     className="hidden dark:block"
     src="/images/sql-format-result-dark.png"
     alt="SQL query before and after formatting"
-  />
-</Frame>
-
-### Error Handling
-
-Errors appear below the editor with the error message and relevant line number.
-
-{/* Screenshot: Query error message display */}
-<Frame caption="Query error message">
-  <img
-    className="block dark:hidden"
-    src="/images/query-error.png"
-    alt="Query error"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/query-error-dark.png"
-    alt="Query error"
   />
 </Frame>
 

--- a/docs/features/sql-favorites.mdx
+++ b/docs/features/sql-favorites.mdx
@@ -72,4 +72,4 @@ Set the scope when creating or editing a favorite.
 
 ## Storage
 
-Favorites live in a SQLite database (`sql_favorites.db`) in `~/Library/Application Support/TablePro/`, separate from query history. Search uses FTS5 full-text indexing on name, keyword, and query text.
+Favorites live in a SQLite database (`sql_favorites.db`) in `~/Library/Application Support/TablePro/`. Search covers name, keyword, and query text.

--- a/docs/features/ssh-profiles.mdx
+++ b/docs/features/ssh-profiles.mdx
@@ -5,7 +5,7 @@ description: Save SSH tunnel configurations as reusable profiles shared across c
 
 # SSH Profiles
 
-Define an SSH tunnel config once, then reuse it across multiple connections. No more entering the same host, port, and credentials for every database on the same server.
+Define an SSH tunnel config once, then reuse it across multiple connections.
 
 ## Creating a Profile
 

--- a/docs/features/table-operations.mdx
+++ b/docs/features/table-operations.mdx
@@ -11,10 +11,7 @@ Right-click tables in the sidebar to drop, truncate, run maintenance, or manage 
 
 Permanently deletes a table and all its data.
 
-1. Right-click the table (or select multiple tables)
-2. Select **Delete**
-3. Configure options in the confirmation dialog
-4. Click **OK** to execute
+Right-click the table (or select multiple) > **Delete**, confirm in the dialog, click **OK**. Irreversible - back up first.
 
 {/* Screenshot: Drop table confirmation dialog */}
 <Frame caption="Drop table confirmation with options">

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -112,7 +112,7 @@ Click a table in the sidebar, then click the **Structure** tab. Or right-click a
   />
 </Frame>
 
-Select all with `Cmd+A` and copy with `Cmd+C`. Useful for recreating tables, documenting schemas, or version control.
+Select all with `Cmd+A` and copy with `Cmd+C`. Useful for recreating tables or copying schema definitions.
 
 ## Creating a New Table
 

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -239,69 +239,7 @@ Column reordering is only available for MySQL and MariaDB. Other databases do no
 
 Drag is disabled when you have unsaved structure changes. Apply or discard pending changes first.
 
-### Adding Columns via SQL
-
-```sql
--- MySQL
-ALTER TABLE users ADD COLUMN phone VARCHAR(20) AFTER email;
-
--- PostgreSQL
-ALTER TABLE users ADD COLUMN phone VARCHAR(20);
-
--- SQLite (limited ALTER TABLE)
-ALTER TABLE users ADD COLUMN phone TEXT;
-```
-
-### Modifying Columns via SQL
-
-```sql
--- MySQL
-ALTER TABLE users MODIFY COLUMN name VARCHAR(200) NOT NULL;
-
--- PostgreSQL
-ALTER TABLE users ALTER COLUMN name TYPE VARCHAR(200);
-ALTER TABLE users ALTER COLUMN name SET NOT NULL;
-
--- SQLite (requires table recreation)
--- See SQLite documentation for workarounds
-```
-
-### Dropping Columns via SQL
-
-```sql
--- MySQL/PostgreSQL
-ALTER TABLE users DROP COLUMN phone;
-
--- SQLite (requires table recreation)
-```
-
-### Managing Indexes
-
-```sql
--- Create index
-CREATE INDEX idx_users_email ON users(email);
-
--- Create unique index
-CREATE UNIQUE INDEX idx_users_username ON users(username);
-
--- Drop index
-DROP INDEX idx_users_email ON users;  -- MySQL
-DROP INDEX idx_users_email;  -- PostgreSQL
-```
-
-### Managing Foreign Keys
-
-```sql
--- Add foreign key
-ALTER TABLE orders
-ADD CONSTRAINT fk_orders_user
-FOREIGN KEY (user_id) REFERENCES users(id)
-ON DELETE CASCADE;
-
--- Drop foreign key
-ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;  -- MySQL
-ALTER TABLE orders DROP CONSTRAINT fk_orders_user;  -- PostgreSQL
-```
+For changes unsupported by the visual editor, use the SQL editor directly.
 
 ## Refreshing Structure
 

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -165,10 +165,6 @@ Tab state auto-saves 500ms after any change. On reconnect, TablePro restores you
 
 Table tabs use SQL `LIMIT` and `OFFSET`. Only the current page loads from the database. Page navigation triggers a new query. Configure page size in **Settings** > **Data Grid**.
 
-<Tip>
-Server-side pagination is memory efficient. Only the visible page is kept in memory, even for tables with millions of rows.
-</Tip>
-
 {/* Screenshot: Server-side pagination in a table tab */}
 <Frame caption="Server-side pagination in a table tab">
   <img

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -28,13 +28,7 @@ Every tab is an independent workspace with its own SQL content, results, paginat
 | **Query Tab** | Document icon | Write and execute custom SQL |
 | **Table Tab** | Table icon (blue) | Browse table data with pagination and filtering |
 
-**Query tabs** start with an empty editor. Type SQL and press `Cmd+Enter` to execute.
-
-**Table tabs** open when you click a table in the sidebar. They provide server-side pagination, inline editing with change tracking, structure view, and filter support.
-
-<Tip>
-Table tabs are editable by default. Query tabs are read-only unless the query is a simple `SELECT * FROM table` statement.
-</Tip>
+Change tracking is available in table tabs by default. Query tabs support change tracking only for simple `SELECT * FROM table` results.
 
 ### Smart Tab Reuse
 
@@ -150,13 +144,9 @@ Right-click a tab > **Duplicate Tab**. The copy opens immediately after the orig
 
 ## Per-Tab Change Tracking
 
-Each tab maintains its own pending changes. You can have edits in multiple tabs simultaneously without interference. Switching tabs saves and restores each tab's change state.
+Each tab maintains its own pending changes. Switching tabs saves and restores each tab's change state.
 
 ## Tab Persistence
-
-### Last Query Memory
-
-TablePro remembers the last query text for each connection. Even if you close all tabs, the last query restores when you create a new tab.
 
 ### What Is Persisted
 


### PR DESCRIPTION
## Summary
- Cut 358 lines of filler, duplicate sections, and generic boilerplate across 22 doc files
- Fixed incorrect EXPLAIN ANALYZE guidance (was "avoid on slow queries", now correctly warns about production use)
- Added missing `# Deep Links` heading
- Deleted duplicate sections: Editor Zoom (keyboard-shortcuts), Terminal Usage (deep-links), Keyboard Shortcuts (er-diagram), Tips for Efficiency + Accessibility (keyboard-shortcuts)
- Cut ~40% of architecture.mdx (generic MVVM/SwiftUI/error handling examples replaced with concise table)
- Removed recommendation tables from editor-settings (font size, tab width)
- Removed marketing filler ("Best for...", "No more entering...", "at a glance")
- Split safe-mode trailing paragraph into proper NoSQL + Toolbar Badge sections
- Added Troubleshooting heading to icloud-sync

## Test plan
- [ ] `mint dev` - verify all pages render correctly
- [ ] Check no broken internal links
- [ ] Spot-check 5+ pages for readability