### PR TITLE
fix: Ollama model selection and error messages in AI settings (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-selection of first item fails with fast input in Database Switcher (#714)
 - AI settings: fix Ollama model selection and improve error messages (#712)
+
 ## [0.31.2] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Auto-selection of first item fails with fast input in Database Switcher (#714)
-
+- AI settings: fix Ollama model selection and improve error messages (#712)
 ## [0.31.2] - 2026-04-13
 
 ### Fixed

--- a/TablePro/Core/AI/OpenAICompatibleProvider.swift
+++ b/TablePro/Core/AI/OpenAICompatibleProvider.swift
@@ -107,9 +107,26 @@ final class OpenAICompatibleProvider: AIProvider {
     func testConnection() async throws -> Bool {
         switch providerType {
         case .ollama:
-            // Ollama is local — just verify reachability
-            let models = try await fetchAvailableModels()
-            return !models.isEmpty
+            // Ollama is local — verify reachability and model availability
+            do {
+                let models = try await fetchAvailableModels()
+                if models.isEmpty {
+                    throw AIProviderError.networkError(
+                        String(localized: "Ollama is running but has no models. Run \"ollama pull <model>\" to download one.")
+                    )
+                }
+                return true
+            } catch let error as AIProviderError {
+                throw error
+            } catch is URLError {
+                throw AIProviderError.networkError(
+                    String(format: String(localized: "Cannot connect to Ollama at %@. Is Ollama running?"), endpoint)
+                )
+            } catch {
+                throw AIProviderError.networkError(
+                    String(format: String(localized: "Cannot connect to Ollama at %@. Is Ollama running?"), endpoint)
+                )
+            }
         default:
             // Send a minimal non-streaming chat request to verify auth
             let chatPath = "/v1/chat/completions"
@@ -306,7 +323,10 @@ final class OpenAICompatibleProvider: AIProvider {
         guard let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200
         else {
-            throw AIProviderError.networkError("Failed to fetch Ollama models")
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw AIProviderError.networkError(
+                String(format: String(localized: "Failed to fetch models from %@ (HTTP %d)"), endpoint, statusCode)
+            )
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data)

--- a/TablePro/Views/Settings/AISettingsView.swift
+++ b/TablePro/Views/Settings/AISettingsView.swift
@@ -400,6 +400,7 @@ private struct AIProviderEditorSheet: View {
             if draft.endpoint.isEmpty || allDefaults.contains(draft.endpoint) {
                 draft.endpoint = newType.defaultEndpoint
             }
+            AIProviderFactory.invalidateCache(for: draft.id)
             fetchedModels = []
             draft.model = ""
             scheduleFetchModels()
@@ -423,6 +424,7 @@ private struct AIProviderEditorSheet: View {
         TextField("Endpoint", text: $draft.endpoint)
             .textFieldStyle(.roundedBorder)
             .onChange(of: draft.endpoint) {
+                AIProviderFactory.invalidateCache(for: draft.id)
                 fetchedModels = []
                 scheduleFetchModels()
             }
@@ -430,23 +432,27 @@ private struct AIProviderEditorSheet: View {
 
     private var modelField: some View {
         VStack(alignment: .leading, spacing: 4) {
-            if fetchedModels.isEmpty {
+            if isFetchingModels {
                 HStack {
                     Text("Model")
                     Spacer()
-                    if isFetchingModels {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Text(String(localized: "No models loaded"))
-                            .foregroundStyle(.secondary)
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            } else if fetchedModels.isEmpty {
+                HStack {
+                    Text("Model")
+                    Spacer()
+                    Button {
+                        fetchModels()
+                    } label: {
+                        Label(String(localized: "Load Models"), systemImage: "arrow.clockwise")
+                            .font(.caption)
                     }
+                    .buttonStyle(.borderless)
                 }
             } else {
                 Picker("Model", selection: $draft.model) {
-                    if !fetchedModels.contains(draft.model) && !draft.model.isEmpty {
-                        Text(draft.model).tag(draft.model)
-                    }
                     ForEach(fetchedModels, id: \.self) { model in
                         Text(model).tag(model)
                     }
@@ -454,18 +460,9 @@ private struct AIProviderEditorSheet: View {
             }
 
             if let error = modelFetchError {
-                HStack {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(Color(nsColor: .systemRed))
-                    Button {
-                        fetchModels()
-                    } label: {
-                        Label("Retry", systemImage: "arrow.clockwise")
-                            .font(.caption)
-                    }
-                    .buttonStyle(.borderless)
-                }
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(Color(nsColor: .systemRed))
             }
         }
     }
@@ -550,7 +547,7 @@ private struct AIProviderEditorSheet: View {
                 let models = try await provider.fetchAvailableModels()
                 fetchedModels = models
 
-                // Auto-select first model if field is empty
+                // Auto-select first model if none is selected
                 if draft.model.isEmpty, let first = models.first {
                     draft.model = first
                 }


### PR DESCRIPTION
## Summary

- Fix model field showing stale models from cached provider when switching to Ollama
- Fix generic "Connection test failed" error with actionable Ollama-specific messages
- Clean up model field to use native Picker only — no custom UI

Closes #712

## Root causes

1. **Stale cached provider**: `AIProviderFactory` caches providers by `config.id`. When editing a draft and switching type (e.g., Claude → Ollama), the draft keeps the same UUID, so the factory returned the old Claude provider — fetching Claude models and failing auth with Ollama's empty API key.

2. **No text input fallback**: When model fetch failed, the UI showed "No models loaded" with no way to retry or interact.

3. **Generic errors**: Ollama test failures showed "Connection test failed" with no guidance about checking if Ollama is running.

## Changes

| File | Change |
|------|--------|
| `AISettingsView.swift` | Invalidate provider cache on type/endpoint change; clean model field: loading → spinner, empty → "Load Models" retry button, loaded → native Picker |
| `OpenAICompatibleProvider.swift` | Ollama-specific error messages: connection refused, no models, HTTP errors with endpoint/status |

## Test plan

- [ ] Add Ollama provider (Ollama running) → models load in Picker, Test succeeds
- [ ] Add Ollama provider (Ollama not running) → "Load Models" button shown, Test shows "Cannot connect to Ollama at... Is Ollama running?"
- [ ] Switch type Claude → Ollama → should fetch Ollama models, not Claude models
- [ ] Change endpoint → should re-fetch models from new endpoint
- [ ] Other providers (Claude, OpenAI, Gemini) → no regression