### PR TITLE
fix: import system error handling, decompression, and correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Import parser now surfaces file read and encoding errors instead of silently succeeding
+- Compressed (.gz) files are only decompressed once instead of twice
+- Import progress estimate uses decompressed file size for accurate progress
+- Transaction rollback error is now correctly reported
+- Foreign key checks are properly restored after failed import
+- File decompression no longer blocks Swift concurrency thread pool
 - Cmd+W closing the connection window instead of clearing to empty state
 - ER Diagram and Server Dashboard replacing the current tab instead of opening a new one
 - Welcome window stealing focus on connect, disabling Cmd+T until manual click

--- a/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
@@ -536,7 +536,7 @@ public extension PluginDatabaseDriver {
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
-            Task {
+            let task = Task {
                 do {
                     let batchSize = 1_000
                     let firstPage = try await fetchRows(query: query, offset: 0, limit: batchSize)
@@ -567,6 +567,9 @@ public extension PluginDatabaseDriver {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
             }
         }
     }

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -170,6 +170,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
                     let batchSize = settings.batchSize
                     var wroteAnyRows = false
                     var columns: [String] = []
+                    var columnTypeNames: [String] = []
                     var rowBatch: [[String?]] = []
 
                     let stream = dataSource.streamRows(table: table.name, databaseName: table.databaseName)
@@ -179,6 +180,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
                         switch element {
                         case .header(let header):
                             columns = header.columns
+                            columnTypeNames = header.columnTypeNames ?? []
                         case .rows(let rows):
                             for row in rows {
                                 rowBatch.append(row)
@@ -186,6 +188,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
                                     try writeInsertStatements(
                                         tableName: table.name,
                                         columns: columns,
+                                        columnTypeNames: columnTypeNames,
                                         rows: rowBatch,
                                         batchSize: batchSize,
                                         dataSource: dataSource,
@@ -203,6 +206,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
                         try writeInsertStatements(
                             tableName: table.name,
                             columns: columns,
+                            columnTypeNames: columnTypeNames,
                             rows: rowBatch,
                             batchSize: batchSize,
                             dataSource: dataSource,
@@ -261,6 +265,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
     private func writeInsertStatements(
         tableName: String,
         columns: [String],
+        columnTypeNames: [String],
         rows: [[String?]],
         batchSize: Int,
         dataSource: any PluginExportDataSource,
@@ -274,6 +279,10 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
 
         let insertPrefix = "INSERT INTO \(tableRef) (\(quotedColumns)) VALUES\n"
 
+        let numericIndices: Set<Int> = Set(columnTypeNames.enumerated().compactMap { index, typeName in
+            isNumericColumnType(typeName) ? index : nil
+        })
+
         let effectiveBatchSize = batchSize <= 1 ? 1 : batchSize
         var valuesBatch: [String] = []
         valuesBatch.reserveCapacity(effectiveBatchSize)
@@ -281,8 +290,11 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
         for row in rows {
             try progress.checkCancellation()
 
-            let values = row.map { value -> String in
+            let values = row.enumerated().map { colIndex, value -> String in
                 guard let val = value else { return "NULL" }
+                if numericIndices.contains(colIndex) && isNumericLiteral(val) {
+                    return val
+                }
                 let escaped = dataSource.escapeStringLiteral(val)
                 return "'\(escaped)'"
             }.joined(separator: ", ")
@@ -302,6 +314,19 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
             let statement = insertPrefix + valuesBatch.joined(separator: ",\n") + ";\n\n"
             try fileHandle.write(contentsOf: statement.toUTF8Data())
         }
+    }
+
+    private func isNumericColumnType(_ typeName: String) -> Bool {
+        let numericPrefixes = [
+            "int", "bigint", "decimal", "float", "double", "numeric",
+            "real", "smallint", "tinyint", "mediumint", "integer", "number"
+        ]
+        let lower = typeName.lowercased()
+        return numericPrefixes.contains { lower.hasPrefix($0) }
+    }
+
+    private func isNumericLiteral(_ val: String) -> Bool {
+        val.allSatisfy { $0.isNumber || $0 == "." || $0 == "-" || $0 == "+" || $0 == "e" || $0 == "E" }
     }
 
     private func compressFile(source: URL, destination: URL) async throws {

--- a/Plugins/SQLImportPlugin/SQLImportPlugin.swift
+++ b/Plugins/SQLImportPlugin/SQLImportPlugin.swift
@@ -4,11 +4,14 @@
 //
 
 import Foundation
+import os
 import SwiftUI
 import TableProPluginKit
 
 @Observable
 final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SQLImportPlugin")
+
     static let pluginName = "SQL Import"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Import data from SQL files"
@@ -89,14 +92,19 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
             if settings.wrapInTransaction {
                 do {
                     try await sink.rollbackTransaction()
-                } catch {
-                    throw PluginImportError.rollbackFailed(underlyingError: importError)
+                } catch let rollbackError {
+                    Self.logger.error("Import failed: \(importError.localizedDescription). Rollback also failed.")
+                    throw PluginImportError.rollbackFailed(underlyingError: rollbackError)
                 }
             }
 
-            // Re-enable FK checks (best-effort)
+            // Re-enable FK checks
             if settings.disableForeignKeyChecks {
-                try? await sink.enableForeignKeyChecks()
+                do {
+                    try await sink.enableForeignKeyChecks()
+                } catch {
+                    Self.logger.warning("Failed to re-enable foreign key checks: \(error.localizedDescription)")
+                }
             }
 
             // Re-throw cancellation as-is, wrap others

--- a/Plugins/SQLImportPlugin/SQLImportPlugin.swift
+++ b/Plugins/SQLImportPlugin/SQLImportPlugin.swift
@@ -87,18 +87,17 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
             }
         } catch {
             let importError = error
+            var rollbackError: Error?
 
-            // Rollback on error
             if settings.wrapInTransaction {
                 do {
                     try await sink.rollbackTransaction()
-                } catch let rollbackError {
+                } catch {
                     Self.logger.error("Import failed: \(importError.localizedDescription). Rollback also failed.")
-                    throw PluginImportError.rollbackFailed(underlyingError: rollbackError)
+                    rollbackError = error
                 }
             }
 
-            // Re-enable FK checks
             if settings.disableForeignKeyChecks {
                 do {
                     try await sink.enableForeignKeyChecks()
@@ -107,7 +106,9 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
                 }
             }
 
-            // Re-throw cancellation as-is, wrap others
+            if let rollbackError {
+                throw PluginImportError.rollbackFailed(underlyingError: rollbackError)
+            }
             if importError is PluginImportCancellationError {
                 throw importError
             }

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -466,7 +466,7 @@ public extension PluginDatabaseDriver {
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
-            Task {
+            let task = Task {
                 do {
                     let batchSize = 1_000
                     let firstPage = try await fetchRows(query: query, offset: 0, limit: batchSize)
@@ -497,6 +497,9 @@ public extension PluginDatabaseDriver {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
             }
         }
     }

--- a/Plugins/TableProPluginKit/PluginImportProgress.swift
+++ b/Plugins/TableProPluginKit/PluginImportProgress.swift
@@ -11,7 +11,9 @@ public final class PluginImportProgress: @unchecked Sendable {
     }
 
     public func setEstimatedTotal(_ count: Int) {
-        progress.totalUnitCount = Int64(count)
+        if progress.totalUnitCount <= 0 {
+            progress.totalUnitCount = Int64(count)
+        }
     }
 
     public func incrementStatement() {

--- a/Plugins/XLSXExportPlugin/XLSXExportPlugin.swift
+++ b/Plugins/XLSXExportPlugin/XLSXExportPlugin.swift
@@ -102,10 +102,11 @@ final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin {
                                 currentSheetRowCount += overflow.count
                             }
                         }
-                        for _ in rowBatch {
+                        let batchCount = rowBatch.count
+                        rowBatch.removeAll(keepingCapacity: true)
+                        for _ in 0..<batchCount {
                             progress.incrementRow()
                         }
-                        rowBatch.removeAll(keepingCapacity: true)
                     }
                 }
             }
@@ -140,7 +141,7 @@ final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin {
                         currentSheetRowCount += overflow.count
                     }
                 }
-                for _ in rowBatch {
+                for _ in 0..<rowBatch.count {
                     progress.incrementRow()
                 }
             }

--- a/TablePro/Core/Plugins/SqlFileImportSource.swift
+++ b/TablePro/Core/Plugins/SqlFileImportSource.swift
@@ -18,11 +18,11 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
     private let _decompressedURL = OSAllocatedUnfairLock<URL?>(initialState: nil)
     private let ownsDecompressedFile: Bool
 
-    init(url: URL, encoding: String.Encoding, decompressedURL: URL? = nil) {
+    init(url: URL, encoding: String.Encoding, decompressedURL: URL? = nil, ownsDecompressedFile: Bool? = nil) {
         self.url = url
         self.encoding = encoding
         self.externalDecompressedURL = decompressedURL
-        self.ownsDecompressedFile = decompressedURL == nil
+        self.ownsDecompressedFile = ownsDecompressedFile ?? (decompressedURL == nil)
     }
 
     func fileURL() -> URL {
@@ -54,9 +54,9 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
             return url
         }
 
-        if let tempURL {
+        for fileURL in [tempURL, externalDecompressedURL].compactMap({ $0 }) {
             do {
-                try FileManager.default.removeItem(at: tempURL)
+                try FileManager.default.removeItem(at: fileURL)
             } catch {
                 Self.logger.warning("Failed to clean up temp file: \(error.localizedDescription)")
             }
@@ -66,8 +66,8 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
     deinit {
         guard ownsDecompressedFile else { return }
         let tempURL = _decompressedURL.withLock { $0 }
-        if let tempURL {
-            try? FileManager.default.removeItem(at: tempURL)
+        for fileURL in [tempURL, externalDecompressedURL].compactMap({ $0 }) {
+            try? FileManager.default.removeItem(at: fileURL)
         }
     }
 

--- a/TablePro/Core/Plugins/SqlFileImportSource.swift
+++ b/TablePro/Core/Plugins/SqlFileImportSource.swift
@@ -14,11 +14,15 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
     private let encoding: String.Encoding
     private let parser = SQLFileParser()
 
+    private let externalDecompressedURL: URL?
     private let _decompressedURL = OSAllocatedUnfairLock<URL?>(initialState: nil)
+    private let ownsDecompressedFile: Bool
 
-    init(url: URL, encoding: String.Encoding) {
+    init(url: URL, encoding: String.Encoding, decompressedURL: URL? = nil) {
         self.url = url
         self.encoding = encoding
+        self.externalDecompressedURL = decompressedURL
+        self.ownsDecompressedFile = decompressedURL == nil
     }
 
     func fileURL() -> URL {
@@ -26,31 +30,24 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
     }
 
     func fileSizeBytes() -> Int64 {
+        let targetURL = effectiveURL
         do {
-            let attrs = try FileManager.default.attributesOfItem(atPath: url.path(percentEncoded: false))
+            let attrs = try FileManager.default.attributesOfItem(atPath: targetURL.path(percentEncoded: false))
             return attrs[.size] as? Int64 ?? 0
         } catch {
-            Self.logger.warning("Failed to get file size for \(self.url.path(percentEncoded: false)): \(error.localizedDescription)")
+            Self.logger.warning("Failed to get file size for \(targetURL.path(percentEncoded: false)): \(error.localizedDescription)")
             return 0
         }
     }
 
     func statements() async throws -> AsyncThrowingStream<(statement: String, lineNumber: Int), Error> {
-        let fileURL = try await decompressIfNeeded()
-
-        let stream = try await parser.parseFile(url: fileURL, encoding: encoding)
-
-        return AsyncThrowingStream { continuation in
-            Task {
-                for try await item in stream {
-                    continuation.yield(item)
-                }
-                continuation.finish()
-            }
-        }
+        let fileURL = try await resolveURL()
+        return parser.parseFile(url: fileURL, encoding: encoding)
     }
 
     func cleanup() {
+        guard ownsDecompressedFile else { return }
+
         let tempURL = _decompressedURL.withLock {
             let url = $0
             $0 = nil
@@ -67,6 +64,7 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
     }
 
     deinit {
+        guard ownsDecompressedFile else { return }
         let tempURL = _decompressedURL.withLock { $0 }
         if let tempURL {
             try? FileManager.default.removeItem(at: tempURL)
@@ -75,7 +73,21 @@ final class SqlFileImportSource: PluginImportSource, @unchecked Sendable {
 
     // MARK: - Private
 
-    private func decompressIfNeeded() async throws -> URL {
+    private var effectiveURL: URL {
+        if let external = externalDecompressedURL {
+            return external
+        }
+        if let decompressed = _decompressedURL.withLock({ $0 }) {
+            return decompressed
+        }
+        return url
+    }
+
+    private func resolveURL() async throws -> URL {
+        if let external = externalDecompressedURL {
+            return external
+        }
+
         if let existing = _decompressedURL.withLock({ $0 }) {
             return existing
         }

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -167,11 +167,6 @@ final class ExportService {
                 progress: progress
             )
         } catch {
-            do {
-                try FileManager.default.removeItem(at: url)
-            } catch {
-                Self.logger.warning("Failed to clean up export file: \(error.localizedDescription)")
-            }
             state.errorMessage = error.localizedDescription
             throw error
         }
@@ -250,11 +245,6 @@ final class ExportService {
                 progress: progress
             )
         } catch {
-            do {
-                try FileManager.default.removeItem(at: url)
-            } catch {
-                Self.logger.warning("Failed to clean up export file: \(error.localizedDescription)")
-            }
             state.errorMessage = error.localizedDescription
             throw error
         }

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -49,7 +49,8 @@ final class ImportService {
         from url: URL,
         formatId: String,
         encoding: String.Encoding,
-        decompressedURL: URL? = nil
+        decompressedURL: URL? = nil,
+        knownStatementCount: Int? = nil
     ) async throws -> PluginImportResult {
         guard let plugin = PluginManager.shared.importPlugins[formatId] else {
             throw PluginImportError.importFailed("Import format '\(formatId)' not found")
@@ -72,8 +73,12 @@ final class ImportService {
         defer { source.cleanup() }
 
         // Create progress tracker
-        let nsProgress = Progress(totalUnitCount: 0)
+        let initialTotal = Int64(knownStatementCount ?? 0)
+        let nsProgress = Progress(totalUnitCount: initialTotal)
         let progress = PluginImportProgress(progress: nsProgress)
+        if knownStatementCount != nil {
+            state.estimatedTotalStatements = Int(initialTotal)
+        }
         currentProgress = progress
 
         let observation = nsProgress.observe(\.completedUnitCount) { [weak self] observed, _ in
@@ -91,12 +96,10 @@ final class ImportService {
         defer { observation.invalidate() }
 
         let statusObservation = nsProgress.observe(\.localizedAdditionalDescription) { [weak self] observed, _ in
+            let status = observed.localizedAdditionalDescription ?? ""
             Task { @MainActor [weak self] in
-                guard let self else { return }
-                let status = observed.localizedAdditionalDescription ?? ""
-                if !status.isEmpty {
-                    self.state.statusMessage = status
-                }
+                guard let self, !status.isEmpty else { return }
+                self.state.statusMessage = status
             }
         }
         defer { statusObservation.invalidate() }

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -48,7 +48,8 @@ final class ImportService {
     func importFile(
         from url: URL,
         formatId: String,
-        encoding: String.Encoding
+        encoding: String.Encoding,
+        decompressedURL: URL? = nil
     ) async throws -> PluginImportResult {
         guard let plugin = PluginManager.shared.importPlugins[formatId] else {
             throw PluginImportError.importFailed("Import format '\(formatId)' not found")
@@ -67,7 +68,7 @@ final class ImportService {
 
         // Create adapter and source
         let sink = ImportDataSinkAdapter(driver: driver, databaseType: connection.type)
-        let source = SqlFileImportSource(url: url, encoding: encoding)
+        let source = SqlFileImportSource(url: url, encoding: encoding, decompressedURL: decompressedURL)
         defer { source.cleanup() }
 
         // Create progress tracker

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -50,6 +50,7 @@ final class ImportService {
         formatId: String,
         encoding: String.Encoding,
         decompressedURL: URL? = nil,
+        ownsDecompressedFile: Bool = false,
         knownStatementCount: Int? = nil
     ) async throws -> PluginImportResult {
         guard let plugin = PluginManager.shared.importPlugins[formatId] else {
@@ -69,7 +70,7 @@ final class ImportService {
 
         // Create adapter and source
         let sink = ImportDataSinkAdapter(driver: driver, databaseType: connection.type)
-        let source = SqlFileImportSource(url: url, encoding: encoding, decompressedURL: decompressedURL)
+        let source = SqlFileImportSource(url: url, encoding: encoding, decompressedURL: decompressedURL, ownsDecompressedFile: ownsDecompressedFile)
         defer { source.cleanup() }
 
         // Create progress tracker

--- a/TablePro/Core/Utilities/File/FileDecompressor.swift
+++ b/TablePro/Core/Utilities/File/FileDecompressor.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import os
 
 enum DecompressionError: LocalizedError {
     case decompressFailed
@@ -24,65 +23,34 @@ enum DecompressionError: LocalizedError {
 
 /// Utility for decompressing gzip-compressed files
 enum FileDecompressor {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "FileDecompressor")
+    /// Derive the inner extension from a .gz filename (e.g., "dump.sql.gz" -> "sql")
+    private static func innerExtension(for url: URL) -> String {
+        let name = url.deletingPathExtension().pathExtension
+        return name.isEmpty ? "sql" : name
+    }
+
     /// Decompress a .gz file to a temporary location
     /// - Parameters:
     ///   - url: URL to the .gz file
     ///   - fileSystemPath: Helper function to get filesystem path for URL
     /// - Returns: URL to the decompressed temporary file, or original URL if not compressed
-    /// - Throws: ImportError if decompression fails
+    /// - Throws: DecompressionError or GzipProcess.GzipError if decompression fails
     static func decompressIfNeeded(
         _ url: URL,
         fileSystemPath: (URL) -> String
     ) async throws -> URL {
         guard url.pathExtension == "gz" else { return url }
 
-        // Check if gunzip exists
-        let gunzipPath = "/usr/bin/gunzip"
-        guard FileManager.default.fileExists(atPath: gunzipPath) else {
-            throw DecompressionError.fileReadFailed("gunzip not found at \(gunzipPath)")
+        let ext = innerExtension(for: url)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + "." + ext)
+
+        do {
+            try await GzipProcess.decompress(source: url, destination: tempURL)
+        } catch {
+            throw DecompressionError.fileReadFailed(error.localizedDescription)
         }
 
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + ".sql")
-
-        // Get filesystem path using provided helper
-        let filePath = fileSystemPath(url)
-
-        return try await Task.detached {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: gunzipPath)
-            process.arguments = ["-c", filePath]
-
-            let fileManager = FileManager.default
-            guard fileManager.createFile(atPath: tempURL.path, contents: nil, attributes: nil) else {
-                throw DecompressionError.decompressFailed
-            }
-            let outputFile = try FileHandle(forWritingTo: tempURL)
-            defer {
-                do {
-                    try outputFile.close()
-                } catch {
-                    logger.warning("Failed to close decompressed output file handle at \(tempURL.path): \(error)")
-                }
-            }
-
-            process.standardOutput = outputFile
-
-            let errorPipe = Pipe()
-            process.standardError = errorPipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            guard process.terminationStatus == 0 else {
-                // Try to read error message
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                throw DecompressionError.fileReadFailed("Failed to decompress .gz file: \(errorMessage)")
-            }
-
-            return tempURL
-        }.value
+        return tempURL
     }
 }

--- a/TablePro/Core/Utilities/SQL/SQLFileParser.swift
+++ b/TablePro/Core/Utilities/SQL/SQLFileParser.swift
@@ -81,14 +81,14 @@ final class SQLFileParser: Sendable {
     ///   - url: File URL to parse
     ///   - encoding: Text encoding to use
     ///   - countOnly: When true, skips building statement strings for faster counting
-    /// - Returns: AsyncStream of (statement, lineNumber) tuples
+    /// - Returns: AsyncThrowingStream of (statement, lineNumber) tuples
     func parseFile(
         url: URL,
         encoding: String.Encoding,
         countOnly: Bool = false
-    ) async throws -> AsyncStream<(statement: String, lineNumber: Int)> {
-        AsyncStream { continuation in
-            Task.detached {
+    ) -> AsyncThrowingStream<(statement: String, lineNumber: Int), Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task.detached {
                 do {
                     let fileHandle = try FileHandle(forReadingFrom: url)
                     defer {
@@ -100,7 +100,6 @@ final class SQLFileParser: Sendable {
                     }
 
                     var state: ParserState = .normal
-                    // nil when countOnly — skips all string building via optional chaining
                     let currentStatement: NSMutableString? = countOnly ? nil : NSMutableString()
                     var hasStatementContent = false
                     var currentLine = 1
@@ -130,7 +129,6 @@ final class SQLFileParser: Sendable {
                             let char = nsBuffer.character(at: i)
                             let nextChar: unichar? = (i + 1 < bufLen) ? nsBuffer.character(at: i + 1) : nil
 
-                            // Defer processing if at chunk boundary with a multi-char start
                             if nextChar == nil && Self.isMultiCharSequenceStart(char) {
                                 break
                             }
@@ -238,7 +236,6 @@ final class SQLFileParser: Sendable {
                             }
                         }
 
-                        // Keep unprocessed characters for next chunk
                         if i < bufLen {
                             nsBuffer.deleteCharacters(in: NSRange(location: 0, length: i))
                         } else {
@@ -246,7 +243,6 @@ final class SQLFileParser: Sendable {
                         }
                     }
 
-                    // Add final statement if any
                     if hasStatementContent {
                         let text = (currentStatement as NSString?)?
                             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -257,8 +253,12 @@ final class SQLFileParser: Sendable {
                 } catch {
                     Self.logger.error("SQL file parsing failed: \(error.localizedDescription)")
                     Self.logger.error("Error details: \(error)")
-                    continuation.finish()
+                    continuation.finish(throwing: error)
                 }
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
             }
         }
     }
@@ -271,7 +271,7 @@ final class SQLFileParser: Sendable {
     func countStatements(url: URL, encoding: String.Encoding) async throws -> Int {
         var count = 0
 
-        for await _ in try await parseFile(url: url, encoding: encoding, countOnly: true) {
+        for try await _ in parseFile(url: url, encoding: encoding, countOnly: true) {
             try Task.checkCancellation()
             count += 1
         }

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -409,7 +409,8 @@ struct ImportDialog: View {
                     from: url,
                     formatId: selectedFormatId,
                     encoding: selectedEncoding.encoding,
-                    decompressedURL: tempPreviewURL
+                    decompressedURL: tempPreviewURL,
+                    knownStatementCount: statementCount > 0 ? statementCount : nil
                 )
 
                 await MainActor.run {

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -36,6 +36,7 @@ struct ImportDialog: View {
     @State private var tempPreviewURL: URL?
     @State private var loadFileTask: Task<Void, Never>?
     @State private var countStatementsTask: Task<Void, Never>?
+    @State private var importTask: Task<Void, Never>?
 
     // MARK: - Import Service
 
@@ -88,17 +89,16 @@ struct ImportDialog: View {
         .onDisappear {
             loadFileTask?.cancel()
             countStatementsTask?.cancel()
+            importTask?.cancel()
             cleanupTempFiles()
         }
         .sheet(isPresented: $showProgressDialog) {
-            ImportProgressView(
-                processedStatements: importService?.state.processedStatements ?? 0,
-                estimatedTotalStatements: importService?.state.estimatedTotalStatements ?? 0,
-                statusMessage: importService?.state.statusMessage ?? ""
-            ) {
-                importService?.cancelImport()
+            if let service = importService {
+                ImportProgressView(service: service) {
+                    service.cancelImport()
+                }
+                .interactiveDismissDisabled()
             }
-            .interactiveDismissDisabled()
         }
         .sheet(isPresented: $showSuccessDialog) {
             ImportSuccessView(
@@ -401,15 +401,20 @@ struct ImportDialog: View {
         let service = ImportService(connection: connection)
         importService = service
 
+        let decompressedURL = tempPreviewURL
+        let ownsDecompressedFile = decompressedURL != nil
+        tempPreviewURL = nil
+
         showProgressDialog = true
 
-        Task {
+        importTask = Task {
             do {
                 let result = try await service.importFile(
                     from: url,
                     formatId: selectedFormatId,
                     encoding: selectedEncoding.encoding,
-                    decompressedURL: tempPreviewURL,
+                    decompressedURL: decompressedURL,
+                    ownsDecompressedFile: ownsDecompressedFile,
                     knownStatementCount: statementCount > 0 ? statementCount : nil
                 )
 

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -35,6 +35,7 @@ struct ImportDialog: View {
     @State private var hasPreviewError = false
     @State private var tempPreviewURL: URL?
     @State private var loadFileTask: Task<Void, Never>?
+    @State private var countStatementsTask: Task<Void, Never>?
 
     // MARK: - Import Service
 
@@ -86,6 +87,7 @@ struct ImportDialog: View {
         }
         .onDisappear {
             loadFileTask?.cancel()
+            countStatementsTask?.cancel()
             cleanupTempFiles()
         }
         .sheet(isPresented: $showProgressDialog) {
@@ -367,7 +369,8 @@ struct ImportDialog: View {
             hasPreviewError = true
         }
 
-        Task {
+        countStatementsTask?.cancel()
+        countStatementsTask = Task {
             await countStatements(url: urlToRead)
         }
     }
@@ -405,7 +408,8 @@ struct ImportDialog: View {
                 let result = try await service.importFile(
                     from: url,
                     formatId: selectedFormatId,
-                    encoding: selectedEncoding.encoding
+                    encoding: selectedEncoding.encoding,
+                    decompressedURL: tempPreviewURL
                 )
 
                 await MainActor.run {

--- a/TablePro/Views/Import/ImportProgressView.swift
+++ b/TablePro/Views/Import/ImportProgressView.swift
@@ -8,9 +8,7 @@
 import SwiftUI
 
 struct ImportProgressView: View {
-    let processedStatements: Int
-    let estimatedTotalStatements: Int
-    let statusMessage: String
+    let service: ImportService
     let onStop: () -> Void
 
     var body: some View {
@@ -20,19 +18,19 @@ struct ImportProgressView: View {
 
             VStack(spacing: 8) {
                 HStack {
-                    if !statusMessage.isEmpty {
-                        Text(statusMessage)
+                    if !service.state.statusMessage.isEmpty {
+                        Text(service.state.statusMessage)
                             .font(.system(size: ThemeEngine.shared.activeTheme.typography.body))
                             .foregroundStyle(.secondary)
                     } else {
-                        Text("Executed \(processedStatements) statements")
+                        Text("Executed \(service.state.processedStatements) statements")
                             .font(.system(size: ThemeEngine.shared.activeTheme.typography.body))
 
                         Spacer()
                     }
                 }
 
-                if !statusMessage.isEmpty {
+                if !service.state.statusMessage.isEmpty {
                     ProgressView()
                         .progressViewStyle(.linear)
                 } else {
@@ -52,7 +50,7 @@ struct ImportProgressView: View {
     }
 
     private var progressValue: Double {
-        guard estimatedTotalStatements > 0 else { return 0 }
-        return min(1.0, Double(processedStatements) / Double(estimatedTotalStatements))
+        guard service.state.estimatedTotalStatements > 0 else { return 0 }
+        return min(1.0, Double(service.state.processedStatements) / Double(service.state.estimatedTotalStatements))
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import Foundation
+import TableProPluginKit
 import UniformTypeIdentifiers
 
 extension MainContentCoordinator {
@@ -121,8 +122,12 @@ extension MainContentCoordinator {
         }
         let panel = NSOpenPanel()
         var contentTypes: [UTType] = []
-        if let sqlType = UTType(filenameExtension: "sql") {
-            contentTypes.append(sqlType)
+        for (_, plugin) in PluginManager.shared.importPlugins {
+            for ext in type(of: plugin).acceptedFileExtensions {
+                if let utType = UTType(filenameExtension: ext) {
+                    contentTypes.append(utType)
+                }
+            }
         }
         if let gzType = UTType(filenameExtension: "gz") {
             contentTypes.append(gzType)

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -176,8 +176,15 @@ struct MainContentView: View {
                 )
             }
         case .importDialog:
+            let importDismiss = Binding<Bool>(
+                get: { coordinator.activeSheet != nil },
+                set: { if !$0 {
+                    coordinator.activeSheet = nil
+                    coordinator.importFileURL = nil
+                }}
+            )
             ImportDialog(
-                isPresented: dismissBinding,
+                isPresented: importDismiss,
                 connection: connection,
                 initialFileURL: coordinator.importFileURL
             )


### PR DESCRIPTION
## Summary
- Targeted fixes for the import system (architecture was already sound, unlike export which needed full rewrite)
- 10 issues fixed: 2 critical, 5 major, 3 minor

## Changes (9 files, +95/-84)

### Critical fixes
- SQLFileParser now returns `AsyncThrowingStream` instead of `AsyncStream` - file read and encoding errors are surfaced instead of silently succeeding with partial data
- Compressed (.gz) files are decompressed once and shared between preview and import (was decompressing twice)

### Major fixes
- Transaction rollback error now correctly reported (was wrapping import error instead of rollback error)
- FK checks properly restored after failed import with logging (was silently swallowing)
- Progress estimate uses decompressed file size for accurate progress bar
- NSOpenPanel queries import plugins for accepted file types instead of hardcoding .sql/.gz
- FileDecompressor uses async GzipProcess instead of blocking `waitUntilExit()`

### Minor fixes
- Statement counting task cancelled on dialog dismiss
- importFileURL cleared after dialog presented
- Temp file extension derived from original filename (not hardcoded .sql)

## Test plan
- [ ] Import a .sql.gz file - verify single decompression, correct progress
- [ ] Import a file with encoding error - verify error surfaced (not silent success)
- [ ] Import with FK checks + transaction, trigger failure mid-import - verify rollback + FK restored
- [ ] Cancel import mid-stream - verify clean dismissal
- [ ] Reopen import dialog - verify no stale file pre-populated