### PR TITLE
fix: favorites folder keyboard navigation

### DIFF
--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -133,6 +133,7 @@ internal struct FavoritesTabView: View {
                 } label: {
                     folderLabel(folder)
                 }
+                .tag(node.id)
             }
         })
     }


### PR DESCRIPTION
## Summary

- Add `.tag(node.id)` to `DisclosureGroup` folders in `FavoritesTabView` so they participate in `List` selection
- Folders were invisible to the selection model — arrow keys skipped them and they couldn't be selected

One-line fix. SidebarViewModel Binding-storage anti-pattern was investigated but deferred — no SwiftUI view reads the binding-proxied properties in its body, so the anti-pattern has no functional impact.

## Test plan

- [ ] Open Favorites tab in sidebar
- [ ] Create a folder with favorites inside
- [ ] Arrow up/down — verify folders are navigable (not skipped)
- [ ] Click a folder label — verify it gets selected (highlighted)
- [ ] Arrow left/right on a folder — verify expand/collapse works