### PR TITLE
feat: restore all open connections and tabs after quitting (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Restore all open connections and tabs after quitting the app (#703)
+
 ## [0.31.2] - 2026-04-13
 
 ### Fixed

--- a/TablePro.xcodeproj/xcshareddata/xcschemes/TablePro.xcscheme
+++ b/TablePro.xcodeproj/xcshareddata/xcschemes/TablePro.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/TablePro/AppDelegate+WindowConfig.swift
+++ b/TablePro/AppDelegate+WindowConfig.swift
@@ -142,6 +142,15 @@ extension AppDelegate {
 
     // MARK: - Welcome Window
 
+    /// Hide the Welcome window immediately when we know we're going to
+    /// auto-reconnect. Prevents a visible flash of the Welcome screen
+    /// before the main editor window appears.
+    func closeWelcomeWindowEagerly() {
+        for window in NSApp.windows where isWelcomeWindow(window) {
+            window.orderOut(nil)
+        }
+    }
+
     func openWelcomeWindow() {
         for window in NSApp.windows where isWelcomeWindow(window) {
             window.makeKeyAndOrderFront(nil)
@@ -323,6 +332,59 @@ extension AppDelegate {
     }
 
     // MARK: - Auto-Reconnect
+
+    func attemptAutoReconnectAll(connectionIds: [UUID]) {
+        let connections = ConnectionStorage.shared.loadConnections()
+        let validConnections = connectionIds.compactMap { id in
+            connections.first { $0.id == id }
+        }
+
+        guard !validConnections.isEmpty else {
+            AppSettingsStorage.shared.saveLastOpenConnectionIds([])
+            AppSettingsStorage.shared.saveLastConnectionId(nil)
+            closeRestoredMainWindows()
+            openWelcomeWindow()
+            return
+        }
+
+        isAutoReconnecting = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.isAutoReconnecting = false }
+
+            for connection in validConnections {
+                let payload = EditorTabPayload(connectionId: connection.id, intent: .restoreOrDefault)
+                WindowOpener.shared.openNativeTab(payload)
+
+                do {
+                    try await DatabaseManager.shared.connectToSession(connection)
+                } catch is CancellationError {
+                    for window in WindowLifecycleMonitor.shared.windows(for: connection.id) {
+                        window.close()
+                    }
+                    continue
+                } catch {
+                    windowLogger.error(
+                        "Auto-reconnect failed for '\(connection.name)': \(error.localizedDescription)"
+                    )
+                    for window in WindowLifecycleMonitor.shared.windows(for: connection.id) {
+                        window.close()
+                    }
+                    continue
+                }
+            }
+
+            for window in NSApp.windows where self.isWelcomeWindow(window) {
+                window.close()
+            }
+
+            // If all connections failed, show the welcome window
+            if !NSApp.windows.contains(where: { self.isMainWindow($0) && $0.isVisible }) {
+                self.openWelcomeWindow()
+            }
+        }
+    }
 
     func attemptAutoReconnect(connectionId: UUID) {
         let connections = ConnectionStorage.shared.loadConnections()

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -109,9 +109,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let settings = AppSettingsStorage.shared.loadGeneral()
-        if settings.startupBehavior == .reopenLast,
-           let lastConnectionId = AppSettingsStorage.shared.loadLastConnectionId() {
-            attemptAutoReconnect(connectionId: lastConnectionId)
+        if settings.startupBehavior == .reopenLast {
+            let connectionIds = AppSettingsStorage.shared.loadLastOpenConnectionIds()
+            if !connectionIds.isEmpty {
+                closeWelcomeWindowEagerly()
+                attemptAutoReconnectAll(connectionIds: connectionIds)
+            } else if let lastConnectionId = AppSettingsStorage.shared.loadLastConnectionId() {
+                // Backward compat: fall back to single lastConnectionId for upgrades
+                closeWelcomeWindowEagerly()
+                attemptAutoReconnect(connectionId: lastConnectionId)
+            } else {
+                // Crash recovery: if the app crashed before applicationWillTerminate
+                // could save the list, scan the TabState directory for connections
+                // that still have saved tab state on disk.
+                Task { @MainActor [weak self] in
+                    let diskIds = await TabDiskActor.shared.connectionIdsWithSavedState()
+                    if !diskIds.isEmpty {
+                        self?.attemptAutoReconnectAll(connectionIds: diskIds)
+                    } else {
+                        self?.closeRestoredMainWindows()
+                    }
+                }
+            }
         } else {
             closeRestoredMainWindows()
         }
@@ -143,6 +162,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        // Save all currently open connection IDs for multi-session restore.
+        // Sort by connection name for deterministic restore order across launches
+        // (Dictionary.keys has no guaranteed order).
+        let connections = ConnectionStorage.shared.loadConnections()
+        let activeIds = Set(DatabaseManager.shared.activeSessions.keys)
+        let openConnectionIds = connections
+            .filter { activeIds.contains($0.id) }
+            .map(\.id)
+        AppSettingsStorage.shared.saveLastOpenConnectionIds(openConnectionIds)
+
         LinkedFolderWatcher.shared.stop()
         UserDefaults.standard.synchronize()
         SSHTunnelManager.shared.terminateAllProcessesSync()

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -125,6 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor [weak self] in
                     let diskIds = await TabDiskActor.shared.connectionIdsWithSavedState()
                     if !diskIds.isEmpty {
+                        self?.closeWelcomeWindowEagerly()
                         self?.attemptAutoReconnectAll(connectionIds: diskIds)
                     } else {
                         self?.closeRestoredMainWindows()

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -31,6 +31,7 @@ final class AppSettingsStorage {
         static let ai = "com.TablePro.settings.ai"
         static let sync = "com.TablePro.settings.sync"
         static let lastConnectionId = "com.TablePro.settings.lastConnectionId"
+        static let lastOpenConnectionIds = "com.TablePro.settings.lastOpenConnectionIds"
         static let hasCompletedOnboarding = "com.TablePro.settings.hasCompletedOnboarding"
     }
 
@@ -143,6 +144,25 @@ final class AppSettingsStorage {
             defaults.set(connectionId.uuidString, forKey: Keys.lastConnectionId)
         } else {
             defaults.removeObject(forKey: Keys.lastConnectionId)
+        }
+    }
+
+    // MARK: - Last Open Connections (for multi-session restore)
+
+    /// Load all connection IDs that were open when the app last quit
+    func loadLastOpenConnectionIds() -> [UUID] {
+        guard let strings = defaults.stringArray(forKey: Keys.lastOpenConnectionIds) else {
+            return []
+        }
+        return strings.compactMap { UUID(uuidString: $0) }
+    }
+
+    /// Save all currently open connection IDs for restoration on next launch
+    func saveLastOpenConnectionIds(_ connectionIds: [UUID]) {
+        if connectionIds.isEmpty {
+            defaults.removeObject(forKey: Keys.lastOpenConnectionIds)
+        } else {
+            defaults.set(connectionIds.map(\.uuidString), forKey: Keys.lastOpenConnectionIds)
         }
     }
 

--- a/TablePro/Core/Storage/TabDiskActor.swift
+++ b/TablePro/Core/Storage/TabDiskActor.swift
@@ -157,6 +157,21 @@ internal actor TabDiskActor {
         }
     }
 
+    /// List all connection IDs that have saved tab state on disk.
+    internal func connectionIdsWithSavedState() -> [UUID] {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: tabStateDirectory,
+            includingPropertiesForKeys: nil
+        ) else {
+            return []
+        }
+        return files.compactMap { url -> UUID? in
+            guard url.pathExtension == "json" else { return nil }
+            return UUID(uuidString: url.deletingPathExtension().lastPathComponent)
+        }
+    }
+
     // MARK: - Static Path Helpers
 
     nonisolated private static func resolvedTabStateDirectory() -> URL {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3086,6 +3086,9 @@
         }
       }
     },
+    "Action Failed" : {
+
+    },
     "Activate" : {
       "localizations" : {
         "tr" : {
@@ -3267,6 +3270,15 @@
           }
         }
       }
+    },
+    "Active Merges" : {
+
+    },
+    "Active Queries" : {
+
+    },
+    "Active Sessions" : {
+
     },
     "Actual" : {
       "localizations" : {
@@ -4109,6 +4121,7 @@
       }
     },
     "ALL DATABASES" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4153,6 +4166,7 @@
       }
     },
     "ALL SCHEMAS" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4880,6 +4894,9 @@
         }
       }
     },
