### PR TITLE
feat: Structure tab P2 — charset/collation, index prefix, partial indexes, ClickHouse parts, FK schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Structure tab: charset and collation column editing for MySQL/MariaDB
+- Structure tab: index prefix length display and editing
+- Structure tab: partial index WHERE clause display and editing (PostgreSQL)
+- Structure tab: cross-schema foreign key reference display and editing
+- Structure tab: ClickHouse parts actions (optimize table, drop/detach partition)
 - Structure tab: filter columns/indexes/FKs by name, sort by clicking headers, count badges on tabs
 - Structure tab: Primary Key column visible in edit mode, dropdown pickers for FK actions and index types
 - Structure tab: DDL view with tree-sitter highlighting and line numbers, "Open in Editor" button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Structure tab: charset and collation column editing for MySQL/MariaDB
-- Structure tab: index prefix length display and editing
-- Structure tab: partial index WHERE clause display and editing (PostgreSQL)
-- Structure tab: cross-schema foreign key reference display and editing
-- Structure tab: ClickHouse parts actions (optimize table, drop/detach partition)
-- Structure tab: filter columns/indexes/FKs by name, sort by clicking headers, count badges on tabs
-- Structure tab: Primary Key column visible in edit mode, dropdown pickers for FK actions and index types
-- Structure tab: DDL view with tree-sitter highlighting and line numbers, "Open in Editor" button
-- Structure tab: Copy As (CSV, JSON, SQL) in context menu, destructive change confirmation
-- Schema changes recorded in query history
+- Structure tab: search, sort, count badges, PK column, Copy As (CSV/JSON/SQL), destructive change confirmation
+- Structure tab: DDL view with tree-sitter highlighting, line numbers, and "Open in Editor"
+- Structure tab: charset/collation (MySQL), index prefix length, partial indexes (PostgreSQL), cross-schema FK
+- Structure tab: dropdown pickers for FK actions and index types, schema changes in query history
+- ClickHouse: parts tab actions (optimize table, drop/detach partition)
 
 ### Changed
 

--- a/Packages/TableProCore/Sources/TableProPluginKit/PluginIndexInfo.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/PluginIndexInfo.swift
@@ -6,18 +6,24 @@ public struct PluginIndexInfo: Codable, Sendable {
     public let isUnique: Bool
     public let isPrimary: Bool
     public let type: String
+    public let columnPrefixes: [String: Int]?
+    public let whereClause: String?
 
     public init(
         name: String,
         columns: [String],
         isUnique: Bool = false,
         isPrimary: Bool = false,
-        type: String = "BTREE"
+        type: String = "BTREE",
+        columnPrefixes: [String: Int]? = nil,
+        whereClause: String? = nil
     ) {
         self.name = name
         self.columns = columns
         self.isUnique = isUnique
         self.isPrimary = isPrimary
         self.type = type
+        self.columnPrefixes = columnPrefixes
+        self.whereClause = whereClause
     }
 }

