### PR TITLE
fix: update activation metadata on validate, privacy + deactivation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- License settings showing stale app version from initial activation instead of current version
-- Raw license key sent in analytics heartbeat — now sends boolean flag only
-- Deactivation showing no feedback when server-side deactivation fails
+- License settings showing stale app version instead of current version
+- Deactivation not reporting server-side failure to user
 
 ## [0.31.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- License settings showing stale app version from initial activation instead of current version
+- Raw license key sent in analytics heartbeat — now sends boolean flag only
+- Deactivation showing no feedback when server-side deactivation fails
+
 ## [0.31.1] - 2026-04-12
 
 ### Fixed

--- a/TablePro/Core/Services/Infrastructure/AnalyticsService.swift
+++ b/TablePro/Core/Services/Infrastructure/AnalyticsService.swift
@@ -134,7 +134,7 @@ final class AnalyticsService {
         let databaseTypes = Array(Set(sessions.values.compactMap { $0.connection.type.rawValue }))
         let connectionCount = sessions.count
 
-        let licenseKey = LicenseStorage.shared.loadLicenseKey()
+        let hasLicense = LicenseStorage.shared.loadLicenseKey() != nil
 
         return AnalyticsPayload(
             machineId: LicenseStorage.shared.machineId,
@@ -144,7 +144,7 @@ final class AnalyticsService {
             locale: locale,
             databaseTypes: databaseTypes.isEmpty ? nil : databaseTypes,
             connectionCount: connectionCount,
-            licenseKey: licenseKey
+            hasLicense: hasLicense
         )
     }
 }
@@ -159,5 +159,5 @@ private struct AnalyticsPayload: Encodable {
     let locale: String
     let databaseTypes: [String]?
     let connectionCount: Int
-    let licenseKey: String?
+    let hasLicense: Bool
 }

