### PR TITLE
fix: preview SQL popover not presenting from toolbar button

### DIFF
--- a/TablePro/Views/Toolbar/TableProToolbarView.swift
+++ b/TablePro/Views/Toolbar/TableProToolbarView.swift
@@ -147,15 +147,17 @@ struct TableProToolbar: ViewModifier {
                 }
 
                 ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        actions?.previewSQL()
-                    } label: {
-                        let langName = PluginManager.shared.queryLanguageName(for: state.databaseType)
-                        Label("Preview \(langName)", systemImage: "eye")
+                    VStack {
+                        Button {
+                            actions?.previewSQL()
+                        } label: {
+                            let langName = PluginManager.shared.queryLanguageName(for: state.databaseType)
+                            Label("Preview \(langName)", systemImage: "eye")
+                        }
+                        .help(String(format: String(localized: "Preview %@ (⌘⇧P)"), PluginManager.shared.queryLanguageName(for: state.databaseType)))
+                        .disabled(!state.hasDataPendingChanges || state.connectionState != .connected)
                     }
-                    .help(String(format: String(localized: "Preview %@ (⌘⇧P)"), PluginManager.shared.queryLanguageName(for: state.databaseType)))
-                    .disabled(!state.hasDataPendingChanges || state.connectionState != .connected)
-                    .popover(isPresented: $state.showSQLReviewPopover, attachmentAnchor: .point(.bottom)) {
+                    .popover(isPresented: $state.showSQLReviewPopover) {
                         SQLReviewPopover(statements: state.previewStatements, databaseType: state.databaseType)
                     }
                 }


### PR DESCRIPTION
## Summary

The "Preview SQL" toolbar popover (eye icon / Cmd+Shift+P) never presents on macOS. Root cause: `.popover(isPresented:)` attached to a `.disabled()` button is silently ignored by SwiftUI — even when the binding is set programmatically.

## Fix

Move `.popover()` from the disabled `Button` to an always-enabled `VStack` wrapper so SwiftUI can anchor the popover regardless of button state.

```swift
// Before — popover on disabled button, never presents
Button { ... }
    .disabled(!state.hasDataPendingChanges || ...)
    .popover(isPresented: $state.showSQLReviewPopover, attachmentAnchor: .point(.bottom)) { ... }

// After — popover on always-enabled wrapper, presents correctly
VStack {
    Button { ... }
        .disabled(!state.hasDataPendingChanges || ...)
}
.popover(isPresented: $state.showSQLReviewPopover) { ... }
```

Also removes `attachmentAnchor: .point(.bottom)` which caused incorrect anchor positioning in macOS toolbars.

## Why this is correct

- `VStack` with a single child is a layout no-op — identical frame as the button
- `.disabled()` stays on the `Button` — native grayed-out appearance and VoiceOver semantics preserved
- `.help()` stays on the `Button` — tooltip properly associated
- Default popover anchor (`.rect(.bounds)`) works correctly in toolbars

## Test plan

- [ ] Connect to a database, open a table, edit a cell → click preview button → popover appears
- [ ] Press Cmd+Shift+P → popover appears
- [ ] Verify button is grayed out when no pending changes
- [ ] Open Structure view → make a schema change → click preview → popover appears
- [ ] Verify popover anchors correctly below the eye icon