+    "Are you sure you want to cancel the running query for this session?" : {
+
+    },
     "Are you sure you want to delete \"%@\"?" : {
       "localizations" : {
         "tr" : {
@@ -4990,6 +5007,9 @@
           }
         }
       }
+    },
+    "Are you sure you want to terminate this session? Any running queries will be aborted." : {
+
     },
     "As Copy" : {
       "localizations" : {
@@ -5781,6 +5801,9 @@
         }
       }
     },
+    "Block Size" : {
+
+    },
     "Blue" : {
       "localizations" : {
         "tr" : {
@@ -6046,6 +6069,12 @@
         }
       }
     },
+    "Bytes Received" : {
+
+    },
+    "Bytes Sent" : {
+
+    },
     "CA Cert" : {
       "localizations" : {
         "tr" : {
@@ -6090,6 +6119,12 @@
         }
       }
     },
+    "Cache Hit Ratio" : {
+
+    },
+    "Cache Size" : {
+
+    },
     "Cancel" : {
       "localizations" : {
         "tr" : {
@@ -6111,6 +6146,12 @@
           }
         }
       }
+    },
+    "Cancel Query" : {
+
+    },
+    "Cancel query for session %@" : {
+
     },
     "Cannot execute write queries: connection is read-only" : {
       "localizations" : {
@@ -6446,6 +6487,7 @@
       }
     },
     "Character Set" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -8202,6 +8244,9 @@
         }
       }
     },
