### PR TITLE
feat: drop database from database switcher (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Drop database from the database switcher dialog (context menu, toolbar button, Delete key)
 - Structure tab: search, sort, count badges, PK column, Copy As (CSV/JSON/SQL), destructive change confirmation
 - Structure tab: DDL view with tree-sitter highlighting, line numbers, and "Open in Editor"
 - Structure tab: charset/collation (MySQL), index prefix length, partial indexes (PostgreSQL), cross-schema FK

--- a/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
@@ -92,6 +92,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func fetchDependentTypes(table: String, schema: String?) async throws -> [(name: String, labels: [String])]
     func fetchDependentSequences(table: String, schema: String?) async throws -> [(name: String, ddl: String)]
     func createDatabase(name: String, charset: String, collation: String?) async throws
+    func dropDatabase(name: String) async throws
     func executeParameterized(query: String, parameters: [String?]) async throws -> PluginQueryResult
 
     // Query building (optional, for NoSQL plugins)
@@ -266,6 +267,11 @@ public extension PluginDatabaseDriver {
             code: -1,
             userInfo: [NSLocalizedDescriptionKey: "createDatabase not supported"]
         )
+    }
+
+    func dropDatabase(name: String) async throws {
+        throw NSError(domain: "PluginDatabaseDriver", code: -1,
+                      userInfo: [NSLocalizedDescriptionKey: "Drop database is not supported by this driver"])
     }
 
     func switchDatabase(to database: String) async throws {

--- a/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
@@ -209,6 +209,8 @@ final class BigQueryPlugin: NSObject, TableProPlugin, DriverPlugin {
         ]
     }
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         BigQueryPluginDriver(config: config)
     }

--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -811,6 +811,12 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         _ = try await conn.executeQuery("CREATE SCHEMA `\(escaped)`")
     }
 
+    func dropDatabase(name: String) async throws {
+        guard let conn = connection else { throw BigQueryError.notConnected }
+        let escaped = name.replacingOccurrences(of: "`", with: "\\`")
+        _ = try await conn.executeQuery("DROP SCHEMA `\(escaped)`")
+    }
+
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
         guard let conn = connection else { return nil }
         let dataset = lock.withLock { _currentDataset } ?? ""

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -104,6 +104,8 @@ internal final class CassandraPlugin: NSObject, TableProPlugin, DriverPlugin {
         )
     }
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         CassandraPluginDriver(config: config)
     }
