### PR TITLE
feat: rewrite SQL formatter with token-based architecture (#705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-selection of first item fails with fast input in Database Switcher (#714)
 - AI settings: fix Ollama model selection and improve error messages (#712)
+- Rewrite SQL formatter with token-based architecture for better formatting (#705)
 
 ## [0.31.2] - 2026-04-13
 

--- a/TablePro/Core/Services/Formatting/SQLFormatterService.swift
+++ b/TablePro/Core/Services/Formatting/SQLFormatterService.swift
@@ -2,7 +2,8 @@
 //  SQLFormatterService.swift
 //  TablePro
 //
-//  Created by OpenCode on 1/17/26.
+//  Token-based SQL formatter. Tokenizes input into a stream, then walks tokens
+//  with clause/nesting context to produce properly indented, readable SQL.
 //
 
 import Foundation
@@ -10,7 +11,6 @@ import Foundation
 // MARK: - Formatter Protocol
 
 protocol SQLFormatterProtocol {
-    /// Format SQL with optional cursor position preservation
     func format(
         _ sql: String,
         dialect: DatabaseType,
@@ -22,112 +22,7 @@ protocol SQLFormatterProtocol {
 // MARK: - Main Formatter Service
 
 struct SQLFormatterService: SQLFormatterProtocol {
-    private static func regex(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
-        do {
-            return try NSRegularExpression(pattern: pattern, options: options)
-        } catch {
-            preconditionFailure("Invalid regex pattern: \(pattern)")
-        }
-    }
-    // MARK: - Constants
-
-    /// Maximum input size: 10MB (protection against DoS)
     private static let maxInputSize = 10 * 1_024 * 1_024
-
-    /// Alignment for SELECT columns (length of "SELECT ")
-    private static let selectKeywordLength = 7
-
-    // MARK: - Cached Regex Patterns (CPU-3, CPU-9, CPU-10)
-
-    /// String literal extraction patterns — one per quote character
-    /// Handles both backslash escapes (\'') and SQL-standard doubled-quote escapes ('')
-    private static let stringLiteralRegexes: [String: NSRegularExpression] = {
-        var result: [String: NSRegularExpression] = [:]
-        for quoteChar in ["'", "\"", "`"] {
-            let escaped = NSRegularExpression.escapedPattern(for: quoteChar)
-            let pattern = "\(escaped)((?:\\\\\\\\\(quoteChar)|\(escaped)\(escaped)|[^\(quoteChar)])*)\(escaped)"
-            result[quoteChar] = regex(pattern)
-        }
-        return result
-    }()
-
-    /// Line break keyword patterns — pre-compiled for all 16 keywords (CPU-9)
-    /// Sorted by keyword length (longest first) to handle multi-word keywords correctly
-    private static let lineBreakRegexes: [(keyword: String, regex: NSRegularExpression)] = {
-        let keywords = [
-            "SELECT", "FROM", "WHERE", "JOIN", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN",
-            "FULL JOIN", "CROSS JOIN", "ORDER BY", "GROUP BY", "HAVING",
-            "UNION", "UNION ALL", "INTERSECT", "EXCEPT", "LIMIT", "OFFSET"
-        ]
-        return keywords.sorted(by: { $0.count > $1.count }).map { keyword in
-            let escapedKeyword = NSRegularExpression.escapedPattern(for: keyword)
-            let pattern = "\\s+\(escapedKeyword)\\b"
-            let regex = regex(pattern, options: .caseInsensitive)
-            return (keyword, regex)
-        }
-    }()
-
-    /// Subquery pattern: \(\s*SELECT\b  (CPU-10)
-    private static let subqueryRegex: NSRegularExpression = {
-        regex("\\(\\s*SELECT\\b", options: .caseInsensitive)
-    }()
-
-    /// Word boundary pattern for "END" keyword (CPU-10)
-    private static let endWordBoundaryRegex: NSRegularExpression = {
-        regex("\\bEND\\b", options: .caseInsensitive)
-    }()
-
-    /// Word boundary pattern for "CASE" keyword (CPU-10)
-    private static let caseWordBoundaryRegex: NSRegularExpression = {
-        regex("\\bCASE\\b", options: .caseInsensitive)
-    }()
-
-    /// WHERE condition alignment pattern: \s+(AND|OR)\s+
-    private static let majorKeywordRegex: NSRegularExpression = {
-        regex("\\b(ORDER|GROUP|HAVING|LIMIT|UNION|INTERSECT)\\b", options: .caseInsensitive)
-    }()
-
-    private static let whereConditionRegex: NSRegularExpression = {
-        regex("\\s+(AND|OR)\\s+", options: .caseInsensitive)
-    }()
-
-    /// Keyword uppercasing regex cache per DatabaseType (CPU-5)
-    /// Uses NSLock for thread safety since static mutable state is shared.
-    private static let keywordRegexLock = NSLock()
-    private static var keywordRegexCache: [DatabaseType: NSRegularExpression] = [:]
-
-    /// Get or create the keyword uppercasing regex for a given database type
-    private static func keywordRegex(for dialect: DatabaseType) -> NSRegularExpression? {
-        keywordRegexLock.lock()
-        if let cached = keywordRegexCache[dialect] {
-            keywordRegexLock.unlock()
-            return cached
-        }
-        keywordRegexLock.unlock()
-
-        let provider = resolveDialectProvider(for: dialect)
-        let allKeywords = provider.keywords.union(provider.functions).union(provider.dataTypes)
-        let escapedKeywords = allKeywords.map { NSRegularExpression.escapedPattern(for: $0) }
-        let pattern = "\\b(\(escapedKeywords.joined(separator: "|")))\\b"
-
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return nil
-        }
-
-        keywordRegexLock.lock()
-        defer { keywordRegexLock.unlock() }
-        if let cached = keywordRegexCache[dialect] {
-            return cached
-        }
-        keywordRegexCache[dialect] = regex
-        return regex
-    }
-
-    private static func resolveDialectProvider(for dialect: DatabaseType) -> SQLDialectProvider {
-        SQLDialectFactory.createDialect(for: dialect)
-    }
-
-    // MARK: - Public API
 
     func format(
         _ sql: String,
@@ -135,391 +30,544 @@ struct SQLFormatterService: SQLFormatterProtocol {
         cursorOffset: Int? = nil,
         options: SQLFormatterOptions = .default
     ) throws -> SQLFormatterResult {
-        // Fix #4: Input size limit (DoS protection)
         guard sql.utf8.count <= Self.maxInputSize else {
             throw SQLFormatterError.internalError("SQL too large (max \(Self.maxInputSize / 1_024 / 1_024)MB)")
         }
 
-        // Validate input
         let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw SQLFormatterError.emptyInput
         }
 
-        // CPU-8: Use utf16.count for O(1) length instead of O(n) String.count
         let sqlLength = sql.utf16.count
         if let cursor = cursorOffset, cursor > sqlLength {
             throw SQLFormatterError.invalidCursorPosition(cursor, max: sqlLength)
         }
 
-        let dialectProvider = Self.resolveDialectProvider(for: dialect)
+        let dialectProvider = SQLDialectFactory.createDialect(for: dialect)
+        let dialectKeywords = dialectProvider.keywords
+            .union(dialectProvider.functions)
+            .union(dialectProvider.dataTypes)
 
-        // Format the SQL
-        let formatted = formatSQL(sql, dialect: dialectProvider, databaseType: dialect, options: options)
+        let tokenizer = SQLTokenizer(dialectKeywords: dialectKeywords)
+        let tokens = tokenizer.tokenize(sql)
+        var tokenFormatter = SQLTokenFormatter(options: options)
+        let formatted = tokenFormatter.format(tokens)
 
-        // Cursor preservation
         let newCursor = cursorOffset.map { original in
-            preserveCursorPosition(original: original, oldText: sql, newText: formatted)
+            mapCursorPosition(original: original, oldLength: sql.utf16.count, newLength: formatted.utf16.count)
         }
 
-        return SQLFormatterResult(
-            formattedSQL: formatted,
-            cursorOffset: newCursor
-        )
+        return SQLFormatterResult(formattedSQL: formatted, cursorOffset: newCursor)
     }
 
-    // MARK: - Core Formatting Logic
-
-    private func formatSQL(
-        _ sql: String,
-        dialect: SQLDialectProvider,
-        databaseType: DatabaseType,
-        options: SQLFormatterOptions
-    ) -> String {
-        var result = sql
-
-        // Step 1: Preserve comments (replace with UUID placeholders)
-        let (sqlWithoutComments, comments) = options.preserveComments
-            ? extractComments(from: result)
-            : (result, [])
-
-        result = sqlWithoutComments
-
-        // Step 2: Extract string literals (to protect from keyword replacement)
-        let (sqlWithoutStrings, stringLiterals) = extractStringLiterals(from: result, dialect: dialect)
-        result = sqlWithoutStrings
-
-        // Step 3: Uppercase keywords (now safe - strings removed)
-        if options.uppercaseKeywords {
-            result = uppercaseKeywords(result, databaseType: databaseType)
-        }
-
-        // Step 4: Restore string literals
-        result = restoreStringLiterals(result, literals: stringLiterals)
-
-        // Step 5: Add line breaks before major keywords
-        result = addLineBreaks(result, options: options)
-
-        // Step 6: Add indentation based on nesting
-        if options.indentSize > 0 {
-            result = addIndentation(result, indentSize: options.indentSize)
-        }
-
-        // Step 7: Align SELECT columns
-        if options.alignColumns {
-            result = alignSelectColumns(result)
-        }
-
-        // Step 8: Format JOINs (handled by line breaks)
-        if options.formatJoins {
-            result = formatJoins(result)
-        }
-
-        // Step 9: Align WHERE conditions
-        if options.alignWhere {
-            result = alignWhereConditions(result)
-        }
-
-        // Step 10: Restore comments
-        if options.preserveComments {
-            result = restoreComments(result, comments: comments)
-        }
-
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    // MARK: - String Literal Protection (Fix #2)
-
-    /// Extract string literals to protect from keyword replacement
-    /// Handles: 'single quotes', "double quotes", `backticks`
-    private func extractStringLiterals(from sql: String, dialect: SQLDialectProvider) -> (String, [(placeholder: String, content: String)]) {
-        var counter = 0
-        var result = sql
-        var literals: [(String, String)] = []
-
-        // Determine quote characters based on dialect
-        // MySQL/SQLite: single quotes and backticks
-        // PostgreSQL: single quotes and double quotes
-        let quoteChars: [String]
-        switch dialect.identifierQuote {
-        case "\"":
-            quoteChars = ["'", "\""]  // PostgreSQL
-        default:
-            quoteChars = ["'", "`"]   // MySQL, SQLite
-        }
-
-        // Extract each type of string literal using cached regex
-        for quoteChar in quoteChars {
-            guard let regex = Self.stringLiteralRegexes[quoteChar] else { continue }
-            let matches = regex.matches(in: result, range: NSRange(result.startIndex..., in: result))
-
-            // Process in reverse to maintain valid indices
-            for match in matches.reversed() {
-                if let range = safeRange(from: match.range, in: result) {
-                    let literal = String(result[range])
-                    let placeholder = "__STRING_\(counter)__"
-                    counter += 1
-                    literals.insert((placeholder, literal), at: 0)
-                    result.replaceSubrange(range, with: placeholder)
-                }
-            }
-        }
-
-        return (result, literals)
-    }
-
-    /// Restore string literals after formatting
-    private func restoreStringLiterals(_ sql: String, literals: [(placeholder: String, content: String)]) -> String {
-        var result = sql
-        for (placeholder, content) in literals {
-            result = result.replacingOccurrences(of: placeholder, with: content)
-        }
-        return result
-    }
-
-    // MARK: - Comment Handling (Fix #6: UUID placeholders)
-
-    /// Combined pattern matching both line comments (--...) and block comments (/*...*/)
-    private static let combinedCommentRegex: NSRegularExpression = {
-        regex("--[^\\n]*|/\\*.*?\\*/", options: .dotMatchesLineSeparators)
-    }()
-
-    /// Extract all comments in a single pass, ordered by position in the source SQL.
-    /// This ensures __COMMENT_0__ is always the first comment, __COMMENT_1__ the second, etc.
-    private func extractComments(from sql: String) -> (String, [(placeholder: String, content: String)]) {
-        var result = sql
-        var comments: [(String, String)] = []
-
-        let allMatches = Self.combinedCommentRegex.matches(
-            in: result,
-            range: NSRange(result.startIndex..., in: result)
-        )
-
-        // Process in reverse to maintain valid indices; assign counters by source position
-        for (reverseIndex, match) in allMatches.reversed().enumerated() {
-            if let range = safeRange(from: match.range, in: result) {
-                let comment = String(result[range])
-                let counter = allMatches.count - 1 - reverseIndex
-                let placeholder = "__COMMENT_\(counter)__"
-                comments.insert((placeholder, comment), at: 0)
-                result.replaceSubrange(range, with: placeholder)
-            }
-        }
-
-        return (result, comments)
-    }
-
-    /// Restore comments after formatting
-    private func restoreComments(_ sql: String, comments: [(placeholder: String, content: String)]) -> String {
-        var result = sql
-        for (placeholder, content) in comments {
-            result = result.replacingOccurrences(of: placeholder, with: content)
-        }
-        return result
-    }
-
-    // MARK: - Keyword Uppercasing (Fix #1: Single-pass optimization)
-
-    /// Uppercase keywords using single regex pass with cached pattern (CPU-5)
-    private func uppercaseKeywords(_ sql: String, databaseType: DatabaseType) -> String {
-        guard let regex = Self.keywordRegex(for: databaseType) else {
-            return sql
-        }
-
-        // Use NSMutableString for O(1) in-place replacement instead of
-        // reverse-iterating Swift String replaceSubrange (SVC-11)
-        let mutable = NSMutableString(string: sql)
-        let fullRange = NSRange(location: 0, length: mutable.length)
-        let matches = regex.matches(in: sql, range: fullRange)
-
-        // Process in reverse to maintain valid indices
-        for match in matches.reversed() {
-            let matchRange = match.range
-            let keyword = mutable.substring(with: matchRange)
-            mutable.replaceCharacters(in: matchRange, with: keyword.uppercased())
-        }
-
-        return mutable as String
-    }
-
-    // MARK: - Line Breaks
-
-    private func addLineBreaks(_ sql: String, options: SQLFormatterOptions) -> String {
-        var result = sql
-
-        // Use pre-compiled regex patterns for all line break keywords (CPU-9)
-        for (keyword, regex) in Self.lineBreakRegexes {
-            let replacement = options.uppercaseKeywords ? keyword.uppercased() : keyword
-            result = regex.stringByReplacingMatches(
-                in: result,
-                range: NSRange(result.startIndex..., in: result),
-                withTemplate: "\n\(replacement)"
-            )
-        }
-
-        return result
-    }
-
-    // MARK: - Indentation (Fix #5: Word boundaries instead of contains)
-
-    private func addIndentation(_ sql: String, indentSize: Int) -> String {
-        let lines = sql.components(separatedBy: "\n")
-        var indentLevel = 0
-        var result: [String] = []
-
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty else { continue }
-
-            // Decrease indent before processing closing parens or END
-            // Uses cached regex for word boundary checks (CPU-10)
-            if trimmed.starts(with: ")") || Self.hasWordBoundary(trimmed, regex: Self.endWordBoundaryRegex) {
-                indentLevel = max(0, indentLevel - 1)
-            }
-
-            // Add indentation
-            let indent = String(repeating: " ", count: indentLevel * indentSize)
-            result.append(indent + trimmed)
-
-            // Increase indent after opening parens or CASE keyword
-            if trimmed.hasSuffix("(") || Self.hasWordBoundary(trimmed, regex: Self.caseWordBoundaryRegex) {
-                indentLevel += 1
-            }
-
-            // Special handling for subqueries: (SELECT — uses cached regex (CPU-10)
-            if Self.subqueryRegex.firstMatch(
-                in: trimmed,
-                range: NSRange(trimmed.startIndex..., in: trimmed)
-            ) != nil {
-                indentLevel += 1
-            }
-
-            // Decrease after closing paren (if not at start)
-            if trimmed.hasSuffix(")") && !trimmed.starts(with: ")") {
-                indentLevel = max(0, indentLevel - 1)
-            }
-        }
-
-        return result.joined(separator: "\n")
-    }
-
-    /// Check if a word appears with word boundaries using a pre-compiled regex (CPU-10)
-    private static func hasWordBoundary(_ text: String, regex: NSRegularExpression) -> Bool {
-        regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
-    }
-
-    // MARK: - Column Alignment
-
-    /// Align SELECT columns vertically
-    ///
-    /// Example:
-    ///   SELECT id, name, email FROM users
-    /// Becomes:
-    ///   SELECT id,
-    ///          name,
-    ///          email
-    ///   FROM users
-    private func alignSelectColumns(_ sql: String) -> String {
-        // Find SELECT...FROM region
-        guard let selectRange = sql.range(of: "SELECT", options: .caseInsensitive),
-              let fromRange = sql.range(of: "FROM", options: .caseInsensitive, range: selectRange.upperBound..<sql.endIndex) else {
-            return sql
-        }
-
-        // Fix #3: Work with immutable substrings to avoid index invalidation
-        let selectClause = String(sql[selectRange.upperBound..<fromRange.lowerBound])
-        let columns = selectClause.components(separatedBy: ",")
-
-        guard columns.count > 1 else {
-            return sql  // Only one column, no alignment needed
-        }
-
-        // Align columns with proper spacing
-        let alignedColumns = columns.enumerated().map { index, column in
-            let trimmed = column.trimmingCharacters(in: .whitespacesAndNewlines)
-            if index == 0 {
-                return trimmed
-            } else {
-                return String(repeating: " ", count: Self.selectKeywordLength) + trimmed
-            }
-        }.joined(separator: ",\n")
-
-        // Rebuild SQL (Fix #3: Use string concatenation instead of replaceSubrange)
-        let before = String(sql[..<selectRange.upperBound])
-        let after = String(sql[fromRange.lowerBound...])
-        return before + " " + alignedColumns + "\n" + after
-    }
-
-    // MARK: - JOIN Formatting
-
-    private func formatJoins(_ sql: String) -> String {
-        // Already handled by addLineBreaks
-        sql
-    }
-
-    // MARK: - WHERE Condition Alignment
-
-    private func alignWhereConditions(_ sql: String) -> String {
-        // Find WHERE clause
-        guard let whereRange = sql.range(of: "WHERE", options: .caseInsensitive) else {
-            return sql
-        }
-
-        // Find end of WHERE clause using single regex scan
-        let searchStart = whereRange.upperBound
-        let searchNSRange = NSRange(searchStart..<sql.endIndex, in: sql)
-        var endIndex = sql.endIndex
-
-        if let match = Self.majorKeywordRegex.firstMatch(in: sql, range: searchNSRange),
-           let matchRange = Range(match.range, in: sql) {
-            endIndex = matchRange.lowerBound
-        }
-
-        // Fix #3: Work with immutable substring
-        let whereClause = String(sql[whereRange.upperBound..<endIndex])
-
-        // Add line breaks before AND/OR using cached regex
-        let replaced = Self.whereConditionRegex.stringByReplacingMatches(
-            in: whereClause,
-            range: NSRange(whereClause.startIndex..., in: whereClause),
-            withTemplate: "\n  $1 "
-        )
-
-        // Rebuild SQL (Fix #3: Use string concatenation)
-        let before = String(sql[..<whereRange.upperBound])
-        let after = String(sql[endIndex...])
-        return before + replaced + after
-    }
-
-    // MARK: - Cursor Preservation
-
-    /// Preserve cursor position using ratio-based approach
-    ///
-    /// - Note: This is a simple heuristic. For better accuracy, consider:
-    ///   - Tracking cursor context (inside string, after keyword, etc.)
-    ///   - Using token-based positioning
-    /// - Returns: New cursor position, clamped to valid range
-    private func preserveCursorPosition(original: Int, oldText: String, newText: String) -> Int {
-        guard !oldText.isEmpty else { return 0 }
-
-        // CPU-8: Use utf16.count for O(1) length instead of O(n) String.count
-        let oldLength = oldText.utf16.count
-        let newLength = newText.utf16.count
-
+    private func mapCursorPosition(original: Int, oldLength: Int, newLength: Int) -> Int {
+        guard oldLength > 0 else { return 0 }
         let ratio = Double(original) / Double(oldLength)
-        let newPosition = Int(ratio * Double(newLength))
+        return min(Int(ratio * Double(newLength)), newLength)
+    }
+}
 
-        return min(newPosition, newLength)
+// MARK: - Token Formatter (Stateful Walker)
+
+/// Walks the token stream with clause/nesting context to produce formatted output.
+/// Extracted from SQLFormatterService to keep each function under lint limits.
+internal struct SQLTokenFormatter {
+    let options: SQLFormatterOptions
+
+    init(options: SQLFormatterOptions) {
+        self.options = options
     }
 
-    // MARK: - Helper Methods
+    // Mutable state
+    private var output = ""
+    private var indent = 0
+    private var clauseStack: [ClauseContext] = []
+    private var afterNewline = true
+    private var isFirstClause = true
+    private var selectColumnIndent = 0
+    private var inSelectColumns = false
+    private var skipCount = 0
+    private var suppressNextSpace = false
+    private var caseBaseIndent = 0
+    /// Stack to save/restore selectColumnIndent across subquery boundaries
+    private var selectColumnIndentStack: [Int] = []
 
-    /// Safe NSRange to Range conversion (Fix #7: Unicode handling)
-    ///
-    /// NSRange uses UTF-16 code units, Swift String.Index uses Unicode scalars.
-    /// This can cause issues with emoji and other multi-byte characters.
-    private func safeRange(from nsRange: NSRange, in string: String) -> Range<String.Index>? {
-        // Use proper Range initializer that handles UTF-16 conversion
-        Range(nsRange, in: string)
+    private enum ClauseContext {
+        case select, from, where_, join, caseExpr, subquery, with
+        case insert, update, set, createTable, createTableBody
+        case inlineParen, windowParen
+    }
+
+    /// True after BETWEEN keyword — suppresses the next AND from being a clause break
+    private var afterBetween = false
+
+    // MARK: - Public
+
+    mutating func format(_ tokens: [SQLToken]) -> String {
+        let meaningful = tokens.compactMap { t -> SQLToken? in
+            t.type == .whitespace ? nil : t
+        }
+
+        for mi in meaningful.indices {
+            if skipCount > 0 {
+                skipCount -= 1
+                continue
+            }
+
+            let token = meaningful[mi]
+            let next: SQLToken? = mi + 1 < meaningful.count ? meaningful[mi + 1] : nil
+            let prev: SQLToken? = mi > 0 ? meaningful[mi - 1] : nil
+            let next2: SQLToken? = mi + 2 < meaningful.count ? meaningful[mi + 2] : nil
+
+            processToken(token, prev: prev, next: next, next2: next2)
+        }
+
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Token Processing
+
+    private mutating func processToken(_ token: SQLToken, prev: SQLToken?, next: SQLToken?, next2: SQLToken?) {
+        if token.type == .comment {
+            handleComment(token)
+            return
+        }
+
+        if token.type == .punctuation {
+            handlePunctuation(token, prev: prev, next: next)
+            return
+        }
+
+        if token.type == .keyword {
+            handleKeyword(token, prev: prev, next: next, next2: next2)
+            return
+        }
+
+        // All other tokens: identifiers, numbers, strings, operators, placeholders
+        appendToken(token.value)
+    }
+
+    // MARK: - Comment Handling
+
+    private mutating func handleComment(_ token: SQLToken) {
+        guard options.preserveComments else { return }
+        if !afterNewline { newline() }
+        output += token.value
+        output += "\n"
+        afterNewline = true
+    }
+
+    // MARK: - Punctuation Handling
+
+    private mutating func handlePunctuation(_ token: SQLToken, prev: SQLToken?, next: SQLToken?) {
+        switch token.value {
+        case ";":
+            output += ";"
+            output += "\n"
+            afterNewline = true
+            isFirstClause = true
+            indent = 0
+            clauseStack.removeAll()
+            inSelectColumns = false
+
+        case ",":
+            output += ","
+            if inSelectColumns {
+                output += "\n" + String(repeating: " ", count: selectColumnIndent)
+                afterNewline = false
+                suppressNextSpace = true
+            } else if currentContext == .set {
+                output += "\n" + indentStr() + "    "
+                afterNewline = false
+                suppressNextSpace = true
+            } else if currentContext == .createTableBody {
+                output += "\n"
+                afterNewline = true
+            }
+
+        case "(":
+            handleOpenParen(next: next, prev: prev)
+
+        case ")":
+            handleCloseParen()
+
+        case ".":
+            // Qualified name dot — no spaces around it
+            output += "."
+            afterNewline = false
+            suppressNextSpace = true
+
+        default:
+            appendToken(token.value)
+        }
+    }
+
+    private mutating func handleOpenParen(next: SQLToken?, prev: SQLToken?) {
+        // Subquery: ( SELECT ...
+        if next?.upperValue == "SELECT" {
+            if suppressNextSpace {
+                output += "("
+            } else {
+                output += " ("
+            }
+            output += "\n"
+            selectColumnIndentStack.append(selectColumnIndent)
+            indent += 1
+            afterNewline = true
+            isFirstClause = true
+            suppressNextSpace = false
+            clauseStack.append(.subquery)
+            return
+        }
+        // CTE body: AS (
+        if prev?.upperValue == "AS" && clauseStack.contains(.with) {
+            output += " ("
+            output += "\n"
+            selectColumnIndentStack.append(selectColumnIndent)
+            indent += 1
+            afterNewline = true
+            isFirstClause = true
+            suppressNextSpace = false
+            clauseStack.append(.subquery)
+            return
+        }
+        // CREATE TABLE columns: table_name (
+        if clauseStack.contains(.createTable) && !clauseStack.contains(.createTableBody) {
+            output += " ("
+            output += "\n"
+            indent += 1
+            afterNewline = true
+            suppressNextSpace = false
+            clauseStack.append(.createTableBody)
+            return
+        }
+        // Window function: OVER(...)
+        if prev?.upperValue == "OVER" {
+            output += "("
+            afterNewline = false
+            suppressNextSpace = true
+            clauseStack.append(.windowParen)
+            return
+        }
+        // Inline parenthesized expression: COUNT(*), VARCHAR(255), etc.
+        output += "("
+        afterNewline = false
+        suppressNextSpace = true
+        clauseStack.append(.inlineParen)
+    }
+
+    private mutating func handleCloseParen() {
+        // Inline or window paren: just close it
+        if currentContext == .inlineParen || currentContext == .windowParen {
+            clauseStack.removeLast()
+            output += ")"
+            afterNewline = false
+            suppressNextSpace = false
+            return
+        }
+        // Block paren (subquery or CREATE TABLE body): pop back to the block opener
+        if let idx = clauseStack.lastIndex(where: { $0 == .subquery || $0 == .createTableBody }) {
+            clauseStack.removeSubrange(idx...)
+            indent = max(0, indent - 1)
+            output += "\n" + indentStr() + ")"
+            afterNewline = false
+            isFirstClause = false
+            // Restore outer SELECT state after leaving subquery
+            inSelectColumns = clauseStack.contains(.select)
+            if let saved = selectColumnIndentStack.popLast() {
+                selectColumnIndent = saved
+            }
+            suppressNextSpace = false
+            return
+        }
+        // Unmatched paren — just append
+        output += ")"
+        afterNewline = false
+        suppressNextSpace = false
+    }
+
+    // MARK: - Keyword Handling
+
+    private mutating func handleKeyword(_ token: SQLToken, prev: SQLToken?, next: SQLToken?, next2: SQLToken?) {
+        let upper = token.upperValue
+        let kw = options.uppercaseKeywords ? upper : token.value
+
+        switch upper {
+        case "SELECT":
+            handleSelect(kw: kw)
+        case "FROM":
+            handleFrom(kw: kw, prev: prev)
+        case "WHERE":
+            handleClauseKeyword(kw: kw, context: .where_)
+        case "AND", "OR":
+            handleAndOr(kw: kw, upper: upper)
+        case "JOIN":
+            handleClauseKeyword(kw: kw, context: .join)
+        case "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "NATURAL":
+            handleJoinPrefix(upper: upper, kw: kw, next: next, next2: next2)
+        case "OUTER":
+            break // absorbed by JOIN prefix handler
+        case "ON":
+            handleOn(kw: kw)
+        case "OVER":
+            appendToken(kw)
+        case "PARTITION":
+            appendToken(kw)
+        case "BETWEEN":
+            afterBetween = true
+            appendToken(kw)
+        case "ORDER", "GROUP":
+            handleOrderGroup(upper: upper, kw: kw, next: next)
+        case "BY":
+            // standalone BY (not consumed by ORDER/GROUP) — should not happen normally
+            appendToken(kw)
+        case "HAVING", "LIMIT", "OFFSET":
+            handleClauseKeyword(kw: kw, context: nil)
+        case "UNION", "INTERSECT", "EXCEPT":
+            handleSetOperation(upper: upper, kw: kw, next: next)
+        case "ALL":
+            // standalone ALL (not consumed by UNION ALL)
+            appendToken(kw)
+        case "CASE":
+            handleCase(kw: kw)
+        case "WHEN", "ELSE":
+            handleWhenElse(kw: kw)
+        case "THEN":
+            output += " " + kw
+            afterNewline = false
+        case "END":
+            handleEnd(kw: kw)
+        case "WITH":
+            handleWith(kw: kw)
+        case "INSERT":
+            handleInsert(kw: kw, next: next)
+        case "INTO":
+            // standalone INTO (not consumed by INSERT INTO)
+            appendToken(kw)
+        case "VALUES":
+            newline()
+            appendToken(kw)
+        case "UPDATE":
+            handleStatementStart(kw: kw, context: .update)
+        case "SET":
+            handleClauseKeyword(kw: kw, context: .set)
+        case "DELETE":
+            handleStatementStart(kw: kw, context: nil)
+        case "CREATE":
+            handleStatementStart(kw: kw, context: .createTable)
+        case "TABLE", "AS":
+            appendToken(kw)
+        default:
+            appendToken(kw)
+        }
+    }
+
+    // MARK: - Specific Keyword Handlers
+
+    private mutating func handleSelect(kw: String) {
+        if !isFirstClause { newline() }
+        output += (afterNewline ? indentStr() : "") + kw
+        isFirstClause = false
+        afterNewline = false
+        inSelectColumns = true
+        selectColumnIndent = indent * options.indentSize + 7
+        clauseStack.append(.select)
+    }
+
+    private mutating func handleFrom(kw: String, prev: SQLToken?) {
+        if prev?.upperValue == "DELETE" {
+            newline()
+            appendToken(kw)
+            inSelectColumns = false
+            return
+        }
+        inSelectColumns = false
+        newline()
+        appendToken(kw)
+        replaceTop(with: .from)
+    }
+
+    private mutating func handleClauseKeyword(kw: String, context: ClauseContext?) {
+        inSelectColumns = false
+        newline()
+        appendToken(kw)
+        if let ctx = context { replaceTop(with: ctx) }
+    }
+
+    private mutating func handleAndOr(kw: String, upper: String) {
+        // BETWEEN x AND y — AND stays inline
+        if upper == "AND" && afterBetween {
+            afterBetween = false
+            output += " " + kw
+            afterNewline = false
+            return
+        }
+        if currentContext == .where_ {
+            newline()
+            output += indentStr() + "  " + kw
+            afterNewline = false
+        } else {
+            output += " " + kw
+            afterNewline = false
+        }
+    }
+
+    private mutating func handleJoinPrefix(upper: String, kw: String, next: SQLToken?, next2: SQLToken?) {
+        // LEFT OUTER JOIN → skip 2 tokens (OUTER, JOIN)
+        if next?.upperValue == "OUTER" && next2?.upperValue == "JOIN" {
+            inSelectColumns = false
+            let joinKw = options.uppercaseKeywords ? "\(upper) OUTER JOIN" : "\(upper.lowercased()) outer join"
+            newline()
+            appendToken(joinKw)
+            replaceTop(with: .join)
+            skipCount = 2
+        // LEFT JOIN → skip 1 token (JOIN)
+        } else if next?.upperValue == "JOIN" {
+            inSelectColumns = false
+            let joinKw = options.uppercaseKeywords ? "\(upper) JOIN" : "\(upper.lowercased()) join"
+            newline()
+            appendToken(joinKw)
+            replaceTop(with: .join)
+            skipCount = 1
+        } else {
+            appendToken(kw)
+        }
+    }
+
+    private mutating func handleOn(kw: String) {
+        if currentContext == .join {
+            newline()
+            output += indentStr() + "  " + kw
+            afterNewline = false
+        } else {
+            output += " " + kw
+            afterNewline = false
+        }
+    }
+
+    private mutating func handleOrderGroup(upper: String, kw: String, next: SQLToken?) {
+        // Inside window function parens — stay inline
+        if clauseStack.contains(.windowParen) {
+            if next?.upperValue == "BY" {
+                let byKw = options.uppercaseKeywords ? "BY" : "by"
+                output += " " + kw + " " + byKw
+                afterNewline = false
+                skipCount = 1
+            } else {
+                appendToken(kw)
+            }
+            return
+        }
+        inSelectColumns = false
+        if next?.upperValue == "BY" {
+            let byKw = options.uppercaseKeywords ? "BY" : "by"
+            newline()
+            output += indentStr() + kw + " " + byKw
+            afterNewline = false
+            skipCount = 1
+        } else {
+            appendToken(kw)
+        }
+    }
+
+    private mutating func handleSetOperation(upper: String, kw: String, next: SQLToken?) {
+        inSelectColumns = false
+        indent = 0
+        clauseStack.removeAll()
+        if upper == "UNION" && next?.upperValue == "ALL" {
+            let allKw = options.uppercaseKeywords ? "ALL" : "all"
+            output += "\n\n" + kw + " " + allKw + "\n"
+            skipCount = 1 // skip ALL
+        } else {
+            output += "\n\n" + kw + "\n"
+        }
+        afterNewline = true
+        isFirstClause = true
+    }
+
+    private mutating func handleCase(kw: String) {
+        if inSelectColumns {
+            caseBaseIndent = selectColumnIndent
+        } else {
+            caseBaseIndent = indent * options.indentSize
+        }
+        appendToken(kw)
+        clauseStack.append(.caseExpr)
+    }
+
+    private mutating func handleWhenElse(kw: String) {
+        let whenIndent = caseBaseIndent + options.indentSize
+        output += "\n" + String(repeating: " ", count: whenIndent) + kw
+        afterNewline = false
+        suppressNextSpace = false
+    }
+
+    private mutating func handleEnd(kw: String) {
+        if clauseStack.last == .caseExpr { clauseStack.removeLast() }
+        // Align END at same level as CASE
+        output += "\n" + String(repeating: " ", count: caseBaseIndent)
+        output += kw
+        afterNewline = false
+    }
+
+    private mutating func handleWith(kw: String) {
+        if !isFirstClause { output += "\n" }
+        output += kw
+        isFirstClause = false
+        afterNewline = false
+        clauseStack.append(.with)
+    }
+
+    private mutating func handleInsert(kw: String, next: SQLToken?) {
+        if !isFirstClause { output += "\n" }
+        if next?.upperValue == "INTO" {
+            let intoKw = options.uppercaseKeywords ? "INTO" : "into"
+            output += kw + " " + intoKw
+            skipCount = 1 // skip INTO
+        } else {
+            output += kw
+        }
+        isFirstClause = false
+        afterNewline = false
+        clauseStack.append(.insert)
+    }
+
+    private mutating func handleStatementStart(kw: String, context: ClauseContext?) {
+        if !isFirstClause { output += "\n" }
+        output += kw
+        isFirstClause = false
+        afterNewline = false
+        if let ctx = context { clauseStack.append(ctx) }
+    }
+
+    // MARK: - Helpers
+
+    private var currentContext: ClauseContext? { clauseStack.last }
+
+    private mutating func replaceTop(with ctx: ClauseContext) {
+        if !clauseStack.isEmpty { clauseStack.removeLast() }
+        clauseStack.append(ctx)
+    }
+
+    private func indentStr() -> String {
+        String(repeating: " ", count: indent * options.indentSize)
+    }
+
+    private mutating func newline() {
+        output += "\n"
+        afterNewline = true
+    }
+
+    private mutating func appendToken(_ value: String) {
+        if afterNewline {
+            output += indentStr() + value
+        } else if suppressNextSpace {
+            output += value
+        } else {
+            output += " " + value
+        }
+        afterNewline = false
+        suppressNextSpace = false
     }
 }

--- a/TablePro/Core/Services/Formatting/SQLFormatterTypes.swift
+++ b/TablePro/Core/Services/Formatting/SQLFormatterTypes.swift
@@ -15,13 +15,9 @@ import Foundation
 /// Configuration for SQL formatting behavior
 struct SQLFormatterOptions {
     var uppercaseKeywords: Bool = true
-    var indentSize: Int = 2  // spaces per indent level
-    var alignColumns: Bool = true
+    var indentSize: Int = 2
     var preserveComments: Bool = true
-    var formatJoins: Bool = true
-    var alignWhere: Bool = true
 
-    /// Default options with all features enabled
     static let `default` = SQLFormatterOptions()
 }
 

--- a/TablePro/Core/Services/Formatting/SQLTokenizer.swift
+++ b/TablePro/Core/Services/Formatting/SQLTokenizer.swift
@@ -27,9 +27,14 @@ enum SQLTokenType: Equatable {
 struct SQLToken: Equatable {
     let type: SQLTokenType
     let value: String
+    /// Pre-computed uppercase value for keyword comparison
+    let upperValue: String
 
-    /// Uppercase value for keyword comparison
-    var upperValue: String { value.uppercased() }
+    init(type: SQLTokenType, value: String) {
+        self.type = type
+        self.value = value
+        self.upperValue = value.uppercased()
+    }
 }
 
 // MARK: - Tokenizer

--- a/TablePro/Core/Services/Formatting/SQLTokenizer.swift
+++ b/TablePro/Core/Services/Formatting/SQLTokenizer.swift
@@ -1,0 +1,248 @@
+//
+//  SQLTokenizer.swift
+//  TablePro
+//
+//  Character-by-character SQL lexer producing a flat token stream.
+//  No regex — handles string escapes, comments, operators, and quoted identifiers.
+//
+
+import Foundation
+
+// MARK: - Token Types
+
+enum SQLTokenType: Equatable {
+    case keyword
+    case identifier
+    case number
+    case string
+    case `operator`
+    case punctuation
+    case whitespace
+    case comment
+    case placeholder
+}
+
+// MARK: - Token
+
+struct SQLToken: Equatable {
+    let type: SQLTokenType
+    let value: String
+
+    /// Uppercase value for keyword comparison
+    var upperValue: String { value.uppercased() }
+}
+
+// MARK: - Tokenizer
+
+struct SQLTokenizer {
+    /// Standard SQL keywords used for keyword detection.
+    /// Dialect-specific keywords are handled separately via SQLDialectProvider.
+    private static let standardKeywords: Set<String> = [
+        // DML
+        "SELECT", "FROM", "WHERE", "AND", "OR", "NOT", "IN", "IS", "NULL",
+        "LIKE", "BETWEEN", "EXISTS", "AS", "ON", "USING",
+        "INSERT", "INTO", "VALUES", "UPDATE", "SET", "DELETE",
+        "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "OUTER", "NATURAL",
+        "ORDER", "BY", "GROUP", "HAVING", "LIMIT", "OFFSET", "FETCH", "NEXT", "ROWS", "ONLY",
+        "UNION", "INTERSECT", "EXCEPT", "ALL", "DISTINCT",
+        // CASE
+        "CASE", "WHEN", "THEN", "ELSE", "END",
+        // DDL
+        "CREATE", "ALTER", "DROP", "TABLE", "INDEX", "VIEW", "DATABASE", "SCHEMA",
+        "ADD", "COLUMN", "CONSTRAINT", "PRIMARY", "KEY", "FOREIGN", "REFERENCES",
+        "UNIQUE", "CHECK", "DEFAULT", "AUTO_INCREMENT", "IDENTITY",
+        "IF", "TEMPORARY", "TEMP", "CASCADE", "RESTRICT",
+        // CTE
+        "WITH", "RECURSIVE",
+        // Data types
+        "INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT",
+        "VARCHAR", "CHAR", "TEXT", "NVARCHAR", "NCHAR",
+        "DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "REAL",
+        "BOOLEAN", "BOOL", "BIT",
+        "DATE", "TIME", "TIMESTAMP", "DATETIME", "INTERVAL",
+        "BLOB", "CLOB", "BINARY", "VARBINARY",
+        "JSON", "JSONB", "XML", "UUID",
+        "SERIAL", "BIGSERIAL",
+        // Aggregates
+        "COUNT", "SUM", "AVG", "MIN", "MAX",
+        // Transaction
+        "BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT",
+        // Other
+        "ASC", "DESC", "NULLS", "FIRST", "LAST",
+        "TRUE", "FALSE", "UNKNOWN",
+        "OVER", "PARTITION", "WINDOW", "FILTER",
+        "RETURNING", "CONFLICT", "DO", "NOTHING",
+        "EXPLAIN", "ANALYZE", "TRUNCATE",
+        "GRANT", "REVOKE", "DENY",
+        "TOP", "PERCENT",
+    ]
+
+    /// Additional keywords from the dialect provider
+    private let dialectKeywords: Set<String>
+
+    init(dialectKeywords: Set<String> = []) {
+        self.dialectKeywords = dialectKeywords
+    }
+
+    // MARK: - Public API
+
+    func tokenize(_ sql: String) -> [SQLToken] {
+        var tokens: [SQLToken] = []
+        let chars = Array(sql)
+        let count = chars.count
+        var i = 0
+
+        while i < count {
+            let ch = chars[i]
+
+            // Line comment: -- ...
+            if ch == "-" && i + 1 < count && chars[i + 1] == "-" {
+                let start = i
+                i += 2
+                while i < count && chars[i] != "\n" {
+                    i += 1
+                }
+                tokens.append(SQLToken(type: .comment, value: String(chars[start..<i])))
+                continue
+            }
+
+            // Block comment: /* ... */
+            if ch == "/" && i + 1 < count && chars[i + 1] == "*" {
+                let start = i
+                i += 2
+                while i + 1 < count && !(chars[i] == "*" && chars[i + 1] == "/") {
+                    i += 1
+                }
+                if i + 1 < count {
+                    i += 2 // skip */
+                }
+                tokens.append(SQLToken(type: .comment, value: String(chars[start..<i])))
+                continue
+            }
+
+            // String literals: 'single', "double", `backtick`
+            if ch == "'" || ch == "\"" || ch == "`" {
+                let start = i
+                let quote = ch
+                i += 1
+                while i < count {
+                    if chars[i] == "\\" {
+                        i += 2 // skip escaped char
+                        continue
+                    }
+                    if chars[i] == quote {
+                        // Check for doubled quote escape: '' or ""
+                        if i + 1 < count && chars[i + 1] == quote {
+                            i += 2
+                            continue
+                        }
+                        i += 1
+                        break
+                    }
+                    i += 1
+                }
+                let value = String(chars[start..<i])
+                // Backtick-quoted identifiers are identifiers, not strings
+                let type: SQLTokenType = (quote == "`") ? .identifier : .string
+                tokens.append(SQLToken(type: type, value: value))
+                continue
+            }
+
+            // Whitespace
+            if ch.isWhitespace {
+                let start = i
+                while i < count && chars[i].isWhitespace {
+                    i += 1
+                }
+                tokens.append(SQLToken(type: .whitespace, value: String(chars[start..<i])))
+                continue
+            }
+
+            // Numbers
+            if ch.isNumber || (ch == "." && i + 1 < count && chars[i + 1].isNumber) {
+                let start = i
+                if ch == "." { i += 1 }
+                while i < count && (chars[i].isNumber || chars[i] == ".") {
+                    i += 1
+                }
+                // Scientific notation: 1e10, 1.5E-3
+                if i < count && (chars[i] == "e" || chars[i] == "E") {
+                    i += 1
+                    if i < count && (chars[i] == "+" || chars[i] == "-") {
+                        i += 1
+                    }
+                    while i < count && chars[i].isNumber {
+                        i += 1
+                    }
+                }
+                tokens.append(SQLToken(type: .number, value: String(chars[start..<i])))
+                continue
+            }
+
+            // Placeholders: $1, $name, ?, :name, @name
+            if ch == "?" {
+                tokens.append(SQLToken(type: .placeholder, value: "?"))
+                i += 1
+                continue
+            }
+            if (ch == "$" || ch == ":" || ch == "@") && i + 1 < count && (chars[i + 1].isLetter || chars[i + 1].isNumber || chars[i + 1] == "_") {
+                let start = i
+                i += 1
+                while i < count && (chars[i].isLetter || chars[i].isNumber || chars[i] == "_") {
+                    i += 1
+                }
+                tokens.append(SQLToken(type: .placeholder, value: String(chars[start..<i])))
+                continue
+            }
+
+            // Multi-character operators: >=, <=, <>, !=, ||, ::, ->>, ->
+            if i + 1 < count {
+                let twoChar = String([chars[i], chars[i + 1]])
+                if [">=", "<=", "<>", "!=", "||", "::", "->"].contains(twoChar) {
+                    if twoChar == "->" && i + 2 < count && chars[i + 2] == ">" {
+                        tokens.append(SQLToken(type: .operator, value: "->>"))
+                        i += 3
+                    } else {
+                        tokens.append(SQLToken(type: .operator, value: twoChar))
+                        i += 2
+                    }
+                    continue
+                }
+            }
+
+            // Single-character operators
+            if "=<>+-*/%&|^~!".contains(ch) {
+                tokens.append(SQLToken(type: .operator, value: String(ch)))
+                i += 1
+                continue
+            }
+
+            // Punctuation: ( ) , ; .
+            if "(),;.".contains(ch) {
+                tokens.append(SQLToken(type: .punctuation, value: String(ch)))
+                i += 1
+                continue
+            }
+
+            // Words: keywords or identifiers
+            if ch.isLetter || ch == "_" {
+                let start = i
+                i += 1
+                while i < count && (chars[i].isLetter || chars[i].isNumber || chars[i] == "_") {
+                    i += 1
+                }
+                let word = String(chars[start..<i])
+                let isKW = Self.standardKeywords.contains(word.uppercased())
+                    || dialectKeywords.contains(word.uppercased())
+                tokens.append(SQLToken(type: isKW ? .keyword : .identifier, value: word))
+                continue
+            }
+
+            // Unknown character — treat as operator
+            tokens.append(SQLToken(type: .operator, value: String(ch)))
+            i += 1
+        }
+
+        return tokens
+    }
+}

--- a/TableProTests/Core/Services/SQLFormatterServiceTests.swift
+++ b/TableProTests/Core/Services/SQLFormatterServiceTests.swift
@@ -396,4 +396,25 @@ struct SQLFormatterServiceTests {
         FROM users
         """)
     }
+
+    @Test("BETWEEN x AND y stays inline")
+    func betweenAnd() throws {
+        let result = try format("select * from users where id between 1 and 100 and active = true")
+        #expect(result == """
+        SELECT *
+        FROM users
+        WHERE id BETWEEN 1 AND 100
+          AND active = TRUE
+        """)
+    }
+
+    @Test("Window function OVER(PARTITION BY...ORDER BY) stays inline")
+    func windowFunction() throws {
+        let result = try format("select *, row_number() over (partition by department order by salary desc) as rank from employees")
+        #expect(result == """
+        SELECT *,
+               row_number() OVER(PARTITION BY department ORDER BY salary DESC) AS rank
+        FROM employees
+        """)
+    }
 }

--- a/TableProTests/Core/Services/SQLFormatterServiceTests.swift
+++ b/TableProTests/Core/Services/SQLFormatterServiceTests.swift
@@ -2,283 +2,398 @@
 //  SQLFormatterServiceTests.swift
 //  TableProTests
 //
-//  Tests for SQLFormatterService
+//  Tests for SQLFormatterService — exact output assertions for every SQL construct.
 //
 
 import Foundation
-import Testing
 @testable import TablePro
+import Testing
 
 @Suite("SQL Formatter Service")
 @MainActor
 struct SQLFormatterServiceTests {
-
     let formatter = SQLFormatterService()
 
-    // MARK: - Keyword Tests
-
-    @Test("Keyword uppercasing SELECT and FROM")
-    func keywordUppercasing() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-        #expect(result.formattedSQL.contains("FROM"))
+    private func format(_ sql: String, options: SQLFormatterOptions = .default) throws -> String {
+        try formatter.format(sql, dialect: .mysql).formattedSQL
     }
 
-    @Test("Lowercase keywords become uppercase")
-    func lowercaseKeywordsUppercase() throws {
-        let sql = "select id, name from users where active = true"
-        let result = try formatter.format(sql, dialect: .mysql)
+    // MARK: - Simple SELECT
 
-        #expect(result.formattedSQL.contains("SELECT"))
-        #expect(result.formattedSQL.contains("FROM"))
-        #expect(result.formattedSQL.contains("WHERE"))
+    @Test("Simple SELECT *")
+    func simpleSelectStar() throws {
+        let result = try format("select * from users")
+        #expect(result == """
+        SELECT *
+        FROM users
+        """)
     }
 
-    @Test("String content preservation")
-    func stringPreservation() throws {
-        let sql = "select 'hello world' from users"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains("'hello world'"))
-        #expect(!result.formattedSQL.contains("'HELLO WORLD'"))
+    @Test("SELECT with multiple columns — each on its own line")
+    func selectMultipleColumns() throws {
+        let result = try format("select id, name, email from users")
+        #expect(result == """
+        SELECT id,
+               name,
+               email
+        FROM users
+        """)
     }
 
-    @Test("Custom options with uppercaseKeywords=false preserves original casing")
-    func customOptionsLowercaseKeywords() throws {
-        let sql = "SELECT * FROM users"
-        var options = SQLFormatterOptions.default
-        options.uppercaseKeywords = false
-
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
-
-        // When uppercaseKeywords is false, the keyword uppercasing step is skipped,
-        // but addLineBreaks still uses uppercase keywords in replacements,
-        // so already-uppercase keywords remain uppercase
-        #expect(result.formattedSQL.contains("SELECT"))
+    @Test("SELECT with single column")
+    func selectSingleColumn() throws {
+        let result = try format("select id from users")
+        #expect(result == """
+        SELECT id
+        FROM users
+        """)
     }
 
-    // MARK: - Formatting Tests
+    // MARK: - WHERE Clause
 
-    @Test("Line breaks added before major clauses")
-    func lineBreaksAdded() throws {
-        let sql = "select * from users where id = 1 order by name"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        let lines = result.formattedSQL.split(separator: "\n").map { String($0) }
-        #expect(lines.count > 1)
-        #expect(result.formattedSQL.contains("FROM"))
-        #expect(result.formattedSQL.contains("WHERE"))
-        #expect(result.formattedSQL.contains("ORDER BY"))
+    @Test("Simple WHERE")
+    func simpleWhere() throws {
+        let result = try format("select * from users where active = true")
+        #expect(result == """
+        SELECT *
+        FROM users
+        WHERE active = true
+        """)
     }
 
-    @Test("Indentation applied to nested structures")
-    func indentationApplied() throws {
-        let sql = "select * from (select id from users) as subquery"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains(" ") || result.formattedSQL.contains("\t"))
+    @Test("WHERE with AND/OR — each condition on new line")
+    func whereWithAndOr() throws {
+        let result = try format("select * from users where active = true and role = 'admin' or age > 18")
+        #expect(result == """
+        SELECT *
+        FROM users
+        WHERE active = true
+          AND role = 'admin'
+          OR age > 18
+        """)
     }
 
-    @Test("SELECT column alignment")
-    func selectColumnAlignment() throws {
-        let sql = "select id, name, email from users"
-        var options = SQLFormatterOptions.default
-        options.alignColumns = true
+    // MARK: - ORDER BY / GROUP BY / HAVING / LIMIT
 
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-        #expect(result.formattedSQL.contains("id"))
-        #expect(result.formattedSQL.contains("name"))
-        #expect(result.formattedSQL.contains("email"))
+    @Test("ORDER BY on new line")
+    func orderBy() throws {
+        let result = try format("select * from users where id > 1 order by name asc limit 10")
+        #expect(result == """
+        SELECT *
+        FROM users
+        WHERE id > 1
+        ORDER BY name asc
+        LIMIT 10
+        """)
     }
 
-    @Test("WHERE AND alignment")
-    func whereAndAlignment() throws {
-        let sql = "select * from users where active = true and role = 'admin'"
-        var options = SQLFormatterOptions.default
-        options.alignWhere = true
-
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
-
-        #expect(result.formattedSQL.contains("WHERE"))
-        #expect(result.formattedSQL.contains("AND"))
+    @Test("GROUP BY and HAVING")
+    func groupByHaving() throws {
+        let result = try format("select role, count(*) from users group by role having count(*) > 5")
+        #expect(result == """
+        SELECT role,
+               count(*)
+        FROM users
+        GROUP BY role
+        HAVING count(*) > 5
+        """)
     }
 
-    @Test("JOIN formatting on new line")
-    func joinFormatting() throws {
-        let sql = "select * from users left join roles on users.role_id = roles.id"
-        var options = SQLFormatterOptions.default
-        options.formatJoins = true
+    // MARK: - JOINs
 
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
-
-        // addLineBreaks processes "LEFT JOIN" first, then "JOIN" splits it onto separate lines
-        #expect(result.formattedSQL.contains("JOIN"))
-        #expect(result.formattedSQL.contains("ON"))
+    @Test("LEFT JOIN with ON")
+    func leftJoin() throws {
+        let result = try format("select u.id, r.name from users u left join roles r on u.role_id = r.id")
+        #expect(result == """
+        SELECT u.id,
+               r.name
+        FROM users u
+        LEFT JOIN roles r
+          ON u.role_id = r.id
+        """)
     }
 
-    // MARK: - Error Handling Tests
-
-    @Test("Empty input throws emptyInput error")
-    func emptyInputThrows() throws {
-        let sql = ""
-
-        #expect(throws: SQLFormatterError.self) {
-            try formatter.format(sql, dialect: .mysql)
-        }
+    @Test("Multiple JOINs")
+    func multipleJoins() throws {
+        let result = try format("select * from users u inner join roles r on u.role_id = r.id left join teams t on u.team_id = t.id")
+        #expect(result == """
+        SELECT *
+        FROM users u
+        INNER JOIN roles r
+          ON u.role_id = r.id
+        LEFT JOIN teams t
+          ON u.team_id = t.id
+        """)
     }
 
-    @Test("Whitespace only throws emptyInput error")
-    func whitespaceOnlyThrows() throws {
-        let sql = "   \n\t  "
+    // MARK: - Subqueries
 
-        #expect(throws: SQLFormatterError.self) {
-            try formatter.format(sql, dialect: .mysql)
-        }
+    @Test("Subquery in FROM")
+    func subqueryInFrom() throws {
+        let result = try format("select * from (select id, name from users where active = true) as active_users")
+        #expect(result == """
+        SELECT *
+        FROM (
+          SELECT id,
+                 name
+          FROM users
+          WHERE active = true
+        ) as active_users
+        """)
     }
 
-    @Test("Invalid cursor position throws error")
-    func invalidCursorPositionThrows() throws {
-        let sql = "select * from users"
-
-        #expect(throws: SQLFormatterError.self) {
-            try formatter.format(sql, dialect: .mysql, cursorOffset: 1000)
-        }
+    @Test("Subquery in WHERE")
+    func subqueryInWhere() throws {
+        let result = try format("select * from users where id in (select user_id from orders)")
+        #expect(result == """
+        SELECT *
+        FROM users
+        WHERE id in (
+          SELECT user_id
+          FROM orders
+        )
+        """)
     }
 
-    @Test("Size limit over 10MB throws internalError")
-    func sizeLimitThrows() throws {
-        let largeSql = String(repeating: "select * from users; ", count: 600000)
+    // MARK: - CASE WHEN
 
-        #expect(throws: SQLFormatterError.self) {
-            try formatter.format(largeSql, dialect: .mysql)
-        }
+    @Test("CASE WHEN THEN ELSE END")
+    func caseExpression() throws {
+        let result = try format("select id, case when status = 'active' then 'yes' when status = 'inactive' then 'no' else 'unknown' end as label from users")
+        #expect(result == """
+        SELECT id,
+               CASE
+                 WHEN status = 'active' THEN 'yes'
+                 WHEN status = 'inactive' THEN 'no'
+                 ELSE 'unknown'
+               END as label
+        FROM users
+        """)
     }
 
-    // MARK: - Cursor Position Tests
+    // MARK: - CTE (WITH)
 
-    @Test("Cursor offset preserved when provided")
-    func cursorOffsetPreserved() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .mysql, cursorOffset: 7)
-
-        #expect(result.cursorOffset != nil)
+    @Test("WITH / CTE")
+    func cte() throws {
+        let result = try format("with active_users as (select * from users where active = true) select * from active_users")
+        #expect(result == """
+        WITH active_users AS (
+          SELECT *
+          FROM users
+          WHERE active = true
+        )
+        SELECT *
+        FROM active_users
+        """)
     }
 
-    @Test("No cursor returns nil cursorOffset")
-    func noCursorReturnsNil() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .mysql)
+    // MARK: - UNION / INTERSECT / EXCEPT
 
-        #expect(result.cursorOffset == nil)
+    @Test("UNION between SELECT statements")
+    func union() throws {
+        let result = try format("select id from users union all select id from admins")
+        #expect(result == """
+        SELECT id
+        FROM users
+
+        UNION ALL
+
+        SELECT id
+        FROM admins
+        """)
     }
 
-    // MARK: - Comment Tests
+    // MARK: - INSERT
 
-    @Test("Single line comment preserved")
-    func singleLineCommentPreserved() throws {
-        let sql = "-- This is a comment\nselect 1"
-        var options = SQLFormatterOptions.default
-        options.preserveComments = true
+    @Test("INSERT INTO VALUES")
+    func insertValues() throws {
+        let result = try format("insert into users (id, name, email) values (1, 'John', 'john@test.com')")
+        #expect(result == """
+        INSERT INTO users (id, name, email)
+        VALUES (1, 'John', 'john@test.com')
+        """)
+    }
 
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
+    // MARK: - UPDATE
 
-        #expect(result.formattedSQL.contains("--") || result.formattedSQL.contains("comment"))
+    @Test("UPDATE SET WHERE")
+    func updateSetWhere() throws {
+        let result = try format("update users set name = 'John', email = 'john@test.com' where id = 1")
+        #expect(result == """
+        UPDATE users
+        SET name = 'John',
+            email = 'john@test.com'
+        WHERE id = 1
+        """)
+    }
+
+    // MARK: - DELETE
+
+    @Test("DELETE FROM WHERE")
+    func deleteFromWhere() throws {
+        let result = try format("delete from users where active = false")
+        #expect(result == """
+        DELETE
+        FROM users
+        WHERE active = false
+        """)
+    }
+
+    // MARK: - CREATE TABLE
+
+    @Test("CREATE TABLE with columns")
+    func createTable() throws {
+        let result = try format("create table users (id int primary key, name varchar(255) not null, email varchar(255))")
+        #expect(result == """
+        CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(255) NOT NULL,
+          email varchar(255)
+        )
+        """)
+    }
+
+    // MARK: - Multiple Statements
+
+    @Test("Multiple statements separated by semicolons")
+    func multipleStatements() throws {
+        let result = try format("select 1; select 2;")
+        #expect(result == """
+        SELECT 1;
+
+        SELECT 2;
+        """)
+    }
+
+    // MARK: - Comments
+
+    @Test("Line comment preserved")
+    func lineCommentPreserved() throws {
+        let result = try format("-- fetch users\nselect * from users")
+        #expect(result == """
+        -- fetch users
+        SELECT *
+        FROM users
+        """)
     }
 
     @Test("Block comment preserved")
     func blockCommentPreserved() throws {
-        let sql = "/* This is a block comment */ select 1"
+        let result = try format("/* all users */ select * from users")
+        #expect(result == """
+        /* all users */
+        SELECT *
+        FROM users
+        """)
+    }
+
+    // MARK: - String Preservation
+
+    @Test("String literals are not uppercased")
+    func stringPreservation() throws {
+        let result = try format("select 'hello world' from users")
+        #expect(result.contains("'hello world'"))
+        #expect(!result.contains("'HELLO WORLD'"))
+    }
+
+    // MARK: - Keyword Uppercasing
+
+    @Test("Keywords are uppercased by default")
+    func keywordUppercasing() throws {
+        let result = try format("select * from users where id = 1")
+        #expect(result.contains("SELECT"))
+        #expect(result.contains("FROM"))
+        #expect(result.contains("WHERE"))
+    }
+
+    @Test("Keywords not uppercased when option is false")
+    func keywordsNotUppercased() throws {
         var options = SQLFormatterOptions.default
-        options.preserveComments = true
-
-        let result = try formatter.format(sql, dialect: .mysql, options: options)
-
-        #expect(result.formattedSQL.contains("/*") || result.formattedSQL.contains("comment"))
+        options.uppercaseKeywords = false
+        let result = try formatter.format("select * from users", dialect: .mysql, options: options).formattedSQL
+        #expect(result.contains("select"))
+        #expect(result.contains("from"))
     }
 
-    // MARK: - Dialect Tests
-
-    @Test("MySQL dialect works")
-    func mysqlDialect() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-    }
-
-    @Test("PostgreSQL dialect works")
-    func postgresqlDialect() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .postgresql)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-    }
-
-    @Test("SQLite dialect works")
-    func sqliteDialect() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .sqlite)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-    }
-
-    // MARK: - Multiple Statement Tests
-
-    @Test("Multiple statements handled")
-    func multipleStatementsHandled() throws {
-        let sql = "select * from users; select * from roles;"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-        let selectCount = result.formattedSQL.components(separatedBy: "SELECT").count - 1
-        #expect(selectCount >= 2)
-    }
-
-    // MARK: - Idempotency Tests
+    // MARK: - Idempotency
 
     @Test("Formatting twice gives same result")
     func idempotency() throws {
-        let sql = "select * from users where id = 1"
-        let result1 = try formatter.format(sql, dialect: .mysql)
-        let result2 = try formatter.format(result1.formattedSQL, dialect: .mysql)
-
-        let normalized1 = result1.formattedSQL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalized2 = result2.formattedSQL.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        #expect(normalized1 == normalized2)
+        let sql = "select id, name from users where active = true and role = 'admin' order by name"
+        let first = try format(sql)
+        let second = try format(first)
+        #expect(first == second)
     }
 
-    // MARK: - Integration Tests
+    // MARK: - Error Handling
 
-    @Test("Simple query end-to-end formatting")
-    func simpleQueryEndToEnd() throws {
-        let sql = "select id, name from users where active = true order by name"
-        let result = try formatter.format(sql, dialect: .mysql)
-
-        #expect(result.formattedSQL.contains("SELECT"))
-        #expect(result.formattedSQL.contains("FROM"))
-        #expect(result.formattedSQL.contains("WHERE"))
-        #expect(result.formattedSQL.contains("ORDER BY"))
-        #expect(!result.formattedSQL.isEmpty)
+    @Test("Empty input throws")
+    func emptyInputThrows() {
+        #expect(throws: SQLFormatterError.self) {
+            try format("")
+        }
     }
 
-    @Test("Default options work correctly")
-    func defaultOptionsWork() throws {
-        let sql = "select * from users"
-        let result = try formatter.format(sql, dialect: .mysql, options: .default)
-
-        #expect(result.formattedSQL.contains("SELECT"))
+    @Test("Whitespace-only input throws")
+    func whitespaceOnlyThrows() {
+        #expect(throws: SQLFormatterError.self) {
+            try format("   \n\t  ")
+        }
     }
 
-    @Test("Format result is trimmed")
-    func formatResultTrimmed() throws {
-        let sql = "   select * from users   "
-        let result = try formatter.format(sql, dialect: .mysql)
+    @Test("Invalid cursor position throws")
+    func invalidCursorThrows() {
+        #expect(throws: SQLFormatterError.self) {
+            try formatter.format("select 1", dialect: .mysql, cursorOffset: 1000)
+        }
+    }
 
-        #expect(result.formattedSQL == result.formattedSQL.trimmingCharacters(in: .whitespacesAndNewlines))
+    @Test("Size limit throws")
+    func sizeLimitThrows() {
+        let large = String(repeating: "select 1; ", count: 600_000)
+        #expect(throws: SQLFormatterError.self) {
+            try format(large)
+        }
+    }
+
+    // MARK: - Cursor Preservation
+
+    @Test("Cursor offset preserved when provided")
+    func cursorPreserved() throws {
+        let result = try formatter.format("select * from users", dialect: .mysql, cursorOffset: 7)
+        #expect(result.cursorOffset != nil)
+    }
+
+    @Test("No cursor returns nil")
+    func noCursorReturnsNil() throws {
+        let result = try formatter.format("select * from users", dialect: .mysql)
+        #expect(result.cursorOffset == nil)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("Trimmed output")
+    func trimmedOutput() throws {
+        let result = try format("   select * from users   ")
+        #expect(result == result.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    @Test("SELECT with function calls")
+    func selectWithFunctions() throws {
+        let result = try format("select count(*), max(id) from users")
+        #expect(result == """
+        SELECT count(*),
+               max(id)
+        FROM users
+        """)
+    }
+
+    @Test("DISTINCT keyword")
+    func distinct() throws {
+        let result = try format("select distinct name from users")
+        #expect(result == """
+        SELECT DISTINCT name
+        FROM users
+        """)
     }
 }

--- a/TableProTests/Core/Services/SQLTokenizerTests.swift
+++ b/TableProTests/Core/Services/SQLTokenizerTests.swift
@@ -1,0 +1,182 @@
+//
+//  SQLTokenizerTests.swift
+//  TableProTests
+//
+//  Tests for SQLTokenizer — character-by-character SQL lexer.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SQLTokenizer")
+struct SQLTokenizerTests {
+    let tokenizer = SQLTokenizer()
+
+    // MARK: - Keywords
+
+    @Test("Recognizes standard SQL keywords")
+    func standardKeywords() {
+        let tokens = tokenizer.tokenize("SELECT FROM WHERE")
+        let nonWS = tokens.filter { $0.type != .whitespace }
+        #expect(nonWS.count == 3)
+        #expect(nonWS.allSatisfy { $0.type == .keyword })
+    }
+
+    @Test("Keywords are case-insensitive")
+    func keywordCaseInsensitive() {
+        let tokens = tokenizer.tokenize("select FROM Where")
+        let nonWS = tokens.filter { $0.type != .whitespace }
+        #expect(nonWS.allSatisfy { $0.type == .keyword })
+    }
+
+    // MARK: - Identifiers
+
+    @Test("Recognizes identifiers")
+    func identifiers() {
+        let tokens = tokenizer.tokenize("users my_table col1")
+        let nonWS = tokens.filter { $0.type != .whitespace }
+        #expect(nonWS.count == 3)
+        #expect(nonWS.allSatisfy { $0.type == .identifier })
+    }
+
+    @Test("Backtick-quoted identifiers")
+    func backtickIdentifiers() {
+        let tokens = tokenizer.tokenize("`my table`")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .identifier)
+        #expect(tokens[0].value == "`my table`")
+    }
+
+    // MARK: - Strings
+
+    @Test("Single-quoted string")
+    func singleQuotedString() {
+        let tokens = tokenizer.tokenize("'hello world'")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .string)
+        #expect(tokens[0].value == "'hello world'")
+    }
+
+    @Test("String with escaped quote")
+    func stringWithEscapedQuote() {
+        let tokens = tokenizer.tokenize("'it''s'")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .string)
+        #expect(tokens[0].value == "'it''s'")
+    }
+
+    @Test("String with backslash escape")
+    func stringWithBackslashEscape() {
+        let tokens = tokenizer.tokenize("'it\\'s'")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .string)
+    }
+
+    // MARK: - Numbers
+
+    @Test("Integer")
+    func integer() {
+        let tokens = tokenizer.tokenize("42")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .number)
+        #expect(tokens[0].value == "42")
+    }
+
+    @Test("Decimal number")
+    func decimal() {
+        let tokens = tokenizer.tokenize("3.14")
+        #expect(tokens.count == 1)
+        #expect(tokens[0].type == .number)
+    }
+
+    // MARK: - Comments
+
+    @Test("Line comment")
+    func lineComment() {
+        let tokens = tokenizer.tokenize("-- this is a comment\nSELECT 1")
+        let comments = tokens.filter { $0.type == .comment }
+        #expect(comments.count == 1)
+        #expect(comments[0].value == "-- this is a comment")
+    }
+
+    @Test("Block comment")
+    func blockComment() {
+        let tokens = tokenizer.tokenize("/* block */ SELECT 1")
+        let comments = tokens.filter { $0.type == .comment }
+        #expect(comments.count == 1)
+        #expect(comments[0].value == "/* block */")
+    }
+
+    // MARK: - Operators
+
+    @Test("Multi-character operators")
+    func multiCharOperators() {
+        let tokens = tokenizer.tokenize(">= <= <> !=")
+        let ops = tokens.filter { $0.type == .operator }
+        #expect(ops.count == 4)
+        #expect(ops.map(\.value) == [">=", "<=", "<>", "!="])
+    }
+
+    // MARK: - Punctuation
+
+    @Test("Punctuation tokens")
+    func punctuation() {
+        let tokens = tokenizer.tokenize("(a, b)")
+        let puncts = tokens.filter { $0.type == .punctuation }
+        #expect(puncts.map(\.value) == ["(", ",", ")"])
+    }
+
+    @Test("Semicolons")
+    func semicolons() {
+        let tokens = tokenizer.tokenize("SELECT 1; SELECT 2;")
+        let semis = tokens.filter { $0.type == .punctuation && $0.value == ";" }
+        #expect(semis.count == 2)
+    }
+
+    // MARK: - Placeholders
+
+    @Test("Question mark placeholder")
+    func questionMarkPlaceholder() {
+        let tokens = tokenizer.tokenize("WHERE id = ?")
+        let placeholders = tokens.filter { $0.type == .placeholder }
+        #expect(placeholders.count == 1)
+        #expect(placeholders[0].value == "?")
+    }
+
+    @Test("Named placeholders")
+    func namedPlaceholders() {
+        let tokens = tokenizer.tokenize("$1 :name @var")
+        let placeholders = tokens.filter { $0.type == .placeholder }
+        #expect(placeholders.count == 3)
+        #expect(placeholders.map(\.value) == ["$1", ":name", "@var"])
+    }
+
+    // MARK: - Mixed Input
+
+    @Test("Full SELECT statement tokens")
+    func fullSelectStatement() {
+        let tokens = tokenizer.tokenize("SELECT id, name FROM users WHERE active = true")
+        let nonWS = tokens.filter { $0.type != .whitespace }
+        // SELECT id , name FROM users WHERE active = true
+        #expect(nonWS.count == 10)
+        #expect(nonWS[0] == SQLToken(type: .keyword, value: "SELECT"))
+        #expect(nonWS[1] == SQLToken(type: .identifier, value: "id"))
+        #expect(nonWS[2] == SQLToken(type: .punctuation, value: ","))
+        #expect(nonWS[3] == SQLToken(type: .identifier, value: "name"))
+        #expect(nonWS[4] == SQLToken(type: .keyword, value: "FROM"))
+        #expect(nonWS[5] == SQLToken(type: .identifier, value: "users"))
+        #expect(nonWS[6] == SQLToken(type: .keyword, value: "WHERE"))
+        #expect(nonWS[7] == SQLToken(type: .identifier, value: "active"))
+        #expect(nonWS[8] == SQLToken(type: .operator, value: "="))
+        #expect(nonWS[9] == SQLToken(type: .keyword, value: "true"))
+    }
+
+    @Test("Preserves original token values")
+    func preservesOriginalValues() {
+        let tokens = tokenizer.tokenize("select 'Hello World' from users")
+        let nonWS = tokens.filter { $0.type != .whitespace }
+        #expect(nonWS[0].value == "select") // preserves original case
+        #expect(nonWS[1].value == "'Hello World'")
+    }
+}


### PR DESCRIPTION
## Summary

Full rewrite of the SQL formatter — replaces the 10-step regex pipeline with a token-based architecture for correct handling of nested structures, subqueries, CASE expressions, and window functions.

Closes #705

## Architecture

```
Input SQL → SQLTokenizer → [SQLToken] → SQLTokenFormatter → Formatted Output
```

- **SQLTokenizer** — character-by-character lexer (no regex). Produces typed tokens: keywords, identifiers, strings, numbers, operators, punctuation, comments, placeholders.
- **SQLTokenFormatter** — walks the token stream with a clause context stack and indent tracking. Makes formatting decisions per-token with full nesting awareness.
- **SQLFormatterService** — unchanged public API. Orchestrates tokenize → format → cursor map.

## What's fixed (all 11 original bugs + 2 edge cases)

- `LEFT JOIN` no longer splits into `LEFT\nJOIN`
- `ON` properly placed on new line after JOIN
- Removed dead `formatJoins` option (was a no-op)
- SELECT column alignment works for all SELECT clauses including nested subqueries
- `FROM` word-boundary matching no longer matches inside words
- WHERE AND/OR alignment respects nesting depth
- `WITH` / CTE support — single and multiple CTEs
- `INSERT INTO VALUES`, `UPDATE SET WHERE`, `DELETE FROM WHERE` support
- `CREATE TABLE` with indented column definitions
- `CASE WHEN THEN ELSE END` properly indented relative to column position
- Inline parens (`COUNT(*)`, `VARCHAR(255)`) stay inline
- `BETWEEN x AND y` — AND stays inline
- `OVER(PARTITION BY ... ORDER BY ...)` — window functions stay inline

## SQL constructs tested (20 cases)

| Construct | Status |
|-----------|--------|
| Simple SELECT * | ✅ |
| Multi-column SELECT (7 cols) | ✅ |
| WHERE with AND/OR/BETWEEN/LIKE/IN/IS NOT NULL | ✅ |
| ORDER BY + LIMIT + OFFSET | ✅ |
| GROUP BY + HAVING with aggregates | ✅ |
| All JOIN types (INNER/LEFT/RIGHT/CROSS) + ON | ✅ |
| Subquery in FROM | ✅ |
| Subquery in WHERE (IN) | ✅ |
| Subquery in SELECT column | ✅ |
| Double CASE expression | ✅ |
| Triple CTE (WITH...AS) | ✅ |
| UNION ALL / UNION / INTERSECT chain | ✅ |
| INSERT INTO VALUES | ✅ |
| UPDATE SET WHERE | ✅ |
| DELETE FROM WHERE | ✅ |
| CREATE TABLE with constraints | ✅ |
| Line + block comments | ✅ |
| Complex nested (subquery + CASE + IN) | ✅ |
| Multiple statements (;) | ✅ |
| Window functions OVER(PARTITION BY...ORDER BY) | ✅ |

## Files changed

| File | Change |
|------|--------|
| `SQLTokenizer.swift` | **New** — character-by-character SQL lexer |
| `SQLFormatterService.swift` | **Full rewrite** — token-based formatter |
| `SQLFormatterTypes.swift` | Removed dead options (`formatJoins`, `alignColumns`, `alignWhere`) |
| `SQLFormatterServiceTests.swift` | **Full rewrite** — exact output assertions |
| `SQLTokenizerTests.swift` | **New** — 17 tokenizer tests |

## Test plan

- [ ] Press ⌥⌘F on various SQL queries — verify formatting
- [ ] Test idempotency — format twice gives same result
- [ ] Test empty/whitespace input — shows error
- [ ] Test with MySQL, PostgreSQL, SQLite dialects