+    "Connected Threads" : {
+
+    },
     "Connecting" : {
       "localizations" : {
         "tr" : {
@@ -8561,6 +8606,9 @@
           }
         }
       }
+    },
+    "Connections" : {
+
     },
     "Connections:" : {
       "localizations" : {
@@ -10183,6 +10231,12 @@
         }
       }
     },
+    "Dashboard" : {
+
+    },
+    "Dashboard Not Available" : {
+
+    },
     "Data" : {
       "localizations" : {
         "tr" : {
@@ -10492,6 +10546,9 @@
           }
         }
       }
+    },
+    "Database Size" : {
+
     },
     "Database Switch Failed" : {
       "localizations" : {
@@ -11923,6 +11980,9 @@
         }
       }
     },
+    "Disk Usage" : {
+
+    },
     "Dismiss" : {
       "localizations" : {
         "tr" : {
@@ -12477,6 +12537,9 @@
           }
         }
       }
+    },
+    "Duration" : {
+
     },
     "Each SQLite file is a separate database.\nTo open a different database, create a new connection." : {
       "localizations" : {
@@ -19261,6 +19324,9 @@
         }
       }
     },
+    "Journal Mode" : {
+
+    },
     "JSON" : {
       "localizations" : {
         "tr" : {
@@ -19393,6 +19459,9 @@
           }
         }
       }
+    },
+    "Keep Running" : {
+
     },
     "Keep This Mac's Version" : {
       "localizations" : {
@@ -20437,6 +20506,9 @@
         }
       }
     },
+    "Loading dashboard..." : {
+
+    },
     "Loading databases..." : {
       "localizations" : {
         "tr" : {
@@ -20858,6 +20930,9 @@
         }
       }
     },
+    "Max Connections" : {
+
+    },
     "Max schema tables: %d" : {
       "localizations" : {
         "tr" : {
@@ -21056,6 +21131,9 @@
           }
         }
       }
+    },
+    "Memory Limit" : {
+
     },
     "METADATA" : {
       "localizations" : {
@@ -23419,6 +23497,9 @@
         }
       }
     },
+    "No slow queries" : {
+
+    },
     "No SSL encryption" : {
       "localizations" : {
         "tr" : {
@@ -24217,6 +24298,9 @@
         }
       }
     },
+    "Off" : {
+
+    },
     "Offset" : {
       "localizations" : {
         "tr" : {
@@ -24503,6 +24587,9 @@
           }
         }
       }
+    },
+    "Open editor" : {
+
     },
     "Open File" : {
       "localizations" : {
@@ -24950,6 +25037,12 @@
         }
       }
     },
+    "Page Count" : {
+
+    },
+    "Page Size" : {
+
+    },
     "Page size must be between %@ and %@" : {
       "localizations" : {
         "en" : {
@@ -24977,6 +25070,9 @@
           }
         }
       }