--- a/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
+++ b/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
@@ -55,18 +55,20 @@ final class LicenseAPIClient {
     /// List all activations for a license key
     func listActivations(licenseKey: String, machineId: String) async throws -> ListActivationsResponse {
         let url = baseURL.appendingPathComponent("activations")
-        let body = LicenseValidationRequest(licenseKey: licenseKey, machineId: machineId)
+        let body = LicenseValidationRequest(
+            licenseKey: licenseKey,
+            machineId: machineId,
+            machineName: LicenseStorage.shared.machineName,
+            appVersion: Bundle.main.appVersion,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString
+        )
         return try await post(url: url, body: body)
     }
 
     /// Deactivate a license key from this machine
     func deactivate(request: LicenseDeactivationRequest) async throws {
         let url = baseURL.appendingPathComponent("deactivate")
-        do {
-            let _: SignedLicensePayload? = try await post(url: url, body: request)
-        } catch {
-            Self.logger.error("License deactivation failed: \(error.localizedDescription)")
-        }
+        let _: DeactivateResponse = try await post(url: url, body: request)
     }
 
     // MARK: - Private

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -158,8 +158,9 @@ final class LicenseManager {
     // MARK: - Deactivation
 
     /// Deactivate the license on this machine
-    func deactivate() async throws {
-        guard let license else { return }
+    @discardableResult
+    func deactivate() async -> Bool {
+        guard let license else { return true }
 
         isValidating = true
         lastError = nil
@@ -170,16 +171,14 @@ final class LicenseManager {
             machineId: storage.machineId
         )
 
+        var serverSuccess = true
         do {
             try await apiClient.deactivate(request: request)
         } catch {
-            // Log but don't block — clear local state regardless.
-            // By design, deactivation always clears local data even if the API call fails.
-            // The user will need their license key to reactivate.
-            Self.logger.warning("Deactivation API call failed: \(error.localizedDescription)")
+            Self.logger.warning("Server deactivation failed: \(error.localizedDescription)")
+            serverSuccess = false
         }
 
-        // Clear local state (Keychain key + UserDefaults payload)
         storage.clearAll()
         self.license = nil
         status = .deactivated
@@ -187,7 +186,8 @@ final class LicenseManager {
         revalidationTask?.cancel()
         revalidationTask = nil
 
-        Self.logger.info("License deactivated")
+        Self.logger.info("License deactivated locally (server: \(serverSuccess ? "ok" : "failed"))")
+        return serverSuccess
     }
 
     // MARK: - Re-validation
@@ -210,7 +210,10 @@ final class LicenseManager {
 
         let request = LicenseValidationRequest(
             licenseKey: license.key,
-            machineId: storage.machineId
+            machineId: storage.machineId,
+            machineName: storage.machineName,
+            appVersion: Bundle.main.appVersion,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString
         )
 
         do {

--- a/TablePro/Models/Settings/License.swift
+++ b/TablePro/Models/Settings/License.swift
@@ -108,10 +108,16 @@ struct LicenseActivationRequest: Codable {
 struct LicenseValidationRequest: Codable {
     let licenseKey: String
     let machineId: String
+    let machineName: String
+    let appVersion: String
+    let osVersion: String
 
     private enum CodingKeys: String, CodingKey {
         case licenseKey = "license_key"
         case machineId = "machine_id"
+        case machineName = "machine_name"
+        case appVersion = "app_version"
+        case osVersion = "os_version"
     }
 }
 
@@ -124,6 +130,11 @@ struct LicenseDeactivationRequest: Codable {
         case licenseKey = "license_key"
         case machineId = "machine_id"
     }
+}
+
+/// Response from the deactivation endpoint
+struct DeactivateResponse: Codable {
+    let message: String
 }
 
 /// Wrapper for API error responses

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3086,6 +3086,9 @@
         }
       }
     },
+    "Action Failed" : {
+
+    },
     "Activate" : {
       "localizations" : {
         "tr" : {
@@ -3267,6 +3270,15 @@
           }
         }
       }
+    },
+    "Active Merges" : {
+
+    },
+    "Active Queries" : {
+
+    },
+    "Active Sessions" : {
+
     },
     "Actual" : {
       "localizations" : {
@@ -4109,6 +4121,7 @@
       }
     },
     "ALL DATABASES" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4153,6 +4166,7 @@
       }
     },
     "ALL SCHEMAS" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4880,6 +4894,9 @@
         }
       }
     },
+    "Are you sure you want to cancel the running query for this session?" : {
+
+    },
     "Are you sure you want to delete \"%@\"?" : {
       "localizations" : {
         "tr" : {
@@ -4990,6 +5007,9 @@
           }
         }
       }
+    },
+    "Are you sure you want to terminate this session? Any running queries will be aborted." : {
+
     },
     "As Copy" : {
       "localizations" : {
@@ -5781,6 +5801,9 @@
         }
       }
     },
+    "Block Size" : {
+
+    },
     "Blue" : {
       "localizations" : {
         "tr" : {
@@ -6046,6 +6069,12 @@
         }
       }
     },
+    "Bytes Received" : {
+
+    },
+    "Bytes Sent" : {
+
+    },
     "CA Cert" : {
       "localizations" : {
         "tr" : {
@@ -6090,6 +6119,12 @@
         }
       }
     },
+    "Cache Hit Ratio" : {
+
+    },
+    "Cache Size" : {
+
+    },
     "Cancel" : {
       "localizations" : {
         "tr" : {
@@ -6111,6 +6146,12 @@
           }
         }
       }
+    },
+    "Cancel Query" : {
+
+    },
+    "Cancel query for session %@" : {
+
     },
     "Cannot execute write queries: connection is read-only" : {
       "localizations" : {
@@ -6446,6 +6487,7 @@
       }
     },
     "Character Set" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -8202,6 +8244,9 @@
         }
       }
     },
+    "Connected Threads" : {
+
+    },
     "Connecting" : {
       "localizations" : {
         "tr" : {
@@ -8561,6 +8606,9 @@
           }
         }
       }
