### PR TITLE
fix: column visibility UX polish (#778)

### DIFF
--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -119,7 +119,8 @@ struct MainStatusBarView: View {
                                     : "eye.circle")
                             Text("Columns")
                             if columnVisibilityManager.hasHiddenColumns {
-                                Text("(\(columnVisibilityManager.hiddenCount) hidden)")
+                                let visible = allColumns.count - columnVisibilityManager.hiddenCount
+                                Text("(\(visible)/\(allColumns.count))")
                                     .foregroundStyle(.secondary)
                             }
                         }

--- a/TablePro/Views/Results/ColumnVisibilityPopover.swift
+++ b/TablePro/Views/Results/ColumnVisibilityPopover.swift
@@ -24,20 +24,28 @@ struct ColumnVisibilityPopover: View {
 
             Divider()
 
-            if columns.count > 10 {
+            if columns.count > 5 {
                 searchField
                 Divider()
             }
 
             columnList
         }
-        .frame(width: 220)
-        .frame(maxHeight: 350)
+        .frame(width: 260)
+        .frame(maxHeight: 420)
+    }
+
+    private var headerTitle: String {
+        let visible = columns.count - columnVisibilityManager.hiddenCount
+        if columnVisibilityManager.hasHiddenColumns {
+            return "\(visible) of \(columns.count)"
+        }
+        return String(localized: "Columns")
     }
 
     private var header: some View {
         HStack {
-            Text("Columns")
+            Text(headerTitle)
                 .font(.headline)
                 .foregroundStyle(.primary)
 


### PR DESCRIPTION
Closes #778

## Summary

UX polish for column visibility popover. The current approach (toggle checkboxes) is correct and matches DataGrip/DBeaver/TablePlus. These changes improve discoverability.

### Changes
- Header shows "5 of 42" when columns are hidden (was just "Columns")
- Status bar shows "Columns (5/42)" instead of "Columns (37 hidden)"
- Popover wider (260px, was 220px) for long column names
- Popover taller (420px, was 350px) for many columns
- Search field shows for 5+ columns (was 10+)

## Test plan
- [x] Build passes
- [ ] Open table with many columns, verify count badge in header and status bar
- [ ] Toggle columns, verify counts update
- [ ] Search field visible for tables with 5+ columns