@@ -1242,6 +1244,11 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
             WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
         """
         _ = try await execute(query: query)
+    }
+
+    func dropDatabase(name: String) async throws {
+        let safeKs = escapeIdentifier(name)
+        _ = try await execute(query: "DROP KEYSPACE \"\(safeKs)\"")
     }
 
     func switchDatabase(to database: String) async throws {

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -53,6 +53,7 @@ final class ClickHousePlugin: NSObject, TableProPlugin, DriverPlugin {
 
     static let structureColumnFields: [StructureColumnField] = [.name, .type, .nullable, .defaultValue, .comment]
     static let supportsQueryProgress = true
+    static let supportsDropDatabase = true
 
     static let sqlDialect: SQLDialectDescriptor? = SQLDialectDescriptor(
         identifierQuote: "`",
@@ -581,6 +582,11 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func createDatabase(name: String, charset: String, collation: String?) async throws {
         let escapedName = name.replacingOccurrences(of: "`", with: "``")
         _ = try await execute(query: "CREATE DATABASE `\(escapedName)`")
+    }
+
+    func dropDatabase(name: String) async throws {
+        let escapedName = name.replacingOccurrences(of: "`", with: "``")
+        _ = try await execute(query: "DROP DATABASE `\(escapedName)`")
     }
 
     // MARK: - All Tables Metadata

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1Plugin.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1Plugin.swift
@@ -99,6 +99,8 @@ final class CloudflareD1Plugin: NSObject, TableProPlugin, DriverPlugin {
         )
     ]
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         CloudflareD1PluginDriver(config: config)
     }

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
@@ -512,6 +512,26 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
         lock.unlock()
     }
 
+    func dropDatabase(name: String) async throws {
+        guard let client = getClient() else {
+            throw CloudflareD1Error.notConnected
+        }
+
+        lock.lock()
+        let uuid = databaseNameToUuid[name]
+        lock.unlock()
+
+        guard let databaseId = uuid ?? (isUuid(name) ? name : nil) else {
+            throw CloudflareD1Error(message: String(format: String(localized: "Database '%@' not found"), name))
+        }
+
+        try await client.deleteDatabase(databaseId: databaseId)
+
+        lock.lock()
+        databaseNameToUuid.removeValue(forKey: name)
+        lock.unlock()
+    }
+
     func switchDatabase(to database: String) async throws {
         lock.lock()
         var uuid = databaseNameToUuid[database]

--- a/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
+++ b/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
@@ -260,6 +260,14 @@ final class D1HttpClient: @unchecked Sendable {
         return result
     }
 
+    func deleteDatabase(databaseId: String) async throws {
+        let url = try baseURL(databaseId: databaseId)
+        let data = try await performRequest(url: url, method: "DELETE", body: nil)
+
+        let envelope = try JSONDecoder().decode(D1ApiResponse<D1DatabaseInfo>.self, from: data)
+        try checkApiSuccess(envelope)
+    }
+
     // MARK: - Private Helpers
 
     private func baseURL(databaseId: String?) throws -> URL {

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -93,6 +93,8 @@ final class MSSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         autoLimitStyle: .top
     )
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         MSSQLPluginDriver(config: config)
     }
@@ -1360,6 +1362,11 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func createDatabase(name: String, charset: String, collation: String?) async throws {
         let quotedName = "[\(name.replacingOccurrences(of: "]", with: "]]"))]"
         _ = try await execute(query: "CREATE DATABASE \(quotedName)")
+    }
+
+    func dropDatabase(name: String) async throws {
+        let quotedName = "[\(name.replacingOccurrences(of: "]", with: "]]"))]"
+        _ = try await execute(query: "DROP DATABASE \(quotedName)")
     }
 
     // MARK: - All Tables Metadata

--- a/Plugins/MongoDBDriverPlugin/MongoDBPlugin.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPlugin.swift
@@ -126,6 +126,8 @@ final class MongoDBPlugin: NSObject, TableProPlugin, DriverPlugin {
         ]
     }
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         MongoDBPluginDriver(config: config)
     }

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -457,6 +457,14 @@ final class MongoDBPluginDriver: PluginDatabaseDriver {
         _ = try await conn.runCommand("{\"drop\": \"__tablepro_init\"}", database: name)
     }
 
+    func dropDatabase(name: String) async throws {
+        guard let conn = mongoConnection else {
+            throw MongoDBPluginError.notConnected
+        }
+
+        _ = try await conn.runCommand("{\"dropDatabase\": 1}", database: name)
+    }
+
     // MARK: - Database Switching
 
     func switchDatabase(to database: String) async throws {

--- a/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
@@ -93,6 +93,8 @@ final class MySQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         requiresBackslashEscaping: true
     )
 
+    static let supportsDropDatabase = true
+
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         MySQLPluginDriver(config: config)
     }

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -650,6 +650,11 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         _ = try await execute(query: query)
     }
 
+    func dropDatabase(name: String) async throws {
+        let escapedName = name.replacingOccurrences(of: "`", with: "``")
+        _ = try await execute(query: "DROP DATABASE `\(escapedName)`")
+    }
+
     // MARK: - Database Switching
 
     func switchDatabase(to database: String) async throws {

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
@@ -66,6 +66,7 @@ final class PostgreSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let supportsForeignKeyDisable = false
     static let requiresReconnectForDatabaseSwitch = true
     static let parameterStyle: ParameterStyle = .dollar
+    static let supportsDropDatabase = true
 
     static let sqlDialect: SQLDialectDescriptor? = SQLDialectDescriptor(
         identifierQuote: "\"",

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -842,6 +842,11 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         _ = try await execute(query: query)
     }
 
+    func dropDatabase(name: String) async throws {
+        let escapedName = name.replacingOccurrences(of: "\"", with: "\"\"")
+        _ = try await execute(query: "DROP DATABASE \"\(escapedName)\"")
+    }
+
     // MARK: - All Tables Metadata
 
     func allTablesMetadataSQL(schema: String?) -> String? {

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
@@ -687,6 +687,11 @@ final class RedshiftPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         _ = try await execute(query: query)
     }
 
+    func dropDatabase(name: String) async throws {
+        let escapedName = name.replacingOccurrences(of: "\"", with: "\"\"")
+        _ = try await execute(query: "DROP DATABASE \"\(escapedName)\"")
+    }
+
     // MARK: - All Tables Metadata
 
     func allTablesMetadataSQL(schema: String?) -> String? {

--- a/Plugins/TableProPluginKit/DriverPlugin.swift
+++ b/Plugins/TableProPluginKit/DriverPlugin.swift
@@ -54,6 +54,7 @@ public protocol DriverPlugin: TableProPlugin {
     static var isDownloadable: Bool { get }
     static var postConnectActions: [PostConnectAction] { get }
     static var parameterStyle: ParameterStyle { get }
+    static var supportsDropDatabase: Bool { get }
 }
 
 public extension DriverPlugin {
@@ -114,4 +115,5 @@ public extension DriverPlugin {
     static var parameterStyle: ParameterStyle { .questionMark }
     static var isDownloadable: Bool { false }
     static var postConnectActions: [PostConnectAction] { [] }
+    static var supportsDropDatabase: Bool { false }
 }

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -78,6 +78,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func fetchDependentTypes(table: String, schema: String?) async throws -> [(name: String, labels: [String])]
     func fetchDependentSequences(table: String, schema: String?) async throws -> [(name: String, ddl: String)]
     func createDatabase(name: String, charset: String, collation: String?) async throws
+    func dropDatabase(name: String) async throws
     func executeParameterized(query: String, parameters: [String?]) async throws -> PluginQueryResult
 
     // Query building (optional, for NoSQL plugins)
@@ -221,6 +222,11 @@ public extension PluginDatabaseDriver {
 
     func createDatabase(name: String, charset: String, collation: String?) async throws {
         throw NSError(domain: "PluginDatabaseDriver", code: -1, userInfo: [NSLocalizedDescriptionKey: "createDatabase not supported"])
+    }
+
+    func dropDatabase(name: String) async throws {
+        throw NSError(domain: "PluginDatabaseDriver", code: -1,
+                      userInfo: [NSLocalizedDescriptionKey: "Drop database is not supported by this driver"])
     }
 
     func switchDatabase(to database: String) async throws {

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -130,6 +130,9 @@ protocol DatabaseDriver: AnyObject {
     /// Create a new database
     func createDatabase(name: String, charset: String, collation: String?) async throws
 
+    /// Drop a database
+    func dropDatabase(name: String) async throws
+
     // MARK: - Maintenance
 
     /// Returns the list of supported maintenance operations (e.g. "VACUUM", "ANALYZE").
@@ -231,6 +234,11 @@ extension DatabaseDriver {
         try await connect()
         disconnect()
         return true
+    }
+
+    func dropDatabase(name: String) async throws {
+        throw NSError(domain: "DatabaseDriver", code: -1,
+                      userInfo: [NSLocalizedDescriptionKey: "Drop database is not supported by this driver"])
     }
 
     /// Default fetchAllDatabaseMetadata: falls back to per-database calls (N+1).

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -258,6 +258,10 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         try await pluginDriver.createDatabase(name: name, charset: charset, collation: collation)
     }
 
+    func dropDatabase(name: String) async throws {
+        try await pluginDriver.dropDatabase(name: name)
+    }
+
     // MARK: - Batch Operations
 
     func fetchAllColumns() async throws -> [String: [ColumnInfo]] {

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -366,6 +366,11 @@ extension PluginManager {
             .supportsColumnReorder ?? false
     }
 
+    func supportsDropDatabase(for databaseType: DatabaseType) -> Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: databaseType.pluginTypeId)?
+            .capabilities.supportsDropDatabase ?? false
+    }
+
     func autoLimitStyle(for databaseType: DatabaseType) -> AutoLimitStyle {
         guard let snapshot = PluginMetadataRegistry.shared.snapshot(forTypeId: databaseType.pluginTypeId) else {
             return .limit

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
@@ -31,7 +31,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "",
@@ -172,7 +173,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -527,7 +527,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -598,7 +599,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -639,7 +641,19 @@ extension PluginMetadataRegistry {
                 queryLanguageName: "SQL", editorLanguage: .sql,
                 connectionMode: .network, supportsDatabaseSwitching: true,
                 supportsColumnReorder: false,
-                capabilities: .defaults,
+                capabilities: PluginMetadataSnapshot.CapabilityFlags(
+                    supportsSchemaSwitching: false,
+                    supportsImport: true,
+                    supportsExport: true,
+                    supportsSSH: true,
+                    supportsSSL: true,
+                    supportsCascadeDrop: false,
+                    supportsForeignKeyDisable: true,
+                    supportsReadOnlyMode: true,
+                    supportsQueryProgress: false,
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
+                ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "dbo",
                     defaultGroupName: "main",
@@ -685,7 +699,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -741,7 +756,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: true,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: true,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -817,7 +833,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -871,7 +888,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -924,7 +942,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -1006,7 +1025,8 @@ extension PluginMetadataRegistry {
                     supportsForeignKeyDisable: true,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "main",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -50,6 +50,7 @@ struct PluginMetadataSnapshot: Sendable {
         let supportsReadOnlyMode: Bool
         let supportsQueryProgress: Bool
         let requiresReconnectForDatabaseSwitch: Bool
+        let supportsDropDatabase: Bool
 
         static let defaults = CapabilityFlags(
             supportsSchemaSwitching: false,
@@ -61,7 +62,8 @@ struct PluginMetadataSnapshot: Sendable {
             supportsForeignKeyDisable: true,
             supportsReadOnlyMode: true,
             supportsQueryProgress: false,
-            requiresReconnectForDatabaseSwitch: false
+            requiresReconnectForDatabaseSwitch: false,
+            supportsDropDatabase: false
         )
     }
 
@@ -343,7 +345,19 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 queryLanguageName: "SQL", editorLanguage: .sql,
                 connectionMode: .network, supportsDatabaseSwitching: true,
                 supportsColumnReorder: true,
-                capabilities: .defaults,
+                capabilities: PluginMetadataSnapshot.CapabilityFlags(
+                    supportsSchemaSwitching: false,
+                    supportsImport: true,
+                    supportsExport: true,
+                    supportsSSH: true,
+                    supportsSSL: true,
+                    supportsCascadeDrop: false,
+                    supportsForeignKeyDisable: true,
+                    supportsReadOnlyMode: true,
+                    supportsQueryProgress: false,
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
+                ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
                     defaultGroupName: "main",
@@ -373,7 +387,19 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 queryLanguageName: "SQL", editorLanguage: .sql,
                 connectionMode: .network, supportsDatabaseSwitching: true,
                 supportsColumnReorder: true,
-                capabilities: .defaults,
+                capabilities: PluginMetadataSnapshot.CapabilityFlags(
+                    supportsSchemaSwitching: false,
+                    supportsImport: true,
+                    supportsExport: true,
+                    supportsSSH: true,
+                    supportsSSL: true,
+                    supportsCascadeDrop: false,
+                    supportsForeignKeyDisable: true,
+                    supportsReadOnlyMode: true,
+                    supportsQueryProgress: false,
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: true
+                ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
                     defaultGroupName: "main",
@@ -414,7 +440,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: true
+                    requiresReconnectForDatabaseSwitch: true,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -458,7 +485,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsForeignKeyDisable: false,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: true
+                    requiresReconnectForDatabaseSwitch: true,
+                    supportsDropDatabase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -501,7 +529,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsForeignKeyDisable: true,
                     supportsReadOnlyMode: true,
                     supportsQueryProgress: false,
-                    requiresReconnectForDatabaseSwitch: false
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -660,7 +689,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 supportsForeignKeyDisable: driverType.supportsForeignKeyDisable,
                 supportsReadOnlyMode: driverType.supportsReadOnlyMode,
                 supportsQueryProgress: driverType.supportsQueryProgress,
-                requiresReconnectForDatabaseSwitch: driverType.requiresReconnectForDatabaseSwitch
+                requiresReconnectForDatabaseSwitch: driverType.requiresReconnectForDatabaseSwitch,
+                supportsDropDatabase: driverType.supportsDropDatabase
             ),
             schema: PluginMetadataSnapshot.SchemaInfo(
                 defaultSchemaName: driverType.defaultSchemaName,

--- a/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
+++ b/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
@@ -140,6 +140,15 @@ final class DatabaseSwitcherViewModel {
         try await driver.createDatabase(name: name, charset: charset, collation: collation)
     }
 
+    /// Drop a database
+    func dropDatabase(name: String) async throws {
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
+            throw DatabaseError.notConnected
+        }
+
+        try await driver.dropDatabase(name: name)
+    }
+
     // MARK: - Keyboard Navigation
 
     func moveUp() {

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -23,6 +23,8 @@ struct DatabaseSwitcherSheet: View {
 
     @State private var viewModel: DatabaseSwitcherViewModel
     @State private var showCreateDialog = false
+    @State private var showDropDialog = false
+    @State private var databaseToDrop: String?
 
     private enum FocusField {
         case search
@@ -118,6 +120,13 @@ struct DatabaseSwitcherSheet: View {
         .sheet(isPresented: $showCreateDialog) {
             CreateDatabaseSheet(databaseType: databaseType, viewModel: viewModel)
         }
+        .sheet(isPresented: $showDropDialog) {
+            if let name = databaseToDrop {
+                DropDatabaseSheet(databaseName: name, viewModel: viewModel) {
+                    databaseToDrop = nil
+                }
+            }
+        }
         .onExitCommand {
             // SwiftUI handles sheet priority automatically - no nested sheets take precedence
             dismiss()
@@ -142,6 +151,11 @@ struct DatabaseSwitcherSheet: View {
         .onKeyPress(characters: .init(charactersIn: "kp"), phases: [.down, .repeat]) { keyPress in
             guard keyPress.modifiers.contains(.control) else { return .ignored }
             viewModel.moveUp()
+            return .handled
+        }
+        .onKeyPress(.delete) {
+            guard canDropSelected else { return .ignored }
+            initiateDropForSelected()
             return .handled
         }
     }
@@ -179,6 +193,17 @@ struct DatabaseSwitcherSheet: View {
                 }
                 .buttonStyle(.borderless)
                 .help(String(localized: "Create new database"))
+            }
+
+            // Drop
+            if !isSchemaMode && PluginManager.shared.supportsDropDatabase(for: databaseType) {
+                Button(action: { initiateDropForSelected() }) {
+                    Image(systemName: "trash")
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canDropSelected)
+                .help(String(localized: "Drop selected database"))
             }
         }
         .padding(.horizontal, 12)
@@ -258,6 +283,18 @@ struct DatabaseSwitcherSheet: View {
                 openSelectedDatabase()
             }
         )
+        .contextMenu {
+            if !isSchemaMode && PluginManager.shared.supportsDropDatabase(for: databaseType)
+                && !database.isSystemDatabase && database.name != activeName
+            {
+                Button(role: .destructive) {
+                    databaseToDrop = database.name
+                    showDropDialog = true
+                } label: {
+                    Label(String(localized: "Drop Database..."), systemImage: "trash")
+                }
+            }
+        }
     }
 
     // MARK: - Empty States
@@ -368,6 +405,24 @@ struct DatabaseSwitcherSheet: View {
             .keyboardShortcut(.return, modifiers: [])
         }
         .padding(12)
+    }
+
+    // MARK: - Drop Helpers
+
+    private var canDropSelected: Bool {
+        guard !isSchemaMode,
+              PluginManager.shared.supportsDropDatabase(for: databaseType),
+              let selected = viewModel.selectedDatabase,
+              selected != activeName
+        else { return false }
+        let isSystem = viewModel.filteredDatabases.first { $0.name == selected }?.isSystemDatabase ?? false
+        return !isSystem
+    }
+
+    private func initiateDropForSelected() {
+        guard canDropSelected, let selected = viewModel.selectedDatabase else { return }
+        databaseToDrop = selected
+        showDropDialog = true
     }
 
     // MARK: - Actions

--- a/TablePro/Views/DatabaseSwitcher/DropDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DropDatabaseSheet.swift
@@ -1,0 +1,97 @@
+//
+//  DropDatabaseSheet.swift
+//  TablePro
+//
+//  Confirmation dialog for dropping a database.
+//
+
+import SwiftUI
+
+struct DropDatabaseSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let databaseName: String
+    let viewModel: DatabaseSwitcherViewModel
+    let onDropped: () -> Void
+
+    @State private var isDropping = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            Text("Drop Database")
+                .font(.system(size: ThemeEngine.shared.activeTheme.typography.body, weight: .semibold))
+                .padding(.vertical, 12)
+
+            Divider()
+
+            // Content
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.red)
+
+                Text(String(format: String(localized: "Drop database '%@'?"), databaseName))
+                    .font(.system(size: ThemeEngine.shared.activeTheme.typography.body, weight: .medium))
+                    .multilineTextAlignment(.center)
+
+                Text("All tables and data will be permanently deleted.")
+                    .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.system(size: ThemeEngine.shared.activeTheme.typography.small))
+                        .foregroundStyle(Color(nsColor: .systemRed))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(20)
+
+            Divider()
+
+            // Footer
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button(isDropping ? String(localized: "Dropping...") : String(localized: "Drop")) {
+                    dropDatabase()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .disabled(isDropping)
+            }
+            .padding(12)
+        }
+        .frame(width: 340)
+        .onExitCommand {
+            if !isDropping {
+                dismiss()
+            }
+        }
+    }
+
+    private func dropDatabase() {
+        isDropping = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await viewModel.dropDatabase(name: databaseName)
+                await viewModel.refreshDatabases()
+                onDropped()
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+                isDropping = false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #758

## Summary

Adds the ability to drop/delete databases from the database switcher dialog.

### Protocol + Capability
- `dropDatabase(name:)` added to `PluginDatabaseDriver` with default "not supported" implementation
- `supportsDropDatabase` capability flag in `DriverPlugin` and `PluginMetadataRegistry`
- No PluginKit version bump needed (additive default extension)

### Plugin Implementations
- MySQL/MariaDB: `DROP DATABASE`
- PostgreSQL/Redshift: `DROP DATABASE`
- ClickHouse: `DROP DATABASE`
- SQL Server: `DROP DATABASE`
- MongoDB: `runCommand dropDatabase`
- Cassandra: `DROP KEYSPACE`
- BigQuery: `DROP SCHEMA`
- Cloudflare D1: HTTP DELETE API

### UI
- Trash button in database switcher toolbar
- Right-click context menu "Drop Database..." on database rows
- Delete key shortcut when database selected
- Confirmation dialog with warning, loading state, error display
- Disabled for system databases, currently connected database, and schema mode

## Test plan
- [x] Build passes
- [ ] MySQL: right-click non-system database, "Drop Database...", confirm, verify deleted
- [ ] PostgreSQL: verify error when trying to drop currently connected database
- [ ] System databases (information_schema, mysql, postgres) have drop disabled
- [ ] Currently connected database has drop disabled
- [ ] Delete key triggers confirmation
- [ ] Schema mode hides drop button
- [ ] SQLite/Redis: no drop button shown