### PR TITLE
fix: crash when creating database on PostgreSQL (macOS 26)

### DIFF
--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3086,6 +3086,9 @@
         }
       }
     },
+    "Action Failed" : {
+
+    },
     "Activate" : {
       "localizations" : {
         "tr" : {
@@ -3267,6 +3270,15 @@
           }
         }
       }
+    },
+    "Active Merges" : {
+
+    },
+    "Active Queries" : {
+
+    },
+    "Active Sessions" : {
+
     },
     "Actual" : {
       "localizations" : {
@@ -4109,6 +4121,7 @@
       }
     },
     "ALL DATABASES" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4153,6 +4166,7 @@
       }
     },
     "ALL SCHEMAS" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -4880,6 +4894,9 @@
         }
       }
     },
+    "Are you sure you want to cancel the running query for this session?" : {
+
+    },
     "Are you sure you want to delete \"%@\"?" : {
       "localizations" : {
         "tr" : {
@@ -4990,6 +5007,9 @@
           }
         }
       }
+    },
+    "Are you sure you want to terminate this session? Any running queries will be aborted." : {
+
     },
     "As Copy" : {
       "localizations" : {
@@ -5781,6 +5801,9 @@
         }
       }
     },
+    "Block Size" : {
+
+    },
     "Blue" : {
       "localizations" : {
         "tr" : {
@@ -6046,6 +6069,12 @@
         }
       }
     },
+    "Bytes Received" : {
+
+    },
+    "Bytes Sent" : {
+
+    },
     "CA Cert" : {
       "localizations" : {
         "tr" : {
@@ -6090,6 +6119,12 @@
         }
       }
     },
+    "Cache Hit Ratio" : {
+
+    },
+    "Cache Size" : {
+
+    },
     "Cancel" : {
       "localizations" : {
         "tr" : {
@@ -6111,6 +6146,15 @@
           }
         }
       }
+    },
+    "Cancel Query" : {
+
+    },
+    "Cancel query for session %@" : {
+
+    },
+    "Cannot connect to Ollama at %@. Is Ollama running?" : {
+
     },
     "Cannot execute write queries: connection is read-only" : {
       "localizations" : {
@@ -6446,6 +6490,7 @@
       }
     },
     "Character Set" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -8202,6 +8247,9 @@
         }
       }
     },
+    "Connected Threads" : {
+
+    },
     "Connecting" : {
       "localizations" : {
         "tr" : {
@@ -8561,6 +8609,9 @@
           }
         }
       }
+    },
+    "Connections" : {
+
     },
     "Connections:" : {
       "localizations" : {
@@ -10183,6 +10234,12 @@
         }
       }
     },
+    "Dashboard" : {
+
+    },
+    "Dashboard Not Available" : {
+
+    },
     "Data" : {
       "localizations" : {
         "tr" : {
@@ -10492,6 +10549,9 @@
           }
         }
       }
+    },
+    "Database Size" : {
+
     },
     "Database Switch Failed" : {
       "localizations" : {
@@ -11923,6 +11983,9 @@
         }
       }
     },
+    "Disk Usage" : {
+
+    },
     "Dismiss" : {
       "localizations" : {
         "tr" : {
@@ -12477,6 +12540,9 @@
           }
         }
       }
+    },
+    "Duration" : {
+
     },
     "Each SQLite file is a separate database.\nTo open a different database, create a new connection." : {
       "localizations" : {
@@ -14888,7 +14954,6 @@
       }
     },
     "Failed to decompress file: %@" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -14995,6 +15060,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步数据编码失败：%@"
+          }
+        }
+      }
+    },
+    "Failed to fetch models from %@ (HTTP %d)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to fetch models from %1$@ (HTTP %2$d)"
           }
         }
       }
@@ -15203,7 +15278,6 @@
       }
     },
     "Failed to load preview using encoding: %@. Try selecting a different text encoding." : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -15226,7 +15300,6 @@
       }
     },
     "Failed to load preview: %@" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -16456,6 +16529,9 @@
           }
         }
       }
