### PR TITLE
feat: auto-detect SQLite schema changes from external tools (#704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI settings: fix Ollama model selection and improve error messages (#712)
 - Rewrite SQL formatter with token-based architecture for better formatting (#705)
 - Fix filter logic: `= NULL` auto-converts to `IS NULL`, BETWEEN works on all drivers, IN/NOT IN handles NULL values (#706)
+- SQLite/DuckDB: auto-detect schema changes from external tools (#704)
 
 ## [0.31.2] - 2026-04-13
 

--- a/TablePro/Core/Services/Infrastructure/DatabaseFileWatcher.swift
+++ b/TablePro/Core/Services/Infrastructure/DatabaseFileWatcher.swift
@@ -1,0 +1,103 @@
+//
+//  DatabaseFileWatcher.swift
+//  TablePro
+//
+//  Watches database files for external modifications using DispatchSource.
+//  After each detected change, the watcher re-opens the file descriptor to
+//  handle SQLite journaling operations that can invalidate the original fd.
+//
+
+import Foundation
+import os
+
+@MainActor
+final class DatabaseFileWatcher {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseFileWatcher")
+
+    private var activeSources: [UUID: DispatchSourceFileSystemObject] = [:]
+    private var debounceTasks: [UUID: Task<Void, Never>] = [:]
+    private var watchedPaths: [UUID: String] = [:]
+    private var callbacks: [UUID: @MainActor () -> Void] = [:]
+
+    private let debounceInterval: Duration = .milliseconds(500)
+
+    // MARK: - Public API
+
+    func watch(filePath: String, connectionId: UUID, onChange: @escaping @MainActor () -> Void) {
+        stopWatching(connectionId: connectionId)
+
+        let expandedPath = (filePath as NSString).expandingTildeInPath
+        watchedPaths[connectionId] = expandedPath
+        callbacks[connectionId] = onChange
+
+        startSource(connectionId: connectionId)
+    }
+
+    func stopWatching(connectionId: UUID) {
+        debounceTasks[connectionId]?.cancel()
+        debounceTasks.removeValue(forKey: connectionId)
+
+        if let source = activeSources.removeValue(forKey: connectionId) {
+            source.cancel()
+        }
+        watchedPaths.removeValue(forKey: connectionId)
+        callbacks.removeValue(forKey: connectionId)
+    }
+
+    func stopAll() {
+        for id in activeSources.keys {
+            stopWatching(connectionId: id)
+        }
+    }
+
+    // MARK: - Private
+
+    private func startSource(connectionId: UUID) {
+        // Cancel any existing source
+        if let existing = activeSources.removeValue(forKey: connectionId) {
+            existing.cancel()
+        }
+
+        guard let path = watchedPaths[connectionId] else { return }
+
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else {
+            Self.logger.warning("Cannot open database file for watching: \(path, privacy: .public)")
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .attrib, .link, .rename, .revoke],
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.handleEvent(connectionId: connectionId)
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        activeSources[connectionId] = source
+        source.resume()
+    }
+
+    private func handleEvent(connectionId: UUID) {
+        // Re-create the watcher to get a fresh file descriptor.
+        // SQLite journaling (rename + recreate) can invalidate the old fd.
+        startSource(connectionId: connectionId)
+
+        // Debounced refresh
+        debounceTasks[connectionId]?.cancel()
+        debounceTasks[connectionId] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: self?.debounceInterval ?? .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            self?.callbacks[connectionId]?()
+        }
+    }
+}

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -137,6 +137,8 @@ final class MainContentCoordinator {
     @ObservationIgnored private var terminationObserver: NSObjectProtocol?
     @ObservationIgnored private var urlFilterObservers: [NSObjectProtocol] = []
     @ObservationIgnored private var pluginDriverObserver: NSObjectProtocol?
+    @ObservationIgnored private var fileWatcher: DatabaseFileWatcher?
+    @ObservationIgnored private var lastSchemaRefreshDate = Date.distantPast
 
     /// Set during handleTabChange to suppress redundant onChange(of: resultColumns) reconfiguration
     @ObservationIgnored internal var isHandlingTabSwitch = false
@@ -342,6 +344,7 @@ final class MainContentCoordinator {
         _didActivate.withLock { $0 = true }
         registerForPersistence()
         setupPluginDriver()
+        startFileWatcherIfNeeded()
         // Retry when driver becomes available (connection may still be in progress)
         if changeManager.pluginDriver == nil {
             pluginDriverObserver = NotificationCenter.default.addObserver(
@@ -352,6 +355,28 @@ final class MainContentCoordinator {
                 }
             }
         }
+    }
+
+    /// Start watching the database file for external changes (SQLite, DuckDB).
+    private func startFileWatcherIfNeeded() {
+        guard PluginManager.shared.connectionMode(for: connection.type) == .fileBased else { return }
+        let filePath = connection.database
+        guard !filePath.isEmpty else { return }
+
+        let watcher = DatabaseFileWatcher()
+        watcher.watch(filePath: filePath, connectionId: connectionId) { [weak self] in
+            guard let self, self.sidebarLoadingState != .loading else { return }
+            Task { await self.refreshTablesIfStale() }
+        }
+        fileWatcher = watcher
+    }
+
+    /// Refresh schema only if not recently refreshed (avoids redundant work
+    /// when both the file watcher and window focus trigger close together).
+    func refreshTablesIfStale() async {
+        guard Date().timeIntervalSince(lastSchemaRefreshDate) > 2 else { return }
+        lastSchemaRefreshDate = Date()
+        await refreshTables()
     }
 
     func showAIChatPanel() {
@@ -381,6 +406,7 @@ final class MainContentCoordinator {
     }
 
     func refreshTables() async {
+        lastSchemaRefreshDate = Date()
         sidebarLoadingState = .loading
         guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
             sidebarLoadingState = .error(String(localized: "Not connected"))
@@ -440,6 +466,8 @@ final class MainContentCoordinator {
             NotificationCenter.default.removeObserver(observer)
             pluginDriverObserver = nil
         }
+        fileWatcher?.stopWatching(connectionId: connectionId)
+        fileWatcher = nil
         currentQueryTask?.cancel()
         currentQueryTask = nil
         changeManagerUpdateTask?.cancel()

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -15,6 +15,7 @@
 
 import Combine
 import SwiftUI
+import TableProPluginKit
 
 /// Main content view - thin presentation layer
 struct MainContentView: View {
@@ -374,6 +375,12 @@ struct MainContentView: View {
                 } ?? false
             if needsLazyLoad && !hasPendingEdits && isConnected {
                 coordinator.runQuery()
+            }
+
+            // Auto-refresh schema for file-based connections (SQLite, DuckDB)
+            // when window regains focus — catches external modifications.
+            if PluginManager.shared.connectionMode(for: connection.type) == .fileBased && isConnected {
+                Task { await coordinator.refreshTablesIfStale() }
             }
             }
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification))


### PR DESCRIPTION
## Summary

SQLite databases modified by external tools (migration runners, CLI, other clients) now auto-refresh the sidebar and autocomplete cache without requiring manual Cmd+R.

Closes #704

## Architecture

Two-layer detection using native macOS `DispatchSource`:

1. **File watcher** (`DatabaseFileWatcher`) — monitors the `.sqlite` file via `DispatchSource.makeFileSystemObjectSource` with `O_EVTONLY`. Re-creates the file descriptor after each event to handle SQLite journaling (which invalidates the original inode via rename operations). 500ms debounce coalesces rapid writes.

2. **Window focus fallback** — when a main window regains key status for a file-based connection, `refreshTablesIfStale()` runs if not recently refreshed (2-second dedup). Catches edge cases the file watcher might miss.

Both layers call the existing `refreshTables()` which updates sidebar + autocomplete cache.

### Root cause of the original bug

`refreshTables()` was only called on Cmd+R (manual) or on initial connection. No mechanism existed to trigger it when the SQLite file was modified externally.

### Root cause of the fd invalidation

SQLite journaling renames the database file during commits. The `DispatchSource`'s file descriptor then points to the old inode, not the file at that path. Fix: re-open the fd after every event.

## Changes

| File | Change |
|------|--------|
| `DatabaseFileWatcher.swift` | **New** — DispatchSource file watcher with fd re-creation and debounce |
| `MainContentCoordinator.swift` | Start/stop watcher on lifecycle, `refreshTablesIfStale()` with 2s dedup |
| `MainContentView.swift` | Refresh on window focus for file-based connections |

## Test plan

- [ ] Open SQLite database in TablePro
- [ ] In terminal: `sqlite3 path/to/db "CREATE TABLE test (id INTEGER PRIMARY KEY)"` → sidebar shows `test` within ~1 second
- [ ] In terminal: `sqlite3 path/to/db "DROP TABLE test"` → sidebar removes `test` within ~1 second
- [ ] In terminal: `sqlite3 path/to/db "ALTER TABLE users ADD COLUMN phone TEXT"` → click table, new column visible
- [ ] Switch away from TablePro, run migration, switch back → sidebar updates on focus
- [ ] Verify no CPU spike when idle with SQLite connection open
- [ ] MySQL/PostgreSQL connections unaffected (no file watcher started)