### PR TITLE
fix: enable toolbar customization and global split view autosave

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -114,9 +114,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
         splitView.dividerStyle = .thin
         splitView.isVertical = true
-        if let connectionId = payload?.connectionId {
-            splitView.autosaveName = "com.TablePro.mainSplit.\(connectionId.uuidString)"
-        }
+        splitView.autosaveName = "com.TablePro.mainSplit"
 
         sidebarHosting = NSHostingController(rootView: AnyView(buildSidebarView()))
         sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarHosting)

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -47,7 +47,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         super.init()
         self.managedToolbar.delegate = self
         self.managedToolbar.displayMode = .iconOnly
-        self.managedToolbar.allowsUserCustomization = false
+        self.managedToolbar.allowsUserCustomization = true
         self.managedToolbar.autosavesConfiguration = false
         // Per WWDC 2023 / Apple Music pattern: do NOT use
         // `centeredItemIdentifiers` together with a right cluster that should


### PR DESCRIPTION
## Summary

- Enable `allowsUserCustomization` on NSToolbar — users can now right-click the toolbar to add/remove items (standard macOS behavior)
- Use a single global `autosaveName` (`"com.TablePro.mainSplit"`) for split view divider positions instead of per-connection keys — sidebar/inspector widths are now remembered app-wide, matching Xcode/Safari pattern

## Test plan

- [ ] Right-click toolbar → "Customize Toolbar..." appears, can add/remove items
- [ ] Resize sidebar, open a different connection → sidebar width is the same (global)
- [ ] Resize inspector, quit & relaunch → inspector width is remembered