+    },
+    "Connections" : {
+
     },
     "Connections:" : {
       "localizations" : {
@@ -10183,6 +10231,12 @@
         }
       }
     },
+    "Dashboard" : {
+
+    },
+    "Dashboard Not Available" : {
+
+    },
     "Data" : {
       "localizations" : {
         "tr" : {
@@ -10492,6 +10546,9 @@
           }
         }
       }
+    },
+    "Database Size" : {
+
     },
     "Database Switch Failed" : {
       "localizations" : {
@@ -10805,6 +10862,7 @@
       }
     },
     "Deactivation Failed" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -11922,6 +11980,9 @@
         }
       }
     },
+    "Disk Usage" : {
+
+    },
     "Dismiss" : {
       "localizations" : {
         "tr" : {
@@ -12476,6 +12537,9 @@
           }
         }
       }
+    },
+    "Duration" : {
+
     },
     "Each SQLite file is a separate database.\nTo open a different database, create a new connection." : {
       "localizations" : {
@@ -19260,6 +19324,9 @@
         }
       }
     },
+    "Journal Mode" : {
+
+    },
     "JSON" : {
       "localizations" : {
         "tr" : {
@@ -19392,6 +19459,9 @@
           }
         }
       }
+    },
+    "Keep Running" : {
+
     },
     "Keep This Mac's Version" : {
       "localizations" : {
@@ -20106,6 +20176,12 @@
         }
       }
     },
+    "License Removed" : {
+
+    },
+    "License removed from this Mac, but the server could not be reached. The activation slot may not be freed until it expires." : {
+
+    },
     "License signature verification failed." : {
       "localizations" : {
         "tr" : {
@@ -20429,6 +20505,9 @@
           }
         }
       }
+    },
+    "Loading dashboard..." : {
+
     },
     "Loading databases..." : {
       "localizations" : {
@@ -20851,6 +20930,9 @@
         }
       }
     },
+    "Max Connections" : {
+
+    },
     "Max schema tables: %d" : {
       "localizations" : {
         "tr" : {
@@ -21049,6 +21131,9 @@
           }
         }
       }
+    },
+    "Memory Limit" : {
+
     },
     "METADATA" : {
       "localizations" : {
@@ -23412,6 +23497,9 @@
         }
       }
     },
+    "No slow queries" : {
+
+    },
     "No SSL encryption" : {
       "localizations" : {
         "tr" : {
@@ -24210,6 +24298,9 @@
         }
       }
     },
+    "Off" : {
+
+    },
     "Offset" : {
       "localizations" : {
         "tr" : {
@@ -24496,6 +24587,9 @@
           }
         }
       }
+    },
+    "Open editor" : {
+
     },
     "Open File" : {
       "localizations" : {
@@ -24943,6 +25037,12 @@
         }
       }
     },
+    "Page Count" : {
+
+    },
+    "Page Size" : {
+
+    },
     "Page size must be between %@ and %@" : {
       "localizations" : {
         "en" : {
@@ -24970,6 +25070,9 @@
           }
         }
       }
+    },
+    "pages" : {
+
     },
     "Pagination" : {
       "localizations" : {
@@ -25058,6 +25161,9 @@
           }
         }
       }
+    },
+    "Part Mutations" : {
+
     },
     "Partition" : {
       "localizations" : {
@@ -25352,6 +25458,9 @@
         }
       }
     },
+    "Pause" : {
+
+    },
     "pending delete" : {
       "localizations" : {
         "tr" : {
@@ -25417,6 +25526,9 @@
           }
         }
       }
+    },
+    "PID" : {
+
     },
     "Pin Result" : {
       "localizations" : {
@@ -27780,6 +27892,7 @@
       }
     },
     "RECENT" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -28208,6 +28321,9 @@
           }
         }
       }
+    },
+    "Refresh Now" : {
+
     },
     "Refreshing will discard all unsaved changes." : {
       "localizations" : {
@@ -28992,6 +29108,9 @@
         }
       }
     },