+    },
+    "pages" : {
+
     },
     "Pagination" : {
       "localizations" : {
@@ -25065,6 +25161,9 @@
           }
         }
       }
+    },
+    "Part Mutations" : {
+
     },
     "Partition" : {
       "localizations" : {
@@ -25359,6 +25458,9 @@
         }
       }
     },
+    "Pause" : {
+
+    },
     "pending delete" : {
       "localizations" : {
         "tr" : {
@@ -25424,6 +25526,9 @@
           }
         }
       }
+    },
+    "PID" : {
+
     },
     "Pin Result" : {
       "localizations" : {
@@ -27787,6 +27892,7 @@
       }
     },
     "RECENT" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -28215,6 +28321,9 @@
           }
         }
       }
+    },
+    "Refresh Now" : {
+
     },
     "Refreshing will discard all unsaved changes." : {
       "localizations" : {
@@ -28999,6 +29108,9 @@
         }
       }
     },
+    "Resume" : {
+
+    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -29551,6 +29663,9 @@
           }
         }
       }
+    },
+    "Running Threads" : {
+
     },
     "Safe Mode" : {
       "localizations" : {
@@ -31126,6 +31241,9 @@
         }
       }
     },
+    "Server Dashboard" : {
+
+    },
     "Server error (%d): %@" : {
       "localizations" : {
         "en" : {
@@ -31182,6 +31300,12 @@
           }
         }
       }
+    },
+    "Server Metrics" : {
+
+    },
+    "Server monitoring is not available for this database type." : {
+
     },
     "Service Account Key" : {
       "localizations" : {
@@ -32186,6 +32310,9 @@
           }
         }
       }
+    },
+    "Slow Queries" : {
+
     },
     "Small" : {
       "localizations" : {
@@ -33218,6 +33345,9 @@
           }
         }
       }
+    },
+    "State" : {
+
     },
     "statement" : {
       "localizations" : {
@@ -34754,6 +34884,15 @@
         }
       }
     },
+    "Terminate" : {
+
+    },
+    "Terminate Session" : {
+
+    },
+    "Terminate session %@" : {
+
+    },
     "Tertiary Text" : {
       "localizations" : {
         "tr" : {
@@ -35821,6 +35960,9 @@
         }
       }
     },
+    "Threads" : {
+
+    },
     "Tier:" : {
       "localizations" : {
         "en" : {
@@ -36427,6 +36569,12 @@
           }
         }
       }
+    },
+    "Total Blocks" : {
+
+    },
+    "Total Queries" : {
+
     },
     "Total Size" : {
       "localizations" : {
@@ -37490,6 +37638,9 @@
         }
       }
     },
+    "Uptime" : {
+
+    },
     "US Long (12/31/2024 11:59:59 PM)" : {
       "localizations" : {
         "tr" : {
@@ -37643,6 +37794,9 @@
           }
         }
       }
+    },
+    "User Sessions" : {
+
     },
     "User-installed" : {
       "localizations" : {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3086,9 +3086,6 @@
         }
       }
     },
-    "Action Failed" : {
-
-    },
     "Activate" : {
       "localizations" : {
         "tr" : {
@@ -3270,15 +3267,6 @@
           }
         }
       }
-    },
-    "Active Merges" : {
-
-    },
-    "Active Queries" : {
-
-    },
-    "Active Sessions" : {
-
     },
     "Actual" : {
       "localizations" : {
@@ -4121,7 +4109,6 @@
       }
     },
     "ALL DATABASES" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4166,7 +4153,6 @@
       }
     },
     "ALL SCHEMAS" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4894,9 +4880,6 @@
         }
       }
     },
-    "Are you sure you want to cancel the running query for this session?" : {
-
-    },
     "Are you sure you want to delete \"%@\"?" : {
       "localizations" : {
         "tr" : {
@@ -5007,9 +4990,6 @@
           }
         }
       }
-    },
-    "Are you sure you want to terminate this session? Any running queries will be aborted." : {
-
     },
     "As Copy" : {
       "localizations" : {
@@ -5801,9 +5781,6 @@
         }
       }
     },