+    },
+    "Format Query" : {
+
     },
     "Format Query (⌥⌘F)" : {
       "localizations" : {
@@ -19261,6 +19337,9 @@
         }
       }
     },
+    "Journal Mode" : {
+
+    },
     "JSON" : {
       "localizations" : {
         "tr" : {
@@ -19393,6 +19472,9 @@
           }
         }
       }
+    },
+    "Keep Running" : {
+
     },
     "Keep This Mac's Version" : {
       "localizations" : {
@@ -20391,6 +20473,9 @@
         }
       }
     },
+    "Load Models" : {
+
+    },
     "Load Table Template" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -20436,6 +20521,9 @@
           }
         }
       }
+    },
+    "Loading dashboard..." : {
+
     },
     "Loading databases..." : {
       "localizations" : {
@@ -20858,6 +20946,9 @@
         }
       }
     },
+    "Max Connections" : {
+
+    },
     "Max schema tables: %d" : {
       "localizations" : {
         "tr" : {
@@ -21056,6 +21147,9 @@
           }
         }
       }
+    },
+    "Memory Limit" : {
+
     },
     "METADATA" : {
       "localizations" : {
@@ -22153,6 +22247,9 @@
         }
       }
     },
+    "Next Page" : {
+
+    },
     "Next Page (⌘])" : {
       "localizations" : {
         "tr" : {
@@ -23021,6 +23118,7 @@
       }
     },
     "No models loaded" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -23418,6 +23516,9 @@
           }
         }
       }
+    },
+    "No slow queries" : {
+
     },
     "No SSL encryption" : {
       "localizations" : {
@@ -24217,6 +24318,9 @@
         }
       }
     },
+    "Off" : {
+
+    },
     "Offset" : {
       "localizations" : {
         "tr" : {
@@ -24260,6 +24364,9 @@
           }
         }
       }
+    },
+    "Ollama is running but has no models. Run \"ollama pull <model>\" to download one." : {
+
     },
     "On Delete" : {
       "localizations" : {
@@ -24503,6 +24610,9 @@
           }
         }
       }
+    },
+    "Open editor" : {
+
     },
     "Open File" : {
       "localizations" : {
@@ -24950,6 +25060,12 @@
         }
       }
     },
+    "Page Count" : {
+
+    },
+    "Page Size" : {
+
+    },
     "Page size must be between %@ and %@" : {
       "localizations" : {
         "en" : {
@@ -24977,6 +25093,9 @@
           }
         }
       }
+    },
+    "pages" : {
+
     },
     "Pagination" : {
       "localizations" : {
@@ -25065,6 +25184,9 @@
           }
         }
       }
+    },
+    "Part Mutations" : {
+
     },
     "Partition" : {
       "localizations" : {
@@ -25359,6 +25481,9 @@
         }
       }
     },
+    "Pause" : {
+
+    },
     "pending delete" : {
       "localizations" : {
         "tr" : {
@@ -25424,6 +25549,9 @@
           }
         }
       }
+    },
+    "PID" : {
+
     },
     "Pin Result" : {
       "localizations" : {
@@ -26627,6 +26755,9 @@
         }
       }
     },
+    "Previous Page" : {
+
+    },
     "Previous Page (⌘[)" : {
       "localizations" : {
         "tr" : {
@@ -27787,6 +27918,7 @@
       }
     },
     "RECENT" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -28215,6 +28347,9 @@
           }
         }
       }
+    },
+    "Refresh Now" : {
+
     },
     "Refreshing will discard all unsaved changes." : {
       "localizations" : {
@@ -28999,6 +29134,9 @@
         }
       }
     },
+    "Resume" : {
+
+    },
     "Retention" : {
       "localizations" : {
         "tr" : {
@@ -29551,6 +29689,9 @@
           }
         }
       }
+    },
+    "Running Threads" : {
+
     },
     "Safe Mode" : {
       "localizations" : {
@@ -31126,6 +31267,9 @@
         }
       }
     },