+    "Resume" : {
+
+    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -29544,6 +29663,9 @@
           }
         }
       }
+    },
+    "Running Threads" : {
+
     },
     "Safe Mode" : {
       "localizations" : {
@@ -31119,6 +31241,9 @@
         }
       }
     },
+    "Server Dashboard" : {
+
+    },
     "Server error (%d): %@" : {
       "localizations" : {
         "en" : {
@@ -31175,6 +31300,12 @@
           }
         }
       }
+    },
+    "Server Metrics" : {
+
+    },
+    "Server monitoring is not available for this database type." : {
+
     },
     "Service Account Key" : {
       "localizations" : {
@@ -32179,6 +32310,9 @@
           }
         }
       }
+    },
+    "Slow Queries" : {
+
     },
     "Small" : {
       "localizations" : {
@@ -33211,6 +33345,9 @@
           }
         }
       }
+    },
+    "State" : {
+
     },
     "statement" : {
       "localizations" : {
@@ -34747,6 +34884,15 @@
         }
       }
     },
+    "Terminate" : {
+
+    },
+    "Terminate Session" : {
+
+    },
+    "Terminate session %@" : {
+
+    },
     "Tertiary Text" : {
       "localizations" : {
         "tr" : {
@@ -35814,6 +35960,9 @@
         }
       }
     },
+    "Threads" : {
+
+    },
     "Tier:" : {
       "localizations" : {
         "en" : {
@@ -36420,6 +36569,12 @@
           }
         }
       }
+    },
+    "Total Blocks" : {
+
+    },
+    "Total Queries" : {
+
     },
     "Total Size" : {
       "localizations" : {
@@ -37483,6 +37638,9 @@
         }
       }
     },
+    "Uptime" : {
+
+    },
     "US Long (12/31/2024 11:59:59 PM)" : {
       "localizations" : {
         "tr" : {
@@ -37636,6 +37794,9 @@
           }
         }
       }
+    },
+    "User Sessions" : {
+
     },
     "User-installed" : {
       "localizations" : {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3086,9 +3086,6 @@
         }
       }
     },
-    "Action Failed" : {
-
-    },
     "Activate" : {
       "localizations" : {
         "tr" : {
@@ -3270,15 +3267,6 @@
           }
         }
       }
-    },
-    "Active Merges" : {
-
-    },
-    "Active Queries" : {
-
-    },
-    "Active Sessions" : {
-
     },
     "Actual" : {
       "localizations" : {
@@ -4121,7 +4109,6 @@
       }
     },
     "ALL DATABASES" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4166,7 +4153,6 @@
       }
     },
     "ALL SCHEMAS" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4894,9 +4880,6 @@
         }
       }
     },
-    "Are you sure you want to cancel the running query for this session?" : {
-
-    },
     "Are you sure you want to delete \"%@\"?" : {
       "localizations" : {
         "tr" : {
@@ -5007,9 +4990,6 @@
           }
         }
       }
-    },
-    "Are you sure you want to terminate this session? Any running queries will be aborted." : {
-
     },
     "As Copy" : {
       "localizations" : {
@@ -5801,9 +5781,6 @@
         }
       }
     },
-    "Block Size" : {
-
-    },
     "Blue" : {
       "localizations" : {
         "tr" : {
@@ -6069,12 +6046,6 @@
         }
       }
     },
-    "Bytes Received" : {
-
-    },
-    "Bytes Sent" : {
-
-    },
     "CA Cert" : {
       "localizations" : {
         "tr" : {
@@ -6119,12 +6090,6 @@
         }
       }
     },
-    "Cache Hit Ratio" : {
-
-    },
-    "Cache Size" : {
-
-    },
     "Cancel" : {
       "localizations" : {
         "tr" : {
@@ -6146,12 +6111,6 @@
           }
         }
       }
-    },
-    "Cancel Query" : {
-
-    },
-    "Cancel query for session %@" : {
-
     },
     "Cannot execute write queries: connection is read-only" : {
       "localizations" : {
@@ -6487,7 +6446,6 @@
       }
     },
     "Character Set" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -8244,9 +8202,6 @@
         }
       }
     },