-    "Block Size" : {
-
-    },
     "Blue" : {
       "localizations" : {
         "tr" : {
@@ -6069,12 +6046,6 @@
         }
       }
     },
-    "Bytes Received" : {
-
-    },
-    "Bytes Sent" : {
-
-    },
     "CA Cert" : {
       "localizations" : {
         "tr" : {
@@ -6119,12 +6090,6 @@
         }
       }
     },
-    "Cache Hit Ratio" : {
-
-    },
-    "Cache Size" : {
-
-    },
     "Cancel" : {
       "localizations" : {
         "tr" : {
@@ -6146,12 +6111,6 @@
           }
         }
       }
-    },
-    "Cancel Query" : {
-
-    },
-    "Cancel query for session %@" : {
-
     },
     "Cannot execute write queries: connection is read-only" : {
       "localizations" : {
@@ -6487,7 +6446,6 @@
       }
     },
     "Character Set" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -8244,9 +8202,6 @@
         }
       }
     },
-    "Connected Threads" : {
-
-    },
     "Connecting" : {
       "localizations" : {
         "tr" : {
@@ -8606,9 +8561,6 @@
           }
         }
       }
-    },
-    "Connections" : {
-
     },
     "Connections:" : {
       "localizations" : {
@@ -10231,12 +10183,6 @@
         }
       }
     },
-    "Dashboard" : {
-
-    },
-    "Dashboard Not Available" : {
-
-    },
     "Data" : {
       "localizations" : {
         "tr" : {
@@ -10546,9 +10492,6 @@
           }
         }
       }
-    },
-    "Database Size" : {
-
     },
     "Database Switch Failed" : {
       "localizations" : {
@@ -11980,9 +11923,6 @@
         }
       }
     },
-    "Disk Usage" : {
-
-    },
     "Dismiss" : {
       "localizations" : {
         "tr" : {
@@ -12537,9 +12477,6 @@
           }
         }
       }
-    },
-    "Duration" : {
-
     },
     "Each SQLite file is a separate database.\nTo open a different database, create a new connection." : {
       "localizations" : {
@@ -19324,9 +19261,6 @@
         }
       }
     },
-    "Journal Mode" : {
-
-    },
     "JSON" : {
       "localizations" : {
         "tr" : {
@@ -19459,9 +19393,6 @@
           }
         }
       }
-    },
-    "Keep Running" : {
-
     },
     "Keep This Mac's Version" : {
       "localizations" : {
@@ -20506,9 +20437,6 @@
         }
       }
     },
-    "Loading dashboard..." : {
-
-    },
     "Loading databases..." : {
       "localizations" : {
         "tr" : {
@@ -20930,9 +20858,6 @@
         }
       }
     },
-    "Max Connections" : {
-
-    },
     "Max schema tables: %d" : {
       "localizations" : {
         "tr" : {
@@ -21131,9 +21056,6 @@
           }
         }
       }
-    },
-    "Memory Limit" : {
-
     },
     "METADATA" : {
       "localizations" : {
@@ -23497,9 +23419,6 @@
         }
       }
     },
-    "No slow queries" : {
-
-    },
     "No SSL encryption" : {
       "localizations" : {
         "tr" : {
@@ -24298,9 +24217,6 @@
         }
       }
     },
-    "Off" : {
-
-    },
     "Offset" : {
       "localizations" : {
         "tr" : {
@@ -24587,9 +24503,6 @@
           }
         }
       }
-    },
-    "Open editor" : {
-
     },
     "Open File" : {
       "localizations" : {
@@ -25037,12 +24950,6 @@
         }
       }
     },
-    "Page Count" : {
-
-    },
-    "Page Size" : {
-
-    },
     "Page size must be between %@ and %@" : {
       "localizations" : {
         "en" : {
@@ -25070,9 +24977,6 @@
           }
         }
       }
-    },
-    "pages" : {
-
     },
     "Pagination" : {
       "localizations" : {
@@ -25161,9 +25065,6 @@
           }
         }
       }
-    },
-    "Part Mutations" : {
-
     },
     "Partition" : {
       "localizations" : {
@@ -25458,9 +25359,6 @@
         }
       }
     },
-    "Pause" : {
-
-    },
     "pending delete" : {
       "localizations" : {
         "tr" : {
@@ -25526,9 +25424,6 @@
           }
         }
       }
