### PR TITLE
fix: selection highlight on last line and add Execute All shortcut (#770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Execute All Statements shortcut (Cmd+Shift+Enter) to run all statements in the editor (#770)
 - Structure tab: search, sort, count badges, PK column, Copy As (CSV/JSON/SQL), destructive change confirmation
 - Structure tab: DDL view with tree-sitter highlighting, line numbers, and "Open in Editor"
 - Structure tab: charset/collation (MySQL), index prefix length, partial indexes (PostgreSQL), cross-schema FK
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Selection highlight not covering the last line on Cmd+A (#770)
 - AI chat freeze when large queries or results are included in the system prompt (#774)
 - AI chat panel not updating when switching database connections
 - Schema restored on reconnect for PostgreSQL, Redshift, and BigQuery (#777)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
@@ -90,7 +90,12 @@ extension TextSelectionManager {
             } else if let maxFragmentRect = layoutManager.rectForOffset(intersectionRange.max) {
                 maxRect = maxFragmentRect
             } else {
-                continue
+                maxRect = CGRect(
+                    x: minRect.maxX,
+                    y: minRect.origin.y,
+                    width: 0,
+                    height: minRect.height
+                )
             }
 
             fillRects.append(CGRect(

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -273,6 +273,12 @@ struct AppMenuCommands: Commands {
             .keyboardShortcut(.return, modifiers: .command)
             .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
 
+            Button(String(localized: "Execute All Statements")) {
+                actions?.runAllStatements()
+            }
+            .keyboardShortcut(.return, modifiers: [.command, .shift])
+            .disabled(!(actions?.isConnected ?? false) || !(actions?.hasQueryText ?? false))
+
             Button("Explain Query") {
                 actions?.explainQuery()
             }

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -188,7 +188,7 @@ struct SQLEditorView: View {
                 indentOption: .spaces(count: ThemeEngine.shared.tabWidth)
             ),
             layout: .init(
-                contentInsets: NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+                contentInsets: NSEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
             ),
             peripherals: .init(
                 showGutter: ThemeEngine.shared.showLineNumbers,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -1,0 +1,93 @@
+//
+//  MainContentCoordinator+ExecuteAll.swift
+//  TablePro
+//
+//  Execute All Statements and safe mode dispatch logic shared
+//  between runQuery() and runAllStatements().
+//
+
+import AppKit
+import Foundation
+
+extension MainContentCoordinator {
+    func runAllStatements() {
+        guard let index = tabManager.selectedTabIndex else { return }
+        guard !tabManager.tabs[index].isExecuting else { return }
+        guard tabManager.tabs[index].tabType == .query else { return }
+
+        let fullQuery = tabManager.tabs[index].query
+        guard !fullQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        let statements = SQLStatementScanner.allStatements(in: fullQuery)
+        guard !statements.isEmpty else { return }
+
+        dispatchStatements(statements, tabIndex: index)
+    }
+
+    internal func dispatchStatements(_ statements: [String], tabIndex index: Int) {
+        let level = safeModeLevel
+
+        if level == .readOnly {
+            let writeStatements = statements.filter { isWriteQuery($0) }
+            if !writeStatements.isEmpty {
+                tabManager.tabs[index].errorMessage =
+                    "Cannot execute write queries: connection is read-only"
+                return
+            }
+        }
+
+        if level == .silent {
+            if statements.count == 1 {
+                Task { @MainActor in
+                    let window = NSApp.keyWindow
+                    guard await confirmDangerousQueryIfNeeded(statements[0], window: window) else { return }
+                    executeQueryInternal(statements[0])
+                }
+            } else {
+                Task { @MainActor in
+                    let window = NSApp.keyWindow
+                    let dangerousStatements = statements.filter { isDangerousQuery($0) }
+                    if !dangerousStatements.isEmpty {
+                        guard await confirmDangerousQueries(dangerousStatements, window: window) else { return }
+                    }
+                    executeMultipleStatements(statements)
+                }
+            }
+        } else if level.requiresConfirmation {
+            guard !isShowingSafeModePrompt else { return }
+            isShowingSafeModePrompt = true
+            Task { @MainActor in
+                defer { isShowingSafeModePrompt = false }
+                let window = NSApp.keyWindow
+                let combinedSQL = statements.joined(separator: "\n")
+                let hasWrite = statements.contains { isWriteQuery($0) }
+                let permission = await SafeModeGuard.checkPermission(
+                    level: level,
+                    isWriteOperation: hasWrite,
+                    sql: combinedSQL,
+                    operationDescription: String(localized: "Execute Query"),
+                    window: window,
+                    databaseType: connection.type
+                )
+                switch permission {
+                case .allowed:
+                    if statements.count == 1 {
+                        executeQueryInternal(statements[0])
+                    } else {
+                        executeMultipleStatements(statements)
+                    }
+                case .blocked(let reason):
+                    if index < tabManager.tabs.count {
+                        tabManager.tabs[index].errorMessage = reason
+                    }
+                }
+            }
+        } else {
+            if statements.count == 1 {
+                executeQueryInternal(statements[0])
+            } else {
+                executeMultipleStatements(statements)
+            }
+        }
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -31,7 +31,7 @@ extension MainContentCoordinator {
             let writeStatements = statements.filter { isWriteQuery($0) }
             if !writeStatements.isEmpty {
                 tabManager.tabs[index].errorMessage =
-                    "Cannot execute write queries: connection is read-only"
+                    String(localized: "Cannot execute write queries: connection is read-only")
                 return
             }
         }

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -644,6 +644,10 @@ final class MainContentCommandActions {
         coordinator?.runQuery()
     }
 
+    func runAllStatements() {
+        coordinator?.runAllStatements()
+    }
+
     func cancelCurrentQuery() {
         coordinator?.cancelCurrentQuery()
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -160,7 +160,7 @@ final class MainContentCoordinator {
     @ObservationIgnored internal var isShowingConfirmAlert = false
 
     /// Guards against duplicate safe mode confirmation prompts
-    @ObservationIgnored private var isShowingSafeModePrompt = false
+    @ObservationIgnored internal var isShowingSafeModePrompt = false
 
     /// Continuation for callers that need to await the result of a fire-and-forget save
     /// (e.g. save-then-close). Set before calling `saveChanges`, resumed by `executeCommitStatements`.
@@ -746,71 +746,7 @@ final class MainContentCoordinator {
         let statements = SQLStatementScanner.allStatements(in: sql)
         guard !statements.isEmpty else { return }
 
-        // Safe mode enforcement for query execution
-        let level = safeModeLevel
-
-        if level == .readOnly {
-            let writeStatements = statements.filter { isWriteQuery($0) }
-            if !writeStatements.isEmpty {
-                tabManager.tabs[index].errorMessage =
-                    "Cannot execute write queries: connection is read-only"
-                return
-            }
-        }
-
-        if level == .silent {
-            if statements.count == 1 {
-                Task { @MainActor in
-                    let window = NSApp.keyWindow
-                    guard await confirmDangerousQueryIfNeeded(statements[0], window: window) else { return }
-                    executeQueryInternal(statements[0])
-                }
-            } else {
-                Task { @MainActor in
-                    let window = NSApp.keyWindow
-                    let dangerousStatements = statements.filter { isDangerousQuery($0) }
-                    if !dangerousStatements.isEmpty {
-                        guard await confirmDangerousQueries(dangerousStatements, window: window) else { return }
-                    }
-                    executeMultipleStatements(statements)
-                }
-            }
-        } else if level.requiresConfirmation {
-            guard !isShowingSafeModePrompt else { return }
-            isShowingSafeModePrompt = true
-            Task { @MainActor in
-                defer { isShowingSafeModePrompt = false }
-                let window = NSApp.keyWindow
-                let combinedSQL = statements.joined(separator: "\n")
-                let hasWrite = statements.contains { isWriteQuery($0) }
-                let permission = await SafeModeGuard.checkPermission(
-                    level: level,
-                    isWriteOperation: hasWrite,
-                    sql: combinedSQL,
-                    operationDescription: String(localized: "Execute Query"),
-                    window: window,
-                    databaseType: connection.type
-                )
-                switch permission {
-                case .allowed:
-                    if statements.count == 1 {
-                        executeQueryInternal(statements[0])
-                    } else {
-                        executeMultipleStatements(statements)
-                    }
-                case .blocked(let reason):
-                    if index < tabManager.tabs.count {
-                        tabManager.tabs[index].errorMessage = reason
-                    }
-                }
-            }
-        } else {
-            if statements.count == 1 {
-                executeQueryInternal(statements[0])
-            } else {
-                executeMultipleStatements(statements)
-            }
-        }
+        dispatchStatements(statements, tabIndex: index)
     }
 
     /// Execute table tab query directly.
@@ -990,7 +926,7 @@ final class MainContentCoordinator {
     }
 
     /// Internal query execution (called after any confirmations)
-    private func executeQueryInternal(
+    internal func executeQueryInternal(
         _ sql: String
     ) {
         guard let index = tabManager.selectedTabIndex else { return }

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -36,6 +36,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Action | Shortcut | Description |
 |--------|----------|-------------|
 | Execute query | `Cmd+Enter` | Run query at cursor, or all selected statements sequentially |
+| Execute all statements | `Cmd+Shift+Enter` | Run all statements in the editor sequentially |
 | Cancel query | `Cmd+.` | Stop the currently running query |
 | Explain query | `Option+Cmd+E` | Show execution plan for query at cursor |
 | Format SQL | `Cmd+Shift+L` | Format SQL query |


### PR DESCRIPTION
## Summary

Closes #770 (items 2 and 3).

**Selection highlight fix:** The blue selection mask now correctly covers the last line when using Cmd+A or block selection. Root cause was in `TextSelectionManager+FillRects.swift` where `rectForOffset` returns nil at the document boundary, causing the last line's fill rect to be skipped entirely.

**Execute All Statements (Cmd+Shift+Enter):** New shortcut to run all statements in the editor sequentially, regardless of cursor position or selection. Industry-standard shortcut matching DBeaver and DataGrip. The safe mode dispatch logic was extracted from `runQuery()` into a shared `dispatchStatements()` helper to avoid duplication.

### Changes
- `TextSelectionManager+FillRects.swift` — fallback rect at document end instead of `continue`
- `SQLEditorView.swift` — bottom content inset 0 → 8 for visual breathing room
- `MainContentCoordinator+ExecuteAll.swift` — new extension with `runAllStatements()` and extracted `dispatchStatements()`
- `MainContentCoordinator.swift` — `runQuery()` now calls shared `dispatchStatements()`
- `TableProApp.swift` — "Execute All Statements" menu item with Cmd+Shift+Enter
- `MainContentCommandActions.swift` — `runAllStatements()` passthrough

## Test plan
- [ ] Type multi-line SQL, press Cmd+A — last line fully highlighted
- [ ] Type `SELECT 1; SELECT 2; SELECT 3;`, cursor on line 1, press Cmd+Shift+Enter — all 3 execute (3 result tabs)
- [ ] Same query, Cmd+Enter — only `SELECT 1` executes (statement at cursor)
- [ ] Query menu shows "Execute All Statements" with Cmd+Shift+Enter
- [ ] Safe mode: Execute All respects read-only and confirmation dialogs