### PR TITLE
fix: tab naming, sidebar restore, and quit-time persistence (#694, #695)

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -39,6 +39,8 @@ struct ContentView: View {
         let defaultTitle: String
         if payload?.tabType == .serverDashboard {
             defaultTitle = String(localized: "Server Dashboard")
+        } else if let tabTitle = payload?.tabTitle {
+            defaultTitle = tabTitle
         } else if let tableName = payload?.tableName {
             defaultTitle = tableName
         } else if let connectionId = payload?.connectionId,
@@ -63,9 +65,14 @@ struct ContentView: View {
 
         if let session = resolvedSession {
             _rightPanelState = State(initialValue: RightPanelState())
-            _sessionState = State(initialValue: SessionStateFactory.create(
+            let state = SessionStateFactory.create(
                 connection: session.connection, payload: payload
-            ))
+            )
+            _sessionState = State(initialValue: state)
+            if payload?.intent == .newEmptyTab,
+               let tabTitle = state.coordinator.tabManager.selectedTab?.title {
+                _windowTitle = State(initialValue: tabTitle)
+            }
         } else {
             _rightPanelState = State(initialValue: nil)
             _sessionState = State(initialValue: nil)

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+import os
+
+private let factoryLogger = Logger(subsystem: "com.TablePro", category: "SessionStateFactory")
 
 @MainActor
 enum SessionStateFactory {
@@ -84,8 +87,10 @@ enum SessionStateFactory {
                         tabMgr.addTab(databaseName: payload.databaseName ?? connection.database)
                     }
                 case .query:
+                    factoryLogger.debug("openContent/query: title=\(payload.tabTitle ?? "nil"), query=\(String((payload.initialQuery ?? "").prefix(50)))")
                     tabMgr.addTab(
                         initialQuery: payload.initialQuery,
+                        title: payload.tabTitle,
                         databaseName: payload.databaseName ?? connection.database,
                         sourceFileURL: payload.sourceFileURL
                     )
@@ -103,9 +108,11 @@ enum SessionStateFactory {
                 }
             case .newEmptyTab:
                 let allTabs = MainContentCoordinator.allTabs(for: connection.id)
-                let title = QueryTabManager.nextQueryTitle(excluding: allTabs)
+                let title = QueryTabManager.nextQueryTitle(existingTabs: allTabs)
+                factoryLogger.debug("newEmptyTab: title=\(title), existingTabs=\(allTabs.count)")
                 tabMgr.addTab(title: title, databaseName: payload.databaseName ?? connection.database)
             case .restoreOrDefault:
+                factoryLogger.debug("restoreOrDefault: no tabs added in factory (deferred to handleRestoreOrDefault)")
                 break
             }
         }

--- a/TablePro/Models/Query/EditorTabPayload.swift
+++ b/TablePro/Models/Query/EditorTabPayload.swift
@@ -49,12 +49,15 @@ internal struct EditorTabPayload: Codable, Hashable {
     internal let sourceFileURL: URL?
     /// Schema key for ER diagram tabs
     internal let erDiagramSchemaKey: String?
+    /// Tab title (for restoring persisted tabs with their original names)
+    internal let tabTitle: String?
     /// The intent behind creating this tab
     internal let intent: TabIntent
 
     private enum CodingKeys: String, CodingKey {
         case id, connectionId, tabType, tableName, databaseName, schemaName
         case initialQuery, isView, showStructure, skipAutoExecute, isPreview
+        case tabTitle
         case initialFilterState, sourceFileURL, erDiagramSchemaKey, intent
         // Legacy key for backward decoding only
         case isNewTab
@@ -75,6 +78,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         initialFilterState: TabFilterState? = nil,
         sourceFileURL: URL? = nil,
         erDiagramSchemaKey: String? = nil,
+        tabTitle: String? = nil,
         intent: TabIntent = .openContent
     ) {
         self.id = id
@@ -91,6 +95,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         self.initialFilterState = initialFilterState
         self.sourceFileURL = sourceFileURL
         self.erDiagramSchemaKey = erDiagramSchemaKey
+        self.tabTitle = tabTitle
         self.intent = intent
     }
 
@@ -110,6 +115,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         initialFilterState = try container.decodeIfPresent(TabFilterState.self, forKey: .initialFilterState)
         sourceFileURL = try container.decodeIfPresent(URL.self, forKey: .sourceFileURL)
         erDiagramSchemaKey = try container.decodeIfPresent(String.self, forKey: .erDiagramSchemaKey)
+        tabTitle = try container.decodeIfPresent(String.self, forKey: .tabTitle)
         if let decodedIntent = try container.decodeIfPresent(TabIntent.self, forKey: .intent) {
             intent = decodedIntent
         } else {
@@ -134,6 +140,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         try container.encodeIfPresent(initialFilterState, forKey: .initialFilterState)
         try container.encodeIfPresent(sourceFileURL, forKey: .sourceFileURL)
         try container.encodeIfPresent(erDiagramSchemaKey, forKey: .erDiagramSchemaKey)
+        try container.encodeIfPresent(tabTitle, forKey: .tabTitle)
         try container.encode(intent, forKey: .intent)
     }
 
@@ -153,6 +160,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         self.initialFilterState = nil
         self.sourceFileURL = tab.sourceFileURL
         self.erDiagramSchemaKey = tab.erDiagramSchemaKey
+        self.tabTitle = tab.title
         self.intent = .openContent
     }
 }

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -46,9 +46,8 @@ final class QueryTabManager {
 
     // MARK: - Tab Naming
 
-    /// Generate next query tab title by finding the max "Query N" number across the given tabs.
-    /// Called with all tabs from all windows for the same connection to avoid duplicate names.
-    static func nextQueryTitle(excluding existingTabs: [QueryTab]) -> String {
+    /// Next "Query N" title based on existing tabs across all windows.
+    static func nextQueryTitle(existingTabs: [QueryTab]) -> String {
         let maxNumber = existingTabs
             .filter { $0.tabType == .query }
             .compactMap { tab -> Int? in
@@ -71,7 +70,7 @@ final class QueryTabManager {
             return
         }
 
-        let tabTitle = title ?? Self.nextQueryTitle(excluding: tabs)
+        let tabTitle = title ?? Self.nextQueryTitle(existingTabs: tabs)
         var newTab = QueryTab(title: tabTitle, tabType: .query)
 
         if let query = initialQuery {

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -6,7 +6,10 @@
 //  for MainContentView. Extracted to reduce main view complexity.
 //
 
+import os
 import SwiftUI
+
+private let setupLogger = Logger(subsystem: "com.TablePro", category: "MainContentView+Setup")
 
 extension MainContentView {
     // MARK: - Initialization
@@ -74,6 +77,7 @@ extension MainContentView {
 
     private func handleRestoreOrDefault() async {
         if WindowLifecycleMonitor.shared.hasOtherWindows(for: connection.id, excluding: windowId) {
+            setupLogger.debug("handleRestoreOrDefault: other windows exist, adding empty tab")
             if tabManager.tabs.isEmpty {
                 tabManager.addTab(databaseName: connection.database)
             }
@@ -81,6 +85,10 @@ extension MainContentView {
         }
 
         let result = await coordinator.persistence.restoreFromDisk()
+        setupLogger.info("handleRestoreOrDefault: restored \(result.tabs.count) tabs from disk (source=\(String(describing: result.source)))")
+        for tab in result.tabs {
+            setupLogger.debug("  restored tab: \(tab.title) query=\(String(tab.query.prefix(50)))")
+        }
         if !result.tabs.isEmpty {
             var restoredTabs = result.tabs
             for i in restoredTabs.indices where restoredTabs[i].tabType == .table {
@@ -94,19 +102,20 @@ extension MainContentView {
             }
 
             let selectedId = result.selectedTabId
-            let selectedIndex = restoredTabs.firstIndex(where: { $0.id == selectedId }) ?? 0
 
-            let selectedTab = restoredTabs[selectedIndex]
-            tabManager.tabs = [selectedTab]
-            tabManager.selectedTabId = selectedTab.id
+            // First tab in the array gets the current window to preserve order.
+            // Remaining tabs open as native window tabs in order.
+            let firstTab = restoredTabs[0]
+            tabManager.tabs = [firstTab]
+            tabManager.selectedTabId = firstTab.id
 
-            let remainingTabs = restoredTabs.enumerated()
-                .filter { $0.offset != selectedIndex }
-                .map(\.element)
+            let remainingTabs = Array(restoredTabs.dropFirst())
 
             if !remainingTabs.isEmpty {
+                setupLogger.debug("handleRestoreOrDefault: opening \(remainingTabs.count) remaining tabs as native windows")
                 Task { @MainActor in
                     for tab in remainingTabs {
+                        setupLogger.debug("  opening native tab: \(tab.title)")
                         let restorePayload = EditorTabPayload(
                             from: tab, connectionId: connection.id, skipAutoExecute: true)
                         WindowOpener.shared.openNativeTab(restorePayload)
@@ -115,18 +124,18 @@ extension MainContentView {
                 }
             }
 
-            if selectedTab.tabType == .table,
-                !selectedTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if firstTab.tabType == .table,
+                !firstTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             {
                 if let session = DatabaseManager.shared.activeSessions[connection.id],
                     session.isConnected
                 {
-                    if !selectedTab.databaseName.isEmpty,
-                        selectedTab.databaseName != session.activeDatabase
+                    if !firstTab.databaseName.isEmpty,
+                        firstTab.databaseName != session.activeDatabase
                     {
-                        Task { await coordinator.switchDatabase(to: selectedTab.databaseName) }
+                        Task { await coordinator.switchDatabase(to: firstTab.databaseName) }
                     } else {
-                        if let tableName = selectedTab.tableName {
+                        if let tableName = firstTab.tableName {
                             coordinator.restoreColumnLayoutForTable(tableName)
                         }
                         coordinator.executeTableTabQueryDirectly()
@@ -154,6 +163,7 @@ extension MainContentView {
     /// Update window title, proxy icon, and dirty dot based on the selected tab.
     func updateWindowTitleAndFileState() {
         let selectedTab = tabManager.selectedTab
+        let oldTitle = windowTitle
         if selectedTab?.tabType == .serverDashboard {
             windowTitle = String(localized: "Server Dashboard")
         } else if selectedTab?.tabType == .createTable {
@@ -166,6 +176,10 @@ extension MainContentView {
             windowTitle = (selectedTab?.tabType == .table ? selectedTab?.tableName : nil)
                 ?? selectedTab?.title
                 ?? (tabManager.tabs.isEmpty ? connection.name : queryLabel)
+        }
+        if windowTitle != oldTitle {
+            let typeStr = selectedTab.map { $0.tabType == .table ? "table" : "query" } ?? "nil"
+            setupLogger.debug("updateWindowTitle: '\(oldTitle)' → '\(self.windowTitle)' (tab.title=\(selectedTab?.title ?? "nil"), tabType=\(typeStr), tableName=\(selectedTab?.tableName ?? "nil"))")
         }
         viewWindow?.representedURL = selectedTab?.sourceFileURL
         viewWindow?.isDocumentEdited = selectedTab?.isFileDirty ?? false

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -207,8 +207,24 @@ final class MainContentCoordinator {
 
     /// Collect non-preview tabs for persistence.
     private static func aggregatedTabs(for connectionId: UUID) -> [QueryTab] {
-        activeCoordinators.values
+        let coordinators = activeCoordinators.values
             .filter { $0.connectionId == connectionId }
+
+        // Sort by native window tab order to preserve left-to-right position
+        let orderedCoordinators: [MainContentCoordinator]
+        if let firstWindow = coordinators.compactMap({ $0.contentWindow }).first,
+           let tabbedWindows = firstWindow.tabbedWindows {
+            let windowOrder = tabbedWindows.map { ObjectIdentifier($0) }
+            orderedCoordinators = coordinators.sorted { a, b in
+                let aIdx = a.contentWindow.flatMap { w in windowOrder.firstIndex(of: ObjectIdentifier(w)) } ?? Int.max
+                let bIdx = b.contentWindow.flatMap { w in windowOrder.firstIndex(of: ObjectIdentifier(w)) } ?? Int.max
+                return aIdx < bIdx
+            }
+        } else {
+            orderedCoordinators = Array(coordinators)
+        }
+
+        return orderedCoordinators
             .flatMap { $0.tabManager.tabs }
             .filter { !$0.isPreview }
     }
@@ -301,12 +317,22 @@ final class MainContentCoordinator {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                guard let self, !self.isTearingDown else { return }
+                guard let self else { return }
                 // Only the first coordinator for this connection saves,
-                // aggregating tabs from all windows to fix last-write-wins bug
-                guard self.isFirstCoordinatorForConnection() else { return }
+                // aggregating tabs from all windows to fix last-write-wins bug.
+                // Skip isTearingDown check: during Cmd+Q, onDisappear fires
+                // markTeardownScheduled() before willTerminate, and we still
+                // need to save here.
+                guard self.isFirstCoordinatorForConnection() else {
+                    Self.logger.debug("willTerminate: skipping (not first coordinator for \(self.connectionId))")
+                    return
+                }
                 let allTabs = Self.aggregatedTabs(for: self.connectionId)
                 let selectedId = Self.aggregatedSelectedTabId(for: self.connectionId)
+                Self.logger.info("willTerminate: saving \(allTabs.count) tabs for \(self.connectionId), selected=\(selectedId?.uuidString ?? "nil")")
+                for tab in allTabs {
+                    Self.logger.debug("  tab: \(tab.title) query=\(String(tab.query.prefix(50)))")
+                }
                 self.persistence.saveNowSync(
                     tabs: allTabs,
                     selectedTabId: selectedId
@@ -360,14 +386,17 @@ final class MainContentCoordinator {
     }
 
     func refreshTables() async {
+        Self.logger.debug("refreshTables: start (connectionId=\(self.connectionId))")
         sidebarLoadingState = .loading
         guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
+            Self.logger.warning("refreshTables: no driver, setting error state")
             sidebarLoadingState = .error(String(localized: "Not connected"))
             return
         }
         do {
             let tables = try await driver.fetchTables()
                 .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            Self.logger.debug("refreshTables: fetched \(tables.count) tables")
             DatabaseManager.shared.updateSession(connectionId) { $0.tables = tables }
             let currentDb = DatabaseManager.shared.session(for: connectionId)?.activeDatabase
             await schemaProvider.resetForDatabase(currentDb, tables: tables, driver: driver)
@@ -395,8 +424,10 @@ final class MainContentCoordinator {
                 }
             }
 
+            Self.logger.debug("refreshTables: done, state=.loaded")
             sidebarLoadingState = .loaded
         } catch {
+            Self.logger.error("refreshTables: failed: \(error.localizedDescription)")
             sidebarLoadingState = .error(error.localizedDescription)
         }
     }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -5,7 +5,10 @@
 //  Created by Ngo Quoc Dat on 16/12/25.
 //
 
+import os
 import SwiftUI
+
+private let sidebarLogger = Logger(subsystem: "com.TablePro", category: "SidebarView")
 
 // MARK: - SidebarView
 
@@ -115,7 +118,23 @@ struct SidebarView: View {
         }
         .onAppear {
             coordinator?.sidebarViewModel = viewModel
-            if coordinator?.sidebarLoadingState == .idle && !tables.isEmpty {
+            let state = coordinator?.sidebarLoadingState ?? .idle
+            let tableCount = tables.count
+            sidebarLogger.debug("onAppear: loadingState=\(String(describing: state)), tables=\(tableCount), coordinator=\(coordinator != nil)")
+            if state == .idle && !tables.isEmpty {
+                sidebarLogger.debug("onAppear: healing .idle → .loaded (tables=\(tableCount))")
+                coordinator?.sidebarLoadingState = .loaded
+            }
+            // Update toolbar version if driver connected before this window's observer was set up
+            if let driver = DatabaseManager.shared.driver(for: connectionId),
+               coordinator?.toolbarState.databaseVersion == nil {
+                coordinator?.toolbarState.databaseVersion = driver.serverVersion
+            }
+        }
+        .onChange(of: tables) { _, newTables in
+            // Heal sidebar state when tables arrive from another window's refreshTables()
+            if !newTables.isEmpty && coordinator?.sidebarLoadingState == .idle {
+                sidebarLogger.debug("onChange(tables): healing .idle → .loaded (tables=\(newTables.count))")
                 coordinator?.sidebarLoadingState = .loaded
             }
         }


### PR DESCRIPTION
## Summary

Fixes multiple issues with native window tab naming, sidebar state in restored tabs, and quit-time tab persistence.

### Tab naming (#695)
- New query tabs now increment correctly across all windows (Query 1, Query 2, Query 3)
- Window title matches internal tab title (not generic "SQL Query")
- `nextQueryTitle()` scans all tabs across windows via `MainContentCoordinator.allTabs(for:)`

### Sidebar empty in new/restored tabs (#694)
- `SidebarView.onAppear` heals `.idle` state to `.loaded` when tables exist
- `onChange(of: tables)` heals sidebar when tables arrive from another window's `refreshTables()`
- Toolbar version updated on `onAppear` if driver connected before observer setup

### Tab persistence
- Quit-time save no longer skipped when `isTearingDown` (Cmd+Q fires `markTeardownScheduled` before `willTerminateNotification`)
- Tabs save in native window tab order (left-to-right) using `NSWindow.tabbedWindows`
- Restore preserves original tab order (first tab in array gets first window)
- `EditorTabPayload.tabTitle` preserves tab names across persist/restore cycle
- `tabTitle` takes priority over `tableName` in window title to prevent query tabs showing table names

### Debug logging
- Added OSLog logging to sidebar, coordinator, session factory, and tab restore flow

## Test plan
- [ ] Open Query 1, Cmd+T for Query 2, Cmd+T for Query 3: titles increment correctly
- [ ] All tabs show tables in sidebar and full DB version in toolbar
- [ ] Cmd+Q with 3 tabs open, reopen: all 3 restore in correct order with correct titles
- [ ] Database switch: no table flash, correct tables load
- [ ] Click table in sidebar: window title shows table name (not query number)