### PR TITLE
fix: filter logic — NULL handling, BETWEEN plugin path, IN/NOT IN (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-selection of first item fails with fast input in Database Switcher (#714)
 - AI settings: fix Ollama model selection and improve error messages (#712)
 - Rewrite SQL formatter with token-based architecture for better formatting (#705)
+- Fix filter logic: `= NULL` auto-converts to `IS NULL`, BETWEEN works on all drivers, IN/NOT IN handles NULL values (#706)
 
 ## [0.31.2] - 2026-04-13
 

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -51,10 +51,14 @@ struct FilterSQLGenerator {
 
         switch filter.filterOperator {
         case .equal:
-            return "\(quotedColumn) = \(escapeValue(filter.value))"
+            let escaped = escapeValue(filter.value)
+            if escaped == "NULL" { return "\(quotedColumn) IS NULL" }
+            return "\(quotedColumn) = \(escaped)"
 
         case .notEqual:
-            return "\(quotedColumn) != \(escapeValue(filter.value))"
+            let escaped = escapeValue(filter.value)
+            if escaped == "NULL" { return "\(quotedColumn) IS NOT NULL" }
+            return "\(quotedColumn) != \(escaped)"
 
         case .contains:
             return generateLikeCondition(column: quotedColumn, pattern: "%\(escapeLikeWildcards(filter.value))%")
@@ -93,18 +97,10 @@ struct FilterSQLGenerator {
             return "(\(quotedColumn) IS NOT NULL AND \(quotedColumn) != '')"
 
         case .inList:
-            let values = parseListValues(filter.value)
-                .map { escapeValue($0) }
-                .joined(separator: ", ")
-            guard !values.isEmpty else { return nil }
-            return "\(quotedColumn) IN (\(values))"
+            return generateInCondition(column: quotedColumn, values: filter.value, negated: false)
 
         case .notInList:
-            let values = parseListValues(filter.value)
-                .map { escapeValue($0) }
-                .joined(separator: ", ")
-            guard !values.isEmpty else { return nil }
-            return "\(quotedColumn) NOT IN (\(values))"
+            return generateInCondition(column: quotedColumn, values: filter.value, negated: true)
 
         case .between:
             guard let secondValue = filter.secondValue, !secondValue.isEmpty else { return nil }
@@ -121,6 +117,48 @@ struct FilterSQLGenerator {
                 return "match(\(quotedColumn), '\(escapedPattern)')"
             }
             return generateRegexCondition(column: quotedColumn, pattern: filter.value)
+        }
+    }
+
+    // MARK: - IN Conditions
+
+    /// Generate IN/NOT IN with proper NULL handling.
+    /// SQL `IN (NULL)` never matches — extract NULLs into a separate IS NULL / IS NOT NULL clause.
+    private func generateInCondition(column: String, values: String, negated: Bool) -> String? {
+        let parsed = parseListValues(values)
+        guard !parsed.isEmpty else { return nil }
+
+        var nonNullValues: [String] = []
+        var hasNull = false
+        for item in parsed {
+            if item.caseInsensitiveCompare("NULL") == .orderedSame {
+                hasNull = true
+            } else {
+                nonNullValues.append(escapeValue(item))
+            }
+        }
+
+        let inClause: String? = nonNullValues.isEmpty ? nil : {
+            let list = nonNullValues.joined(separator: ", ")
+            return negated
+                ? "\(column) NOT IN (\(list))"
+                : "\(column) IN (\(list))"
+        }()
+
+        let nullClause: String? = hasNull ? {
+            negated ? "\(column) IS NOT NULL" : "\(column) IS NULL"
+        }() : nil
+
+        switch (inClause, nullClause) {
+        case let (inC?, nullC?):
+            let joiner = negated ? " AND " : " OR "
+            return "(\(inC)\(joiner)\(nullC))"
+        case let (inC?, nil):
+            return inC
+        case let (nil, nullC?):
+            return nullC
+        case (nil, nil):
+            return nil
         }
     }
 
@@ -262,7 +300,15 @@ extension FilterSQLGenerator {
         if let pluginDriver {
             let filterTuples = filters
                 .filter { $0.isEnabled && !$0.columnName.isEmpty }
-                .map { ($0.columnName, $0.filterOperator.rawValue, $0.value) }
+                .map { filter in
+                    let value: String
+                    if filter.filterOperator == .between, let second = filter.secondValue {
+                        value = "\(filter.value),\(second)"
+                    } else {
+                        value = filter.value
+                    }
+                    return (filter.columnName, filter.filterOperator.rawValue, value)
+                }
             if let result = pluginDriver.buildFilteredQuery(
                 table: tableName, filters: filterTuples,
                 logicMode: logicMode == .and ? "and" : "or",

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -105,7 +105,15 @@ struct TableQueryBuilder {
             let sortCols = sortColumnsAsTuples(sortState)
             let filterTuples = filters
                 .filter { $0.isEnabled && !$0.columnName.isEmpty }
-                .map { ($0.columnName, $0.filterOperator.rawValue, $0.value) }
+                .map { filter in
+                    let value: String
+                    if filter.filterOperator == .between, let second = filter.secondValue {
+                        value = "\(filter.value),\(second)"
+                    } else {
+                        value = filter.value
+                    }
+                    return (filter.columnName, filter.filterOperator.rawValue, value)
+                }
             if let result = pluginDriver.buildFilteredQuery(
                 table: tableName, filters: filterTuples,
                 logicMode: logicMode == .and ? "and" : "or",

--- a/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
@@ -1039,4 +1039,96 @@ struct FilterSQLGeneratorTests {
         let result = generator.generateWhereClause(from: filters, logicMode: .or)
         #expect(result == "WHERE \"age\" > 18 OR \"status\" = 'active'")
     }
+
+    // MARK: - NULL Value Auto-Conversion (Fix A)
+
+    @Test("Equal with NULL value generates IS NULL")
+    func testEqualNullGeneratesIsNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "name", filterOperator: .equal,
+            value: "NULL", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`name` IS NULL")
+    }
+
+    @Test("Equal with null (lowercase) generates IS NULL")
+    func testEqualNullLowercaseGeneratesIsNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "name", filterOperator: .equal,
+            value: "null", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`name` IS NULL")
+    }
+
+    @Test("Not equal with NULL value generates IS NOT NULL")
+    func testNotEqualNullGeneratesIsNotNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "name", filterOperator: .notEqual,
+            value: "NULL", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`name` IS NOT NULL")
+    }
+
+    @Test("Equal with regular string value unchanged")
+    func testEqualRegularStringUnchanged() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "name", filterOperator: .equal,
+            value: "hello", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`name` = 'hello'")
+    }
+
+    // MARK: - IN/NOT IN with NULL Values (Fix D)
+
+    @Test("IN list containing NULL generates OR IS NULL")
+    func testInListWithNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "status", filterOperator: .inList,
+            value: "1, NULL, 3", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "(`status` IN (1, 3) OR `status` IS NULL)")
+    }
+
+    @Test("NOT IN list containing NULL generates AND IS NOT NULL")
+    func testNotInListWithNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "status", filterOperator: .notInList,
+            value: "1, NULL, 3", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "(`status` NOT IN (1, 3) AND `status` IS NOT NULL)")
+    }
+
+    @Test("IN list without NULL unchanged")
+    func testInListWithoutNullUnchanged() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "id", filterOperator: .inList,
+            value: "1, 2, 3", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`id` IN (1, 2, 3)")
+    }
+
+    @Test("IN list with only NULL generates IS NULL")
+    func testInListOnlyNull() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(
+            id: UUID(), columnName: "status", filterOperator: .inList,
+            value: "NULL", secondValue: nil, isSelected: true, isEnabled: true, rawSQL: nil
+        )
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "`status` IS NULL")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes filter logic inconsistencies compared to TablePlus behavior. Three bugs fixed with 8 new exact-output tests.

Closes #706

## Fixes

### A. `= NULL` auto-converts to `IS NULL` (matches TablePlus)
**Before:** `col = NULL` — always false in SQL, never matches NULL rows
**After:** `col IS NULL` — correctly matches NULL rows

Same for `!= NULL` → `IS NOT NULL`. Case-insensitive (`null`, `Null`, `NULL` all work).

### B. BETWEEN `secondValue` included in plugin-dispatch path
**Before:** Plugin tuple was `(column, operator, value)` — `secondValue` dropped, BETWEEN broken for MSSQL and all plugin-implemented filter paths
**After:** BETWEEN values combined as `"value1,value2"` in the tuple for plugin parsing

### D. IN/NOT IN with NULL values handled correctly
**Before:** `IN (1, NULL, 3)` — SQL `IN (NULL)` never matches NULL rows
**After:** `(col IN (1, 3) OR col IS NULL)` — compound condition handles NULL correctly

Same for NOT IN: `(col NOT IN (1, 3) AND col IS NOT NULL)`

## Tests added (8 new)

- Equal with NULL → IS NULL (uppercase + lowercase)
- Not Equal with NULL → IS NOT NULL
- Equal with regular string (regression guard)
- IN list containing NULL → OR IS NULL
- NOT IN list containing NULL → AND IS NOT NULL
- IN list without NULL (regression guard)
- IN list with only NULL → IS NULL

## Test plan

- [ ] Filter with `=` operator and value `NULL` → should match NULL rows
- [ ] Filter with `!=` operator and value `NULL` → should exclude NULL rows
- [ ] Filter with `IN` operator and value `1, NULL, 3` → should match rows with id 1, 3, or NULL
- [ ] Filter with `BETWEEN` on MSSQL connection → should work correctly
- [ ] Existing filters (equals, contains, etc.) still work unchanged