### PR TITLE
fix: sidebar gap inconsistent when switching tabs (#728)

### DIFF
--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -195,11 +195,6 @@ struct ContentView: View {
                         coordinator: sessionState.coordinator
                     )
                 }
-                .searchable(
-                    text: sidebarSearchTextBinding(for: currentSession.connection.id),
-                    placement: .sidebar,
-                    prompt: sidebarSearchPrompt(for: currentSession.connection.id)
-                )
                 .navigationSplitViewColumnWidth(min: 200, ideal: 250, max: 600)
             } else {
                 Color.clear
@@ -309,23 +304,7 @@ struct ContentView: View {
         )
     }
 
-    private func sidebarSearchTextBinding(for connectionId: UUID) -> Binding<String> {
-        let state = SharedSidebarState.forConnection(connectionId)
-        return Binding(
-            get: { state.searchText },
-            set: { state.searchText = $0 }
-        )
-    }
 
-    private func sidebarSearchPrompt(for connectionId: UUID) -> String {
-        let state = SharedSidebarState.forConnection(connectionId)
-        switch state.selectedSidebarTab {
-        case .tables:
-            return String(localized: "Filter")
-        case .favorites:
-            return String(localized: "Filter favorites")
-        }
-    }
 
     private var sessionTableOperationOptionsBinding: Binding<[String: TableOperationOptions]> {
         createSessionBinding(

--- a/TablePro/ContentView.swift
+++ b/TablePro/ContentView.swift
@@ -304,8 +304,6 @@ struct ContentView: View {
         )
     }
 
-
-
     private var sessionTableOperationOptionsBinding: Binding<[String: TableOperationOptions]> {
         createSessionBinding(
             get: { $0.tableOperationOptions },

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -18,6 +18,8 @@ struct NativeSearchField: NSViewRepresentable {
         field.delegate = context.coordinator
         field.bezelStyle = .roundedBezel
         field.controlSize = .regular
+        field.sendsSearchStringImmediately = true
+        field.setAccessibilityIdentifier("sidebar-filter")
         return field
     }
 
@@ -42,6 +44,11 @@ struct NativeSearchField: NSViewRepresentable {
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSSearchField else { return }
             text.wrappedValue = field.stringValue
+        }
+
+        func searchFieldDidEndSearching(_ sender: NSSearchField) {
+            text.wrappedValue = ""
+            sender.window?.makeFirstResponder(sender.superview)
         }
     }
 }

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -1,0 +1,47 @@
+//
+//  NativeSearchField.swift
+//  TablePro
+//
+//  Native NSSearchField wrapped for SwiftUI.
+//
+
+import AppKit
+import SwiftUI
+
+struct NativeSearchField: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let field = NSSearchField()
+        field.placeholderString = placeholder
+        field.delegate = context.coordinator
+        field.bezelStyle = .roundedBezel
+        field.controlSize = .regular
+        return field
+    }
+
+    func updateNSView(_ field: NSSearchField, context: Context) {
+        if field.stringValue != text {
+            field.stringValue = text
+        }
+        field.placeholderString = placeholder
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSSearchField else { return }
+            text.wrappedValue = field.stringValue
+        }
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -98,7 +98,9 @@ struct SidebarView: View {
                         get: { sidebarState.searchText },
                         set: { sidebarState.searchText = $0 }
                     ),
-                    placeholder: String(localized: "Filter")
+                    placeholder: sidebarState.selectedSidebarTab == .tables
+                        ? String(localized: "Filter")
+                        : String(localized: "Filter favorites")
                 )
                 .padding(.horizontal, 8)
                 .padding(.top, 6)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -78,11 +78,9 @@ struct SidebarView: View {
     // MARK: - Body
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ZStack {
             tablesContent
                 .opacity(sidebarState.selectedSidebarTab == .tables ? 1 : 0)
-                .frame(maxHeight: sidebarState.selectedSidebarTab == .tables ? .infinity : 0)
-                .clipped()
                 .allowsHitTesting(sidebarState.selectedSidebarTab == .tables)
 
             FavoritesTabView(
@@ -91,23 +89,33 @@ struct SidebarView: View {
                 coordinator: coordinator
             )
             .opacity(sidebarState.selectedSidebarTab == .favorites ? 1 : 0)
-            .frame(maxHeight: sidebarState.selectedSidebarTab == .favorites ? .infinity : 0)
-            .clipped()
             .allowsHitTesting(sidebarState.selectedSidebarTab == .favorites)
         }
-        .animation(.easeInOut(duration: 0.18), value: sidebarState.selectedSidebarTab)
         .safeAreaInset(edge: .top, spacing: 0) {
-            Picker("", selection: Binding(
-                get: { sidebarState.selectedSidebarTab },
-                set: { sidebarState.selectedSidebarTab = $0 }
-            )) {
-                Text("Tables").tag(SidebarTab.tables)
-                Text("Favorites").tag(SidebarTab.favorites)
+            VStack(spacing: 0) {
+                NativeSearchField(
+                    text: Binding(
+                        get: { sidebarState.searchText },
+                        set: { sidebarState.searchText = $0 }
+                    ),
+                    placeholder: String(localized: "Filter")
+                )
+                .padding(.horizontal, 8)
+                .padding(.top, 6)
+                .padding(.bottom, 4)
+
+                Picker("", selection: Binding(
+                    get: { sidebarState.selectedSidebarTab },
+                    set: { sidebarState.selectedSidebarTab = $0 }
+                )) {
+                    Text("Tables").tag(SidebarTab.tables)
+                    Text("Favorites").tag(SidebarTab.favorites)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
         }
         .frame(minWidth: 280)
         .onChange(of: sidebarState.searchText) { _, newValue in


### PR DESCRIPTION
## Summary

Fixes intermittent extra spacing above sidebar content when switching between native window tabs.

### Root cause
`.searchable(placement: .sidebar)` on `NavigationSplitView` causes SwiftUI to inconsistently calculate the sidebar top inset when native window tabs switch, producing a visible gap shift.

### Fix
- Replaced `.searchable(placement: .sidebar)` with a native `NSSearchField` (`NSViewRepresentable`) inside the sidebar's `safeAreaInset`
- Full control over layout, no SwiftUI internal inset recalculation
- Cleaned up ZStack tab switching (removed `.frame(maxHeight: 0)`, `.clipped()`, `.animation()`)

### Files
- `NativeSearchField.swift` (new) - native `NSSearchField` wrapper
- `SidebarView.swift` - custom search field in `safeAreaInset`
- `ContentView.swift` - removed `.searchable` and unused helpers

## Test plan
- [ ] Switch between multiple window tabs - no gap shift
- [ ] Filter field works (type, clear, placeholder)
- [ ] Tables/Favorites segmented control works
- [ ] Search filters both tables and favorites