### PR TITLE
fix: SSH Agent auth falls back to key file when agent has no loaded identities (#729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix AI chat hanging the app during streaming, schema fetch, and conversation loading (#735)
+- SSH Agent auth: fall back to key file from `~/.ssh/config` or default paths when agent has no loaded identities (#729)
 - SSH-tunneled connections failing to reconnect after idle/sleep — health monitor now rebuilds the tunnel, OS-level TCP keepalive detects dead NAT mappings, and wake-from-sleep triggers immediate validation (#736)
 
 ## [0.31.4] - 2026-04-14

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -556,11 +556,12 @@ internal enum LibSSH2TunnelFactory {
             return identityFile
         }
 
-        let home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh", isDirectory: true)
         let defaultPaths = [
-            "\(home).ssh/id_ed25519",
-            "\(home).ssh/id_rsa",
-            "\(home).ssh/id_ecdsa",
+            sshDir.appendingPathComponent("id_ed25519").path,
+            sshDir.appendingPathComponent("id_rsa").path,
+            sshDir.appendingPathComponent("id_ecdsa").path
         ]
         for path in defaultPaths {
             if FileManager.default.isReadableFile(atPath: path) {

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -493,15 +493,26 @@ internal enum LibSSH2TunnelFactory {
 
         case .sshAgent:
             let socketPath = config.agentSocketPath.isEmpty ? nil : config.agentSocketPath
-            let primary = AgentAuthenticator(socketPath: socketPath)
+            var authenticators: [any SSHAuthenticator] = [AgentAuthenticator(socketPath: socketPath)]
+
+            // Fallback: try key file if agent has no loaded identities
+            if let keyPath = resolveIdentityFile(config: config) {
+                authenticators.append(PublicKeyAuthenticator(
+                    privateKeyPath: keyPath,
+                    passphrase: credentials.keyPassphrase
+                ))
+            }
+
             if config.totpMode != .none {
-                let totpAuth = KeyboardInteractiveAuthenticator(
+                authenticators.append(KeyboardInteractiveAuthenticator(
                     password: nil,
                     totpProvider: buildTOTPProvider(config: config, credentials: credentials)
-                )
-                return CompositeAuthenticator(authenticators: [primary, totpAuth])
+                ))
             }
-            return primary
+
+            return authenticators.count == 1
+                ? authenticators[0]
+                : CompositeAuthenticator(authenticators: authenticators)
 
         case .keyboardInteractive:
             let totpProvider = buildTOTPProvider(config: config, credentials: credentials)
@@ -520,8 +531,44 @@ internal enum LibSSH2TunnelFactory {
                 passphrase: nil
             )
         case .sshAgent:
-            return AgentAuthenticator(socketPath: nil)
+            let agent = AgentAuthenticator(socketPath: nil)
+            if !jumpHost.privateKeyPath.isEmpty {
+                let keyAuth = PublicKeyAuthenticator(
+                    privateKeyPath: jumpHost.privateKeyPath,
+                    passphrase: nil
+                )
+                return CompositeAuthenticator(authenticators: [agent, keyAuth])
+            }
+            return agent
         }
+    }
+
+    /// Resolve an identity file path for agent auth fallback.
+    /// Priority: user-configured path > ~/.ssh/config IdentityFile > default key paths.
+    private static func resolveIdentityFile(config: SSHConfiguration) -> String? {
+        if !config.privateKeyPath.isEmpty {
+            return config.privateKeyPath
+        }
+
+        if let entry = SSHConfigParser.findEntry(for: config.host),
+           let identityFile = entry.identityFile,
+           !identityFile.isEmpty {
+            return identityFile
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+        let defaultPaths = [
+            "\(home).ssh/id_ed25519",
+            "\(home).ssh/id_rsa",
+            "\(home).ssh/id_ecdsa",
+        ]
+        for path in defaultPaths {
+            if FileManager.default.isReadableFile(atPath: path) {
+                return path
+            }
+        }
+
+        return nil
     }
 
     private static func buildTOTPProvider(


### PR DESCRIPTION
## Summary

- When SSH Agent auth fails (no loaded identities), fall back to key file authentication using `CompositeAuthenticator` (agent → key file chain)
- Identity file resolution priority: user-configured path → `IdentityFile` from `~/.ssh/config` → default paths (`~/.ssh/id_ed25519`, `id_rsa`, `id_ecdsa`)
- Also adds key file fallback for jump host SSH Agent auth
- Matches OpenSSH behavior: agent is tried first, then key files

Fixes #729

## Root cause

`buildAuthenticator()` returned a standalone `AgentAuthenticator` with no fallback. When the agent had no loaded identities (passphrase-protected key not yet unlocked via `ssh-add`), auth failed immediately. OpenSSH handles this by trying `IdentityFile` from config and default key paths automatically.

## Test plan

- [ ] `ssh-add -D` (clear agent) → Test Connection with SSH Agent → should succeed via key file fallback
- [ ] `ssh-add ~/.ssh/id_ed25519` (load key) → Test Connection → should succeed via agent (no fallback needed)
- [ ] Test with `~/.ssh/config` `IdentityFile` directive pointing to a non-default key path
- [ ] Test SSH Agent + TOTP combo still works
- [ ] Test jump host with SSH Agent auth