### PR TITLE
fix: context menu selection side-effect and native pattern fixes

### DIFF
--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -101,8 +101,8 @@ final class SidebarViewModel {
 
     // MARK: - Batch Operations
 
-    func batchToggleTruncate() {
-        let tablesToToggle = selectedTables.isEmpty ? [] : Array(selectedTables.map { $0.name })
+    func batchToggleTruncate(tableNames: [String]? = nil) {
+        let tablesToToggle = tableNames ?? (selectedTables.isEmpty ? [] : Array(selectedTables.map { $0.name }))
         guard !tablesToToggle.isEmpty else { return }
 
         // Check if all tables are already pending truncate - if so, remove them
@@ -124,8 +124,8 @@ final class SidebarViewModel {
         }
     }
 
-    func batchToggleDelete() {
-        let tablesToToggle = selectedTables.isEmpty ? [] : Array(selectedTables.map { $0.name })
+    func batchToggleDelete(tableNames: [String]? = nil) {
+        let tablesToToggle = tableNames ?? (selectedTables.isEmpty ? [] : Array(selectedTables.map { $0.name }))
         guard !tablesToToggle.isEmpty else { return }
 
         // Check if all tables are already pending delete - if so, remove them

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -455,20 +455,13 @@ struct MainEditorContentView: View {
     }
 
     private func emptyResultView(executionTime: TimeInterval?) -> some View {
-        VStack(spacing: 12) {
-            Spacer()
-            Image(systemName: "tray")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            Text("No rows returned")
-                .font(.body.weight(.medium))
-            if let time = executionTime {
-                Text(String(format: "%.3fs", time))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+        let description: String? = executionTime.map { String(format: "%.3fs", $0) }
+        return ContentUnavailableView {
+            Label(String(localized: "No rows returned"), systemImage: "tray")
+        } description: {
+            if let description {
+                Text(description)
             }
-            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -101,7 +101,8 @@ extension MainContentCoordinator {
 
     // MARK: - Export/Import
 
-    func openExportDialog() {
+    func openExportDialog(preselectedTableNames: Set<String>? = nil) {
+        exportPreselectedTableNames = preselectedTableNames
         activeSheet = .exportDialog
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -131,6 +131,7 @@ final class MainContentCoordinator {
     // Removed: showErrorAlert and errorAlertMessage - errors now display inline
     var activeSheet: ActiveSheet?
     var importFileURL: URL?
+    var exportPreselectedTableNames: Set<String>?
     var needsLazyLoad = false
     var sidebarLoadingState: SidebarLoadingState = .idle
 

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -125,7 +125,10 @@ struct MainContentView: View {
     private func sheetContent(for sheet: ActiveSheet) -> some View {
         let dismissBinding = Binding<Bool>(
             get: { coordinator.activeSheet != nil },
-            set: { if !$0 { coordinator.activeSheet = nil } }
+            set: { if !$0 {
+                coordinator.activeSheet = nil
+                coordinator.exportPreselectedTableNames = nil
+            } }
         )
 
         switch sheet {
@@ -154,7 +157,8 @@ struct MainContentView: View {
                 isPresented: dismissBinding,
                 mode: .tables(
                     connection: exportConnection,
-                    preselectedTables: Set(sidebarState.selectedTables.map(\.name))
+                    preselectedTables: coordinator.exportPreselectedTableNames
+                        ?? Set(sidebarState.selectedTables.map(\.name))
                 ),
                 sidebarTables: tables
             )

--- a/TablePro/Views/Results/ResultTabBar.swift
+++ b/TablePro/Views/Results/ResultTabBar.swift
@@ -55,6 +55,7 @@ struct ResultTabBar: View {
         )
         .contentShape(Rectangle())
         .onTapGesture { activeResultSetId = rs.id }
+        .accessibilityAddTraits(.isButton)
         .contextMenu {
             Button(rs.isPinned ? String(localized: "Unpin") : String(localized: "Pin Result")) {
                 onPin?(rs.id)

--- a/TablePro/Views/RightSidebar/RightSidebarView.swift
+++ b/TablePro/Views/RightSidebar/RightSidebarView.swift
@@ -139,12 +139,12 @@ struct RightSidebarView: View {
 
         return VStack(spacing: 0) {
             // Inline search field
-            SearchFieldView(
-                placeholder: "Search for field...",
+            NativeSearchField(
                 text: $searchText,
-                fontSize: 11
+                placeholder: String(localized: "Search for field..."),
+                controlSize: .small
             )
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 6)
 
             Divider()
 

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -11,13 +11,13 @@ import SwiftUI
 struct NativeSearchField: NSViewRepresentable {
     @Binding var text: String
     var placeholder: String
+    var controlSize: NSControl.ControlSize = .regular
 
     func makeNSView(context: Context) -> NSSearchField {
         let field = NSSearchField()
         field.placeholderString = placeholder
         field.delegate = context.coordinator
-        field.bezelStyle = .roundedBezel
-        field.controlSize = .regular
+        field.controlSize = controlSize
         field.sendsSearchStringImmediately = true
         field.setAccessibilityIdentifier("sidebar-filter")
         return field

--- a/TablePro/Views/Sidebar/SidebarContextMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarContextMenu.swift
@@ -34,10 +34,10 @@ enum SidebarContextMenuLogic {
 /// Unified context menu for sidebar — used for both table rows and empty space
 struct SidebarContextMenu: View {
     let clickedTable: TableInfo?
-    @Binding var selectedTables: Set<TableInfo>
+    let selectedTables: Set<TableInfo>
     let isReadOnly: Bool
-    let onBatchToggleTruncate: () -> Void
-    let onBatchToggleDelete: () -> Void
+    let onBatchToggleTruncate: ([String]) -> Void
+    let onBatchToggleDelete: ([String]) -> Void
     let coordinator: MainContentCoordinator?
 
     private var hasSelection: Bool {
@@ -46,6 +46,13 @@ struct SidebarContextMenu: View {
 
     private var isView: Bool {
         SidebarContextMenuLogic.isView(clickedTable: clickedTable)
+    }
+
+    private var effectiveTableNames: [String] {
+        if selectedTables.isEmpty, let table = clickedTable {
+            return [table.name]
+        }
+        return selectedTables.map(\.name).sorted()
     }
 
     var body: some View {
@@ -82,21 +89,12 @@ struct SidebarContextMenu: View {
         }
 
         Button("Copy Name") {
-            let names: [String]
-            if selectedTables.isEmpty, let table = clickedTable {
-                names = [table.name]
-            } else {
-                names = selectedTables.map { $0.name }.sorted()
-            }
-            ClipboardService.shared.writeText(names.joined(separator: ","))
+            ClipboardService.shared.writeText(effectiveTableNames.joined(separator: ","))
         }
         .disabled(!hasSelection)
 
         Button("Export...") {
-            if selectedTables.isEmpty, let table = clickedTable {
-                selectedTables.insert(table)
-            }
-            coordinator?.openExportDialog()
+            coordinator?.openExportDialog(preselectedTableNames: Set(effectiveTableNames))
         }
         .disabled(!hasSelection)
 
@@ -129,10 +127,7 @@ struct SidebarContextMenu: View {
 
         if !isView {
             Button("Truncate") {
-                if selectedTables.isEmpty, let table = clickedTable {
-                    selectedTables.insert(table)
-                }
-                onBatchToggleTruncate()
+                onBatchToggleTruncate(effectiveTableNames)
             }
             .disabled(!hasSelection || isReadOnly)
         }
@@ -141,10 +136,7 @@ struct SidebarContextMenu: View {
             isView ? String(localized: "Drop View") : String(localized: "Delete"),
             role: .destructive
         ) {
-            if selectedTables.isEmpty, let table = clickedTable {
-                selectedTables.insert(table)
-            }
-            onBatchToggleDelete()
+            onBatchToggleDelete(effectiveTableNames)
         }
         .disabled(!hasSelection || isReadOnly)
     }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -228,10 +228,10 @@ struct SidebarView: View {
                         .contextMenu {
                             SidebarContextMenu(
                                 clickedTable: table,
-                                selectedTables: selectedTablesBinding,
+                                selectedTables: sidebarState.selectedTables,
                                 isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
-                                onBatchToggleTruncate: { viewModel.batchToggleTruncate() },
-                                onBatchToggleDelete: { viewModel.batchToggleDelete() },
+                                onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
+                                onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
                                 coordinator: coordinator
                             )
                         }
@@ -274,10 +274,10 @@ struct SidebarView: View {
         .contextMenu {
             SidebarContextMenu(
                 clickedTable: nil,
-                selectedTables: selectedTablesBinding,
+                selectedTables: sidebarState.selectedTables,
                 isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
-                onBatchToggleTruncate: { viewModel.batchToggleTruncate() },
-                onBatchToggleDelete: { viewModel.batchToggleDelete() },
+                onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
+                onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
                 coordinator: coordinator
             )
         }


### PR DESCRIPTION
## Summary

- Context menu actions (Export, Truncate, Delete) no longer mutate sidebar `selectedTables` — computes effective tables from the clicked item without changing List selection, matching standard macOS right-click behavior
- Replace custom `SearchFieldView` with `NativeSearchField` (NSSearchField) in inspector row detail for native search field appearance
- Add `controlSize` parameter to `NativeSearchField` for compact usage in inspector
- Replace custom "No rows returned" VStack with `ContentUnavailableView` for consistency with all other empty states
- Add `.accessibilityAddTraits(.isButton)` to `ResultTabBar` tabs for VoiceOver activation
- Add `exportPreselectedTableNames` to coordinator so context menu export passes tables without mutating selection

## Test plan

- [ ] Right-click unselected table → context menu appears, sidebar selection does NOT change
- [ ] Right-click unselected table → Export → export dialog shows the clicked table preselected
- [ ] Right-click unselected table → Truncate → confirmation dialog shows the clicked table
- [ ] Right-click unselected table → Delete → confirmation dialog shows the clicked table
- [ ] Multi-select tables → right-click within selection → Export/Truncate/Delete operate on full selection
- [ ] Inspector: select a row → search field in row details uses native NSSearchField appearance
- [ ] Query with no results → "No rows returned" shows as ContentUnavailableView style
- [ ] VoiceOver: ResultTabBar tabs announce as buttons
- [ ] Existing SidebarViewModel tests pass (verified: 10/10 pass)