### PR TITLE
fix: sidebar gap when switching between table and query tabs (#759)

### DIFF
--- a/TablePro/Views/Toolbar/TableProToolbarView.swift
+++ b/TablePro/Views/Toolbar/TableProToolbarView.swift
@@ -162,19 +162,23 @@ struct TableProToolbar: ViewModifier {
                     }
                 }
 
-                if !state.isTableTab {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button { actions?.toggleResults() } label: {
-                            Label(
-                                "Results",
-                                systemImage: state.isResultsCollapsed
-                                    ? "rectangle.bottomhalf.inset.filled"
-                                    : "rectangle.inset.filled"
-                            )
-                        }
-                        .help(String(localized: "Toggle Results (⌘⌥R)"))
-                        .disabled(state.connectionState != .connected)
+                // Always include this ToolbarItem to keep the toolbar layout
+                // stable across tab types. Conditionally adding/removing
+                // ToolbarItems causes NavigationSplitView to recalculate the
+                // sidebar's top safe-area inset, producing a visible gap (#759).
+                ToolbarItem(placement: .primaryAction) {
+                    Button { actions?.toggleResults() } label: {
+                        Label(
+                            "Results",
+                            systemImage: state.isResultsCollapsed
+                                ? "rectangle.bottomhalf.inset.filled"
+                                : "rectangle.inset.filled"
+                        )
                     }
+                    .help(String(localized: "Toggle Results (⌘⌥R)"))
+                    .disabled(state.connectionState != .connected)
+                    .opacity(state.isTableTab ? 0 : 1)
+                    .allowsHitTesting(!state.isTableTab)
                 }
 
                 ToolbarItem(placement: .primaryAction) {


### PR DESCRIPTION
## Summary

The \"Toggle Results\" toolbar button was conditionally added/removed based on tab type. `NavigationSplitView`'s `NSSplitViewController` recalculates the sidebar's top safe-area inset whenever toolbar items change on the detail column, producing a visible gap shift.

Always include the button but hide it on table tabs with `opacity(0)` + `allowsHitTesting(false)`. Toolbar layout stays stable across tab switches.

**1 file, 16 additions, 12 deletions.**

## Test plan
- [ ] Switch between table tab and query tab — no gap shift in sidebar
- [ ] "Toggle Results" button visible and functional on query tabs
- [ ] "Toggle Results" button invisible and non-interactive on table tabs
- [ ] Multiple window tabs — gap consistent across all

Closes #759