### PR TITLE
fix: correct PostgreSQL version display for v10+

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -231,9 +231,14 @@ final class LibPQPluginConnection: @unchecked Sendable {
             let version = PQserverVersion(connection)
             if version > 0 {
                 let major = version / 10_000
-                let minor = (version / 100) % 100
-                let revision = version % 100
-                self._cachedServerVersion = "\(major).\(minor).\(revision)"
+                if major >= 10 {
+                    let minor = version % 10_000
+                    self._cachedServerVersion = "\(major).\(minor)"
+                } else {
+                    let minor = (version / 100) % 100
+                    let revision = version % 100
+                    self._cachedServerVersion = "\(major).\(minor).\(revision)"
+                }
             }
 
             self.stateLock.lock()


### PR DESCRIPTION
## Summary
- Fix `PQserverVersion()` integer decoding for PostgreSQL 10+ (two-part versioning scheme)
- PostgreSQL 18.3 was displayed as "18.0.3" because the code only handled the pre-10 three-part format

Closes #698

## Test plan
- Connect to PostgreSQL >= 10, verify version in toolbar shows correct format (e.g. "18.3" not "18.0.3")
- Connect to PostgreSQL < 10 (if available), verify three-part version still works (e.g. "9.6.5")