-    },
-    "PID" : {
-
     },
     "Pin Result" : {
       "localizations" : {
@@ -27892,7 +27787,6 @@
       }
     },
     "RECENT" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -28321,9 +28215,6 @@
           }
         }
       }
-    },
-    "Refresh Now" : {
-
     },
     "Refreshing will discard all unsaved changes." : {
       "localizations" : {
@@ -29108,9 +28999,6 @@
         }
       }
     },
-    "Resume" : {
-
-    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -29663,9 +29551,6 @@
           }
         }
       }
-    },
-    "Running Threads" : {
-
     },
     "Safe Mode" : {
       "localizations" : {
@@ -31241,9 +31126,6 @@
         }
       }
     },
-    "Server Dashboard" : {
-
-    },
     "Server error (%d): %@" : {
       "localizations" : {
         "en" : {
@@ -31300,12 +31182,6 @@
           }
         }
       }
-    },
-    "Server Metrics" : {
-
-    },
-    "Server monitoring is not available for this database type." : {
-
     },
     "Service Account Key" : {
       "localizations" : {
@@ -32310,9 +32186,6 @@
           }
         }
       }
-    },
-    "Slow Queries" : {
-
     },
     "Small" : {
       "localizations" : {
@@ -33345,9 +33218,6 @@
           }
         }
       }
-    },
-    "State" : {
-
     },
     "statement" : {
       "localizations" : {
@@ -34884,15 +34754,6 @@
         }
       }
     },
-    "Terminate" : {
-
-    },
-    "Terminate Session" : {
-
-    },
-    "Terminate session %@" : {
-
-    },
     "Tertiary Text" : {
       "localizations" : {
         "tr" : {
@@ -35960,9 +35821,6 @@
         }
       }
     },
-    "Threads" : {
-
-    },
     "Tier:" : {
       "localizations" : {
         "en" : {
@@ -36569,12 +36427,6 @@
           }
         }
       }
-    },
-    "Total Blocks" : {
-
-    },
-    "Total Queries" : {
-
     },
     "Total Size" : {
       "localizations" : {
@@ -37638,9 +37490,6 @@
         }
       }
     },
-    "Uptime" : {
-
-    },
     "US Long (12/31/2024 11:59:59 PM)" : {
       "localizations" : {
         "tr" : {
@@ -37794,9 +37643,6 @@
           }
         }
       }
