### PR TITLE
fix: Cmd+W closing wrong window when Settings is open

### DIFF
--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -236,6 +236,10 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         Self.lifecycleLogger.debug(
             "[switch] windowDidResignKey seq=\(seq) controllerId=\(self.controllerId, privacy: .public)"
         )
+        if let actions = coordinator.commandActions,
+           CommandActionsRegistry.shared.current === actions {
+            CommandActionsRegistry.shared.current = nil
+        }
         activity?.resignCurrent()
         coordinator.handleWindowDidResignKey()
         Self.lifecycleLogger.debug("[switch] windowDidResignKey seq=\(seq) total ms=\(Int(Date().timeIntervalSince(t0) * 1_000))")

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -220,13 +220,8 @@ struct AppMenuCommands: Commands {
             Button(actions != nil ? "Close Tab" : "Close") {
                 if let resolved = resolvedCloseTabActions {
                     resolved.closeTab()
-                } else if let window = NSApp.keyWindow {
-                    if window.identifier?.rawValue.hasPrefix("main") == true,
-                       let coordinator = MainContentCoordinator.coordinator(forWindow: window) {
-                        coordinator.commandActions?.closeTab()
-                    } else {
-                        window.performClose(nil)
-                    }
+                } else {
+                    NSApp.keyWindow?.performClose(nil)
                 }
             }
             .optionalKeyboardShortcut(shortcut(for: .closeTab))


### PR DESCRIPTION
## Summary
- Clear `CommandActionsRegistry.shared.current` in `windowDidResignKey` so stale main-window actions don't persist when a non-main window (Settings, Welcome) becomes key
- Simplify the Close Tab button action by removing a redundant main-window coordinator fallback that `resolvedCloseTabActions` already covers

## Root cause
`CommandActionsRegistry` was only cleared on `windowWillClose`, not on `windowDidResignKey`. When the user opened Settings (Cmd+,) from a main editor window, the registry retained the main window's `commandActions`. Pressing Cmd+W then resolved those stale actions via `resolvedCloseTabActions` and called `closeTab()` on the main window instead of closing the Settings window.

## Test plan
- [ ] Open a database connection, Cmd+, to open Settings, Cmd+W — only Settings should close
- [ ] Open Settings from the Welcome window, Cmd+W — only Settings should close
- [ ] Cmd+W on the Welcome window (no Settings) — Welcome should close normally
- [ ] Cmd+W on a main editor tab — tab should close as before
- [ ] Rapid Cmd+W spam with Settings open — no unexpected window closures