-    "Connected Threads" : {
-
-    },
     "Connecting" : {
       "localizations" : {
         "tr" : {
@@ -8606,9 +8561,6 @@
           }
         }
       }
-    },
-    "Connections" : {
-
     },
     "Connections:" : {
       "localizations" : {
@@ -10231,12 +10183,6 @@
         }
       }
     },
-    "Dashboard" : {
-
-    },
-    "Dashboard Not Available" : {
-
-    },
     "Data" : {
       "localizations" : {
         "tr" : {
@@ -10546,9 +10492,6 @@
           }
         }
       }
-    },
-    "Database Size" : {
-
     },
     "Database Switch Failed" : {
       "localizations" : {
@@ -11980,9 +11923,6 @@
         }
       }
     },
-    "Disk Usage" : {
-
-    },
     "Dismiss" : {
       "localizations" : {
         "tr" : {
@@ -12537,9 +12477,6 @@
           }
         }
       }
-    },
-    "Duration" : {
-
     },
     "Each SQLite file is a separate database.\nTo open a different database, create a new connection." : {
       "localizations" : {
@@ -19324,9 +19261,6 @@
         }
       }
     },
-    "Journal Mode" : {
-
-    },
     "JSON" : {
       "localizations" : {
         "tr" : {
@@ -19459,9 +19393,6 @@
           }
         }
       }
-    },
-    "Keep Running" : {
-
     },
     "Keep This Mac's Version" : {
       "localizations" : {
@@ -20506,9 +20437,6 @@
         }
       }
     },
-    "Loading dashboard..." : {
-
-    },
     "Loading databases..." : {
       "localizations" : {
         "tr" : {
@@ -20930,9 +20858,6 @@
         }
       }
     },
-    "Max Connections" : {
-
-    },
     "Max schema tables: %d" : {
       "localizations" : {
         "tr" : {
@@ -21131,9 +21056,6 @@
           }
         }
       }
-    },
-    "Memory Limit" : {
-
     },
     "METADATA" : {
       "localizations" : {
@@ -23497,9 +23419,6 @@
         }
       }
     },
-    "No slow queries" : {
-
-    },
     "No SSL encryption" : {
       "localizations" : {
         "tr" : {
@@ -24298,9 +24217,6 @@
         }
       }
     },
-    "Off" : {
-
-    },
     "Offset" : {
       "localizations" : {
         "tr" : {
@@ -24587,9 +24503,6 @@
           }
         }
       }
-    },
-    "Open editor" : {
-
     },
     "Open File" : {
       "localizations" : {
@@ -25037,12 +24950,6 @@
         }
       }
     },
-    "Page Count" : {
-
-    },
-    "Page Size" : {
-
-    },
     "Page size must be between %@ and %@" : {
       "localizations" : {
         "en" : {
@@ -25070,9 +24977,6 @@
           }
         }
       }
-    },
-    "pages" : {
-
     },
     "Pagination" : {
       "localizations" : {
@@ -25161,9 +25065,6 @@
           }
         }
       }
-    },
-    "Part Mutations" : {
-
     },
     "Partition" : {
       "localizations" : {
@@ -25458,9 +25359,6 @@
         }
       }
     },
-    "Pause" : {
-
-    },
     "pending delete" : {
       "localizations" : {
         "tr" : {
@@ -25526,9 +25424,6 @@
           }
         }
       }
-    },
-    "PID" : {
-
     },
     "Pin Result" : {
       "localizations" : {
@@ -27892,7 +27787,6 @@
       }
     },
     "RECENT" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -28321,9 +28215,6 @@
           }
         }
       }
-    },
-    "Refresh Now" : {
-
     },
     "Refreshing will discard all unsaved changes." : {
       "localizations" : {
@@ -29108,9 +28999,6 @@
         }
       }
     },
