### PR TITLE
feat: refactor menu bar to follow macOS HIG (#722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keyboard shortcuts follow macOS HIG — `⌘F` is Find, `⌘⇧F` for filters, `⌘⌥I` for inspector, `⌘0` for sidebar
 - Format Query and Pagination shortcuts now customizable in Settings
+- Menu bar restructured per macOS HIG: ⌘N opens connection list (#722), new Query menu, Help search restored, duplicate items removed
 
 ## [0.31.2] - 2026-04-13
 

--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -95,7 +95,8 @@ struct ContentView: View {
                 Text("Are you sure you want to delete \"\(connection.name)\"?")
             }
             .onReceive(NotificationCenter.default.publisher(for: .newConnection)) { _ in
-                openWindow(id: "connection-form", value: nil as UUID?)
+                // ⌘N opens the Welcome window (connection list) — not the blank form
+                NotificationCenter.default.post(name: .openWelcomeWindow, object: nil)
             }
             // Right sidebar toggle is handled by MainContentView (has the binding)
             // Left sidebar toggle uses native NSSplitViewController.toggleSidebar via responder chain

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -36,7 +36,7 @@ enum ShortcutCategory: String, Codable, CaseIterable, Identifiable {
 /// All customizable keyboard shortcut actions
 enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     // File
-    case newConnection
+    case manageConnections
     case newTab
     case openDatabase
     case openFile
@@ -46,6 +46,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case previewSQL
     case closeTab
     case refresh
+    case executeQuery
     case explainQuery
     case formatQuery
     case export
@@ -83,10 +84,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case closeResultTab
 
     // Tabs
-    case showPreviousTabBrackets
-    case showNextTabBrackets
-    case previousTabArrows
-    case nextTabArrows
+    case showPreviousTab
+    case showNextTab
 
     // AI
     case aiExplainQuery
@@ -96,9 +95,9 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
 
     var category: ShortcutCategory {
         switch self {
-        case .newConnection, .newTab, .openDatabase, .openFile, .switchConnection,
+        case .manageConnections, .newTab, .openDatabase, .openFile, .switchConnection,
              .saveChanges, .saveAs, .previewSQL, .closeTab, .refresh,
-             .explainQuery, .formatQuery, .export, .importData, .quickSwitcher,
+             .executeQuery, .explainQuery, .formatQuery, .export, .importData, .quickSwitcher,
              .previousPage, .nextPage:
             return .file
         case .undo, .redo, .cut, .copy, .copyWithHeaders, .copyAsJson, .paste,
@@ -108,8 +107,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .toggleTableBrowser, .toggleInspector, .toggleFilters, .toggleHistory,
              .toggleResults, .previousResultTab, .nextResultTab, .closeResultTab:
             return .view
-        case .showPreviousTabBrackets, .showNextTabBrackets,
-             .previousTabArrows, .nextTabArrows:
+        case .showPreviousTab, .showNextTab:
             return .tabs
         case .aiExplainQuery, .aiOptimizeQuery:
             return .ai
@@ -118,7 +116,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .newConnection: return String(localized: "New Connection")
+        case .manageConnections: return String(localized: "Manage Connections")
+        case .executeQuery: return String(localized: "Execute Query")
         case .newTab: return String(localized: "New Tab")
         case .openDatabase: return String(localized: "Open Database")
         case .openFile: return String(localized: "Open File")
@@ -157,10 +156,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .previousResultTab: return String(localized: "Previous Result")
         case .nextResultTab: return String(localized: "Next Result")
         case .closeResultTab: return String(localized: "Close Result Tab")
-        case .showPreviousTabBrackets: return String(localized: "Show Previous Tab")
-        case .showNextTabBrackets: return String(localized: "Show Next Tab")
-        case .previousTabArrows: return String(localized: "Previous Tab (Alt)")
-        case .nextTabArrows: return String(localized: "Next Tab (Alt)")
+        case .showPreviousTab: return String(localized: "Show Previous Tab")
+        case .showNextTab: return String(localized: "Show Next Tab")
         case .aiExplainQuery: return String(localized: "Explain with AI")
         case .aiOptimizeQuery: return String(localized: "Optimize with AI")
         }
@@ -452,7 +449,8 @@ struct KeyboardSettings: Codable, Equatable {
     /// Default shortcuts — applied when user has no overrides
     static let defaultShortcuts: [ShortcutAction: KeyCombo] = [
         // File
-        .newConnection: KeyCombo(key: "n", command: true),
+        .manageConnections: KeyCombo(key: "n", command: true),
+        .executeQuery: KeyCombo(key: "return", command: true, isSpecialKey: true),
         .newTab: KeyCombo(key: "t", command: true),
         .openDatabase: KeyCombo(key: "k", command: true),
         .openFile: KeyCombo(key: "o", command: true),
@@ -497,10 +495,8 @@ struct KeyboardSettings: Codable, Equatable {
         .closeResultTab: KeyCombo(key: "w", command: true, shift: true),
 
         // Tabs
-        .showPreviousTabBrackets: KeyCombo(key: "[", command: true, shift: true),
-        .showNextTabBrackets: KeyCombo(key: "]", command: true, shift: true),
-        .previousTabArrows: KeyCombo(key: "leftArrow", command: true, option: true, isSpecialKey: true),
-        .nextTabArrows: KeyCombo(key: "rightArrow", command: true, option: true, isSpecialKey: true),
+        .showPreviousTab: KeyCombo(key: "[", command: true, shift: true),
+        .showNextTab: KeyCombo(key: "]", command: true, shift: true),
 
         // AI
         .aiExplainQuery: KeyCombo(key: "l", command: true),

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -182,8 +182,15 @@ struct AppMenuCommands: Commands {
             Button(actions != nil ? "Close Tab" : "Close") {
                 if let actions {
                     actions.closeTab()
-                } else {
-                    NSApp.keyWindow?.performClose(nil)
+                } else if let window = NSApp.keyWindow {
+                    // Only performClose for non-main windows (Settings, Welcome, Connection Form).
+                    // For main windows where @FocusedValue hasn't resolved yet, do nothing —
+                    // prevents accidentally closing the connection window when user intended
+                    // to close a tab.
+                    let isMainWindow = window.identifier?.rawValue.hasPrefix("main") == true
+                    if !isMainWindow {
+                        window.performClose(nil)
+                    }
                 }
             }
             .optionalKeyboardShortcut(shortcut(for: .closeTab))

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -135,10 +135,10 @@ struct AppMenuCommands: Commands {
 
         // File menu
         CommandGroup(replacing: .newItem) {
-            Button("New Connection...") {
+            Button("Manage Connections") {
                 NotificationCenter.default.post(name: .newConnection, object: nil)
             }
-            .optionalKeyboardShortcut(shortcut(for: .newConnection))
+            .optionalKeyboardShortcut(shortcut(for: .manageConnections))
         }
 
         CommandGroup(after: .newItem) {
@@ -165,18 +165,6 @@ struct AppMenuCommands: Commands {
             .optionalKeyboardShortcut(shortcut(for: .openFile))
             .disabled(!(actions?.isConnected ?? false))
 
-            Button("Switch Connection...") {
-                NotificationCenter.default.post(name: .openConnectionSwitcher, object: nil)
-            }
-            .optionalKeyboardShortcut(shortcut(for: .switchConnection))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button("Quick Switcher...") {
-                actions?.openQuickSwitcher()
-            }
-            .optionalKeyboardShortcut(shortcut(for: .quickSwitcher))
-            .disabled(!(actions?.isConnected ?? false))
-
             Divider()
 
             Button("Save Changes") {
@@ -191,58 +179,14 @@ struct AppMenuCommands: Commands {
             .optionalKeyboardShortcut(shortcut(for: .saveAs))
             .disabled(!(actions?.isConnected ?? false))
 
-            Button {
-                actions?.previewSQL()
-            } label: {
-                if let dbType = actions?.currentDatabaseType {
-                    Text(String(format: String(localized: "Preview %@"), PluginManager.shared.queryLanguageName(for: dbType)))
-                } else {
-                    Text("Preview SQL")
-                }
-            }
-            .optionalKeyboardShortcut(shortcut(for: .previewSQL))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button("Close Tab") {
+            Button(actions != nil ? "Close Tab" : "Close") {
                 if let actions {
                     actions.closeTab()
                 } else {
-                    // No active connection — fall back to standard macOS close behavior.
-                    // This handles Settings, Welcome, and other non-main windows.
                     NSApp.keyWindow?.performClose(nil)
                 }
             }
             .optionalKeyboardShortcut(shortcut(for: .closeTab))
-
-            Divider()
-
-            Button("Refresh") {
-                NotificationCenter.default.post(name: .refreshData, object: nil)
-            }
-            .optionalKeyboardShortcut(shortcut(for: .refresh))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button("Explain Query") {
-                actions?.explainQuery()
-            }
-            .optionalKeyboardShortcut(shortcut(for: .explainQuery))
-            .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
-
-            Button(String(localized: "Preview FK Reference")) {
-                actions?.previewFKReference()
-            }
-            .optionalKeyboardShortcut(shortcut(for: .previewFKReference))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button(String(localized: "View ER Diagram")) {
-                actions?.showERDiagram()
-            }
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button(String(localized: "Server Dashboard")) {
-                actions?.showServerDashboard()
-            }
-            .disabled(!(actions?.isConnected ?? false) || !(actions?.supportsServerDashboard ?? false))
 
             Divider()
 
@@ -267,13 +211,76 @@ struct AppMenuCommands: Commands {
             }
             .disabled(!(actions?.isConnected ?? false))
 
-            if actions.map({ PluginManager.shared.supportsImport(for: $0.currentDatabaseType) }) ?? true {
-                Button("Import...") {
-                    actions?.importTables()
-                }
-                .optionalKeyboardShortcut(shortcut(for: .importData))
-                .disabled(!(actions?.isConnected ?? false) || actions?.isReadOnly ?? false)
+            Button("Import...") {
+                actions?.importTables()
             }
+            .optionalKeyboardShortcut(shortcut(for: .importData))
+            .disabled(
+                !(actions?.isConnected ?? false)
+                    || actions?.isReadOnly ?? false
+                    || !(actions.map { PluginManager.shared.supportsImport(for: $0.currentDatabaseType) } ?? true)
+            )
+        }
+
+        // Query menu
+        CommandMenu("Query") {
+            Button("Execute Query") {
+                actions?.runQuery()
+            }
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
+
+            Button("Explain Query") {
+                actions?.explainQuery()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .explainQuery))
+            .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
+
+            Button("Format Query") {
+                actions?.formatQuery()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .formatQuery))
+            .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
+
+            Button {
+                actions?.previewSQL()
+            } label: {
+                if let dbType = actions?.currentDatabaseType {
+                    Text(String(format: String(localized: "Preview %@"), PluginManager.shared.queryLanguageName(for: dbType)))
+                } else {
+                    Text("Preview SQL")
+                }
+            }
+            .optionalKeyboardShortcut(shortcut(for: .previewSQL))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Divider()
+
+            Button("Refresh") {
+                NotificationCenter.default.post(name: .refreshData, object: nil)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .refresh))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button("Quick Switcher...") {
+                actions?.openQuickSwitcher()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .quickSwitcher))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Divider()
+
+            Button(String(localized: "Preview FK Reference")) {
+                actions?.previewFKReference()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .previewFKReference))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button("Switch Connection...") {
+                NotificationCenter.default.post(name: .openConnectionSwitcher, object: nil)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .switchConnection))
+            .disabled(!(actions?.isConnected ?? false))
         }
 
         // Edit menu - Undo/Redo (smart handling for both text editor and data grid)
@@ -337,12 +344,6 @@ struct AppMenuCommands: Commands {
 
         // View menu
         CommandGroup(after: .sidebar) {
-            Button("Toggle Table Browser") {
-                NSApp.sendAction(#selector(NSSplitViewController.toggleSidebar(_:)), to: nil, from: nil)
-            }
-            .optionalKeyboardShortcut(shortcut(for: .toggleTableBrowser))
-            .disabled(!(actions?.isConnected ?? false))
-
             Button("Toggle Inspector") {
                 actions?.toggleRightSidebar()
             }
@@ -391,12 +392,24 @@ struct AppMenuCommands: Commands {
 
             Divider()
 
-            Button("Zoom In") {
+            Button(String(localized: "View ER Diagram")) {
+                actions?.showERDiagram()
+            }
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button(String(localized: "Server Dashboard")) {
+                actions?.showServerDashboard()
+            }
+            .disabled(!(actions?.isConnected ?? false) || !(actions?.supportsServerDashboard ?? false))
+
+            Divider()
+
+            Button("Increase Text Size") {
                 ThemeEngine.shared.adjustEditorFontSize(by: 1)
             }
             .keyboardShortcut("=", modifiers: .command)
 
-            Button("Zoom Out") {
+            Button("Decrease Text Size") {
                 ThemeEngine.shared.adjustEditorFontSize(by: -1)
             }
             .keyboardShortcut("-", modifiers: .command)
@@ -422,33 +435,25 @@ struct AppMenuCommands: Commands {
             Button("Show Previous Tab") {
                 NSApp.sendAction(#selector(NSWindow.selectPreviousTab(_:)), to: nil, from: nil)
             }
-            .optionalKeyboardShortcut(shortcut(for: .showPreviousTabBrackets))
+            .optionalKeyboardShortcut(shortcut(for: .showPreviousTab))
             .disabled(!(actions?.isConnected ?? false))
 
             // Next tab (Cmd+Shift+]) — delegate to native macOS tab switching
             Button("Show Next Tab") {
                 NSApp.sendAction(#selector(NSWindow.selectNextTab(_:)), to: nil, from: nil)
             }
-            .optionalKeyboardShortcut(shortcut(for: .showNextTabBrackets))
+            .optionalKeyboardShortcut(shortcut(for: .showNextTab))
             .disabled(!(actions?.isConnected ?? false))
 
-            // Previous tab (Cmd+Option+Left)
-            Button("Previous Tab") {
-                NSApp.sendAction(#selector(NSWindow.selectPreviousTab(_:)), to: nil, from: nil)
-            }
-            .optionalKeyboardShortcut(shortcut(for: .previousTabArrows))
-            .disabled(!(actions?.isConnected ?? false))
+            Divider()
 
-            // Next tab (Cmd+Option+Right)
-            Button("Next Tab") {
-                NSApp.sendAction(#selector(NSWindow.selectNextTab(_:)), to: nil, from: nil)
+            Button("Bring All to Front") {
+                NSApp.arrangeInFront(nil)
             }
-            .optionalKeyboardShortcut(shortcut(for: .nextTabArrows))
-            .disabled(!(actions?.isConnected ?? false))
         }
 
-        // Help menu
-        CommandGroup(replacing: .help) {
+        // Help menu — append after system-provided search field
+        CommandGroup(after: .help) {
             Button(String(localized: "TablePro Website")) {
                 if let url = URL(string: "https://tablepro.app") { NSWorkspace.shared.open(url) }
             }
@@ -461,10 +466,6 @@ struct AppMenuCommands: Commands {
 
             Button("GitHub Repository") {
                 if let url = URL(string: "https://github.com/TableProApp/TablePro") { NSWorkspace.shared.open(url) }
-            }
-
-            Button(String(localized: "Sponsor TablePro")) {
-                if let url = URL(string: "https://github.com/sponsors/datlechin") { NSWorkspace.shared.open(url) }
             }
         }
     }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -129,13 +129,8 @@ final class WelcomeViewModel {
             }
         }
 
-        newConnectionObserver = NotificationCenter.default.addObserver(
-            forName: .newConnection, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.openWindow?(id: "connection-form", value: nil as UUID?)
-            }
-        }
+        // ⌘N now shows the Welcome window (handled by ContentView and AppDelegate).
+        // The Welcome window is already open in this context, so no action needed here.
 
         connectionUpdatedObserver = NotificationCenter.default.addObserver(
             forName: .connectionUpdated, object: nil, queue: .main

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -600,6 +600,31 @@ final class MainContentCommandActions {
         )
     }
 
+    func runQuery() {
+        coordinator?.runQuery()
+    }
+
+    func formatQuery() {
+        guard let coordinator,
+              let tabIndex = coordinator.tabManager.selectedTabIndex else { return }
+        let tab = coordinator.tabManager.tabs[tabIndex]
+        let dbType = connection.type
+        let formatter = SQLFormatterService()
+        let options = SQLFormatterOptions.default
+
+        do {
+            let result = try formatter.format(
+                tab.query,
+                dialect: dbType,
+                cursorOffset: 0,
+                options: options
+            )
+            coordinator.tabManager.tabs[tabIndex].query = result.formattedSQL
+        } catch {
+            Self.logger.error("SQL Formatting error: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     // MARK: - UI Operations (Group A — Called Directly)
 
     func toggleHistoryPanel() {


### PR DESCRIPTION
## Summary

Full menu bar restructure to align with Apple Human Interface Guidelines. Addresses #722 (⌘N remap) plus 17 additional non-standard patterns found in deep audit.

## Key Changes

### ⌘N → Manage Connections (was "New Connection...")
Opens the Welcome window (connection list) instead of a blank connection form. Matches TablePlus behavior and macOS convention where ⌘N shows the app's primary workspace/browser.

### New "Query" Menu
Items previously misplaced in the File menu now have a dedicated Query menu:
- Execute Query (⌘↩)
- Explain Query (⌘⌥E)
- Format Query (⌘⌥F)
- Preview SQL (⌘⇧P)
- Refresh (⌘R)
- Quick Switcher (⌘P)
- Preview FK Reference
- Switch Connection (⌘⌃C)

### File Menu — Cleaned Up
Only file-appropriate actions remain: New Tab, Open, Close, Save, Export, Import.
"Close Tab" label is now dynamic — shows "Close" when no connection is active.

### View Menu — Updated
- Removed "Toggle Table Browser" (duplicate of system-injected "Show/Hide Sidebar")
- Added "View ER Diagram" and "Server Dashboard" (moved from File)
- "Zoom In/Out" → "Increase/Decrease Text Size" (macOS HIG)

### Window Menu — Cleaned Up
- Removed duplicate Previous/Next Tab buttons (kept ⌘⇧[/])
- Added "Bring All to Front" (standard macOS item)

### Help Menu — Search Restored
Changed from `CommandGroup(replacing: .help)` to `CommandGroup(after: .help)` — preserves macOS's built-in ⌘? menu search field. Removed "Sponsor TablePro" (non-standard placement).

### Keyboard Shortcuts Model
- `.newConnection` → `.manageConnections`
- Added `.executeQuery` (⌘↩)
- Removed duplicate `.previousTabArrows` / `.nextTabArrows`
- Simplified to `.showPreviousTab` / `.showNextTab`

## Files changed (6)

| File | Change |
|------|--------|
| `TableProApp.swift` | Full menu restructure |
| `KeyboardShortcutModels.swift` | Renamed/added/removed shortcut actions |
| `ContentView.swift` | ⌘N opens Welcome window |
| `WelcomeViewModel.swift` | Removed redundant notification handler |
| `MainContentCommandActions.swift` | Added `runQuery()` and `formatQuery()` methods |
| `CHANGELOG.md` | Entry |

## Test plan

- [ ] ⌘N → Welcome window opens (not connection form)
- [ ] Query menu visible with Execute, Explain, Format, Preview, Refresh, Quick Switcher
- [ ] View menu → "Increase Text Size" / "Decrease Text Size" (not "Zoom In/Out")
- [ ] View menu → ER Diagram and Server Dashboard present
- [ ] Window menu → "Bring All to Front" present
- [ ] Window menu → only one set of Previous/Next Tab
- [ ] Help menu → search field at top (⌘? works)
- [ ] ⌘W on Settings window → closes correctly (shows "Close" not "Close Tab")
- [ ] Execute Query from menu → runs query
- [ ] Format Query from menu → formats SQL