### PR TITLE
fix: persist SSH jumphost and tunnel mode in connections.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - SSH jumphost configuration lost after disconnect/reconnect (#790)
-- Keychain errors now distinguished between locked and missing states (#780)
+- Password loading now detects Keychain locked state and logs a warning instead of silent nil (#780)
 - SQL import parser rewritten: fixes chunk boundary quote escapes, adds DELIMITER support, MySQL conditional comments, and hash comments
 - Import parser now surfaces file read and encoding errors instead of silently succeeding
 - Compressed (.gz) files are only decompressed once instead of twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- SSH jumphost configuration lost after disconnect/reconnect (#790)
-- Password loading now detects Keychain locked state and logs a warning instead of silent nil (#780)
+- SSH jumphost lost after disconnect or app restart (#790)
+- Password appears missing when Keychain is locked after reboot (#780)
 - SQL import parser rewritten: fixes chunk boundary quote escapes, adds DELIMITER support, MySQL conditional comments, and hash comments
 - Import parser now surfaces file read and encoding errors instead of silently succeeding
 - Compressed (.gz) files are only decompressed once instead of twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SSH jumphost configuration lost after disconnect/reconnect (#790)
+- Keychain errors now distinguished between locked and missing states (#780)
 - SQL import parser rewritten: fixes chunk boundary quote escapes, adds DELIMITER support, MySQL conditional comments, and hash comments
 - Import parser now surfaces file read and encoding errors instead of silently succeeding
 - Compressed (.gz) files are only decompressed once instead of twice

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -188,6 +188,7 @@ enum ConnectionExportService {
                 color: color,
                 tagName: tagName,
                 groupName: groupName,
+                sshProfileId: connection.sshProfileId?.uuidString,
                 safeModeLevel: safeModeLevel,
                 aiPolicy: aiPolicy,
                 additionalFields: additionalFields,
@@ -653,6 +654,8 @@ enum ConnectionExportService {
             GroupStorage.shared.loadGroups().first { $0.name.lowercased() == name.lowercased() }?.id
         }
 
+        let parsedSSHProfileId = exportable.sshProfileId.flatMap { UUID(uuidString: $0) }
+
         return DatabaseConnection(
             id: id,
             name: name,
@@ -666,6 +669,7 @@ enum ConnectionExportService {
             color: exportable.color.flatMap { ConnectionColor(rawValue: $0) } ?? .none,
             tagId: tagId,
             groupId: groupId,
+            sshProfileId: parsedSSHProfileId,
             safeModeLevel: exportable.safeModeLevel.flatMap { SafeModeLevel(rawValue: $0) } ?? .silent,
             aiPolicy: exportable.aiPolicy.flatMap { AIConnectionPolicy(rawValue: $0) },
             redisDatabase: exportable.redisDatabase,

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -239,7 +239,11 @@ final class ConnectionStorage {
 
     func loadPassword(for connectionId: UUID) -> String? {
         let key = "com.TablePro.password.\(connectionId.uuidString)"
-        return KeychainHelper.shared.loadString(forKey: key)
+        let (value, isLocked) = KeychainHelper.shared.loadStringWithStatus(forKey: key)
+        if isLocked {
+            Self.logger.warning("Database password unavailable — Keychain locked (connId=\(connectionId.uuidString, privacy: .public))")
+        }
+        return value
     }
 
     func deletePassword(for connectionId: UUID) {
@@ -256,7 +260,11 @@ final class ConnectionStorage {
 
     func loadSSHPassword(for connectionId: UUID) -> String? {
         let key = "com.TablePro.sshpassword.\(connectionId.uuidString)"
-        return KeychainHelper.shared.loadString(forKey: key)
+        let (value, isLocked) = KeychainHelper.shared.loadStringWithStatus(forKey: key)
+        if isLocked {
+            Self.logger.warning("SSH password unavailable — Keychain locked (connId=\(connectionId.uuidString, privacy: .public))")
+        }
+        return value
     }
 
     func deleteSSHPassword(for connectionId: UUID) {
@@ -273,7 +281,11 @@ final class ConnectionStorage {
 
     func loadKeyPassphrase(for connectionId: UUID) -> String? {
         let key = "com.TablePro.keypassphrase.\(connectionId.uuidString)"
-        return KeychainHelper.shared.loadString(forKey: key)
+        let (value, isLocked) = KeychainHelper.shared.loadStringWithStatus(forKey: key)
+        if isLocked {
+            Self.logger.warning("Key passphrase unavailable — Keychain locked (connId=\(connectionId.uuidString, privacy: .public))")
+        }
+        return value
     }
 
     func deleteKeyPassphrase(for connectionId: UUID) {

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -191,10 +191,12 @@ final class ConnectionStorage {
             tagId: connection.tagId,
             groupId: connection.groupId,
             sshProfileId: connection.sshProfileId,
+            sshTunnelMode: connection.sshTunnelMode,
             safeModeLevel: connection.safeModeLevel,
             aiPolicy: connection.aiPolicy,
             redisDatabase: connection.redisDatabase,
             startupCommands: connection.startupCommands,
+            sortOrder: connection.sortOrder,
             additionalFields: connection.additionalFields.isEmpty ? nil : connection.additionalFields
         )
 
@@ -420,6 +422,9 @@ private struct StoredConnection: Codable {
     let totpDigits: Int
     let totpPeriod: Int
 
+    // SSH tunnel mode (v2 JSON blob preserving jump hosts + profile links)
+    let sshTunnelModeJson: Data?
+
     // Plugin-driven additional fields
     let additionalFields: [String: String]?
 
@@ -486,6 +491,9 @@ private struct StoredConnection: Codable {
         // Sort order
         self.sortOrder = connection.sortOrder
 
+        // SSH tunnel mode (v2 format preserving jump hosts, profiles, etc.)
+        self.sshTunnelModeJson = try? JSONEncoder().encode(connection.sshTunnelMode)
+
         // Plugin-driven additional fields
         self.additionalFields = connection.additionalFields.isEmpty ? nil : connection.additionalFields
     }
@@ -502,6 +510,7 @@ private struct StoredConnection: Codable {
         case aiPolicy
         case mongoAuthSource, mongoReadPreference, mongoWriteConcern, redisDatabase
         case mssqlSchema, oracleServiceName, startupCommands, sortOrder
+        case sshTunnelModeJson
         case additionalFields
     }
 
@@ -539,6 +548,7 @@ private struct StoredConnection: Codable {
         try container.encodeIfPresent(redisDatabase, forKey: .redisDatabase)
         try container.encodeIfPresent(startupCommands, forKey: .startupCommands)
         try container.encode(sortOrder, forKey: .sortOrder)
+        try container.encodeIfPresent(sshTunnelModeJson, forKey: .sshTunnelModeJson)
         try container.encodeIfPresent(additionalFields, forKey: .additionalFields)
     }
 
@@ -602,6 +612,7 @@ private struct StoredConnection: Codable {
         oracleServiceName = try container.decodeIfPresent(String.self, forKey: .oracleServiceName)
         startupCommands = try container.decodeIfPresent(String.self, forKey: .startupCommands)
         sortOrder = try container.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
+        sshTunnelModeJson = try container.decodeIfPresent(Data.self, forKey: .sshTunnelModeJson)
         additionalFields = try container.decodeIfPresent([String: String].self, forKey: .additionalFields)
     }
 
@@ -620,6 +631,23 @@ private struct StoredConnection: Codable {
         sshConfig.totpAlgorithm = TOTPAlgorithm(rawValue: totpAlgorithm) ?? .sha1
         sshConfig.totpDigits = totpDigits
         sshConfig.totpPeriod = totpPeriod
+
+        // Prefer sshTunnelModeJson (v2 format) over legacy flat fields
+        let resolvedTunnelMode: SSHTunnelMode
+        if let json = sshTunnelModeJson,
+           let decoded = try? JSONDecoder().decode(SSHTunnelMode.self, from: json) {
+            resolvedTunnelMode = decoded
+            switch decoded {
+            case .disabled:
+                break
+            case .inline(let config):
+                sshConfig = config
+            case .profile(_, let snapshot):
+                sshConfig = snapshot
+            }
+        } else {
+            resolvedTunnelMode = .disabled
+        }
 
         let sslConfig = SSLConfiguration(
             mode: SSLMode(rawValue: sslMode) ?? .disabled,
@@ -665,6 +693,7 @@ private struct StoredConnection: Codable {
             tagId: parsedTagId,
             groupId: parsedGroupId,
             sshProfileId: parsedSSHProfileId,
+            sshTunnelMode: resolvedTunnelMode,
             safeModeLevel: SafeModeLevel(rawValue: safeModeLevel) ?? .silent,
             aiPolicy: parsedAIPolicy,
             redisDatabase: redisDatabase,

--- a/TablePro/Core/Storage/KeychainHelper.swift
+++ b/TablePro/Core/Storage/KeychainHelper.swift
@@ -166,6 +166,17 @@ final class KeychainHelper {
         return String(data: data, encoding: .utf8)
     }
 
+    func loadStringWithStatus(forKey key: String) -> (value: String?, isLocked: Bool) {
+        switch loadWithStatus(key: key) {
+        case .success(let data):
+            return (String(data: data, encoding: .utf8), false)
+        case .locked:
+            return (nil, true)
+        case .notFound, .error:
+            return (nil, false)
+        }
+    }
+
     // MARK: - Migration
 
     func migrateFromLegacyKeychainIfNeeded() {

--- a/TablePro/Core/Storage/KeychainHelper.swift
+++ b/TablePro/Core/Storage/KeychainHelper.swift
@@ -7,6 +7,13 @@ import Foundation
 import os
 import Security
 
+enum KeychainLoadResult {
+    case success(Data)
+    case notFound
+    case locked
+    case error(OSStatus)
+}
+
 final class KeychainHelper {
     static let shared = KeychainHelper()
 
@@ -90,6 +97,38 @@ final class KeychainHelper {
         }
 
         return result as? Data
+    }
+
+    func loadWithStatus(key: String) -> KeychainLoadResult {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            if let data = result as? Data {
+                return .success(data)
+            }
+            return .notFound
+        case errSecItemNotFound:
+            return .notFound
+        case errSecInteractionNotAllowed:
+            Self.logger.warning("Keychain locked (before first unlock) for key '\(key, privacy: .public)'")
+            return .locked
+        default:
+            Self.logger.error("Keychain error for key '\(key, privacy: .public)': \(status)")
+            return .error(status)
+        }
     }
 
     func delete(key: String) {

--- a/TablePro/Models/Connection/ConnectionExport.swift
+++ b/TablePro/Models/Connection/ConnectionExport.swift
@@ -51,6 +51,7 @@ struct ExportableConnection: Codable {
     let color: String?
     let tagName: String?
     let groupName: String?
+    let sshProfileId: String?
     let safeModeLevel: String?
     let aiPolicy: String?
     let additionalFields: [String: String]?


### PR DESCRIPTION
## Summary

Closes #790. Partial fix for #780.

**Root cause of #790:** `StoredConnection` used flat scalar fields for SSH config (`sshHost`, `sshPort`, etc.) but never persisted `jumpHosts` or `sshTunnelMode`. Every save/load cycle silently dropped all jump host configuration. First connect worked (in-memory object correct), but reconnecting after app restart failed because `connections.json` had no jumphost data.

### Changes

**StoredConnection — `sshTunnelModeJson` field:**
- Added `sshTunnelModeJson: Data?` that encodes the full `SSHTunnelMode` enum (already Codable, includes inline config with jumpHosts, profile with snapshot)
- On load: prefers JSON blob when present, falls back to legacy flat fields for old `connections.json` files
- On save: writes both JSON blob (source of truth) and flat fields (backward compat with older app versions)
- No migration needed. Old files decode via `decodeIfPresent` returning nil, legacy flat-field path runs unchanged. Next save writes the blob.

**KeychainHelper — `loadWithStatus`:**
- Added `KeychainLoadResult` enum: `.success(Data)`, `.notFound`, `.locked`, `.error(OSStatus)`
- Added `loadWithStatus(key:)` that distinguishes `errSecInteractionNotAllowed` (Keychain locked before first unlock after reboot) from `errSecItemNotFound`
- Existing `load(key:) -> Data?` preserved for backward compat

**duplicateConnection — pass sshTunnelMode:**
- Now passes `sshTunnelMode: connection.sshTunnelMode` explicitly instead of relying on auto-derive logic

**Export — sshProfileId:**
- Added `sshProfileId: String?` to `ExportableConnection`
- Export includes profile binding; import restores it

## Test plan
- [ ] Create MySQL connection with SSH tunnel + jumphost, save, quit app, reopen - jumphost still present
- [ ] Connect with jumphost - succeeds
- [ ] Duplicate connection with jumphost - duplicate has jumphost
- [ ] Old `connections.json` without `sshTunnelModeJson` key loads correctly (flat fields used)
- [ ] Export/import connection with SSH profile - profile binding preserved