### PR TITLE
feat: Xcode-style sidebar toggle buttons next to traffic lights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sidebar toggle: Tables and Favorites buttons next to traffic lights replace the segmented picker, matching Xcode's navigator toggle pattern
 - Sidebar and inspector panels now use native macOS split view controls with standard resize dividers
 - Theme system: UI colors now adapt to system appearance, accent color, and high contrast settings by default. Custom themes can still override with hex values.
 - Theme system: removed Layout tab from theme editor. Font sizes now follow system text styles for better accessibility support.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -138,6 +138,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
         if currentSession == nil {
             sidebarSplitItem.isCollapsed = true
+        } else {
+            sidebarContainer.updateSidebarState(
+                SharedSidebarState.forConnection(currentSession!.connection.id) // swiftlint:disable:this force_unwrapping
+            )
         }
         inspectorSplitItem.isCollapsed = !UserDefaults.standard.bool(forKey: Self.inspectorPresentedKey)
     }
@@ -470,8 +474,16 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         syncSidebarVisibility()
     }
 
+    override func splitViewDidResizeSubviews(_ notification: Notification) {
+        super.splitViewDidResizeSubviews(notification)
+        syncSidebarVisibility()
+    }
+
     private func syncSidebarVisibility() {
-        sessionState?.coordinator.toolbarState.isSidebarVisible = isSidebarVisible
+        let visible = isSidebarVisible
+        if sessionState?.coordinator.toolbarState.isSidebarVisible != visible {
+            sessionState?.coordinator.toolbarState.isSidebarVisible = visible
+        }
     }
 
     // MARK: - Constants

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -154,6 +154,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         if let sessionState {
             sessionState.coordinator.inspectorProxy = self
             sessionState.coordinator.sidebarProxy = self
+            syncSidebarVisibility()
             installToolbar(coordinator: sessionState.coordinator)
         }
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -13,7 +13,7 @@ import os
 import SwiftUI
 
 @MainActor
-internal final class MainSplitViewController: NSSplitViewController, InspectorVisibilityProxy {
+internal final class MainSplitViewController: NSSplitViewController, InspectorVisibilityProxy, SidebarVisibilityProxy {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     // MARK: - Payload & Session
@@ -153,6 +153,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
         if let sessionState {
             sessionState.coordinator.inspectorProxy = self
+            sessionState.coordinator.sidebarProxy = self
             installToolbar(coordinator: sessionState.coordinator)
         }
 
@@ -246,6 +247,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                 } else {
                     sidebarSplitItem.isCollapsed = true
                 }
+                syncSidebarVisibility()
             }
             return
         }
@@ -268,6 +270,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             let state = SessionStateFactory.create(connection: newSession.connection, payload: payload)
             sessionState = state
             state.coordinator.inspectorProxy = self
+            state.coordinator.sidebarProxy = self
             installToolbar(coordinator: state.coordinator)
         }
 
@@ -276,6 +279,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         } else {
             sidebarSplitItem.isCollapsed = false
         }
+        syncSidebarVisibility()
         rebuildPanes()
     }
 
@@ -429,6 +433,32 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     func hideInspector() {
         inspectorSplitItem?.animator().isCollapsed = true
         UserDefaults.standard.set(false, forKey: Self.inspectorPresentedKey)
+    }
+
+    // MARK: - SidebarVisibilityProxy
+
+    var isSidebarVisible: Bool {
+        guard let sidebarSplitItem else { return false }
+        return !sidebarSplitItem.isCollapsed
+    }
+
+    func showSidebar() {
+        sidebarSplitItem?.animator().isCollapsed = false
+        syncSidebarVisibility()
+    }
+
+    func hideSidebar() {
+        sidebarSplitItem?.animator().isCollapsed = true
+        syncSidebarVisibility()
+    }
+
+    override func toggleSidebar(_ sender: Any?) {
+        super.toggleSidebar(sender)
+        syncSidebarVisibility()
+    }
+
+    private func syncSidebarVisibility() {
+        sessionState?.coordinator.toolbarState.isSidebarVisible = isSidebarVisible
     }
 
     // MARK: - Constants

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -34,7 +34,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private var detailSplitItem: NSSplitViewItem!
     private var inspectorSplitItem: NSSplitViewItem!
 
-    private var sidebarHosting: NSHostingController<AnyView>!
+    private var sidebarContainer: SidebarContainerViewController!
     private var detailHosting: NSHostingController<AnyView>!
     private var inspectorHosting: NSHostingController<AnyView>!
 
@@ -116,8 +116,8 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         splitView.isVertical = true
         splitView.autosaveName = "com.TablePro.mainSplit"
 
-        sidebarHosting = NSHostingController(rootView: AnyView(buildSidebarView()))
-        sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarHosting)
+        sidebarContainer = SidebarContainerViewController(rootView: AnyView(buildSidebarView()))
+        sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarContainer)
         sidebarSplitItem.canCollapse = true
         sidebarSplitItem.minimumThickness = 200
         sidebarSplitItem.maximumThickness = 600
@@ -155,6 +155,12 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             sessionState.coordinator.inspectorProxy = self
             sessionState.coordinator.sidebarProxy = self
             installToolbar(coordinator: sessionState.coordinator)
+        }
+
+        if let currentSession {
+            sidebarContainer.updateSidebarState(
+                SharedSidebarState.forConnection(currentSession.connection.id)
+            )
         }
 
         installObservers()
@@ -242,6 +248,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                 sessionState?.coordinator.teardown()
                 sessionState = nil
                 currentSession = nil
