### PR TITLE
fix(ios): SQLite file picker not updating after file selection

### DIFF
--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -29,6 +29,7 @@ struct ConnectionFormView: View {
         var id: Int { hashValue }
     }
     @State private var activeFilePicker: ActiveFilePicker?
+    @State private var pendingFilePicker: ActiveFilePicker?
     @State private var selectedFileURL: URL?
     @State private var showNewDatabaseAlert = false
     @State private var newDatabaseName = ""
@@ -252,7 +253,8 @@ struct ConnectionFormView: View {
                 allowedContentTypes: activeFilePicker == .sqliteDatabase ? sqliteContentTypes : [.data],
                 allowsMultipleSelection: false
             ) { result in
-                let picker = activeFilePicker
+                let picker = pendingFilePicker
+                pendingFilePicker = nil
                 activeFilePicker = nil
                 switch picker {
                 case .sqliteDatabase:
@@ -320,6 +322,7 @@ struct ConnectionFormView: View {
             }
 
             Button {
+                pendingFilePicker = .sqliteDatabase
                 activeFilePicker = .sqliteDatabase
             } label: {
                 Label("Open Database File", systemImage: "folder")
@@ -398,6 +401,7 @@ struct ConnectionFormView: View {
 
                     if sshKeyInputMode == .file {
                         Button {
+                            pendingFilePicker = .sshKey
                             activeFilePicker = .sshKey
                         } label: {
                             HStack {

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -255,7 +255,6 @@ struct ConnectionFormView: View {
             ) { result in
                 let picker = pendingFilePicker
                 pendingFilePicker = nil
-                activeFilePicker = nil
                 switch picker {
                 case .sqliteDatabase:
                     handleFilePickerResult(result)


### PR DESCRIPTION
## Summary
- Fix race condition in `.fileImporter` where SwiftUI dismisses the picker (setting `activeFilePicker = nil` via binding) **before** the result handler runs, causing the handler to always hit `case nil: break` and do nothing
- Add `pendingFilePicker` state that preserves which picker was requested, unaffected by the binding's dismiss logic
- Applies to both SQLite database file picker and SSH key file picker

## Test plan
- [ ] Open iOS app → create new SQLite connection → tap "Open Database File" → select a `.sqlite`/`.db` file → verify file name appears and `database` path is set
- [ ] Verify SSH key file import still works (tap Import File in SSH section → select key file)
- [ ] Verify "Create New Database" flow is unaffected