-    "Resume" : {
-
-    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -29663,9 +29551,6 @@
           }
         }
       }
-    },
-    "Running Threads" : {
-
     },
     "Safe Mode" : {
       "localizations" : {
@@ -31241,9 +31126,6 @@
         }
       }
     },
-    "Server Dashboard" : {
-
-    },
     "Server error (%d): %@" : {
       "localizations" : {
         "en" : {
@@ -31300,12 +31182,6 @@
           }
         }
       }
-    },
-    "Server Metrics" : {
-
-    },
-    "Server monitoring is not available for this database type." : {
-
     },
     "Service Account Key" : {
       "localizations" : {
@@ -32310,9 +32186,6 @@
           }
         }
       }
-    },
-    "Slow Queries" : {
-
     },
     "Small" : {
       "localizations" : {
@@ -33345,9 +33218,6 @@
           }
         }
       }
-    },
-    "State" : {
-
     },
     "statement" : {
       "localizations" : {
@@ -34884,15 +34754,6 @@
         }
       }
     },
-    "Terminate" : {
-
-    },
-    "Terminate Session" : {
-
-    },
-    "Terminate session %@" : {
-
-    },
     "Tertiary Text" : {
       "localizations" : {
         "tr" : {
@@ -35960,9 +35821,6 @@
         }
       }
     },
-    "Threads" : {
-
-    },
     "Tier:" : {
       "localizations" : {
         "en" : {
@@ -36569,12 +36427,6 @@
           }
         }
       }
-    },
-    "Total Blocks" : {
-
-    },
-    "Total Queries" : {
-
     },
     "Total Size" : {
       "localizations" : {
@@ -37638,9 +37490,6 @@
         }
       }
     },
-    "Uptime" : {
-
-    },
     "US Long (12/31/2024 11:59:59 PM)" : {
       "localizations" : {
         "tr" : {
@@ -37794,9 +37643,6 @@
           }
         }
       }
-    },
-    "User Sessions" : {
-
     },
     "User-installed" : {
       "localizations" : {

--- a/TablePro/Views/Settings/LicenseSettingsView.swift
+++ b/TablePro/Views/Settings/LicenseSettingsView.swift
@@ -242,12 +242,11 @@ struct LicenseSettingsView: View {
     }
 
     private func deactivate() async {
-        do {
-            try await licenseManager.deactivate()
-        } catch {
-            AlertHelper.showErrorSheet(
-                title: String(localized: "Deactivation Failed"),
-                message: error.localizedDescription,
+        let serverSuccess = await licenseManager.deactivate()
+        if !serverSuccess {
+            AlertHelper.showInfoSheet(
+                title: String(localized: "License Removed"),
+                message: String(localized: "License removed from this Mac, but the server could not be reached. The activation slot may not be freed until it expires."),
                 window: NSApp.keyWindow
             )
         }


### PR DESCRIPTION
## Summary

- **Stale activation metadata**: `LicenseValidationRequest` now sends `machineName`, `appVersion`, `osVersion` so the server can update activation records on periodic revalidation. Fixes Settings showing old app version (e.g. 0.27.4 instead of 0.31.1).
- **Analytics privacy**: Heartbeat sends `hasLicense: Bool` instead of raw `licenseKey: String?`. The license key never leaves the client.
- **Deactivation error handling**: `deactivate()` now decodes the correct `DeactivateResponse` type (was trying to decode `SignedLicensePayload?` causing misleading error logs). Returns `Bool` to indicate server success. Shows info sheet when server-side deactivation fails but local state is cleared.

Companion server PR: TableProApp/license#TBD

## Test plan

- [ ] Build succeeds
- [ ] Activate license → check Settings shows correct version
- [ ] Wait for periodic revalidation (or trigger manually) → version stays current
- [ ] Deactivate license online → clean deactivation, no warning
- [ ] Deactivate license offline → info sheet warns about activation slot
- [ ] Analytics heartbeat sends `has_license` bool, not raw key (verify via server logs)