### PR TITLE
feat: import error handling modes (stop/rollback, stop/commit, skip/continue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Import error handling modes: Stop and Rollback, Stop and Commit, Skip and Continue
 - Handoff via NSUserActivity
 
 ## [0.32.1] - 2026-04-17

--- a/Packages/TableProCore/Sources/TableProPluginKit/ImportFormatPlugin.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/ImportFormatPlugin.swift
@@ -1,21 +1,41 @@
 import Foundation
 
+public enum ImportErrorHandling: String, Codable, CaseIterable, Sendable {
+    case stopAndRollback
+    case stopAndCommit
+    case skipAndContinue
+}
+
 public struct PluginImportResult: Sendable {
     public let executedStatements: Int
+    public let skippedStatements: Int
     public let executionTime: TimeInterval
-    public let failedStatement: String?
-    public let failedLine: Int?
+    public let errors: [ImportStatementError]
 
     public init(
         executedStatements: Int,
         executionTime: TimeInterval,
-        failedStatement: String? = nil,
-        failedLine: Int? = nil
+        skippedStatements: Int = 0,
+        errors: [ImportStatementError] = []
     ) {
         self.executedStatements = executedStatements
+        self.skippedStatements = skippedStatements
         self.executionTime = executionTime
-        self.failedStatement = failedStatement
-        self.failedLine = failedLine
+        self.errors = errors
+    }
+}
+
+public extension PluginImportResult {
+    struct ImportStatementError: Sendable {
+        public let statement: String
+        public let line: Int
+        public let errorMessage: String
+
+        public init(statement: String, line: Int, errorMessage: String) {
+            self.statement = statement
+            self.line = line
+            self.errorMessage = errorMessage
+        }
     }
 }
 

--- a/Plugins/SQLImportPlugin/SQLImportOptions.swift
+++ b/Plugins/SQLImportPlugin/SQLImportOptions.swift
@@ -4,8 +4,10 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 struct SQLImportOptions: Equatable, Codable {
+    var errorHandling: ImportErrorHandling = .stopAndRollback
     var wrapInTransaction: Bool = true
     var disableForeignKeyChecks: Bool = true
 }

--- a/Plugins/SQLImportPlugin/SQLImportOptionsView.swift
+++ b/Plugins/SQLImportPlugin/SQLImportOptionsView.swift
@@ -4,17 +4,27 @@
 //
 
 import SwiftUI
+import TableProPluginKit
 
 struct SQLImportOptionsView: View {
     let plugin: SQLImportPlugin
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            Picker("On error:", selection: Bindable(plugin).settings.errorHandling) {
+                Text("Stop and Rollback").tag(ImportErrorHandling.stopAndRollback)
+                Text("Stop and Commit").tag(ImportErrorHandling.stopAndCommit)
+                Text("Skip and Continue").tag(ImportErrorHandling.skipAndContinue)
+            }
+            .pickerStyle(.menu)
+            .font(.system(size: 13))
+
             Toggle("Wrap in transaction (BEGIN/COMMIT)", isOn: Bindable(plugin).settings.wrapInTransaction)
                 .font(.system(size: 13))
-                .help(
-                    "Execute all statements in a single transaction. If any statement fails, all changes are rolled back."
-                )
+                .disabled(plugin.settings.errorHandling == .skipAndContinue)
+                .help(plugin.settings.errorHandling == .skipAndContinue
+                    ? String(localized: "Not available in skip-and-continue mode")
+                    : String(localized: "Execute all statements in a single transaction. If any statement fails, all changes are rolled back."))
 
             Toggle("Disable foreign key checks", isOn: Bindable(plugin).settings.disableForeignKeyChecks)
                 .font(.system(size: 13))

--- a/Plugins/SQLImportPlugin/SQLImportPlugin.swift
+++ b/Plugins/SQLImportPlugin/SQLImportPlugin.swift
@@ -79,8 +79,13 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
                         )
 
                     case .stopAndCommit:
+                        let statementError = error
                         if useTransaction {
-                            try await sink.commitTransaction()
+                            do {
+                                try await sink.commitTransaction()
+                            } catch {
+                                Self.logger.warning("Failed to commit partial import: \(error.localizedDescription)")
+                            }
                         }
                         if settings.disableForeignKeyChecks {
                             do {
@@ -92,13 +97,13 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
                         throw PluginImportError.statementFailed(
                             statement: statement,
                             line: lineNumber,
-                            underlyingError: error
+                            underlyingError: statementError
                         )
 
                     case .skipAndContinue:
                         skippedCount += 1
                         if errors.count < maxErrors {
-                            let snippet = statement.count > 200
+                            let snippet = (statement as NSString).length > 200
                                 ? String(statement.prefix(200)) + "..."
                                 : statement
                             errors.append(.init(

--- a/Plugins/SQLImportPlugin/SQLImportPlugin.swift
+++ b/Plugins/SQLImportPlugin/SQLImportPlugin.swift
@@ -40,24 +40,26 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
     ) async throws -> PluginImportResult {
         let startTime = Date()
         var executedCount = 0
+        var skippedCount = 0
+        var errors: [PluginImportResult.ImportStatementError] = []
+        let maxErrors = 1_000
 
-        // Estimate total from file size (~500 bytes per statement)
+        let errorMode = settings.errorHandling
+        let useTransaction = settings.wrapInTransaction && errorMode != .skipAndContinue
+
         let fileSizeBytes = source.fileSizeBytes()
         let estimatedTotal = max(1, Int(fileSizeBytes / 500))
         progress.setEstimatedTotal(estimatedTotal)
 
         do {
-            // Disable FK checks if enabled
             if settings.disableForeignKeyChecks {
                 try await sink.disableForeignKeyChecks()
             }
 
-            // Begin transaction if enabled
-            if settings.wrapInTransaction {
+            if useTransaction {
                 try await sink.beginTransaction()
             }
 
-            // Stream and execute statements
             let stream = try await source.statements()
 
             for try await (statement, lineNumber) in stream {
@@ -68,20 +70,52 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
                     executedCount += 1
                     progress.incrementStatement()
                 } catch {
-                    throw PluginImportError.statementFailed(
-                        statement: statement,
-                        line: lineNumber,
-                        underlyingError: error
-                    )
+                    switch errorMode {
+                    case .stopAndRollback:
+                        throw PluginImportError.statementFailed(
+                            statement: statement,
+                            line: lineNumber,
+                            underlyingError: error
+                        )
+
+                    case .stopAndCommit:
+                        if useTransaction {
+                            try await sink.commitTransaction()
+                        }
+                        if settings.disableForeignKeyChecks {
+                            do {
+                                try await sink.enableForeignKeyChecks()
+                            } catch {
+                                Self.logger.warning("Failed to re-enable foreign key checks: \(error.localizedDescription)")
+                            }
+                        }
+                        throw PluginImportError.statementFailed(
+                            statement: statement,
+                            line: lineNumber,
+                            underlyingError: error
+                        )
+
+                    case .skipAndContinue:
+                        skippedCount += 1
+                        if errors.count < maxErrors {
+                            let snippet = statement.count > 200
+                                ? String(statement.prefix(200)) + "..."
+                                : statement
+                            errors.append(.init(
+                                statement: snippet,
+                                line: lineNumber,
+                                errorMessage: error.localizedDescription
+                            ))
+                        }
+                        progress.incrementStatement()
+                    }
                 }
             }
 
-            // Commit transaction
-            if settings.wrapInTransaction {
+            if useTransaction {
                 try await sink.commitTransaction()
             }
 
-            // Re-enable FK checks
             if settings.disableForeignKeyChecks {
                 try await sink.enableForeignKeyChecks()
             }
@@ -89,7 +123,7 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
             let importError = error
             var rollbackError: Error?
 
-            if settings.wrapInTransaction {
+            if useTransaction {
                 do {
                     try await sink.rollbackTransaction()
                 } catch {
@@ -122,7 +156,9 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
 
         return PluginImportResult(
             executedStatements: executedCount,
-            executionTime: Date().timeIntervalSince(startTime)
+            executionTime: Date().timeIntervalSince(startTime),
+            skippedStatements: skippedCount,
+            errors: errors
         )
     }
 }

--- a/Plugins/TableProPluginKit/PluginImportTypes.swift
+++ b/Plugins/TableProPluginKit/PluginImportTypes.swift
@@ -5,22 +5,42 @@
 
 import Foundation
 
+public enum ImportErrorHandling: String, Codable, CaseIterable, Sendable {
+    case stopAndRollback
+    case stopAndCommit
+    case skipAndContinue
+}
+
 public struct PluginImportResult: Sendable {
     public let executedStatements: Int
+    public let skippedStatements: Int
     public let executionTime: TimeInterval
-    public let failedStatement: String?
-    public let failedLine: Int?
+    public let errors: [ImportStatementError]
 
     public init(
         executedStatements: Int,
         executionTime: TimeInterval,
-        failedStatement: String? = nil,
-        failedLine: Int? = nil
+        skippedStatements: Int = 0,
+        errors: [ImportStatementError] = []
     ) {
         self.executedStatements = executedStatements
+        self.skippedStatements = skippedStatements
         self.executionTime = executionTime
-        self.failedStatement = failedStatement
-        self.failedLine = failedLine
+        self.errors = errors
+    }
+}
+
+public extension PluginImportResult {
+    struct ImportStatementError: Sendable {
+        public let statement: String
+        public let line: Int
+        public let errorMessage: String
+
+        public init(statement: String, line: Int, errorMessage: String) {
+            self.statement = statement
+            self.line = line
+            self.errorMessage = errorMessage
+        }
     }
 }
 

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -17,6 +17,7 @@ struct ImportState {
     var isImporting: Bool = false
     var progress: Double = 0.0
     var processedStatements: Int = 0
+    var skippedStatements: Int = 0
     var estimatedTotalStatements: Int = 0
     var statusMessage: String = ""
     var errorMessage: String?
@@ -131,7 +132,8 @@ final class ImportService {
 
         // Update final state
         state.processedStatements = result.executedStatements
-        state.estimatedTotalStatements = result.executedStatements
+        state.skippedStatements = result.skippedStatements
+        state.estimatedTotalStatements = result.executedStatements + result.skippedStatements
         state.progress = 1.0
 
         // Record success history

--- a/TablePro/Views/Import/ImportSuccessView.swift
+++ b/TablePro/Views/Import/ImportSuccessView.swift
@@ -12,20 +12,37 @@ struct ImportSuccessView: View {
     let result: PluginImportResult?
     let onClose: () -> Void
 
+    private var hasErrors: Bool {
+        guard let result else { return false }
+        return result.skippedStatements > 0
+    }
+
     var body: some View {
         VStack(spacing: 20) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 48))
-                .foregroundStyle(Color(nsColor: .systemGreen))
+            if hasErrors {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color(nsColor: .systemYellow))
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color(nsColor: .systemGreen))
+            }
 
             VStack(spacing: 6) {
-                Text("Import Successful")
+                Text(hasErrors ? "Import Completed with Errors" : "Import Successful")
                     .font(.system(size: ThemeEngine.shared.activeTheme.typography.title3, weight: .semibold))
 
                 if let result {
-                    Text("\(result.executedStatements) statements executed")
-                        .font(.system(size: ThemeEngine.shared.activeTheme.typography.body))
-                        .foregroundStyle(.secondary)
+                    if hasErrors {
+                        Text("\(result.executedStatements) statements executed, \(result.skippedStatements) failed")
+                            .font(.system(size: ThemeEngine.shared.activeTheme.typography.body))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("\(result.executedStatements) statements executed")
+                            .font(.system(size: ThemeEngine.shared.activeTheme.typography.body))
+                            .foregroundStyle(.secondary)
+                    }
 
                     let formattedTime = String(format: "%.2f", result.executionTime)
                     Text(String(format: String(localized: "%@ seconds"), formattedTime))
@@ -34,13 +51,56 @@ struct ImportSuccessView: View {
                 }
             }
 
-            Button("Close") {
-                onClose()
+            if let result, !result.errors.isEmpty {
+                errorListView(errors: result.errors)
             }
-            .buttonStyle(.borderedProminent)
+
+            HStack(spacing: 12) {
+                if let result, !result.errors.isEmpty {
+                    Button("Copy Errors to Clipboard") {
+                        copyErrorsToClipboard(errors: result.errors)
+                    }
+                }
+
+                Button("Close") {
+                    onClose()
+                }
+                .buttonStyle(.borderedProminent)
+            }
         }
         .padding(24)
-        .frame(width: 300)
+        .frame(width: hasErrors ? 500 : 300)
         .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private func errorListView(errors: [PluginImportResult.ImportStatementError]) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(Array(errors.enumerated()), id: \.offset) { _, error in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Line \(error.line): \(error.statement)")
+                            .font(.system(size: ThemeEngine.shared.activeTheme.typography.medium, design: .monospaced))
+                            .lineLimit(2)
+
+                        Text(error.errorMessage)
+                            .font(.system(size: ThemeEngine.shared.activeTheme.typography.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(8)
+        }
+        .frame(maxHeight: 200)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func copyErrorsToClipboard(errors: [PluginImportResult.ImportStatementError]) {
+        let text = errors.map { error in
+            "Line \(error.line): \(error.statement)\nError: \(error.errorMessage)"
+        }.joined(separator: "\n\n")
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
     }
 }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -143,7 +143,7 @@ Export data in five formats (CSV, JSON, SQL, MQL, XLSX), import SQL files with g
     | Include headers (bold first row) | Yes |
     | NULL as empty cells | Yes |
 
-    Each table exports as a separate worksheet. Numbers are stored as numeric cells for proper Excel formatting. Handles 175K+ rows.
+    Each table exports as a separate worksheet. Numbers are stored as numeric cells for proper Excel formatting. Tables exceeding 1,048,576 rows (Excel's limit) auto-split into multiple sheets.
 
     {/* Screenshot: Excel export options */}
     <Frame caption="Excel export options">
@@ -222,13 +222,26 @@ Import `.sql` and `.sql.gz` files. Statements execute directly against your data
 
 | Option | Description | Default |
 |--------|-------------|---------|
+| On error | How to handle failed statements (see below) | Stop and Rollback |
 | Encoding | File encoding: UTF-8, UTF-16, Latin1, or ASCII | UTF-8 |
 | Wrap in transaction | Execute all statements within a single transaction | Yes |
 | Disable foreign key checks | Temporarily disable FK constraints during import | Yes |
 
+### Error Handling Modes
+
+Three modes for handling errors during import:
+
+| Mode | Behavior |
+|------|----------|
+| **Stop and Rollback** | Stops on first error. If transaction is enabled, rolls back all changes. Default. |
+| **Stop and Commit** | Stops on first error. Commits statements that succeeded before the error. |
+| **Skip and Continue** | Logs failed statements and continues importing. Shows a summary with all errors at the end. Transaction wrapping is disabled in this mode. |
+
+In **Skip and Continue** mode, failed statements are collected (up to 1,000) with line numbers and error messages. After import completes, a summary dialog shows how many succeeded vs failed, with a scrollable error list and a "Copy Errors to Clipboard" button.
+
 ## Progress and Errors
 
-During import, a progress bar shows statements processed, current statement, and overall completion.
+During import, a progress bar shows statements processed and overall completion.
 
 {/* Screenshot: Import progress bar */}
 <Frame caption="Import progress">
@@ -243,5 +256,3 @@ During import, a progress bar shows statements processed, current statement, and
     alt="Import progress"
   />
 </Frame>
-
-Import stops on the first error. If wrapped in a transaction, all changes roll back automatically.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -46,7 +46,7 @@ Native macOS client for every database. Built on SwiftUI and AppKit. Ships under
 **SQL Editor**: Syntax highlighting, autocomplete, line numbers.
 **Data Grid**: Spreadsheet-like interface with inline editing, sorting, filtering.
 **Table Structure**: Inspect and modify columns, indexes, foreign keys.
-**Import & Export**: CSV, JSON, SQL, and multiple export formats.
+**Import & Export**: CSV, JSON, SQL, XLSX, MQL. Streaming export, error handling modes for import.
 **Query History**: Full-text search across query history.
 **AI Assistant**: Explain, optimize, or write SQL with Claude, OpenAI, or Ollama.
 


### PR DESCRIPTION
## Summary
Adds 3 import error handling modes, closing the biggest feature gap vs DBeaver/DataGrip/Navicat.

## Changes (8 files, +193/-42)

### Error Handling Modes
- **Stop and Rollback** (default, existing behavior): first error rolls back all changes
- **Stop and Commit**: first error commits what succeeded, then shows error
- **Skip and Continue**: logs failed statements (up to 1,000), continues to completion

### UI
- Picker dropdown in import options: "On error: [Stop and Rollback / Stop and Commit / Skip and Continue]"
- "Wrap in transaction" auto-disabled in skip mode (with help text)
- Enhanced success dialog shows warning icon + error list when statements were skipped
- "Copy Errors to Clipboard" button for debugging
- Error list shows line number, SQL snippet (truncated 200 chars), and error message

### Plugin Protocol
- `PluginImportResult` gains `skippedStatements: Int` and `errors: [ImportStatementError]` (backward compatible defaults)
- `ImportErrorHandling` enum added to PluginKit

## Test plan
- [ ] Import valid .sql with Stop and Rollback - verify unchanged behavior
- [ ] Import .sql with errors + Skip and Continue - verify errors collected, import completes, summary shows details
- [ ] Import with Stop and Commit + error mid-file - verify partial commit
- [ ] Verify "Wrap in transaction" disables when Skip and Continue selected
- [ ] Copy errors to clipboard - verify format
- [ ] Import with >1,000 errors - verify cap