--- a/Packages/TableProCore/Sources/TableProPluginKit/SchemaTypes.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/SchemaTypes.swift
@@ -10,6 +10,8 @@ public struct PluginColumnDefinition: Sendable {
     public let comment: String?
     public let unsigned: Bool
     public let onUpdate: String?
+    public let charset: String?
+    public let collation: String?
 
     public init(
         name: String,
@@ -20,7 +22,9 @@ public struct PluginColumnDefinition: Sendable {
         autoIncrement: Bool = false,
         comment: String? = nil,
         unsigned: Bool = false,
-        onUpdate: String? = nil
+        onUpdate: String? = nil,
+        charset: String? = nil,
+        collation: String? = nil
     ) {
         self.name = name
         self.dataType = dataType
@@ -31,6 +35,8 @@ public struct PluginColumnDefinition: Sendable {
         self.comment = comment
         self.unsigned = unsigned
         self.onUpdate = onUpdate
+        self.charset = charset
+        self.collation = collation
     }
 }
 
@@ -39,17 +45,23 @@ public struct PluginIndexDefinition: Sendable {
     public let columns: [String]
     public let isUnique: Bool
     public let indexType: String?
+    public let columnPrefixes: [String: Int]?
+    public let whereClause: String?
 
     public init(
         name: String,
         columns: [String],
         isUnique: Bool = false,
-        indexType: String? = nil
+        indexType: String? = nil,
+        columnPrefixes: [String: Int]? = nil,
+        whereClause: String? = nil
     ) {
         self.name = name
         self.columns = columns
         self.isUnique = isUnique
         self.indexType = indexType
+        self.columnPrefixes = columnPrefixes
+        self.whereClause = whereClause
     }
 }
 
@@ -60,6 +72,7 @@ public struct PluginForeignKeyDefinition: Sendable {
     public let referencedColumns: [String]
     public let onDelete: String
     public let onUpdate: String
+    public let referencedSchema: String?
 
     public init(
         name: String,
@@ -67,7 +80,8 @@ public struct PluginForeignKeyDefinition: Sendable {
         referencedTable: String,
         referencedColumns: [String],
         onDelete: String = "NO ACTION",
-        onUpdate: String = "NO ACTION"
+        onUpdate: String = "NO ACTION",
+        referencedSchema: String? = nil
     ) {
         self.name = name
         self.columns = columns
@@ -75,6 +89,7 @@ public struct PluginForeignKeyDefinition: Sendable {
         self.referencedColumns = referencedColumns
         self.onDelete = onDelete
         self.onUpdate = onUpdate
+        self.referencedSchema = referencedSchema
     }
 }
 

--- a/Packages/TableProCore/Sources/TableProPluginKit/StructureColumnField.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/StructureColumnField.swift
@@ -13,15 +13,15 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
 
     public var displayName: String {
         switch self {
-        case .name: return "Name"
-        case .type: return "Type"
-        case .nullable: return "Nullable"
-        case .defaultValue: return "Default"
-        case .primaryKey: return "Primary Key"
-        case .autoIncrement: return "Auto Inc"
-        case .comment: return "Comment"
-        case .charset: return "Charset"
-        case .collation: return "Collation"
+        case .name: String(localized: "Name")
+        case .type: String(localized: "Type")
+        case .nullable: String(localized: "Nullable")
+        case .defaultValue: String(localized: "Default")
+        case .primaryKey: String(localized: "Primary Key")
+        case .autoIncrement: String(localized: "Auto Inc")
+        case .comment: String(localized: "Comment")
+        case .charset: String(localized: "Charset")
+        case .collation: String(localized: "Collation")
         }
     }
 }

--- a/Packages/TableProCore/Sources/TableProPluginKit/StructureColumnField.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/StructureColumnField.swift
@@ -8,6 +8,8 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
     case primaryKey
     case autoIncrement
     case comment
+    case charset
+    case collation
 
     public var displayName: String {
         switch self {
@@ -18,6 +20,8 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
         case .primaryKey: return "Primary Key"
         case .autoIncrement: return "Auto Inc"
         case .comment: return "Comment"
+        case .charset: return "Charset"
+        case .collation: return "Collation"
         }
     }
 }

--- a/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
@@ -44,6 +44,10 @@ final class MySQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         "Spatial": ["GEOMETRY", "POINT", "LINESTRING", "POLYGON"]
     ]
 
+    static let structureColumnFields: [StructureColumnField] = [
+        .name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation
+    ]
+
     static let sqlDialect: SQLDialectDescriptor? = SQLDialectDescriptor(
         identifierQuote: "`",
         keywords: [

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -283,7 +283,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let safeTable = table.replacingOccurrences(of: "`", with: "``")
         let result = try await execute(query: "SHOW INDEX FROM `\(safeTable)`")
 
-        var indexMap: [String: (columns: [String], isUnique: Bool, type: String)] = [:]
+        var indexMap: [String: (columns: [String], isUnique: Bool, type: String, prefixes: [String: Int])] = [:]
 
         for row in result.rows {
             guard let indexName = row[safe: 2] ?? nil,
@@ -292,12 +292,20 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
             let nonUnique = (row[safe: 1] ?? nil) == "1"
             let indexType = (row[safe: 10] ?? nil) ?? "BTREE"
+            let subPart = (row[safe: 7] ?? nil).flatMap { Int($0) }
 
             if var existing = indexMap[indexName] {
                 existing.columns.append(columnName)
+                if let subPart {
+                    existing.prefixes[columnName] = subPart
+                }
                 indexMap[indexName] = existing
             } else {
-                indexMap[indexName] = (columns: [columnName], isUnique: !nonUnique, type: indexType)
+                var prefixes: [String: Int] = [:]
+                if let subPart {
+                    prefixes[columnName] = subPart
+                }
+                indexMap[indexName] = (columns: [columnName], isUnique: !nonUnique, type: indexType, prefixes: prefixes)
             }
         }
 
@@ -305,7 +313,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             .map { name, info in
                 PluginIndexInfo(
                     name: name, columns: info.columns, isUnique: info.isUnique,
-                    isPrimary: name == "PRIMARY", type: info.type
+                    isPrimary: name == "PRIMARY", type: info.type,
+                    columnPrefixes: info.prefixes.isEmpty ? nil : info.prefixes
                 )
             }
             .sorted { $0.isPrimary && !$1.isPrimary }
@@ -749,6 +758,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if column.unsigned {
             def += " UNSIGNED"
         }
+        if let charset = column.charset, !charset.isEmpty {
+            def += " CHARACTER SET \(charset)"
+        }
+        if let collation = column.collation, !collation.isEmpty {
+            def += " COLLATE \(collation)"
+        }
         if column.isNullable {
             def += " NULL"
         } else {
@@ -783,7 +798,13 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func buildIndexDefinitionSQL(_ index: PluginIndexDefinition) -> String {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
+        let cols = index.columns.map { col -> String in
+            let quoted = quoteIdentifier(col)
+            if let prefixes = index.columnPrefixes, let prefix = prefixes[col] {
+                return "\(quoted)(\(prefix))"
+            }
+            return quoted
+        }.joined(separator: ", ")
         var def = ""
 
         let upperType = index.indexType?.uppercased() ?? ""
@@ -809,7 +830,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private func buildForeignKeyDefinitionSQL(_ fk: PluginForeignKeyDefinition) -> String {
         let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
         let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refTable = quoteIdentifier(fk.referencedTable)
+        let refTable: String
+        if let schema = fk.referencedSchema, !schema.isEmpty {
+            refTable = "\(quoteIdentifier(schema)).\(quoteIdentifier(fk.referencedTable))"
+        } else {
+            refTable = quoteIdentifier(fk.referencedTable)
+        }
 
         var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(refTable) (\(refCols))"
 
@@ -849,6 +875,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         var def = "\(column.dataType)"
         if column.unsigned {
             def += " UNSIGNED"
+        }
+        if let charset = column.charset, !charset.isEmpty {
+            def += " CHARACTER SET \(charset)"
+        }
+        if let collation = column.collation, !collation.isEmpty {
+            def += " COLLATE \(collation)"
         }
         if column.isNullable {
             def += " NULL"

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -393,14 +393,15 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 ARRAY_AGG(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns,
                 ix.indisunique AS is_unique,
                 ix.indisprimary AS is_primary,
-                am.amname AS index_type
+                am.amname AS index_type,
+                pg_get_expr(ix.indpred, ix.indrelid) AS predicate
             FROM pg_index ix
             JOIN pg_class i ON i.oid = ix.indexrelid
             JOIN pg_class t ON t.oid = ix.indrelid
             JOIN pg_am am ON am.oid = i.relam
             JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
             WHERE t.relname = '\(escapeLiteral(table))'
-            GROUP BY i.relname, ix.indisunique, ix.indisprimary, am.amname
+            GROUP BY i.relname, ix.indisunique, ix.indisprimary, am.amname, ix.indpred, ix.indrelid
             ORDER BY ix.indisprimary DESC, i.relname
             """
         let result = try await execute(query: query)
@@ -409,12 +410,14 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             let columns = columnsStr
                 .trimmingCharacters(in: CharacterSet(charactersIn: "{}"))
                 .components(separatedBy: ",")
+            let whereClause = row.count > 5 ? row[5] : nil
             return PluginIndexInfo(
                 name: name,
                 columns: columns,
                 isUnique: row[2] == "t",
                 isPrimary: row[3] == "t",
-                type: row[4]?.uppercased() ?? "BTREE"
+                type: row[4]?.uppercased() ?? "BTREE",
+                whereClause: whereClause
             )
         }
     }
@@ -898,13 +901,22 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             def += " USING \(type.lowercased())"
         }
         def += " (\(cols))"
+        if let whereClause = index.whereClause, !whereClause.isEmpty {
+            def += " WHERE \(whereClause)"
+        }
         return def
     }
 
     private func pgForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
         let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
         let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
+        let refTable: String
+        if let schema = fk.referencedSchema, !schema.isEmpty {
+            refTable = "\(quoteIdentifier(schema)).\(quoteIdentifier(fk.referencedTable))"
+        } else {
+            refTable = quoteIdentifier(fk.referencedTable)
+        }
+        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(refTable) (\(refCols))"
         if fk.onDelete != "NO ACTION" {
             def += " ON DELETE \(fk.onDelete)"
         }

--- a/Plugins/TableProPluginKit/PluginIndexInfo.swift
+++ b/Plugins/TableProPluginKit/PluginIndexInfo.swift
@@ -6,18 +6,24 @@ public struct PluginIndexInfo: Codable, Sendable {
     public let isUnique: Bool
     public let isPrimary: Bool
     public let type: String
+    public let columnPrefixes: [String: Int]?
+    public let whereClause: String?
 
     public init(
         name: String,
         columns: [String],
         isUnique: Bool = false,
         isPrimary: Bool = false,
-        type: String = "BTREE"
+        type: String = "BTREE",
+        columnPrefixes: [String: Int]? = nil,
+        whereClause: String? = nil
     ) {
         self.name = name
         self.columns = columns
         self.isUnique = isUnique
         self.isPrimary = isPrimary
         self.type = type
+        self.columnPrefixes = columnPrefixes
+        self.whereClause = whereClause
     }
 }

--- a/Plugins/TableProPluginKit/SchemaTypes.swift
+++ b/Plugins/TableProPluginKit/SchemaTypes.swift
@@ -18,6 +18,8 @@ public struct PluginColumnDefinition: Sendable {
     public let comment: String?
     public let unsigned: Bool
     public let onUpdate: String?
+    public let charset: String?
+    public let collation: String?
 
     public init(
         name: String,
@@ -28,7 +30,9 @@ public struct PluginColumnDefinition: Sendable {
         autoIncrement: Bool = false,
         comment: String? = nil,
         unsigned: Bool = false,
-        onUpdate: String? = nil
+        onUpdate: String? = nil,
+        charset: String? = nil,
+        collation: String? = nil
     ) {
         self.name = name
         self.dataType = dataType
@@ -39,6 +43,8 @@ public struct PluginColumnDefinition: Sendable {
         self.comment = comment
         self.unsigned = unsigned
         self.onUpdate = onUpdate
+        self.charset = charset
+        self.collation = collation
     }
 }
 
@@ -48,17 +54,23 @@ public struct PluginIndexDefinition: Sendable {
     public let columns: [String]
     public let isUnique: Bool
     public let indexType: String?
+    public let columnPrefixes: [String: Int]?
+    public let whereClause: String?
 
     public init(
         name: String,
         columns: [String],
         isUnique: Bool = false,
-        indexType: String? = nil
+        indexType: String? = nil,
+        columnPrefixes: [String: Int]? = nil,
+        whereClause: String? = nil
     ) {
         self.name = name
         self.columns = columns
         self.isUnique = isUnique
         self.indexType = indexType
+        self.columnPrefixes = columnPrefixes
+        self.whereClause = whereClause
     }
 }
 
@@ -70,6 +82,7 @@ public struct PluginForeignKeyDefinition: Sendable {
     public let referencedColumns: [String]
     public let onDelete: String
     public let onUpdate: String
+    public let referencedSchema: String?
 
     public init(
         name: String,
@@ -77,7 +90,8 @@ public struct PluginForeignKeyDefinition: Sendable {
         referencedTable: String,
         referencedColumns: [String],
         onDelete: String = "NO ACTION",
-        onUpdate: String = "NO ACTION"
+        onUpdate: String = "NO ACTION",
+        referencedSchema: String? = nil
     ) {
         self.name = name
         self.columns = columns
@@ -85,6 +99,7 @@ public struct PluginForeignKeyDefinition: Sendable {
         self.referencedColumns = referencedColumns
         self.onDelete = onDelete
         self.onUpdate = onUpdate
+        self.referencedSchema = referencedSchema
     }
 }
 

--- a/Plugins/TableProPluginKit/StructureColumnField.swift
+++ b/Plugins/TableProPluginKit/StructureColumnField.swift
@@ -8,6 +8,8 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
     case primaryKey
     case autoIncrement
     case comment
+    case charset
+    case collation
 
     public var displayName: String {
         switch self {
@@ -18,6 +20,8 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
         case .primaryKey: String(localized: "Primary Key")
         case .autoIncrement: String(localized: "Auto Inc")
         case .comment: String(localized: "Comment")
+        case .charset: String(localized: "Charset")
+        case .collation: String(localized: "Collation")
         }
     }
 }

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -171,7 +171,9 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
                 columns: idx.columns,
                 isUnique: idx.isUnique,
                 isPrimary: idx.isPrimary,
-                type: idx.type
+                type: idx.type,
+                columnPrefixes: idx.columnPrefixes,
+                whereClause: idx.whereClause
             )
         }
     }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -354,7 +354,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     systemSchemaNames: [],
                     fileExtensions: [],
                     databaseGroupingStrategy: .byDatabase,
-                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
+                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
                     sqlDialect: mysqlDialect,
@@ -384,7 +384,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     systemSchemaNames: [],
                     fileExtensions: [],
                     databaseGroupingStrategy: .byDatabase,
-                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
+                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
                     sqlDialect: mysqlDialect,

--- a/TablePro/Core/SchemaTracking/StructureChangeManager.swift
+++ b/TablePro/Core/SchemaTracking/StructureChangeManager.swift
@@ -88,6 +88,7 @@ final class StructureChangeManager {
                 columns: fkInfos.map { $0.column },
                 referencedTable: first.referencedTable,
                 referencedColumns: fkInfos.map { $0.referencedColumn },
+                referencedSchema: first.referencedSchema,
                 onDelete: EditableForeignKeyDefinition.ReferentialAction(rawValue: first.onDelete.uppercased()) ?? .noAction,
                 onUpdate: EditableForeignKeyDefinition.ReferentialAction(rawValue: first.onUpdate.uppercased()) ?? .noAction
             )
@@ -810,7 +811,7 @@ final class StructureChangeManager {
             state = RowVisualState(
                 isDeleted: isDeleted,
                 isInserted: isInserted,
-                modifiedColumns: isModified ? Set(0..<4) : []
+                modifiedColumns: isModified ? Set(0..<5) : []
             )
 
         case .foreignKeys:
@@ -825,7 +826,7 @@ final class StructureChangeManager {
             state = RowVisualState(
                 isDeleted: isDeleted,
                 isInserted: isInserted,
-                modifiedColumns: isModified ? Set(0..<6) : []
+                modifiedColumns: isModified ? Set(0..<7) : []
             )
 
         case .ddl:

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -116,6 +116,26 @@ struct IndexInfo: Identifiable, Hashable {
     let isUnique: Bool
     let isPrimary: Bool
     let type: String  // BTREE, HASH, FULLTEXT, etc.
+    let columnPrefixes: [String: Int]?
+    let whereClause: String?
+
+    init(
+        name: String,
+        columns: [String],
+        isUnique: Bool,
+        isPrimary: Bool,
+        type: String,
+        columnPrefixes: [String: Int]? = nil,
+        whereClause: String? = nil
+    ) {
+        self.name = name
+        self.columns = columns
+        self.isUnique = isUnique
+        self.isPrimary = isPrimary
+        self.type = type
+        self.columnPrefixes = columnPrefixes
+        self.whereClause = whereClause
+    }
 }
 
 /// Information about a foreign key relationship

--- a/TablePro/Models/Schema/ColumnDefinition.swift
+++ b/TablePro/Models/Schema/ColumnDefinition.swift
@@ -74,7 +74,7 @@ struct EditableColumnDefinition: Hashable, Codable, Identifiable {
         PluginColumnDefinition(
             name: name, dataType: dataType, isNullable: isNullable, defaultValue: defaultValue,
             isPrimaryKey: isPrimaryKey, autoIncrement: autoIncrement, comment: comment,
-            unsigned: unsigned, onUpdate: onUpdate
+            unsigned: unsigned, onUpdate: onUpdate, charset: charset, collation: collation
         )
     }
 

--- a/TablePro/Models/Schema/ForeignKeyDefinition.swift
+++ b/TablePro/Models/Schema/ForeignKeyDefinition.swift
@@ -15,6 +15,7 @@ struct EditableForeignKeyDefinition: Hashable, Codable, Identifiable {
     var columns: [String]
     var referencedTable: String
     var referencedColumns: [String]
+    var referencedSchema: String?
     var onDelete: ReferentialAction
     var onUpdate: ReferentialAction
 
@@ -34,6 +35,7 @@ struct EditableForeignKeyDefinition: Hashable, Codable, Identifiable {
             columns: [],
             referencedTable: "",
             referencedColumns: [],
+            referencedSchema: nil,
             onDelete: .noAction,
             onUpdate: .noAction
         )
@@ -55,6 +57,7 @@ struct EditableForeignKeyDefinition: Hashable, Codable, Identifiable {
             columns: [fkInfo.column],
             referencedTable: fkInfo.referencedTable,
             referencedColumns: [fkInfo.referencedColumn],
+            referencedSchema: fkInfo.referencedSchema,
             onDelete: ReferentialAction(rawValue: fkInfo.onDelete.uppercased()) ?? .noAction,
             onUpdate: ReferentialAction(rawValue: fkInfo.onUpdate.uppercased()) ?? .noAction
         )
@@ -63,7 +66,8 @@ struct EditableForeignKeyDefinition: Hashable, Codable, Identifiable {
     func toPlugin() -> PluginForeignKeyDefinition {
         PluginForeignKeyDefinition(
             name: name, columns: columns, referencedTable: referencedTable,
-            referencedColumns: referencedColumns, onDelete: onDelete.rawValue, onUpdate: onUpdate.rawValue
+            referencedColumns: referencedColumns, onDelete: onDelete.rawValue, onUpdate: onUpdate.rawValue,
+            referencedSchema: referencedSchema
         )
     }
 
@@ -79,6 +83,7 @@ struct EditableForeignKeyDefinition: Hashable, Codable, Identifiable {
             column: column,
             referencedTable: referencedTable,
             referencedColumn: referencedColumn,
+            referencedSchema: referencedSchema,
             onDelete: onDelete.rawValue,
             onUpdate: onUpdate.rawValue
         )

--- a/TablePro/Models/Schema/IndexDefinition.swift
+++ b/TablePro/Models/Schema/IndexDefinition.swift
@@ -17,6 +17,8 @@ struct EditableIndexDefinition: Hashable, Codable, Identifiable {
     var isUnique: Bool
     var isPrimary: Bool
     var comment: String?
+    var columnPrefixes: [String: Int] = [:]
+    var whereClause: String?
 
     enum IndexType: String, Codable, CaseIterable {
         case btree = "BTREE"
@@ -37,7 +39,9 @@ struct EditableIndexDefinition: Hashable, Codable, Identifiable {
             type: .btree,
             isUnique: false,
             isPrimary: false,
-            comment: nil
+            comment: nil,
+            columnPrefixes: [:],
+            whereClause: nil
         )
     }
 
@@ -56,12 +60,18 @@ struct EditableIndexDefinition: Hashable, Codable, Identifiable {
             type: IndexType(rawValue: indexInfo.type.uppercased()) ?? .btree,
             isUnique: indexInfo.isUnique,
             isPrimary: indexInfo.isPrimary,
-            comment: nil
+            comment: nil,
+            columnPrefixes: indexInfo.columnPrefixes ?? [:],
+            whereClause: indexInfo.whereClause
         )
     }
 
     func toPlugin() -> PluginIndexDefinition {
-        PluginIndexDefinition(name: name, columns: columns, isUnique: isUnique, indexType: type.rawValue)
+        PluginIndexDefinition(
+            name: name, columns: columns, isUnique: isUnique, indexType: type.rawValue,
+            columnPrefixes: columnPrefixes.isEmpty ? nil : columnPrefixes,
+            whereClause: whereClause
+        )
     }
 
     /// Convert back to IndexInfo
@@ -71,7 +81,9 @@ struct EditableIndexDefinition: Hashable, Codable, Identifiable {
             columns: columns,
             isUnique: isUnique,
             isPrimary: isPrimary,
-            type: type.rawValue
+            type: type.rawValue,
+            columnPrefixes: columnPrefixes.isEmpty ? nil : columnPrefixes,
+            whereClause: whereClause
         )
     }
 }

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -17,6 +17,7 @@ struct ClickHousePartsView: View {
     @State private var parts: [ClickHousePartInfo] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var selection: Set<UUID> = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -44,14 +45,40 @@ struct ClickHousePartsView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
+                partsToolbar
                 partsTable
             }
         }
         .task { await loadParts() }
     }
 
+    private var partsToolbar: some View {
+        HStack(spacing: 8) {
+            Button(action: optimizeTable) {
+                Label(String(localized: "Optimize"), systemImage: "arrow.triangle.merge")
+            }
+            .help(String(localized: "Optimize table (merge parts)"))
+
+            Button(action: dropSelectedPartition) {
+                Label(String(localized: "Drop Partition"), systemImage: "trash")
+            }
+            .disabled(selection.isEmpty)
+            .help(String(localized: "Drop selected partition"))
+
+            Button(action: detachSelectedPartition) {
+                Label(String(localized: "Detach Partition"), systemImage: "arrow.down.doc")
+            }
+            .disabled(selection.isEmpty)
+            .help(String(localized: "Detach selected partition"))
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 6)
+    }
+
     private var partsTable: some View {
-        Table(parts) {
+        Table(parts, selection: $selection) {
             TableColumn("Partition", value: \.partition)
                 .width(min: 80, ideal: 120)
             TableColumn("Name", value: \.name)
@@ -75,6 +102,85 @@ struct ClickHousePartsView: View {
             .width(min: 50, ideal: 60)
         }
     }
+
+    // MARK: - Actions
+
+    private func optimizeTable() {
+        Task {
+            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
+            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
+            let sql = "OPTIMIZE TABLE `\(escapedTable)` FINAL"
+            do {
+                _ = try await driver.execute(query: sql)
+                await loadParts()
+            } catch {
+                Self.logger.error("Optimize failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func dropSelectedPartition() {
+        guard let partitionValue = selectedPartitionValue() else { return }
+        Task { @MainActor in
+            let confirmed = await AlertHelper.confirmDestructive(
+                title: String(localized: "Drop Partition?"),
+                message: String(
+                    format: String(localized: "This will permanently delete all data in partition '%@'."),
+                    partitionValue
+                ),
+                confirmButton: String(localized: "Drop"),
+                cancelButton: String(localized: "Cancel")
+            )
+            guard confirmed else { return }
+
+            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
+            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
+            let sql = "ALTER TABLE `\(escapedTable)` DROP PARTITION '\(partitionValue.replacingOccurrences(of: "'", with: "''"))'"
+            do {
+                _ = try await driver.execute(query: sql)
+                selection.removeAll()
+                await loadParts()
+            } catch {
+                Self.logger.error("Drop partition failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func detachSelectedPartition() {
+        guard let partitionValue = selectedPartitionValue() else { return }
+        Task { @MainActor in
+            let confirmed = await AlertHelper.confirmDestructive(
+                title: String(localized: "Detach Partition?"),
+                message: String(
+                    format: String(localized: "This will detach partition '%@'. Data will be preserved but inaccessible until re-attached."),
+                    partitionValue
+                ),
+                confirmButton: String(localized: "Detach"),
+                cancelButton: String(localized: "Cancel")
+            )
+            guard confirmed else { return }
+
+            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
+            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
+            let sql = "ALTER TABLE `\(escapedTable)` DETACH PARTITION '\(partitionValue.replacingOccurrences(of: "'", with: "''"))'"
+            do {
+                _ = try await driver.execute(query: sql)
+                selection.removeAll()
+                await loadParts()
+            } catch {
+                Self.logger.error("Detach partition failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func selectedPartitionValue() -> String? {
+        guard let selectedId = selection.first,
+              let part = parts.first(where: { $0.id == selectedId })
+        else { return nil }
+        return part.partition
+    }
+
+    // MARK: - Data Loading
 
     private func loadParts() async {
         isLoading = true
@@ -119,6 +225,8 @@ struct ClickHousePartsView: View {
 
         isLoading = false
     }
+
+    // MARK: - Formatting
 
     private static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -62,13 +62,13 @@ struct ClickHousePartsView: View {
             Button(action: dropSelectedPartition) {
                 Label(String(localized: "Drop Partition"), systemImage: "trash")
             }
-            .disabled(selection.isEmpty)
+            .disabled(selection.count != 1)
             .help(String(localized: "Drop selected partition"))
 
             Button(action: detachSelectedPartition) {
                 Label(String(localized: "Detach Partition"), systemImage: "arrow.down.doc")
             }
-            .disabled(selection.isEmpty)
+            .disabled(selection.count != 1)
             .help(String(localized: "Detach selected partition"))
 
             Spacer()

--- a/TablePro/Views/Structure/StructureEditingSupport.swift
+++ b/TablePro/Views/Structure/StructureEditingSupport.swift
@@ -27,18 +27,34 @@ enum StructureEditingSupport {
         case .primaryKey: column.isPrimaryKey = value.uppercased() == "YES" || value == "1"
         case .autoIncrement: column.autoIncrement = value.uppercased() == "YES" || value == "1"
         case .comment: column.comment = value.isEmpty ? nil : value
+        case .charset: column.charset = value.isEmpty ? nil : value
+        case .collation: column.collation = value.isEmpty ? nil : value
         }
     }
 
     static func updateIndex(_ index: inout EditableIndexDefinition, at colIndex: Int, with value: String) {
         switch colIndex {
         case 0: index.name = value
-        case 1: index.columns = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        case 1:
+            var prefixes: [String: Int] = [:]
+            index.columns = value.split(separator: ",").map { part in
+                let trimmed = part.trimmingCharacters(in: .whitespaces)
+                if let parenStart = trimmed.firstIndex(of: "("),
+                   let parenEnd = trimmed.firstIndex(of: ")"),
+                   let prefix = Int(trimmed[trimmed.index(after: parenStart)..<parenEnd]) {
+                    let name = String(trimmed[..<parenStart])
+                    prefixes[name] = prefix
+                    return name
+                }
+                return trimmed
+            }
+            index.columnPrefixes = prefixes
         case 2:
             if let indexType = EditableIndexDefinition.IndexType(rawValue: value.uppercased()) {
                 index.type = indexType
             }
         case 3: index.isUnique = value.uppercased() == "YES" || value == "1"
+        case 4: index.whereClause = value.isEmpty ? nil : value
         default: break
         }
     }
@@ -49,11 +65,12 @@ enum StructureEditingSupport {
         case 1: fk.columns = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
         case 2: fk.referencedTable = value
         case 3: fk.referencedColumns = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-        case 4:
+        case 4: fk.referencedSchema = value.isEmpty ? nil : value
+        case 5:
             if let action = EditableForeignKeyDefinition.ReferentialAction(rawValue: value.uppercased()) {
                 fk.onDelete = action
             }
-        case 5:
+        case 6:
             if let action = EditableForeignKeyDefinition.ReferentialAction(rawValue: value.uppercased()) {
                 fk.onUpdate = action
             }

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -238,7 +238,9 @@ final class StructureGridDelegate: DataGridViewDelegate {
                     type: item.type,
                     isUnique: item.isUnique,
                     isPrimary: item.isPrimary,
-                    comment: item.comment
+                    comment: item.comment,
+                    columnPrefixes: item.columnPrefixes,
+                    whereClause: item.whereClause
                 )
                 structureChangeManager.addIndex(newIndex)
             }
@@ -254,6 +256,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                     columns: item.columns,
                     referencedTable: item.referencedTable,
                     referencedColumns: item.referencedColumns,
+                    referencedSchema: item.referencedSchema,
                     onDelete: item.onDelete,
                     onUpdate: item.onUpdate
                 )
@@ -498,7 +501,8 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 let copy = structureChangeManager.workingIndexes[row]
                 structureChangeManager.addIndex(EditableIndexDefinition(
                     id: UUID(), name: copy.name, columns: copy.columns,
-                    type: copy.type, isUnique: copy.isUnique, isPrimary: false, comment: copy.comment
+                    type: copy.type, isUnique: copy.isUnique, isPrimary: false, comment: copy.comment,
+                    columnPrefixes: copy.columnPrefixes, whereClause: copy.whereClause
                 ))
             case .foreignKeys:
                 guard row < structureChangeManager.workingForeignKeys.count else { continue }
@@ -506,6 +510,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 structureChangeManager.addForeignKey(EditableForeignKeyDefinition(
                     id: UUID(), name: copy.name, columns: copy.columns,
                     referencedTable: copy.referencedTable, referencedColumns: copy.referencedColumns,
+                    referencedSchema: copy.referencedSchema,
                     onDelete: copy.onDelete, onUpdate: copy.onUpdate
                 ))
             case .ddl, .parts:

--- a/TablePro/Views/Structure/StructureRowProvider.swift
+++ b/TablePro/Views/Structure/StructureRowProvider.swift
@@ -19,7 +19,7 @@ struct StructureSortDescriptor {
 @MainActor
 final class StructureRowProvider {
     private static let canonicalFieldOrder: [StructureColumnField] = [
-        .name, .type, .nullable, .defaultValue, .primaryKey, .autoIncrement, .comment
+        .name, .type, .nullable, .defaultValue, .primaryKey, .autoIncrement, .comment, .charset, .collation
     ]
 
     private let changeManager: StructureChangeManager
@@ -49,7 +49,8 @@ final class StructureRowProvider {
                 String(localized: "Name"),
                 String(localized: "Columns"),
                 String(localized: "Type"),
-                String(localized: "Unique")
+                String(localized: "Unique"),
+                String(localized: "Condition")
             ]
         case .foreignKeys:
             return [
@@ -57,6 +58,7 @@ final class StructureRowProvider {
                 String(localized: "Columns"),
                 String(localized: "Ref Table"),
                 String(localized: "Ref Columns"),
+                String(localized: "Ref Schema"),
                 String(localized: "On Delete"),
                 String(localized: "On Update")
             ]
@@ -91,7 +93,7 @@ final class StructureRowProvider {
         switch tab {
         case .foreignKeys:
             let actions = EditableForeignKeyDefinition.ReferentialAction.allCases.map(\.rawValue)
-            return [4: actions, 5: actions]
+            return [5: actions, 6: actions]
         case .indexes:
             let types = EditableIndexDefinition.IndexType.allCases.map(\.rawValue)
             return [2: types]
@@ -190,17 +192,26 @@ final class StructureRowProvider {
                     case .primaryKey: column.isPrimaryKey ? "YES" : "NO"
                     case .autoIncrement: column.autoIncrement ? "YES" : "NO"
                     case .comment: column.comment ?? ""
+                    case .charset: column.charset ?? ""
+                    case .collation: column.collation ?? ""
                     }
                 }
                 return IndexedRow(sourceIndex: index, row: row)
             }
         case .indexes:
             return changeManager.workingIndexes.enumerated().map { index, indexInfo in
-                IndexedRow(sourceIndex: index, row: [
+                let columnsStr = indexInfo.columns.map { col in
+                    if let prefix = indexInfo.columnPrefixes[col] {
+                        return "\(col)(\(prefix))"
+                    }
+                    return col
+                }.joined(separator: ", ")
+                return IndexedRow(sourceIndex: index, row: [
                     indexInfo.name,
-                    indexInfo.columns.joined(separator: ", "),
+                    columnsStr,
                     indexInfo.type.rawValue,
-                    indexInfo.isUnique ? "YES" : "NO"
+                    indexInfo.isUnique ? "YES" : "NO",
+                    indexInfo.whereClause ?? ""
                 ])
             }
         case .foreignKeys:
@@ -210,6 +221,7 @@ final class StructureRowProvider {
                     fk.columns.joined(separator: ", "),
                     fk.referencedTable,
                     fk.referencedColumns.joined(separator: ", "),
+                    fk.referencedSchema ?? "",
                     fk.onDelete.rawValue,
                     fk.onUpdate.rawValue
                 ])

--- a/docs/databases/clickhouse.mdx
+++ b/docs/databases/clickhouse.mdx
@@ -44,7 +44,7 @@ For each table, TablePro shows:
 - **Structure**: Columns with ClickHouse data types, default expressions, and comments
 - **Indexes**: Data skipping indices (minmax, set, bloom_filter, etc.)
 - **DDL**: The full CREATE TABLE statement including engine and settings
-- **Parts**: Partition and part details from `system.parts` (rows, disk size, active status)
+- **Parts**: Partition and part details from `system.parts` (rows, disk size, active status). Actions: Optimize Table, Drop Partition, Detach Partition
 
 **Engines**:
 

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -48,6 +48,8 @@ Click a table in the sidebar, then click the **Structure** tab. Or right-click a
 | **Primary Key** | Whether the column is part of the primary key |
 | **Auto Inc** | AUTO_INCREMENT / SERIAL |
 | **Comment** | Column comment |
+| **Charset** | Character set (MySQL/MariaDB only) |
+| **Collation** | Collation (MySQL/MariaDB only) |
 
 Use the filter field at the top to search columns by name. Click any column header to sort.
 
@@ -70,10 +72,10 @@ Use the filter field at the top to search columns by name. Click any column head
 | Property | Description |
 |----------|-------------|
 | **Name** | Index name |
-| **Columns** | Columns included in the index |
-| **Type** | BTREE, HASH, FULLTEXT, etc. |
+| **Columns** | Columns included in the index. MySQL prefix lengths shown as `col(10)` |
+| **Type** | BTREE, HASH, FULLTEXT, GIN, GIST, BRIN, etc. |
 | **Unique** | Whether the index enforces uniqueness |
-| **Primary** | Whether this is the primary key |
+| **Condition** | WHERE clause for partial indexes (PostgreSQL) |
 
 ## Foreign Keys Tab
 
@@ -97,6 +99,7 @@ Use the filter field at the top to search columns by name. Click any column head
 | **Columns** | Local column(s) |
 | **Ref Table** | Referenced table |
 | **Ref Columns** | Referenced column(s) |
+| **Ref Schema** | Referenced schema (for cross-schema references) |
 | **On Delete** | Action when referenced row is deleted (NO ACTION, CASCADE, SET NULL, SET DEFAULT, RESTRICT) |
 | **On Update** | Action when referenced row is updated |
 


### PR DESCRIPTION
## Summary

5 P2 features for the Structure tab. Bumps PluginKit to v5.

### Features
- **Charset/Collation** (MySQL/MariaDB) - editable columns with DDL support
- **Index prefix length** (MySQL) - `col(10)` display/edit format
- **Partial indexes** (PostgreSQL) - Condition column with WHERE clause
- **ClickHouse parts actions** - Optimize/Drop/Detach partition with confirmation
- **Cross-schema FK** - Ref Schema column for cross-schema references

## Test plan
- [x] Build passes
- [x] All structure tests pass