### PR TITLE
fix: auto-selection of first item fails with fast input in Database Switcher (#714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restore all open connections and tabs after quitting the app (#703)
 
+### Fixed
+
+- Auto-selection of first item fails with fast input in Database Switcher (#714)
+
 ## [0.31.2] - 2026-04-13
 
 ### Fixed

--- a/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
+++ b/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
@@ -25,7 +25,9 @@ final class DatabaseSwitcherViewModel {
     // MARK: - Published State
 
     var databases: [DatabaseMetadata] = []
-    var searchText = ""
+    var searchText = "" {
+        didSet { selectedDatabase = filteredDatabases.first?.name }
+    }
     var selectedDatabase: String?
     var isLoading = false
     var errorMessage: String?
@@ -102,6 +104,7 @@ final class DatabaseSwitcherViewModel {
                 do {
                     let metadataList = try await driver.fetchAllDatabaseMetadata()
                     databases = metadataList.sorted { $0.name < $1.name }
+                    preselectDatabase()
                 } catch {
                     Self.logger.error("Failed to fetch database metadata: \(error)")
                 }
@@ -135,6 +138,31 @@ final class DatabaseSwitcherViewModel {
         }
 
         try await driver.createDatabase(name: name, charset: charset, collation: collation)
+    }
+
+    // MARK: - Keyboard Navigation
+
+    func moveUp() {
+        let items = filteredDatabases
+        guard !items.isEmpty else { return }
+        guard let current = selectedDatabase,
+              let index = items.firstIndex(where: { $0.name == current }),
+              index > 0
+        else { return }
+        selectedDatabase = items[index - 1].name
+    }
+
+    func moveDown() {
+        let items = filteredDatabases
+        guard !items.isEmpty else { return }
+        if let current = selectedDatabase,
+           let index = items.firstIndex(where: { $0.name == current }),
+           index < items.count - 1
+        {
+            selectedDatabase = items[index + 1].name
+        } else if selectedDatabase == nil {
+            selectedDatabase = items.first?.name
+        }
     }
 
     // MARK: - Private Methods

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -131,21 +131,21 @@ struct DatabaseSwitcherSheet: View {
             return .handled
         }
         .onKeyPress(.upArrow) {
-            moveSelection(up: true)
+            viewModel.moveUp()
             return .handled
         }
         .onKeyPress(.downArrow) {
-            moveSelection(up: false)
+            viewModel.moveDown()
             return .handled
         }
         .onKeyPress(characters: .init(charactersIn: "jn"), phases: [.down, .repeat]) { keyPress in
             guard keyPress.modifiers.contains(.control) else { return .ignored }
-            moveSelection(up: false)
+            viewModel.moveDown()
             return .handled
         }
         .onKeyPress(characters: .init(charactersIn: "kp"), phases: [.down, .repeat]) { keyPress in
             guard keyPress.modifiers.contains(.control) else { return .ignored }
-            moveSelection(up: true)
+            viewModel.moveUp()
             return .handled
         }
     }
@@ -375,28 +375,6 @@ struct DatabaseSwitcherSheet: View {
     }
 
     // MARK: - Actions
-
-    private func moveSelection(up: Bool) {
-        let allDbs = viewModel.filteredDatabases
-        guard !allDbs.isEmpty else { return }
-
-        // Defer state update to avoid "Publishing changes from within view updates" warning
-        Task { @MainActor in
-            if let selected = viewModel.selectedDatabase,
-               let currentIndex = allDbs.firstIndex(where: { $0.name == selected })
-            {
-                if up {
-                    let newIndex = max(0, currentIndex - 1)
-                    viewModel.selectedDatabase = allDbs[newIndex].name
-                } else {
-                    let newIndex = min(allDbs.count - 1, currentIndex + 1)
-                    viewModel.selectedDatabase = allDbs[newIndex].name
-                }
-            } else {
-                viewModel.selectedDatabase = up ? allDbs.last?.name : allDbs.first?.name
-            }
-        }
-    }
 
     private func openSelectedDatabase() {
         guard let database = viewModel.selectedDatabase else { return }

--- a/TablePro/Views/Results/ForeignKeyPopoverContentView.swift
+++ b/TablePro/Views/Results/ForeignKeyPopoverContentView.swift
@@ -86,6 +86,9 @@ struct ForeignKeyPopoverContentView: View {
         .frame(width: 420)
         .fixedSize(horizontal: false, vertical: true)
         .task { await fetchForeignKeyValues() }
+        .onChange(of: searchText) {
+            selectedId = filteredValues.first?.id
+        }
     }
 
     // MARK: - Row View


### PR DESCRIPTION
## Summary

- Fix `selectedDatabase` never updating when search text changes in Database Switcher — caused stale selection on fast typing
- Move keyboard navigation logic (`moveUp`/`moveDown`) from View into ViewModel as synchronous methods, matching QuickSwitcher pattern
- Fix same stale-selection bug in Foreign Key popover
- Re-select after Phase 2 metadata load to handle re-sorting

Closes #714

## Root cause

`DatabaseSwitcherViewModel.searchText` had no `didSet` observer. `selectedDatabase` was set exactly once during `preselectDatabase()` at load time and never updated when the filter changed. When typing fast, `selectedDatabase` pointed to an item no longer in the filtered list.

The QuickSwitcher didn't have this bug because it uses `didSet { updateFilter() }` on `searchText` and always ends with `selectedItemId = filteredItems.first?.id`.

## Changes

| File | Change |
|------|--------|
| `DatabaseSwitcherViewModel.swift` | Add `didSet` on `searchText` to auto-select first filtered result; add synchronous `moveUp()`/`moveDown()`; call `preselectDatabase()` after Phase 2 metadata load |
| `DatabaseSwitcherSheet.swift` | Remove `moveSelection(up:)` with async `Task` wrapper; call ViewModel methods directly |
| `ForeignKeyPopoverContentView.swift` | Add `.onChange(of: searchText)` to reset `selectedId` to first filtered value |

## Test plan

- [ ] Open Database Switcher, type quickly — first result should always be selected
- [ ] Clear text, type slowly — same behavior
- [ ] Arrow keys should navigate immediately (no one-frame lag)
- [ ] Press Return — should open the visually highlighted database
- [ ] Open FK column popover, type to filter — selection should track first result