-    },
-    "User Sessions" : {
-
     },
     "User-installed" : {
       "localizations" : {

--- a/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
@@ -234,6 +234,64 @@ struct TabPersistenceCoordinatorTests {
         #expect(afterClear.source == .none)
     }
 
+    @Test("Preview tabs are excluded from persistence")
+    func previewTabsExcludedFromPersistence() async {
+        let coordinator = makeCoordinator()
+        var normalTab = QueryTab(id: UUID(), title: "Normal", query: "SELECT 1", tabType: .query)
+        var previewTab = QueryTab(id: UUID(), title: "Preview", query: "SELECT 2", tabType: .table, tableName: "users")
+        previewTab.isPreview = true
+
+        coordinator.saveNow(tabs: [normalTab, previewTab], selectedTabId: normalTab.id)
+        await sleep()
+
+        let result = await coordinator.restoreFromDisk()
+
+        #expect(result.tabs.count == 1)
+        #expect(result.tabs[0].id == normalTab.id)
+        #expect(result.tabs[0].title == "Normal")
+
+        coordinator.clearSavedState()
+        await sleep()
+    }
+
+    @Test("All-preview tabs clears saved state")
+    func allPreviewTabsClearsSavedState() async {
+        let coordinator = makeCoordinator()
+        let normalTab = QueryTab(id: UUID(), title: "Normal", query: "SELECT 1", tabType: .query)
+
+        // First save a normal tab
+        coordinator.saveNow(tabs: [normalTab], selectedTabId: normalTab.id)
+        await sleep()
+
+        // Now save only preview tabs — should clear state
+        var previewTab = QueryTab(id: UUID(), title: "Preview", query: "SELECT 2", tabType: .table, tableName: "users")
+        previewTab.isPreview = true
+        coordinator.saveNow(tabs: [previewTab], selectedTabId: previewTab.id)
+        await sleep()
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.tabs.isEmpty)
+        #expect(result.source == .none)
+    }
+
+    @Test("selectedTabId normalizes when selected tab is preview")
+    func selectedTabIdNormalizesWhenPreview() async {
+        let coordinator = makeCoordinator()
+        let normalTab = QueryTab(id: UUID(), title: "Normal", query: "SELECT 1", tabType: .query)
+        var previewTab = QueryTab(id: UUID(), title: "Preview", query: "SELECT 2", tabType: .table, tableName: "users")
+        previewTab.isPreview = true
+
+        // Select the preview tab — should normalize to first non-preview tab
+        coordinator.saveNow(tabs: [normalTab, previewTab], selectedTabId: previewTab.id)
+        await sleep()
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.selectedTabId == normalTab.id)
+
+        coordinator.clearSavedState()
+        await sleep()
+    }
+
     @Test("Tab properties preserved: tableName, isView, databaseName")
     func tabPropertiesPreserved() async {
         let coordinator = makeCoordinator()

--- a/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
@@ -237,7 +237,7 @@ struct TabPersistenceCoordinatorTests {
     @Test("Preview tabs are excluded from persistence")
     func previewTabsExcludedFromPersistence() async {
         let coordinator = makeCoordinator()
-        var normalTab = QueryTab(id: UUID(), title: "Normal", query: "SELECT 1", tabType: .query)
+        let normalTab = QueryTab(id: UUID(), title: "Normal", query: "SELECT 1", tabType: .query)
         var previewTab = QueryTab(id: UUID(), title: "Preview", query: "SELECT 2", tabType: .table, tableName: "users")
         previewTab.isPreview = true
 

--- a/TableProTests/Core/Storage/AppSettingsStorageTests.swift
+++ b/TableProTests/Core/Storage/AppSettingsStorageTests.swift
@@ -1,0 +1,98 @@
+//
+//  AppSettingsStorageTests.swift
+//  TableProTests
+//
+//  Tests for AppSettingsStorage multi-connection session restoration.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AppSettingsStorage - Last Open Connection IDs")
+struct AppSettingsStorageLastOpenConnectionTests {
+    private let storage = AppSettingsStorage.shared
+
+    /// Clean state before and after each test to prevent cross-test pollution.
+    private func cleanup() {
+        storage.saveLastOpenConnectionIds([])
+    }
+
+    @Test("saveLastOpenConnectionIds + loadLastOpenConnectionIds round-trip")
+    func roundTrip() {
+        cleanup()
+        let ids = [UUID(), UUID(), UUID()]
+
+        storage.saveLastOpenConnectionIds(ids)
+        let loaded = storage.loadLastOpenConnectionIds()
+
+        #expect(loaded == ids)
+
+        cleanup()
+    }
+
+    @Test("loadLastOpenConnectionIds returns empty when nothing saved")
+    func returnsEmptyWhenNothingSaved() {
+        cleanup()
+        let loaded = storage.loadLastOpenConnectionIds()
+        #expect(loaded.isEmpty)
+    }
+
+    @Test("saveLastOpenConnectionIds with empty array clears state")
+    func emptyArrayClearsState() {
+        cleanup()
+        let ids = [UUID()]
+        storage.saveLastOpenConnectionIds(ids)
+        storage.saveLastOpenConnectionIds([])
+
+        let loaded = storage.loadLastOpenConnectionIds()
+        #expect(loaded.isEmpty)
+    }
+
+    @Test("saveLastOpenConnectionIds overwrites previous state")
+    func overwritesPreviousState() {
+        cleanup()
+        let first = [UUID(), UUID()]
+        let second = [UUID()]
+
+        storage.saveLastOpenConnectionIds(first)
+        storage.saveLastOpenConnectionIds(second)
+
+        let loaded = storage.loadLastOpenConnectionIds()
+        #expect(loaded == second)
+
+        cleanup()
+    }
+
+    @Test("loadLastOpenConnectionIds ignores malformed UUID strings")
+    func ignoresMalformedUUIDs() {
+        cleanup()
+        // Write raw strings directly to verify the load method handles bad data
+        let validId = UUID()
+        storage.saveLastOpenConnectionIds([validId])
+
+        // Overwrite with raw strings including invalid UUIDs
+        UserDefaults.standard.set(
+            [validId.uuidString, "not-a-uuid", "also-bad"],
+            forKey: "com.TablePro.settings.lastOpenConnectionIds"
+        )
+
+        let loaded = storage.loadLastOpenConnectionIds()
+        #expect(loaded == [validId])
+
+        cleanup()
+    }
+
+    @Test("Preserves order of connection IDs")
+    func preservesOrder() {
+        cleanup()
+        let ids = (0..<5).map { _ in UUID() }
+
+        storage.saveLastOpenConnectionIds(ids)
+        let loaded = storage.loadLastOpenConnectionIds()
+
+        #expect(loaded == ids)
+
+        cleanup()
+    }
+}

--- a/TableProTests/Core/Storage/TabDiskActorTests.swift
+++ b/TableProTests/Core/Storage/TabDiskActorTests.swift
@@ -313,4 +313,42 @@ struct TabDiskActorTests {
 
         await actor.clear(connectionId: connectionId)
     }
+
+    // MARK: - connectionIdsWithSavedState
+
+    @Test("connectionIdsWithSavedState returns correct IDs after saving multiple connections")
+    func connectionIdsWithSavedStateReturnsCorrectIds() async throws {
+        let connA = UUID()
+        let connB = UUID()
+        let tab = makeTab()
+
+        try await actor.save(connectionId: connA, tabs: [tab], selectedTabId: tab.id)
+        try await actor.save(connectionId: connB, tabs: [tab], selectedTabId: tab.id)
+
+        let ids = await actor.connectionIdsWithSavedState()
+
+        #expect(ids.contains(connA))
+        #expect(ids.contains(connB))
+
+        await actor.clear(connectionId: connA)
+        await actor.clear(connectionId: connB)
+    }
+
+    @Test("connectionIdsWithSavedState excludes cleared connections")
+    func connectionIdsWithSavedStateExcludesCleared() async throws {
+        let connA = UUID()
+        let connB = UUID()
+        let tab = makeTab()
+
+        try await actor.save(connectionId: connA, tabs: [tab], selectedTabId: tab.id)
+        try await actor.save(connectionId: connB, tabs: [tab], selectedTabId: tab.id)
+        await actor.clear(connectionId: connA)
+
+        let ids = await actor.connectionIdsWithSavedState()
+
+        #expect(!ids.contains(connA))
+        #expect(ids.contains(connB))
+
+        await actor.clear(connectionId: connB)
+    }
 }


### PR DESCRIPTION
## Summary

- Save all open connection IDs at quit time and restore all connections on relaunch when "Reopen Last Session" is enabled
- Support multi-connection restore (previously only the last-used connection was restored)
- Add crash-recovery fallback: scan TabState directory for restorable connections if the saved list is missing
- Hide Welcome window immediately during auto-reconnect to prevent visible flash
- Deterministic restore order by using ConnectionStorage ordering instead of random Dictionary.keys

Closes #703

## Changes

| File | Change |
|------|--------|
| `AppSettingsStorage.swift` | `saveLastOpenConnectionIds` / `loadLastOpenConnectionIds` for multi-connection ID persistence |
| `TabDiskActor.swift` | `connectionIdsWithSavedState()` for crash-recovery disk scan |
| `AppDelegate.swift` | Save all connections at quit; 3-tier restore: multi-connection → single legacy → disk scan |
| `AppDelegate+WindowConfig.swift` | `attemptAutoReconnectAll(connectionIds:)` + `closeWelcomeWindowEagerly()` |
| `AppSettingsStorageTests.swift` | 6 new tests for multi-connection ID save/load |
| `TabDiskActorTests.swift` | 2 new tests for `connectionIdsWithSavedState` |
| `TabPersistenceCoordinatorTests.swift` | 3 new tests for preview tab filtering |

## Test plan

- [ ] Set startup to "Reopen Last Session", open 1 connection with multiple tabs, quit, relaunch → all tabs restored
- [ ] Open 2+ connections with tabs, quit, relaunch → all connections and tabs restored
- [ ] Delete a saved connection, relaunch → Welcome screen appears gracefully
- [ ] Set startup to "Show Welcome Screen", quit, relaunch → Welcome screen shows, clicking a connection restores its tabs
- [ ] Verify no Welcome window flash during auto-reconnect