### PR TITLE
refactor: replace Timer with Task.sleep, remove AnyView, add accessibility labels

### DIFF
--- a/TablePro/Core/Services/Infrastructure/ClipboardService.swift
+++ b/TablePro/Core/Services/Infrastructure/ClipboardService.swift
@@ -7,6 +7,7 @@
 //
 
 import AppKit
+import UniformTypeIdentifiers
 
 /// Protocol for clipboard operations
 /// Abstraction allows for mocking in tests
@@ -30,8 +31,10 @@ struct NSPasteboardClipboardProvider: ClipboardProvider {
     }
 
     func writeText(_ text: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+        pb.setString(text, forType: NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier))
     }
 
     var hasText: Bool {

--- a/TablePro/ViewModels/ERDiagramViewModel.swift
+++ b/TablePro/ViewModels/ERDiagramViewModel.swift
@@ -53,7 +53,7 @@ final class ERDiagramViewModel {
 
     // MARK: - Auto-Pan
 
-    @ObservationIgnored nonisolated(unsafe) private var autoPanTimer: Timer?
+    @ObservationIgnored nonisolated(unsafe) private var autoPanTask: Task<Void, Never>?
     @ObservationIgnored private var autoPanVelocity: CGPoint = .zero
     @ObservationIgnored private var autoPanAccum: CGPoint = .zero
 
@@ -77,8 +77,7 @@ final class ERDiagramViewModel {
     }
 
     deinit {
-        autoPanTimer?.invalidate()
-        autoPanTimer = nil
+        autoPanTask?.cancel()
         layoutTask?.cancel()
     }
 
@@ -320,15 +319,16 @@ final class ERDiagramViewModel {
         }
 
         autoPanVelocity = v
-        if v != .zero && autoPanTimer == nil {
-            autoPanTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60, repeats: true) { [weak self] _ in
-                MainActor.assumeIsolated {
+        if v != .zero && autoPanTask == nil {
+            autoPanTask = Task { @MainActor [weak self] in
+                while !Task.isCancelled {
                     self?.autoPanTick()
+                    try? await Task.sleep(for: .milliseconds(16))
                 }
             }
-        } else if v == .zero && autoPanTimer != nil {
-            autoPanTimer?.invalidate()
-            autoPanTimer = nil
+        } else if v == .zero && autoPanTask != nil {
+            autoPanTask?.cancel()
+            autoPanTask = nil
         }
     }
 
@@ -356,8 +356,8 @@ final class ERDiagramViewModel {
     }
 
     private func stopAutoPan() {
-        autoPanTimer?.invalidate()
-        autoPanTimer = nil
+        autoPanTask?.cancel()
+        autoPanTask = nil
         autoPanVelocity = .zero
         autoPanAccum = .zero
     }

--- a/TablePro/Views/ERDiagram/ERDiagramView.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramView.swift
@@ -230,39 +230,27 @@ struct ERDiagramView: View {
         let nodeIndex = viewModel.graph.nodeIndex
 
         let padding: CGFloat = 40
-        var minX: CGFloat = .infinity, minY: CGFloat = .infinity
-        var maxX: CGFloat = 0, maxY: CGFloat = 0
-        for (_, rect) in nodeRects {
-            minX = min(minX, rect.minX)
-            minY = min(minY, rect.minY)
-            maxX = max(maxX, rect.maxX)
-            maxY = max(maxY, rect.maxY)
-        }
-        guard minX.isFinite else {
-            return AnyView(Color.clear.frame(width: 100, height: 100))
-        }
-        let exportWidth = maxX - minX + padding * 2
-        let exportHeight = maxY - minY + padding * 2
-        let offsetX = -minX + padding
-        let offsetY = -minY + padding
+        let bounds = nodeRects.values.reduce(CGRect.null) { $0.union($1) }
+        let exportWidth = bounds.isNull ? 100 : bounds.width + padding * 2
+        let exportHeight = bounds.isNull ? 100 : bounds.height + padding * 2
+        let offsetX = bounds.isNull ? 0 : -bounds.minX + padding
+        let offsetY = bounds.isNull ? 0 : -bounds.minY + padding
 
-        return AnyView(
-            Canvas { context, _ in
-                context.translateBy(x: offsetX, y: offsetY)
-                ERDiagramEdgeRenderer.drawEdges(
-                    context: context,
-                    edges: edges,
-                    nodeRects: nodeRects,
-                    nodeIndex: nodeIndex
-                )
-                for node in nodes {
-                    guard let rect = nodeRects[node.id] else { continue }
-                    ERDiagramNodeRenderer.drawNode(context: &context, node: node, rect: rect, isSelected: false)
-                }
+        return Canvas { context, _ in
+            context.translateBy(x: offsetX, y: offsetY)
+            ERDiagramEdgeRenderer.drawEdges(
+                context: context,
+                edges: edges,
+                nodeRects: nodeRects,
+                nodeIndex: nodeIndex
+            )
+            for node in nodes {
+                guard let rect = nodeRects[node.id] else { continue }
+                ERDiagramNodeRenderer.drawNode(context: &context, node: node, rect: rect, isSelected: false)
             }
-            .frame(width: exportWidth, height: exportHeight)
-            .background(Color(nsColor: .controlBackgroundColor))
-        )
+        }
+        .frame(width: exportWidth, height: exportHeight)
+        .background(Color(nsColor: .controlBackgroundColor))
     }
 
     private func copyDiagramToClipboard() {

--- a/TablePro/Views/Results/ResultTabBar.swift
+++ b/TablePro/Views/Results/ResultTabBar.swift
@@ -44,6 +44,7 @@ struct ResultTabBar: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Close result tab"))
             }
         }
         .padding(.horizontal, 10)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -111,6 +111,7 @@ struct SidebarView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .accessibilityLabel(String(localized: "Sidebar view"))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
             }


### PR DESCRIPTION
## Summary

- Replaced `Timer.scheduledTimer` with `Task.sleep` loop in `ERDiagramViewModel` auto-pan (proper cancellation via structured concurrency)
- Removed `AnyView` from `ERDiagramView.makeExportView()` — simplified bounds calculation using `CGRect.null`/`union`
- Added accessibility labels to result tab close button and sidebar view picker
- Added `UTType.utf8PlainText` to `ClipboardService.writeText()` for better cross-app paste compatibility

Note: 3 recursive tree-rendering functions (`FavoritesTabView`, `RedisKeyTreeView`, `WelcomeWindowView`) retain `AnyView` — Swift requires type erasure for recursive `@ViewBuilder` functions.

5 files changed, -7 lines net.

## Test plan

- [ ] ER Diagram: drag a node near the viewport edge — auto-pan should scroll smoothly at ~60fps
- [ ] ER Diagram: release the node — auto-pan should stop immediately
- [ ] ER Diagram: export diagram as image — should render correctly
- [ ] Result tabs: VoiceOver should announce "Close result tab" on the close button
- [ ] Sidebar: VoiceOver should announce "Sidebar view" on the Tables/Favorites picker
- [ ] Copy any text (query, cell value, error) — paste into a rich text editor (TextEdit, Notes) should work