### PR TITLE
feat: PostgreSQL fetchFirstPage optimization and streaming query export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cancel running query from toolbar or `Cmd+.`
 - Query result limit setting in Data Grid preferences
+- Streaming export for query results with partial loading (exports directly from database, no memory limit)
 - Import error handling modes: Stop and Rollback, Stop and Commit, Skip and Continue
 - Handoff via NSUserActivity
 

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -136,6 +136,50 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return Int(countStr ?? "0") ?? 0
     }
 
+    func fetchFirstPage(query: String, limit: Int) async throws -> PluginPagedResult {
+        guard limit > 0 else {
+            let result = try await execute(query: query)
+            return PluginPagedResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+
+        if let regex = Self.limitRegex,
+           regex.firstMatch(in: query, range: NSRange(query.startIndex..., in: query)) != nil
+        {
+            let result = try await execute(query: query)
+            return PluginPagedResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+
+        let baseQuery = stripLimitOffset(from: query)
+        let probeQuery = "\(baseQuery) LIMIT \(limit + 1)"
+        let result = try await execute(query: probeQuery)
+
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+
+        return PluginPagedResult(
+            columns: result.columns,
+            columnTypeNames: result.columnTypeNames,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: rows.count
+        )
+    }
+
     func fetchRows(query: String, offset: Int, limit: Int) async throws -> PluginQueryResult {
         let baseQuery = stripLimitOffset(from: query)
         let paginatedQuery = "\(baseQuery) LIMIT \(limit) OFFSET \(offset)"

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
@@ -125,6 +125,50 @@ final class RedshiftPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return Int(countStr ?? "0") ?? 0
     }
 
+    func fetchFirstPage(query: String, limit: Int) async throws -> PluginPagedResult {
+        guard limit > 0 else {
+            let result = try await execute(query: query)
+            return PluginPagedResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+
+        if let regex = Self.limitRegex,
+           regex.firstMatch(in: query, range: NSRange(query.startIndex..., in: query)) != nil
+        {
+            let result = try await execute(query: query)
+            return PluginPagedResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+
+        let baseQuery = stripLimitOffset(from: query)
+        let probeQuery = "\(baseQuery) LIMIT \(limit + 1)"
+        let result = try await execute(query: probeQuery)
+
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+
+        return PluginPagedResult(
+            columns: result.columns,
+            columnTypeNames: result.columnTypeNames,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: rows.count
+        )
+    }
+
     func fetchRows(query: String, offset: Int, limit: Int) async throws -> PluginQueryResult {
         let baseQuery = stripLimitOffset(from: query)
         let paginatedQuery = "\(baseQuery) LIMIT \(limit) OFFSET \(offset)"

--- a/TablePro/Core/Plugins/StreamingQueryExportDataSource.swift
+++ b/TablePro/Core/Plugins/StreamingQueryExportDataSource.swift
@@ -35,7 +35,7 @@ final class StreamingQueryExportDataSource: PluginExportDataSource, @unchecked S
     }
 
     func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? {
-        try? await driver.fetchRowCount(query: query)
+        nil
     }
 
     func quoteIdentifier(_ identifier: String) -> String {

--- a/TablePro/Core/Plugins/StreamingQueryExportDataSource.swift
+++ b/TablePro/Core/Plugins/StreamingQueryExportDataSource.swift
@@ -1,0 +1,71 @@
+//
+//  StreamingQueryExportDataSource.swift
+//  TablePro
+//
+//  Streaming export data source for query results.
+//  Re-executes the query and streams rows directly from the database to the export plugin,
+//  bypassing RowBuffer. Allows exporting large result sets without loading all rows into memory.
+//
+
+import Foundation
+import os
+import TableProPluginKit
+
+final class StreamingQueryExportDataSource: PluginExportDataSource, @unchecked Sendable {
+    let databaseTypeId: String
+
+    private let query: String
+    private let driver: DatabaseDriver
+    private let dbType: DatabaseType
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "StreamingQueryExport")
+
+    init(query: String, driver: DatabaseDriver, databaseType: DatabaseType) {
+        self.query = query
+        self.driver = driver
+        self.dbType = databaseType
+        self.databaseTypeId = databaseType.rawValue
+    }
+
+    func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+        guard let pluginDriver = (driver as? PluginDriverAdapter)?.schemaPluginDriver else {
+            return AsyncThrowingStream { $0.finish(throwing: PluginExportError.exportFailed("No plugin driver available")) }
+        }
+        return pluginDriver.streamRows(query: query)
+    }
+
+    func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? {
+        try? await driver.fetchRowCount(query: query)
+    }
+
+    func quoteIdentifier(_ identifier: String) -> String {
+        driver.quoteIdentifier(identifier)
+    }
+
+    func escapeStringLiteral(_ value: String) -> String {
+        driver.escapeStringLiteral(value)
+    }
+
+    func fetchTableDDL(table: String, databaseName: String) async throws -> String {
+        ""
+    }
+
+    func execute(query: String) async throws -> PluginQueryResult {
+        let result = try await driver.execute(query: query)
+        return PluginQueryResult(
+            columns: result.columns,
+            columnTypeNames: result.columnTypes.map { $0.rawType ?? "" },
+            rows: result.rows,
+            rowsAffected: result.rowsAffected,
+            executionTime: result.executionTime
+        )
+    }
+
+    func fetchDependentSequences(table: String, databaseName: String) async throws -> [PluginSequenceInfo] {
+        []
+    }
+
+    func fetchDependentTypes(table: String, databaseName: String) async throws -> [PluginEnumTypeInfo] {
+        []
+    }
+}

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -256,6 +256,74 @@ final class ExportService {
         }
     }
 
+    func exportStreamingQuery(
+        query: String,
+        config: ExportConfiguration,
+        to url: URL
+    ) async throws {
+        guard let plugin = PluginManager.shared.exportPlugins[config.formatId] else {
+            throw ExportError.formatNotFound(config.formatId)
+        }
+        guard let driver else {
+            throw ExportError.exportFailed("No database connection")
+        }
+
+        let estimatedRows = (try? await driver.fetchRowCount(query: query)) ?? 0
+        state = ExportState(isExporting: true, totalTables: 1, totalRows: estimatedRows)
+        isCancelled = false
+
+        defer {
+            state.isExporting = false
+            isCancelled = false
+            state.statusMessage = ""
+            currentProgress = nil
+        }
+
+        let dataSource = StreamingQueryExportDataSource(
+            query: query,
+            driver: driver,
+            databaseType: databaseType
+        )
+
+        let nsProgress = Progress(totalUnitCount: Int64(max(estimatedRows, 1)))
+        let progress = PluginExportProgress(progress: nsProgress)
+        currentProgress = progress
+
+        let observation = nsProgress.observe(\.completedUnitCount) { [weak self] observed, _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.state.processedRows = Int(observed.completedUnitCount)
+            }
+        }
+        defer { observation.invalidate() }
+
+        let exportTable = PluginExportTable(
+            name: config.fileName,
+            databaseName: "",
+            tableType: "query",
+            optionValues: plugin.defaultTableOptionValues()
+        )
+
+        let result: ExportFormatResult
+        do {
+            result = try await plugin.export(
+                tables: [exportTable],
+                dataSource: dataSource,
+                destination: url,
+                progress: progress
+            )
+        } catch {
+            state.errorMessage = error.localizedDescription
+            throw error
+        }
+
+        state.processedRows = progress.processedRows
+
+        if !result.warnings.isEmpty {
+            state.warningMessage = result.warnings.joined(separator: "\n")
+        }
+    }
+
     // MARK: - Row Count Fetching
 
     private func qualifiedTableRef(for table: ExportTableItem, driver: DatabaseDriver) -> String {

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -268,7 +268,7 @@ final class ExportService {
             throw ExportError.exportFailed("No database connection")
         }
 
-        let estimatedRows = (try? await driver.fetchRowCount(query: query)) ?? 0
+        let estimatedRows = 0
         state = ExportState(isExporting: true, totalTables: 1, totalRows: estimatedRows)
         isCancelled = false
 

--- a/TablePro/Models/Export/ExportModels.swift
+++ b/TablePro/Models/Export/ExportModels.swift
@@ -12,6 +12,7 @@ import TableProPluginKit
 enum ExportMode {
     case tables(connection: DatabaseConnection, preselectedTables: Set<String>)
     case queryResults(connection: DatabaseConnection, rowBuffer: RowBuffer, suggestedFileName: String)
+    case streamingQuery(connection: DatabaseConnection, query: String, suggestedFileName: String)
 }
 
 // MARK: - Export Configuration

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -42,12 +42,15 @@ struct ExportDialog: View {
         switch mode {
         case .tables(let conn, _): return conn
         case .queryResults(let conn, _, _): return conn
+        case .streamingQuery(let conn, _, _): return conn
         }
     }
 
     private var isQueryResultsMode: Bool {
-        if case .queryResults = mode { return true }
-        return false
+        switch mode {
+        case .queryResults, .streamingQuery: return true
+        default: return false
+        }
     }
 
     private var queryResultsRowCount: Int {
@@ -112,8 +115,13 @@ struct ExportDialog: View {
         }
         .task {
             if isQueryResultsMode {
-                if case .queryResults(_, _, let suggestedFileName) = mode {
+                switch mode {
+                case .queryResults(_, _, let suggestedFileName):
                     config.fileName = suggestedFileName
+                case .streamingQuery(_, _, let suggestedFileName):
+                    config.fileName = suggestedFileName
+                default:
+                    break
                 }
                 isLoading = false
             } else {
@@ -758,7 +766,9 @@ struct ExportDialog: View {
         }
 
         let formatName = currentPlugin.map { type(of: $0).formatDisplayName } ?? config.formatId.uppercased()
-        if isQueryResultsMode {
+        if case .streamingQuery = mode {
+            savePanel.message = String(format: String(localized: "Export query results to %@"), formatName)
+        } else if isQueryResultsMode {
             savePanel.message = String(format: String(localized: "Export %d row(s) to %@"), queryResultsRowCount, formatName)
         } else {
             savePanel.message = String(format: String(localized: "Export %d table(s) to %@"), exportableCount, formatName)
@@ -828,8 +838,6 @@ struct ExportDialog: View {
 
     @MainActor
     private func startQueryResultsExport(to url: URL) async {
-        guard case .queryResults(_, let rowBuffer, _) = mode else { return }
-
         isExporting = true
         exportedFileURL = url
 
@@ -838,11 +846,28 @@ struct ExportDialog: View {
         showProgressDialog = true
 
         do {
-            try await service.exportQueryResults(
-                rowBuffer: rowBuffer,
-                config: config,
-                to: url
-            )
+            switch mode {
+            case .streamingQuery(_, let query, _):
+                guard let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
+                let streamingService = ExportService(
+                    driver: driver,
+                    databaseType: connection.type
+                )
+                exportService = streamingService
+                try await streamingService.exportStreamingQuery(
+                    query: query,
+                    config: config,
+                    to: url
+                )
+            case .queryResults(_, let rowBuffer, _):
+                try await service.exportQueryResults(
+                    rowBuffer: rowBuffer,
+                    config: config,
+                    to: url
+                )
+            default:
+                return
+            }
 
             showProgressDialog = false
             isExporting = false

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -302,6 +302,10 @@ struct ExportDialog: View {
                         }
                         .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
                         .buttonStyle(.link)
+                    } else if case .streamingQuery = mode {
+                        Text("All rows (streaming from database)")
+                            .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
+                            .foregroundStyle(.secondary)
                     } else if isQueryResultsMode {
                         Text("\(queryResultsRowCount) row\(queryResultsRowCount == 1 ? "" : "s") to export")
                             .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
@@ -437,6 +441,9 @@ struct ExportDialog: View {
     private var isExportDisabled: Bool {
         if isExporting || !isFileNameValid || availableFormats.isEmpty || isProGatedFormat(config.formatId) {
             return true
+        }
+        if case .streamingQuery = mode {
+            return false
         }
         if isQueryResultsMode {
             return queryResultsRowCount == 0

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -303,7 +303,7 @@ struct ExportDialog: View {
                         .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
                         .buttonStyle(.link)
                     } else if case .streamingQuery = mode {
-                        Text("All rows (streaming from database)")
+                        Text("All rows")
                             .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
                             .foregroundStyle(.secondary)
                     } else if isQueryResultsMode {
@@ -847,31 +847,20 @@ struct ExportDialog: View {
     private func startQueryResultsExport(to url: URL) async {
         isExporting = true
         exportedFileURL = url
-
-        let service = ExportService(databaseType: connection.type)
-        exportService = service
         showProgressDialog = true
 
         do {
+            let service: ExportService
             switch mode {
             case .streamingQuery(_, let query, _):
                 guard let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
-                let streamingService = ExportService(
-                    driver: driver,
-                    databaseType: connection.type
-                )
-                exportService = streamingService
-                try await streamingService.exportStreamingQuery(
-                    query: query,
-                    config: config,
-                    to: url
-                )
+                service = ExportService(driver: driver, databaseType: connection.type)
+                exportService = service
+                try await service.exportStreamingQuery(query: query, config: config, to: url)
             case .queryResults(_, let rowBuffer, _):
-                try await service.exportQueryResults(
-                    rowBuffer: rowBuffer,
-                    config: config,
-                    to: url
-                )
+                service = ExportService(databaseType: connection.type)
+                exportService = service
+                try await service.exportQueryResults(rowBuffer: rowBuffer, config: config, to: url)
             default:
                 return
             }

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -163,14 +163,26 @@ struct MainContentView: View {
             )
         case .exportQueryResults:
             if let tab = coordinator.tabManager.selectedTab {
-                ExportDialog(
-                    isPresented: dismissBinding,
-                    mode: .queryResults(
-                        connection: connectionWithCurrentDatabase,
-                        rowBuffer: tab.rowBuffer,
-                        suggestedFileName: tab.tableName ?? "query_results"
+                let fileName = tab.tableName ?? "query_results"
+                if tab.pagination.hasMoreRows, let baseQuery = tab.pagination.baseQueryForMore {
+                    ExportDialog(
+                        isPresented: dismissBinding,
+                        mode: .streamingQuery(
+                            connection: connectionWithCurrentDatabase,
+                            query: baseQuery,
+                            suggestedFileName: fileName
+                        )
                     )
-                )
+                } else {
+                    ExportDialog(
+                        isPresented: dismissBinding,
+                        mode: .queryResults(
+                            connection: connectionWithCurrentDatabase,
+                            rowBuffer: tab.rowBuffer,
+                            suggestedFileName: fileName
+                        )
+                    )
+                }
             }
         case .importDialog:
             let importDismiss = Binding<Bool>(


### PR DESCRIPTION
## Summary

- PostgreSQL and Redshift `fetchFirstPage` override with LIMIT n+1 sentinel (same pattern as MySQL from #789). Previously these used the default `fetchRows` fallback.
- Streaming query export: when exporting query results with partial loading (hasMoreRows=true), the export dialog streams rows directly from the database via `pluginDriver.streamRows(query:)` instead of requiring all rows in memory first.
- New `StreamingQueryExportDataSource` that reuses the existing `PluginExportDataSource` protocol. All format plugins (CSV, JSON, SQL, XLSX) work without changes.
- Export dialog shows "All rows (streaming from database)" for streaming mode instead of "0 rows to export".

## Test plan
- [ ] Connect to PostgreSQL, run `SELECT * FROM large_table` - verify 10K rows with Load More (check logs for `[fetchFirstPage]` with LIMIT 10001)
- [ ] With partial results loaded, File > Export Query Results - dialog shows "All rows (streaming from database)"
- [ ] Export to CSV - verify all rows exported (not just loaded ones)
- [ ] Export with all rows loaded (no hasMoreRows) - uses in-memory path as before
- [ ] Table export (File > Export) - unchanged, still streaming