+    "Server Dashboard" : {
+
+    },
     "Server error (%d): %@" : {
       "localizations" : {
         "en" : {
@@ -31182,6 +31326,12 @@
           }
         }
       }
+    },
+    "Server Metrics" : {
+
+    },
+    "Server monitoring is not available for this database type." : {
+
     },
     "Service Account Key" : {
       "localizations" : {
@@ -32186,6 +32336,9 @@
           }
         }
       }
+    },
+    "Slow Queries" : {
+
     },
     "Small" : {
       "localizations" : {
@@ -33218,6 +33371,9 @@
           }
         }
       }
+    },
+    "State" : {
+
     },
     "statement" : {
       "localizations" : {
@@ -34754,6 +34910,15 @@
         }
       }
     },
+    "Terminate" : {
+
+    },
+    "Terminate Session" : {
+
+    },
+    "Terminate session %@" : {
+
+    },
     "Tertiary Text" : {
       "localizations" : {
         "tr" : {
@@ -35821,6 +35986,9 @@
         }
       }
     },
+    "Threads" : {
+
+    },
     "Tier:" : {
       "localizations" : {
         "en" : {
@@ -36427,6 +36595,12 @@
           }
         }
       }
+    },
+    "Total Blocks" : {
+
+    },
+    "Total Queries" : {
+
     },
     "Total Size" : {
       "localizations" : {
@@ -37490,6 +37664,9 @@
         }
       }
     },
+    "Uptime" : {
+
+    },
     "US Long (12/31/2024 11:59:59 PM)" : {
       "localizations" : {
         "tr" : {
@@ -37643,6 +37820,9 @@
           }
         }
       }
+    },
+    "User Sessions" : {
+
     },
     "User-installed" : {
       "localizations" : {

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
@@ -133,18 +133,14 @@ struct CreateDatabaseSheet: View {
         isCreating = true
         errorMessage = nil
 
-        // Capture @State values as local lets before the async boundary.
-        // This avoids passing strings through async closure thunks which
-        // have a macOS 26 (Tahoe) runtime bug with ImplicitActor argument shifting.
         let name = databaseName
         let cs = config.showOptions ? charset : ""
         let col: String? = config.showOptions ? collation : nil
-        let vm = viewModel
 
         Task {
             do {
-                try await vm.createDatabase(name: name, charset: cs, collation: col)
-                await vm.refreshDatabases()
+                try await viewModel.createDatabase(name: name, charset: cs, collation: col)
+                await viewModel.refreshDatabases()
                 dismiss()
             } catch {
                 errorMessage = error.localizedDescription

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -116,11 +116,7 @@ struct DatabaseSwitcherSheet: View {
         .defaultFocus($focus, .search)
         .task { await viewModel.fetchDatabases() }
         .sheet(isPresented: $showCreateDialog) {
-            CreateDatabaseSheet(databaseType: databaseType) { name, charset, collation in
-                try await viewModel.createDatabase(
-                    name: name, charset: charset, collation: collation)
-                await viewModel.refreshDatabases()
-            }
+            CreateDatabaseSheet(databaseType: databaseType, viewModel: viewModel)
         }
         .onExitCommand {
             // SwiftUI handles sheet priority automatically - no nested sheets take precedence


### PR DESCRIPTION
## Summary
- Fix `EXC_BAD_ACCESS` crash in `swift_retain` when clicking Create in the Create Database dialog on PostgreSQL connections running macOS 26 (Tahoe)
- Root cause: macOS 26 Swift runtime injects `Builtin.ImplicitActor` into async closure thunks, shifting String argument slots and corrupting them with the MainActor protocol witness table address
- Fix: pass `DatabaseSwitcherViewModel` directly to `CreateDatabaseSheet` instead of an async `onCreate` closure, eliminating the problematic thunk chain entirely

## Test plan
- [ ] Connect to PostgreSQL, open Create Database dialog, enter a name, click Create — no crash
- [ ] Verify the database is actually created on the server
- [ ] Verify the database list refreshes after creation
- [ ] Test Cancel button still works
- [ ] Test on macOS 15 (Sequoia) to confirm no regression