+                sidebarContainer.updateSidebarState(nil)
                 if view.window?.isVisible == true {
                     sidebarSplitItem.animator().isCollapsed = true
                 } else {
@@ -286,7 +293,12 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     // MARK: - Pane Construction
 
     private func rebuildPanes() {
-        sidebarHosting.rootView = AnyView(buildSidebarView())
+        sidebarContainer.rootView = AnyView(buildSidebarView())
+        if let currentSession {
+            sidebarContainer.updateSidebarState(
+                SharedSidebarState.forConnection(currentSession.connection.id)
+            )
+        }
         detailHosting.rootView = AnyView(buildDetailView())
         inspectorHosting.rootView = AnyView(buildInspectorView())
     }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -518,20 +518,13 @@ private struct SidebarToggleToolbarButtons: View {
             sidebarButton(
                 tab: .tables,
                 icon: "tablecells",
-                activeIcon: "tablecells.fill",
                 label: String(localized: "Tables"),
                 isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
                 sidebarState: sidebarState
             )
-            if !state.isSidebarVisible {
-                Divider()
-                    .frame(height: 14)
-                    .padding(.horizontal, 1)
-            }
             sidebarButton(
                 tab: .favorites,
                 icon: "star",
-                activeIcon: "star.fill",
                 label: String(localized: "Favorites"),
                 isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites,
                 sidebarState: sidebarState
@@ -543,34 +536,26 @@ private struct SidebarToggleToolbarButtons: View {
     private func sidebarButton(
         tab: SidebarTab,
         icon: String,
-        activeIcon: String,
         label: String,
         isActive: Bool,
         sidebarState: SharedSidebarState
     ) -> some View {
-        Button {
-            if coordinator.toolbarState.isSidebarVisible {
-                if sidebarState.selectedSidebarTab == tab {
-                    coordinator.sidebarProxy?.hideSidebar()
-                } else {
+        Toggle(isOn: Binding(
+            get: { isActive },
+            set: { newValue in
+                if newValue {
                     sidebarState.selectedSidebarTab = tab
+                    if !coordinator.toolbarState.isSidebarVisible {
+                        coordinator.sidebarProxy?.showSidebar()
+                    }
+                } else {
+                    coordinator.sidebarProxy?.hideSidebar()
                 }
-            } else {
-                sidebarState.selectedSidebarTab = tab
-                coordinator.sidebarProxy?.showSidebar()
             }
-        } label: {
-            Image(systemName: isActive ? activeIcon : icon)
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
+        )) {
+            Label(label, systemImage: icon)
         }
-        .buttonStyle(.plain)
-        .background(
-            isActive
-                ? RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(.quaternary)
-                : nil
-        )
+        .toggleStyle(.button)
         .help(label)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -563,6 +563,7 @@ extension MainWindowToolbar {
         guard let coordinator else { return }
         let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
         let tabs: [SidebarTab] = [.tables, .favorites]
+        guard sender.tag >= 0, sender.tag < tabs.count else { return }
         let tab = tabs[sender.tag]
 
         if coordinator.toolbarState.isSidebarVisible {

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -520,7 +520,7 @@ extension MainWindowToolbar {
         segmented.segmentCount = 2
         segmented.trackingMode = .selectAny
         segmented.segmentStyle = .separated
-        segmented.selectedSegmentBezelColor = .labelColor.withAlphaComponent(0.08)
+        segmented.selectedSegmentBezelColor = .white.withAlphaComponent(0.05)
         segmented.target = self
         segmented.action = #selector(sidebarSegmentClicked(_:))
 
@@ -571,14 +571,16 @@ extension MainWindowToolbar {
 
         segmented.isEnabled = isConnected
 
-        if state.isSidebarVisible && isConnected {
-            let activeIndex = sidebarState.selectedSidebarTab == .tables ? 0 : 1
-            segmented.setSelected(true, forSegment: activeIndex)
-            segmented.setSelected(false, forSegment: activeIndex == 0 ? 1 : 0)
-        } else {
-            segmented.setSelected(false, forSegment: 0)
-            segmented.setSelected(false, forSegment: 1)
-        }
+        let tablesActive = state.isSidebarVisible && isConnected && sidebarState.selectedSidebarTab == .tables
+        let favoritesActive = state.isSidebarVisible && isConnected && sidebarState.selectedSidebarTab == .favorites
+
+        segmented.setSelected(tablesActive, forSegment: 0)
+        segmented.setSelected(favoritesActive, forSegment: 1)
+
+        let tablesIcon = tablesActive ? "tablecells.fill" : "tablecells"
+        let favoritesIcon = favoritesActive ? "star.fill" : "star"
+        segmented.setImage(NSImage(systemSymbolName: tablesIcon, accessibilityDescription: String(localized: "Tables")), forSegment: 0)
+        segmented.setImage(NSImage(systemSymbolName: favoritesIcon, accessibilityDescription: String(localized: "Favorites")), forSegment: 1)
     }
 
     fileprivate func startSidebarObservation(coordinator: MainContentCoordinator) {

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -514,76 +514,54 @@ private struct SidebarToggleToolbarButtons: View {
         let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
         let isDisabled = state.connectionState != .connected
 
-        HStack(spacing: 0) {
-            SidebarToggleNSButton(
+        HStack(spacing: 2) {
+            sidebarButton(
+                tab: .tables,
                 icon: "tablecells",
                 label: String(localized: "Tables"),
-                isOn: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables
-            ) {
-                handleToggle(tab: .tables, sidebarState: sidebarState)
-            }
-            if !state.isSidebarVisible {
-                Divider()
-                    .frame(height: 14)
-                    .padding(.horizontal, 1)
-            }
-            SidebarToggleNSButton(
+                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
+                sidebarState: sidebarState
+            )
+            sidebarButton(
+                tab: .favorites,
                 icon: "star",
                 label: String(localized: "Favorites"),
-                isOn: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites
-            ) {
-                handleToggle(tab: .favorites, sidebarState: sidebarState)
-            }
+                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites,
+                sidebarState: sidebarState
+            )
         }
         .disabled(isDisabled)
     }
 
-    private func handleToggle(tab: SidebarTab, sidebarState: SharedSidebarState) {
-        if coordinator.toolbarState.isSidebarVisible {
-            if sidebarState.selectedSidebarTab == tab {
-                coordinator.sidebarProxy?.hideSidebar()
+    private func sidebarButton(
+        tab: SidebarTab,
+        icon: String,
+        label: String,
+        isActive: Bool,
+        sidebarState: SharedSidebarState
+    ) -> some View {
+        Button {
+            if coordinator.toolbarState.isSidebarVisible {
+                if sidebarState.selectedSidebarTab == tab {
+                    coordinator.sidebarProxy?.hideSidebar()
+                } else {
+                    sidebarState.selectedSidebarTab = tab
+                }
             } else {
                 sidebarState.selectedSidebarTab = tab
+                coordinator.sidebarProxy?.showSidebar()
             }
-        } else {
-            sidebarState.selectedSidebarTab = tab
-            coordinator.sidebarProxy?.showSidebar()
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .medium))
+                .frame(width: 28, height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color.primary.opacity(isActive ? 0.12 : 0))
+                )
         }
-    }
-}
-
-private struct SidebarToggleNSButton: NSViewRepresentable {
-    let icon: String
-    let label: String
-    let isOn: Bool
-    let action: () -> Void
-
-    func makeNSView(context: Context) -> NSButton {
-        let button = NSButton()
-        button.bezelStyle = .accessoryBar
-        button.setButtonType(.pushOnPushOff)
-        button.isBordered = true
-        button.imagePosition = .imageOnly
-        button.target = context.coordinator
-        button.action = #selector(Coordinator.clicked)
-        button.setAccessibilityLabel(label)
-        return button
-    }
-
-    func updateNSView(_ button: NSButton, context: Context) {
-        button.image = NSImage(systemSymbolName: icon, accessibilityDescription: label)
-        button.state = isOn ? .on : .off
-        button.isEnabled = button.superview?.isDescendant(of: button.window?.contentView ?? NSView()) ?? true
-        context.coordinator.action = action
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(action: action)
-    }
-
-    final class Coordinator: NSObject {
-        var action: () -> Void
-        init(action: @escaping () -> Void) { self.action = action }
-        @objc func clicked() { action() }
+        .buttonStyle(.plain)
+        .help(label)
+        .accessibilityLabel(label)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -520,6 +520,7 @@ extension MainWindowToolbar {
         segmented.segmentCount = 2
         segmented.trackingMode = .selectAny
         segmented.segmentStyle = .separated
+        segmented.selectedSegmentBezelColor = .unemphasizedSelectedContentBackgroundColor
         segmented.target = self
         segmented.action = #selector(sidebarSegmentClicked(_:))
 

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -515,52 +515,75 @@ private struct SidebarToggleToolbarButtons: View {
         let isDisabled = state.connectionState != .connected
 
         HStack(spacing: 0) {
-            sidebarToggle(
-                tab: .tables,
+            SidebarToggleNSButton(
                 icon: "tablecells",
                 label: String(localized: "Tables"),
-                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
-                sidebarState: sidebarState
-            )
+                isOn: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables
+            ) {
+                handleToggle(tab: .tables, sidebarState: sidebarState)
+            }
             if !state.isSidebarVisible {
                 Divider()
                     .frame(height: 14)
                     .padding(.horizontal, 1)
             }
-            sidebarToggle(
-                tab: .favorites,
+            SidebarToggleNSButton(
                 icon: "star",
                 label: String(localized: "Favorites"),
-                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites,
-                sidebarState: sidebarState
-            )
+                isOn: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites
+            ) {
+                handleToggle(tab: .favorites, sidebarState: sidebarState)
+            }
         }
-        .buttonStyle(.accessoryBar)
         .disabled(isDisabled)
     }
 
-    private func sidebarToggle(
-        tab: SidebarTab,
-        icon: String,
-        label: String,
-        isActive: Bool,
-        sidebarState: SharedSidebarState
-    ) -> some View {
-        Toggle(isOn: Binding(
-            get: { isActive },
-            set: { newValue in
-                if newValue {
-                    sidebarState.selectedSidebarTab = tab
-                    if !coordinator.toolbarState.isSidebarVisible {
-                        coordinator.sidebarProxy?.showSidebar()
-                    }
-                } else {
-                    coordinator.sidebarProxy?.hideSidebar()
-                }
+    private func handleToggle(tab: SidebarTab, sidebarState: SharedSidebarState) {
+        if coordinator.toolbarState.isSidebarVisible {
+            if sidebarState.selectedSidebarTab == tab {
+                coordinator.sidebarProxy?.hideSidebar()
+            } else {
+                sidebarState.selectedSidebarTab = tab
             }
-        )) {
-            Label(label, systemImage: icon)
+        } else {
+            sidebarState.selectedSidebarTab = tab
+            coordinator.sidebarProxy?.showSidebar()
         }
-        .toggleStyle(.button)
+    }
+}
+
+private struct SidebarToggleNSButton: NSViewRepresentable {
+    let icon: String
+    let label: String
+    let isOn: Bool
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.bezelStyle = .accessoryBar
+        button.setButtonType(.pushOnPushOff)
+        button.isBordered = true
+        button.imagePosition = .imageOnly
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.clicked)
+        button.setAccessibilityLabel(label)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        button.image = NSImage(systemSymbolName: icon, accessibilityDescription: label)
+        button.state = isOn ? .on : .off
+        button.isEnabled = button.superview?.isDescendant(of: button.window?.contentView ?? NSView()) ?? true
+        context.coordinator.action = action
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+        init(action: @escaping () -> Void) { self.action = action }
+        @objc func clicked() { action() }
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -522,6 +522,11 @@ private struct SidebarToggleToolbarButtons: View {
                 isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
                 sidebarState: sidebarState
             )
+            if !state.isSidebarVisible {
+                Divider()
+                    .frame(height: 14)
+                    .padding(.horizontal, 1)
+            }
             sidebarButton(
                 tab: .favorites,
                 icon: "star",

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -36,6 +36,8 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// deallocs immediately and its view becomes orphaned, producing zero-size
     /// items that get pushed right by flexibleSpace.
     private var hostingControllers: [NSToolbarItem.Identifier: NSHostingController<AnyView>] = [:]
+    private var sidebarSegmentedControl: NSSegmentedControl?
+    private var sidebarObservationTask: Task<Void, Never>?
 
     internal init(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
@@ -65,6 +67,9 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// Release all hosted toolbar views and sever the coordinator reference.
     /// Called by TabWindowController.windowWillClose before coordinator teardown.
     func invalidate() {
+        sidebarObservationTask?.cancel()
+        sidebarObservationTask = nil
+        sidebarSegmentedControl = nil
         hostingControllers.removeAll()
         coordinator = nil
     }
@@ -139,8 +144,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
         switch itemIdentifier {
         case Self.sidebarToggle:
-            return hostingItem(id: itemIdentifier, label: String(localized: "Sidebar"),
-                               content: SidebarToggleToolbarButtons(coordinator: coordinator))
+            return makeSidebarToggleItem(coordinator: coordinator)
         case Self.connection:
             return hostingItem(id: itemIdentifier, label: String(localized: "Connection"),
                                content: ConnectionToolbarButton(coordinator: coordinator))
@@ -504,64 +508,98 @@ private struct ImportToolbarButton: View {
     }
 }
 
-// MARK: - Sidebar Toggle Buttons
+// MARK: - Sidebar Toggle (Pure AppKit)
 
-private struct SidebarToggleToolbarButtons: View {
-    let coordinator: MainContentCoordinator
+extension MainWindowToolbar {
+    fileprivate func makeSidebarToggleItem(coordinator: MainContentCoordinator) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: Self.sidebarToggle)
+        item.label = String(localized: "Sidebar")
+        item.paletteLabel = String(localized: "Sidebar")
 
-    var body: some View {
-        let state = coordinator.toolbarState
-        let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
-        let isDisabled = state.connectionState != .connected
+        let segmented = NSSegmentedControl()
+        segmented.segmentCount = 2
+        segmented.trackingMode = .selectAny
+        segmented.segmentStyle = .separated
+        segmented.target = self
+        segmented.action = #selector(sidebarSegmentClicked(_:))
 
-        HStack(spacing: 2) {
-            sidebarButton(
-                tab: .tables,
-                icon: "tablecells",
-                label: String(localized: "Tables"),
-                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
-                sidebarState: sidebarState
-            )
-            sidebarButton(
-                tab: .favorites,
-                icon: "star",
-                label: String(localized: "Favorites"),
-                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites,
-                sidebarState: sidebarState
-            )
-        }
-        .disabled(isDisabled)
+        let tablesImage = NSImage(systemSymbolName: "tablecells", accessibilityDescription: String(localized: "Tables"))
+        let favoritesImage = NSImage(systemSymbolName: "star", accessibilityDescription: String(localized: "Favorites"))
+        segmented.setImage(tablesImage, forSegment: 0)
+        segmented.setImage(favoritesImage, forSegment: 1)
+        segmented.setWidth(0, forSegment: 0)
+        segmented.setWidth(0, forSegment: 1)
+        segmented.segmentDistribution = .fit
+
+        sidebarSegmentedControl = segmented
+        item.view = segmented
+
+        syncSidebarSegmentedState(coordinator: coordinator)
+        startSidebarObservation(coordinator: coordinator)
+
+        return item
     }
 
-    private func sidebarButton(
-        tab: SidebarTab,
-        icon: String,
-        label: String,
-        isActive: Bool,
-        sidebarState: SharedSidebarState
-    ) -> some View {
-        Button {
-            if coordinator.toolbarState.isSidebarVisible {
-                if sidebarState.selectedSidebarTab == tab {
-                    coordinator.sidebarProxy?.hideSidebar()
-                } else {
-                    sidebarState.selectedSidebarTab = tab
-                }
-            } else {
-                sidebarState.selectedSidebarTab = tab
+    @objc fileprivate func sidebarSegmentClicked(_ sender: NSSegmentedControl) {
+        guard let coordinator else { return }
+        let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
+        let clickedSegment = sender.selectedSegment
+        let tabs: [SidebarTab] = [.tables, .favorites]
+
+        guard clickedSegment >= 0, clickedSegment < tabs.count else { return }
+        let tab = tabs[clickedSegment]
+        let isSelected = sender.isSelected(forSegment: clickedSegment)
+
+        if !isSelected {
+            coordinator.sidebarProxy?.hideSidebar()
+        } else {
+            let otherSegment = clickedSegment == 0 ? 1 : 0
+            sender.setSelected(false, forSegment: otherSegment)
+            sidebarState.selectedSidebarTab = tab
+            if !coordinator.toolbarState.isSidebarVisible {
                 coordinator.sidebarProxy?.showSidebar()
             }
-        } label: {
-            Image(systemName: icon)
-                .font(.system(size: 13, weight: .medium))
-                .frame(width: 28, height: 22)
-                .background(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .fill(Color.primary.opacity(isActive ? 0.12 : 0))
-                )
         }
-        .buttonStyle(.plain)
-        .help(label)
-        .accessibilityLabel(label)
+    }
+
+    fileprivate func syncSidebarSegmentedState(coordinator: MainContentCoordinator) {
+        guard let segmented = sidebarSegmentedControl else { return }
+        let state = coordinator.toolbarState
+        let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
+        let isConnected = state.connectionState == .connected || state.connectionState == .executing
+
+        segmented.isEnabled = isConnected
+
+        if state.isSidebarVisible && isConnected {
+            let activeIndex = sidebarState.selectedSidebarTab == .tables ? 0 : 1
+            segmented.setSelected(true, forSegment: activeIndex)
+            segmented.setSelected(false, forSegment: activeIndex == 0 ? 1 : 0)
+        } else {
+            segmented.setSelected(false, forSegment: 0)
+            segmented.setSelected(false, forSegment: 1)
+        }
+    }
+
+    fileprivate func startSidebarObservation(coordinator: MainContentCoordinator) {
+        sidebarObservationTask?.cancel()
+        sidebarObservationTask = Task { [weak self, weak coordinator] in
+            guard let coordinator else { return }
+            while !Task.isCancelled {
+                let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = coordinator.toolbarState.isSidebarVisible
+                        _ = coordinator.toolbarState.connectionState
+                        _ = sidebarState.selectedSidebarTab
+                    } onChange: {
+                        continuation.resume()
+                    }
+                }
+                guard !Task.isCancelled, let self else { return }
+                await MainActor.run {
+                    self.syncSidebarSegmentedState(coordinator: coordinator)
+                }
+            }
+        }
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -560,8 +560,17 @@ private struct SidebarToggleToolbarButtons: View {
                 coordinator.sidebarProxy?.showSidebar()
             }
         } label: {
-            Label(label, systemImage: isActive ? activeIcon : icon)
+            Image(systemName: isActive ? activeIcon : icon)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .background(
+            isActive
+                ? RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(.quaternary)
+                : nil
+        )
         .help(label)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -545,22 +545,54 @@ private struct SidebarToggleToolbarButtons: View {
         isActive: Bool,
         sidebarState: SharedSidebarState
     ) -> some View {
-        Toggle(isOn: Binding(
-            get: { isActive },
-            set: { newValue in
-                if newValue {
-                    sidebarState.selectedSidebarTab = tab
-                    if !coordinator.toolbarState.isSidebarVisible {
-                        coordinator.sidebarProxy?.showSidebar()
-                    }
-                } else {
-                    coordinator.sidebarProxy?.hideSidebar()
+        ToolbarToggleButton(
+            icon: icon,
+            accessibilityLabel: label,
+            isOn: isActive
+        ) {
+            if isActive {
+                coordinator.sidebarProxy?.hideSidebar()
+            } else {
+                sidebarState.selectedSidebarTab = tab
+                if !coordinator.toolbarState.isSidebarVisible {
+                    coordinator.sidebarProxy?.showSidebar()
                 }
             }
-        )) {
-            Label(label, systemImage: icon)
         }
-        .toggleStyle(.button)
         .help(label)
+    }
+}
+
+private struct ToolbarToggleButton: NSViewRepresentable {
+    let icon: String
+    let accessibilityLabel: String
+    let isOn: Bool
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.bezelStyle = .accessoryBarAction
+        button.setButtonType(.toggle)
+        button.isBordered = true
+        button.imagePosition = .imageOnly
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.clicked)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        button.image = NSImage(systemSymbolName: icon, accessibilityDescription: accessibilityLabel)
+        button.state = isOn ? .on : .off
+        context.coordinator.action = action
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+        init(action: @escaping () -> Void) { self.action = action }
+        @objc func clicked() { action() }
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -36,7 +36,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// deallocs immediately and its view becomes orphaned, producing zero-size
     /// items that get pushed right by flexibleSpace.
     private var hostingControllers: [NSToolbarItem.Identifier: NSHostingController<AnyView>] = [:]
-    private var sidebarSegmentedControl: NSSegmentedControl?
+    private var sidebarButtons: [NSButton] = []
     private var sidebarObservationTask: Task<Void, Never>?
 
     internal init(coordinator: MainContentCoordinator) {
@@ -69,7 +69,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     func invalidate() {
         sidebarObservationTask?.cancel()
         sidebarObservationTask = nil
-        sidebarSegmentedControl = nil
+        sidebarButtons = []
         hostingControllers.removeAll()
         coordinator = nil
     }
@@ -516,71 +516,82 @@ extension MainWindowToolbar {
         item.label = String(localized: "Sidebar")
         item.paletteLabel = String(localized: "Sidebar")
 
-        let segmented = NSSegmentedControl()
-        segmented.segmentCount = 2
-        segmented.trackingMode = .selectAny
-        segmented.segmentStyle = .separated
-        segmented.selectedSegmentBezelColor = .white.withAlphaComponent(0.05)
-        segmented.target = self
-        segmented.action = #selector(sidebarSegmentClicked(_:))
+        let container = NSStackView()
+        container.orientation = .horizontal
+        container.spacing = 2
 
-        let tablesImage = NSImage(systemSymbolName: "tablecells", accessibilityDescription: String(localized: "Tables"))
-        let favoritesImage = NSImage(systemSymbolName: "star", accessibilityDescription: String(localized: "Favorites"))
-        segmented.setImage(tablesImage, forSegment: 0)
-        segmented.setImage(favoritesImage, forSegment: 1)
-        segmented.setWidth(0, forSegment: 0)
-        segmented.setWidth(0, forSegment: 1)
-        segmented.segmentDistribution = .fit
+        let tablesButton = makeSidebarNSButton(
+            icon: "tablecells",
+            label: String(localized: "Tables"),
+            tag: 0
+        )
+        let favoritesButton = makeSidebarNSButton(
+            icon: "star",
+            label: String(localized: "Favorites"),
+            tag: 1
+        )
 
-        sidebarSegmentedControl = segmented
-        item.view = segmented
+        container.addArrangedSubview(tablesButton)
+        container.addArrangedSubview(favoritesButton)
 
-        syncSidebarSegmentedState(coordinator: coordinator)
+        sidebarButtons = [tablesButton, favoritesButton]
+        item.view = container
+
+        syncSidebarButtonState(coordinator: coordinator)
         startSidebarObservation(coordinator: coordinator)
 
         return item
     }
 
-    @objc fileprivate func sidebarSegmentClicked(_ sender: NSSegmentedControl) {
+    private func makeSidebarNSButton(icon: String, label: String, tag: Int) -> NSButton {
+        let button = NSButton()
+        button.bezelStyle = .recessed
+        button.setButtonType(.pushOnPushOff)
+        button.showsBorderOnlyWhileMouseInside = true
+        button.isBordered = true
+        button.image = NSImage(systemSymbolName: icon, accessibilityDescription: label)
+        button.imagePosition = .imageOnly
+        button.tag = tag
+        button.target = self
+        button.action = #selector(sidebarButtonClicked(_:))
+        button.setAccessibilityLabel(label)
+        button.toolTip = label
+        return button
+    }
+
+    @objc fileprivate func sidebarButtonClicked(_ sender: NSButton) {
         guard let coordinator else { return }
         let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
-        let clickedSegment = sender.selectedSegment
         let tabs: [SidebarTab] = [.tables, .favorites]
+        let tab = tabs[sender.tag]
 
-        guard clickedSegment >= 0, clickedSegment < tabs.count else { return }
-        let tab = tabs[clickedSegment]
-        let isSelected = sender.isSelected(forSegment: clickedSegment)
-
-        if !isSelected {
-            coordinator.sidebarProxy?.hideSidebar()
-        } else {
-            let otherSegment = clickedSegment == 0 ? 1 : 0
-            sender.setSelected(false, forSegment: otherSegment)
-            sidebarState.selectedSidebarTab = tab
-            if !coordinator.toolbarState.isSidebarVisible {
-                coordinator.sidebarProxy?.showSidebar()
+        if coordinator.toolbarState.isSidebarVisible {
+            if sidebarState.selectedSidebarTab == tab {
+                coordinator.sidebarProxy?.hideSidebar()
+            } else {
+                sidebarState.selectedSidebarTab = tab
             }
+        } else {
+            sidebarState.selectedSidebarTab = tab
+            coordinator.sidebarProxy?.showSidebar()
         }
     }
 
-    fileprivate func syncSidebarSegmentedState(coordinator: MainContentCoordinator) {
-        guard let segmented = sidebarSegmentedControl else { return }
+    fileprivate func syncSidebarButtonState(coordinator: MainContentCoordinator) {
+        guard sidebarButtons.count == 2 else { return }
         let state = coordinator.toolbarState
         let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
         let isConnected = state.connectionState == .connected || state.connectionState == .executing
+        let icons = ["tablecells", "star"]
 
-        segmented.isEnabled = isConnected
-
-        let tablesActive = state.isSidebarVisible && isConnected && sidebarState.selectedSidebarTab == .tables
-        let favoritesActive = state.isSidebarVisible && isConnected && sidebarState.selectedSidebarTab == .favorites
-
-        segmented.setSelected(tablesActive, forSegment: 0)
-        segmented.setSelected(favoritesActive, forSegment: 1)
-
-        let tablesIcon = tablesActive ? "tablecells.fill" : "tablecells"
-        let favoritesIcon = favoritesActive ? "star.fill" : "star"
-        segmented.setImage(NSImage(systemSymbolName: tablesIcon, accessibilityDescription: String(localized: "Tables")), forSegment: 0)
-        segmented.setImage(NSImage(systemSymbolName: favoritesIcon, accessibilityDescription: String(localized: "Favorites")), forSegment: 1)
+        for (index, button) in sidebarButtons.enumerated() {
+            let isActive = state.isSidebarVisible && isConnected
+                && (index == 0 ? sidebarState.selectedSidebarTab == .tables : sidebarState.selectedSidebarTab == .favorites)
+            button.isEnabled = isConnected
+            button.state = isActive ? .on : .off
+            button.showsBorderOnlyWhileMouseInside = !isActive
+            button.image = NSImage(systemSymbolName: icons[index], accessibilityDescription: button.accessibilityLabel())
+        }
     }
 
     fileprivate func startSidebarObservation(coordinator: MainContentCoordinator) {
@@ -600,7 +611,7 @@ extension MainWindowToolbar {
                 }
                 guard !Task.isCancelled, let self else { return }
                 await MainActor.run {
-                    self.syncSidebarSegmentedState(coordinator: coordinator)
+                    self.syncSidebarButtonState(coordinator: coordinator)
                 }
             }
         }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -515,7 +515,7 @@ private struct SidebarToggleToolbarButtons: View {
         let isDisabled = state.connectionState != .connected
 
         HStack(spacing: 0) {
-            sidebarButton(
+            sidebarToggle(
                 tab: .tables,
                 icon: "tablecells",
                 label: String(localized: "Tables"),
@@ -527,7 +527,7 @@ private struct SidebarToggleToolbarButtons: View {
                     .frame(height: 14)
                     .padding(.horizontal, 1)
             }
-            sidebarButton(
+            sidebarToggle(
                 tab: .favorites,
                 icon: "star",
                 label: String(localized: "Favorites"),
@@ -535,64 +535,32 @@ private struct SidebarToggleToolbarButtons: View {
                 sidebarState: sidebarState
             )
         }
+        .buttonStyle(.accessoryBar)
         .disabled(isDisabled)
     }
 
-    private func sidebarButton(
+    private func sidebarToggle(
         tab: SidebarTab,
         icon: String,
         label: String,
         isActive: Bool,
         sidebarState: SharedSidebarState
     ) -> some View {
-        ToolbarToggleButton(
-            icon: icon,
-            accessibilityLabel: label,
-            isOn: isActive
-        ) {
-            if isActive {
-                coordinator.sidebarProxy?.hideSidebar()
-            } else {
-                sidebarState.selectedSidebarTab = tab
-                if !coordinator.toolbarState.isSidebarVisible {
-                    coordinator.sidebarProxy?.showSidebar()
+        Toggle(isOn: Binding(
+            get: { isActive },
+            set: { newValue in
+                if newValue {
+                    sidebarState.selectedSidebarTab = tab
+                    if !coordinator.toolbarState.isSidebarVisible {
+                        coordinator.sidebarProxy?.showSidebar()
+                    }
+                } else {
+                    coordinator.sidebarProxy?.hideSidebar()
                 }
             }
+        )) {
+            Label(label, systemImage: icon)
         }
-        .help(label)
-    }
-}
-
-private struct ToolbarToggleButton: NSViewRepresentable {
-    let icon: String
-    let accessibilityLabel: String
-    let isOn: Bool
-    let action: () -> Void
-
-    func makeNSView(context: Context) -> NSButton {
-        let button = NSButton()
-        button.bezelStyle = .accessoryBarAction
-        button.setButtonType(.toggle)
-        button.isBordered = true
-        button.imagePosition = .imageOnly
-        button.target = context.coordinator
-        button.action = #selector(Coordinator.clicked)
-        return button
-    }
-
-    func updateNSView(_ button: NSButton, context: Context) {
-        button.image = NSImage(systemSymbolName: icon, accessibilityDescription: accessibilityLabel)
-        button.state = isOn ? .on : .off
-        context.coordinator.action = action
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(action: action)
-    }
-
-    final class Coordinator: NSObject {
-        var action: () -> Void
-        init(action: @escaping () -> Void) { self.action = action }
-        @objc func clicked() { action() }
+        .toggleStyle(.button)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -88,12 +88,13 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     private static let importTables = NSToolbarItem.Identifier("com.TablePro.toolbar.import")
     private static let refreshSaveGroup = NSToolbarItem.Identifier("com.TablePro.toolbar.refreshSaveGroup")
     private static let exportImportGroup = NSToolbarItem.Identifier("com.TablePro.toolbar.exportImportGroup")
+    private static let sidebarToggle = NSToolbarItem.Identifier("com.TablePro.toolbar.sidebarToggle")
 
     // MARK: - NSToolbarDelegate
 
     internal func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
-            .toggleSidebar,
+            Self.sidebarToggle,
             .sidebarTrackingSeparator,
             Self.connection,
             Self.database,
@@ -137,6 +138,9 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         guard let coordinator else { return nil }
 
         switch itemIdentifier {
+        case Self.sidebarToggle:
+            return hostingItem(id: itemIdentifier, label: String(localized: "Sidebar"),
+                               content: SidebarToggleToolbarButtons(coordinator: coordinator))
         case Self.connection:
             return hostingItem(id: itemIdentifier, label: String(localized: "Connection"),
                                content: ConnectionToolbarButton(coordinator: coordinator))
@@ -497,5 +501,67 @@ private struct ImportToolbarButton: View {
         )
         .opacity(supportsImport ? 1 : 0)
         .allowsHitTesting(supportsImport)
+    }
+}
+
+// MARK: - Sidebar Toggle Buttons
+
+private struct SidebarToggleToolbarButtons: View {
+    let coordinator: MainContentCoordinator
+
+    var body: some View {
+        let state = coordinator.toolbarState
+        let sidebarState = SharedSidebarState.forConnection(coordinator.connectionId)
+        let isDisabled = state.connectionState != .connected
+
+        HStack(spacing: 0) {
+            sidebarButton(
+                tab: .tables,
+                icon: "tablecells",
+                activeIcon: "tablecells.fill",
+                label: String(localized: "Tables"),
+                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .tables,
+                sidebarState: sidebarState
+            )
+            if !state.isSidebarVisible {
+                Divider()
+                    .frame(height: 14)
+                    .padding(.horizontal, 1)
+            }
+            sidebarButton(
+                tab: .favorites,
+                icon: "star",
+                activeIcon: "star.fill",
+                label: String(localized: "Favorites"),
+                isActive: state.isSidebarVisible && sidebarState.selectedSidebarTab == .favorites,
+                sidebarState: sidebarState
+            )
+        }
+        .disabled(isDisabled)
+    }
+
+    private func sidebarButton(
+        tab: SidebarTab,
+        icon: String,
+        activeIcon: String,
+        label: String,
+        isActive: Bool,
+        sidebarState: SharedSidebarState
+    ) -> some View {
+        Button {
+            if coordinator.toolbarState.isSidebarVisible {
+                if sidebarState.selectedSidebarTab == tab {
+                    coordinator.sidebarProxy?.hideSidebar()
+                } else {
+                    sidebarState.selectedSidebarTab = tab
+                }
+            } else {
+                sidebarState.selectedSidebarTab = tab
+                coordinator.sidebarProxy?.showSidebar()
+            }
+        } label: {
+            Label(label, systemImage: isActive ? activeIcon : icon)
+        }
+        .help(label)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -520,7 +520,7 @@ extension MainWindowToolbar {
         segmented.segmentCount = 2
         segmented.trackingMode = .selectAny
         segmented.segmentStyle = .separated
-        segmented.selectedSegmentBezelColor = .unemphasizedSelectedContentBackgroundColor
+        segmented.selectedSegmentBezelColor = .labelColor.withAlphaComponent(0.08)
         segmented.target = self
         segmented.action = #selector(sidebarSegmentClicked(_:))
 

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -14,6 +14,7 @@ internal final class SidebarContainerViewController: NSViewController {
     private let searchField = NSSearchField()
     private var hostingController: NSHostingController<AnyView>
     private var sidebarState: SharedSidebarState?
+    private var observationGeneration = 0
 
     var rootView: AnyView {
         get { hostingController.rootView }
@@ -58,17 +59,10 @@ internal final class SidebarContainerViewController: NSViewController {
         ])
     }
 
-    // MARK: - Cmd+F Support
-
-    @objc func focusSearchField(_ sender: Any?) {
-        view.window?.makeFirstResponder(searchField)
-    }
-
-    override var acceptsFirstResponder: Bool { true }
-
     // MARK: - State Management
 
     func updateSidebarState(_ state: SharedSidebarState?) {
+        observationGeneration += 1
         sidebarState = state
         guard let state else {
             searchField.isHidden = true
@@ -76,18 +70,19 @@ internal final class SidebarContainerViewController: NSViewController {
         }
         searchField.isHidden = false
         syncFromState(state)
-        startObserving(state)
+        startObserving(state, generation: observationGeneration)
     }
 
-    private func startObserving(_ state: SharedSidebarState) {
+    private func startObserving(_ state: SharedSidebarState, generation: Int) {
         withObservationTracking {
             _ = state.searchText
             _ = state.selectedSidebarTab
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
-                guard let self, let sidebarState = self.sidebarState else { return }
+                guard let self, generation == self.observationGeneration,
+                      let sidebarState = self.sidebarState else { return }
                 self.syncFromState(sidebarState)
-                self.startObserving(sidebarState)
+                self.startObserving(sidebarState, generation: generation)
             }
         }
     }

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -1,0 +1,116 @@
+//
+//  SidebarContainerViewController.swift
+//  TablePro
+//
+//  AppKit container that places a native NSSearchField above the SwiftUI sidebar content.
+//  The search field inherits sidebar vibrancy from the NSSplitViewItem automatically.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+internal final class SidebarContainerViewController: NSViewController {
+    private let searchField = NSSearchField()
+    private var hostingController: NSHostingController<AnyView>
+    private var sidebarState: SharedSidebarState?
+
+    var rootView: AnyView {
+        get { hostingController.rootView }
+        set { hostingController.rootView = newValue }
+    }
+
+    init(rootView: AnyView) {
+        self.hostingController = NSHostingController(rootView: rootView)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("SidebarContainerViewController does not support NSCoder init")
+    }
+
+    override func loadView() {
+        view = NSView()
+
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.placeholderString = String(localized: "Filter")
+        searchField.controlSize = .large
+        searchField.sendsSearchStringImmediately = true
+        searchField.delegate = self
+        searchField.setAccessibilityIdentifier("sidebar-filter")
+        view.addSubview(searchField)
+
+        addChild(hostingController)
+        let hostingView = hostingController.view
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingView)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 5),
+            searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+            searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+
+            hostingView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 5),
+            hostingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    // MARK: - Cmd+F Support
+
+    @objc func focusSearchField(_ sender: Any?) {
+        view.window?.makeFirstResponder(searchField)
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    // MARK: - State Management
+
+    func updateSidebarState(_ state: SharedSidebarState?) {
+        sidebarState = state
+        guard let state else {
+            searchField.isHidden = true
+            return
+        }
+        searchField.isHidden = false
+        syncFromState(state)
+        startObserving(state)
+    }
+
+    private func startObserving(_ state: SharedSidebarState) {
+        withObservationTracking {
+            _ = state.searchText
+            _ = state.selectedSidebarTab
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, let sidebarState = self.sidebarState else { return }
+                self.syncFromState(sidebarState)
+                self.startObserving(sidebarState)
+            }
+        }
+    }
+
+    private func syncFromState(_ state: SharedSidebarState) {
+        if searchField.stringValue != state.searchText {
+            searchField.stringValue = state.searchText
+        }
+        searchField.placeholderString = state.selectedSidebarTab == .tables
+            ? String(localized: "Filter")
+            : String(localized: "Filter favorites")
+    }
+}
+
+// MARK: - NSSearchFieldDelegate
+
+extension SidebarContainerViewController: NSSearchFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        guard let field = obj.object as? NSSearchField else { return }
+        sidebarState?.searchText = field.stringValue
+    }
+
+    func searchFieldDidEndSearching(_ sender: NSSearchField) {
+        sidebarState?.searchText = ""
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/SidebarVisibilityProxy.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarVisibilityProxy.swift
@@ -1,0 +1,22 @@
+//
+//  SidebarVisibilityProxy.swift
+//  TablePro
+//
+//  Protocol for coordinator → split view controller sidebar toggle.
+//
+
+import Foundation
+
+@MainActor
+internal protocol SidebarVisibilityProxy: AnyObject {
+    var isSidebarVisible: Bool { get }
+    func showSidebar()
+    func hideSidebar()
+    func toggleSidebar()
+}
+
+internal extension SidebarVisibilityProxy {
+    func toggleSidebar() {
+        if isSidebarVisible { hideSidebar() } else { showSidebar() }
+    }
+}

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -133,6 +133,9 @@ final class ConnectionToolbarState {
     /// Current connection state
     var connectionState: ToolbarConnectionState = .disconnected
 
+    /// Whether the sidebar is currently visible (synced from NSSplitViewItem)
+    var isSidebarVisible: Bool = true
+
     // MARK: - Query Execution
 
     /// Whether a query is currently executing.

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -115,6 +115,9 @@ final class MainContentCoordinator {
     /// Proxy for toggling the inspector NSSplitViewItem from coordinator code
     @ObservationIgnored weak var inspectorProxy: InspectorVisibilityProxy?
 
+    /// Proxy for toggling the sidebar NSSplitViewItem from toolbar buttons
+    @ObservationIgnored weak var sidebarProxy: SidebarVisibilityProxy?
+
     /// Direct reference to this coordinator's content window, used for presenting alerts.
     /// Avoids NSApp.keyWindow which may return a sheet window, causing stuck dialogs.
     @ObservationIgnored weak var contentWindow: NSWindow?

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -269,11 +269,8 @@ internal struct FavoritesTabView: View {
     }
 
     private var noMatchState: some View {
-        ContentUnavailableView(
-            String(localized: "No Matching Favorites"),
-            systemImage: "magnifyingglass"
-        )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ContentUnavailableView.search(text: searchText)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Bottom Toolbar

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -182,60 +182,60 @@ struct SidebarView: View {
         let showAllLabel = String(format: String(localized: "Show All %@"), entityLabel)
         return List(selection: selectedTablesBinding) {
             Section(isExpanded: $viewModel.isTablesExpanded) {
-                    ForEach(filteredTables) { table in
-                        TableRow(
-                            table: table,
-                            isPendingTruncate: pendingTruncates.contains(table.name),
-                            isPendingDelete: pendingDeletes.contains(table.name)
-                        )
-                        .tag(table)
-                        .overlay {
-                            DoubleClickDetector {
-                                onDoubleClick?(table)
-                            }
-                        }
-                        .contextMenu {
-                            SidebarContextMenu(
-                                clickedTable: table,
-                                selectedTables: sidebarState.selectedTables,
-                                isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
-                                onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
-                                onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
-                                coordinator: coordinator
-                            )
+                ForEach(filteredTables) { table in
+                    TableRow(
+                        table: table,
+                        isPendingTruncate: pendingTruncates.contains(table.name),
+                        isPendingDelete: pendingDeletes.contains(table.name)
+                    )
+                    .tag(table)
+                    .overlay {
+                        DoubleClickDetector {
+                            onDoubleClick?(table)
                         }
                     }
-                } header: {
-                    Text(entityLabel)
-                        .help(helpLabel)
-                        .contextMenu {
-                            Button(showAllLabel) {
-                                coordinator?.showAllTablesMetadata()
-                            }
-                        }
+                    .contextMenu {
+                        SidebarContextMenu(
+                            clickedTable: table,
+                            selectedTables: sidebarState.selectedTables,
+                            isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
+                            onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
+                            onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
+                            coordinator: coordinator
+                        )
+                    }
                 }
+            } header: {
+                Text(entityLabel)
+                    .help(helpLabel)
+                    .contextMenu {
+                        Button(showAllLabel) {
+                            coordinator?.showAllTablesMetadata()
+                        }
+                    }
+            }
 
-                if viewModel.databaseType == .redis, let keyTreeVM = sidebarState.redisKeyTreeViewModel {
-                    Section(isExpanded: $viewModel.isRedisKeysExpanded) {
-                        RedisKeyTreeView(
-                            nodes: keyTreeVM.displayNodes(searchText: viewModel.searchText),
-                            expandedPrefixes: Binding(
-                                get: { keyTreeVM.expandedPrefixes },
-                                set: { keyTreeVM.expandedPrefixes = $0 }
-                            ),
-                            isLoading: keyTreeVM.isLoading,
-                            isTruncated: keyTreeVM.isTruncated,
-                            onSelectNamespace: { prefix in
-                                coordinator?.browseRedisNamespace(prefix)
-                            },
-                            onSelectKey: { key, keyType in
-                                coordinator?.openRedisKey(key, keyType: keyType)
-                            }
-                        )
-                    } header: {
-                        Text("Keys")
-                    }
+            if viewModel.databaseType == .redis, let keyTreeVM = sidebarState.redisKeyTreeViewModel {
+                Section(isExpanded: $viewModel.isRedisKeysExpanded) {
+                    RedisKeyTreeView(
+                        nodes: keyTreeVM.displayNodes(searchText: viewModel.searchText),
+                        expandedPrefixes: Binding(
+                            get: { keyTreeVM.expandedPrefixes },
+                            set: { keyTreeVM.expandedPrefixes = $0 }
+                        ),
+                        isLoading: keyTreeVM.isLoading,
+                        isTruncated: keyTreeVM.isTruncated,
+                        onSelectNamespace: { prefix in
+                            coordinator?.browseRedisNamespace(prefix)
+                        },
+                        onSelectKey: { key, keyType in
+                            coordinator?.openRedisKey(key, keyType: keyType)
+                        }
+                    )
+                } header: {
+                    Text("Keys")
                 }
+            }
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -88,33 +88,18 @@ struct SidebarView: View {
             }
         }
         .safeAreaInset(edge: .top, spacing: 0) {
-            VStack(spacing: 0) {
-                NativeSearchField(
-                    text: Binding(
-                        get: { sidebarState.searchText },
-                        set: { sidebarState.searchText = $0 }
-                    ),
-                    placeholder: sidebarState.selectedSidebarTab == .tables
-                        ? String(localized: "Filter")
-                        : String(localized: "Filter favorites")
-                )
-                .padding(.horizontal, 8)
-                .padding(.top, 6)
-                .padding(.bottom, 4)
-
-                Picker("", selection: Binding(
-                    get: { sidebarState.selectedSidebarTab },
-                    set: { sidebarState.selectedSidebarTab = $0 }
-                )) {
-                    Text("Tables").tag(SidebarTab.tables)
-                    Text("Favorites").tag(SidebarTab.favorites)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .accessibilityLabel(String(localized: "Sidebar view"))
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-            }
+            NativeSearchField(
+                text: Binding(
+                    get: { sidebarState.searchText },
+                    set: { sidebarState.searchText = $0 }
+                ),
+                placeholder: sidebarState.selectedSidebarTab == .tables
+                    ? String(localized: "Filter")
+                    : String(localized: "Filter favorites")
+            )
+            .padding(.horizontal, 8)
+            .padding(.top, 6)
+            .padding(.bottom, 4)
         }
         .frame(minWidth: 280)
         .onChange(of: sidebarState.searchText) { _, newValue in

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -87,20 +87,6 @@ struct SidebarView: View {
                 )
             }
         }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            NativeSearchField(
-                text: Binding(
-                    get: { sidebarState.searchText },
-                    set: { sidebarState.searchText = $0 }
-                ),
-                placeholder: sidebarState.selectedSidebarTab == .tables
-                    ? String(localized: "Filter")
-                    : String(localized: "Filter favorites")
-            )
-            .padding(.horizontal, 8)
-            .padding(.top, 6)
-            .padding(.bottom, 4)
-        }
         .frame(minWidth: 280)
         .onChange(of: sidebarState.searchText) { _, newValue in
             viewModel.searchText = newValue
@@ -143,6 +129,8 @@ struct SidebarView: View {
             errorState(message: message)
         case .loaded where tables.isEmpty:
             emptyState
+        case .loaded where !viewModel.searchText.isEmpty && filteredTables.isEmpty:
+            noMatchState
         case .loaded:
             tableList
         case .idle:
@@ -169,6 +157,11 @@ struct SidebarView: View {
         .padding()
     }
 
+    private var noMatchState: some View {
+        ContentUnavailableView.search(text: viewModel.searchText)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var emptyState: some View {
         let entityName = PluginManager.shared.tableEntityName(for: viewModel.databaseType)
         let noItemsLabel = String(format: String(localized: "No %@"), entityName)
@@ -185,19 +178,10 @@ struct SidebarView: View {
 
     private var tableList: some View {
         let entityLabel = PluginManager.shared.tableEntityName(for: viewModel.databaseType)
-        let noMatchLabel = String(format: String(localized: "No matching %@"), entityLabel.lowercased())
         let helpLabel = String(format: String(localized: "Right-click to show all %@"), entityLabel.lowercased())
         let showAllLabel = String(format: String(localized: "Show All %@"), entityLabel)
         return List(selection: selectedTablesBinding) {
-            if filteredTables.isEmpty {
-                ContentUnavailableView(
-                    noMatchLabel,
-                    systemImage: "magnifyingglass"
-                )
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-            } else {
-                Section(isExpanded: $viewModel.isTablesExpanded) {
+            Section(isExpanded: $viewModel.isTablesExpanded) {
                     ForEach(filteredTables) { table in
                         TableRow(
                             table: table,
@@ -252,7 +236,6 @@ struct SidebarView: View {
                         Text("Keys")
                     }
                 }
-            }
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Summary

- Replace `.toggleSidebar` with two custom toolbar buttons (Tables + Favorites) positioned before `.sidebarTrackingSeparator` — appears next to traffic lights in unified toolbar style
- Toggle logic follows Xcode's navigator pattern: click active tab → close sidebar, click inactive tab → switch tab, click when closed → open + show tab
- Active button shows filled SF Symbol (`tablecells.fill` / `star.fill`), inactive shows outline
- Remove segmented Tables/Favorites picker from inside the sidebar body — toolbar buttons replace it
- Add `SidebarVisibilityProxy` protocol mirroring existing `InspectorVisibilityProxy`
- Add `isSidebarVisible` to `ConnectionToolbarState` for reactive toolbar button state
- View menu "Toggle Sidebar" (Cmd+0) still works via responder chain

## Test plan

- [ ] Two buttons visible next to traffic lights (Tables icon + Star icon)
- [ ] Click Tables when sidebar closed → sidebar opens showing Tables
- [ ] Click Tables again → sidebar closes
- [ ] Click Favorites when sidebar open on Tables → switches to Favorites
- [ ] Click Favorites again → sidebar closes
- [ ] Active button shows filled icon, inactive shows outline
- [ ] View menu "Toggle Sidebar" still works
- [ ] Cmd+0 still works
- [ ] Segmented picker removed from sidebar body
- [ ] Search field placeholder changes based on active tab
- [ ] Buttons disabled when not connected