### PR TITLE
fix: resolve bare SSH key filenames to ~/.ssh/ paths in importers

### DIFF
--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -239,12 +239,12 @@ struct DBeaverImporter: ForeignAppImporter {
         guard components.count >= 3 else { return nil }
         let (r, g, b) = (components[0], components[1], components[2])
 
-        if r > 200 && g < 100 && b < 100 { return "red" }
-        if r > 200 && g > 100 && g < 200 && b < 100 { return "orange" }
-        if r > 200 && g > 200 && b < 100 { return "yellow" }
-        if r < 100 && g > 150 && b < 100 { return "green" }
-        if r < 100 && g < 100 && b > 200 { return "blue" }
-        if r > 100 && g < 100 && b > 150 { return "purple" }
+        if r > 200 && g < 100 && b < 100 { return "Red" }
+        if r > 200 && g > 100 && g < 200 && b < 100 { return "Orange" }
+        if r > 200 && g > 200 && b < 100 { return "Yellow" }
+        if r < 100 && g > 150 && b < 100 { return "Green" }
+        if r < 100 && g < 100 && b > 200 { return "Blue" }
+        if r > 100 && g < 100 && b > 150 { return "Purple" }
         return nil
     }
 

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -204,7 +204,8 @@ struct DBeaverImporter: ForeignAppImporter {
         }
         let username = properties["username"] as? String ?? ""
         let authType = properties["authType"] as? String ?? "PASSWORD"
-        let keyPath = properties["keyPath"] as? String ?? ""
+        let rawKeyPath = properties["keyPath"] as? String ?? ""
+        let keyPath = ForeignAppPathHelper.resolveKeyPath(rawKeyPath)
 
         let authMethod: String
         switch authType {

--- a/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
@@ -58,6 +58,16 @@ enum ForeignAppImporterRegistry {
     ]
 }
 
+// MARK: - Path Helpers
+
+enum ForeignAppPathHelper {
+    static func resolveKeyPath(_ path: String) -> String {
+        guard !path.isEmpty else { return "" }
+        if path.hasPrefix("/") || path.hasPrefix("~/") { return path }
+        return "~/.ssh/\(path)"
+    }
+}
+
 // MARK: - Keychain Reader
 
 enum ForeignKeychainReader {

--- a/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
@@ -151,8 +151,14 @@ struct SequelAceImporter: ForeignAppImporter {
     ) throws -> ExportableConnection {
         let name = entry["name"] as? String ?? "Untitled"
         let host = entry["host"] as? String ?? "localhost"
-        let portString = entry["port"] as? String ?? ""
-        let port = Int(portString) ?? 3306
+        let port: Int
+        if let intPort = entry["port"] as? Int {
+            port = intPort
+        } else if let strPort = entry["port"] as? String, let parsed = Int(strPort) {
+            port = parsed
+        } else {
+            port = 3306
+        }
         let username = entry["user"] as? String ?? ""
         let database = entry["database"] as? String ?? ""
 
@@ -223,7 +229,7 @@ struct SequelAceImporter: ForeignAppImporter {
         guard useSSL else { return nil }
 
         return ExportableSSLConfig(
-            mode: "required",
+            mode: "Required",
             caCertificatePath: entry["sslCACertFileLocation"] as? String,
             clientCertificatePath: entry["sslCertificateFileLocation"] as? String,
             clientKeyPath: entry["sslKeyFileLocation"] as? String
@@ -263,14 +269,14 @@ struct SequelAceImporter: ForeignAppImporter {
 
     private func mapColorIndex(_ index: Int) -> String? {
         switch index {
-        case 0: return "red"
-        case 1: return "orange"
-        case 2: return "yellow"
-        case 3: return "green"
-        case 4: return "blue"
-        case 5: return "purple"
-        case 6: return "pink"
-        case 7: return "gray"
+        case 0: return "Red"
+        case 1: return "Orange"
+        case 2: return "Yellow"
+        case 3: return "Green"
+        case 4: return "Blue"
+        case 5: return "Purple"
+        case 6: return "Pink"
+        case 7: return "Gray"
         default: return nil
         }
     }

--- a/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
@@ -191,7 +191,8 @@ struct SequelAceImporter: ForeignAppImporter {
         let portString = entry["sshPort"] as? String ?? "22"
         let port = Int(portString) ?? 22
         let keyEnabled = (entry["sshKeyLocationEnabled"] as? Int ?? 0) != 0
-        let keyPath = entry["sshKeyLocation"] as? String ?? ""
+        let rawKeyPath = entry["sshKeyLocation"] as? String ?? ""
+        let keyPath = ForeignAppPathHelper.resolveKeyPath(rawKeyPath)
 
         return ExportableSSHConfig(
             enabled: true,

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -124,8 +124,14 @@ struct TablePlusImporter: ForeignAppImporter {
         let dbType = mapDriver(driverString)
 
         let host = entry["DatabaseHost"] as? String ?? "localhost"
-        let portString = entry["DatabasePort"] as? String ?? ""
-        let port = Int(portString) ?? defaultPort(for: dbType)
+        let port: Int
+        if let intPort = entry["DatabasePort"] as? Int {
+            port = intPort
+        } else if let strPort = entry["DatabasePort"] as? String, let parsed = Int(strPort) {
+            port = parsed
+        } else {
+            port = defaultPort(for: dbType)
+        }
         let username = entry["DatabaseUser"] as? String ?? ""
         let database: String
         if dbType == "SQLite" {
@@ -199,7 +205,7 @@ struct TablePlusImporter: ForeignAppImporter {
 
         let paths = entry["TlsKeyPaths"] as? [String] ?? []
         return ExportableSSLConfig(
-            mode: "required",
+            mode: "Required",
             caCertificatePath: paths.count > 0 ? paths[0] : nil,
             clientCertificatePath: paths.count > 1 ? paths[1] : nil,
             clientKeyPath: paths.count > 2 ? paths[2] : nil
@@ -252,10 +258,10 @@ struct TablePlusImporter: ForeignAppImporter {
 
     private func mapEnvironmentColor(_ environment: String?) -> String? {
         switch environment {
-        case "staging": return "yellow"
-        case "production": return "red"
-        case "testing": return "blue"
-        case "development": return "green"
+        case "staging": return "Yellow"
+        case "production": return "Red"
+        case "testing": return "Blue"
+        case "development": return "Green"
         default: return nil
         }
     }

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -173,7 +173,8 @@ struct TablePlusImporter: ForeignAppImporter {
         let port = Int(portString) ?? 22
         let username = entry["ServerUser"] as? String ?? ""
         let useKey = entry["isUsePrivateKey"] as? Bool ?? false
-        let keyPath = entry["ServerPrivateKeyName"] as? String ?? ""
+        let rawKeyPath = entry["ServerPrivateKeyName"] as? String ?? ""
+        let keyPath = ForeignAppPathHelper.resolveKeyPath(rawKeyPath)
 
         return ExportableSSHConfig(
             enabled: true,

--- a/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
@@ -457,12 +457,12 @@ struct DBeaverImporterTests {
         let result = try importer.importConnections(includePasswords: false)
         let colorMap = Dictionary(uniqueKeysWithValues: result.envelope.connections.map { ($0.name, $0.color) })
 
-        #expect(colorMap["Red"] == "red")
-        #expect(colorMap["Orange"] == "orange")
-        #expect(colorMap["Yellow"] == "yellow")
-        #expect(colorMap["Green"] == "green")
-        #expect(colorMap["Blue"] == "blue")
-        #expect(colorMap["Purple"] == "purple")
+        #expect(colorMap["Red"] == "Red")
+        #expect(colorMap["Orange"] == "Orange")
+        #expect(colorMap["Yellow"] == "Yellow")
+        #expect(colorMap["Green"] == "Green")
+        #expect(colorMap["Blue"] == "Blue")
+        #expect(colorMap["Purple"] == "Purple")
         #expect(colorMap["No Color"] == Optional<String>.none)
     }
 

--- a/TableProTests/Core/Services/ForeignApp/SequelAceImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/SequelAceImporterTests.swift
@@ -214,7 +214,7 @@ struct SequelAceImporterTests {
         let ssl = result.envelope.connections[0].sslConfig
 
         #expect(ssl != nil)
-        #expect(ssl?.mode == "required")
+        #expect(ssl?.mode == "Required")
         #expect(ssl?.caCertificatePath == "/path/to/ca.pem")
         #expect(ssl?.clientCertificatePath == "/path/to/client-cert.pem")
         #expect(ssl?.clientKeyPath == "/path/to/client-key.pem")
@@ -264,14 +264,14 @@ struct SequelAceImporterTests {
     @Test("importConnections color index mapping")
     func testImportConnections_colorIndexMapping() throws {
         let colorMappings: [(Int, String?)] = [
-            (0, "red"),
-            (1, "orange"),
-            (2, "yellow"),
-            (3, "green"),
-            (4, "blue"),
-            (5, "purple"),
-            (6, "pink"),
-            (7, "gray"),
+            (0, "Red"),
+            (1, "Orange"),
+            (2, "Yellow"),
+            (3, "Green"),
+            (4, "Blue"),
+            (5, "Purple"),
+            (6, "Pink"),
+            (7, "Gray"),
             (-1, nil),
             (99, nil)
         ]

--- a/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
@@ -231,7 +231,7 @@ struct TablePlusImporterTests {
         let ssl = conn.sslConfig
 
         #expect(ssl != nil)
-        #expect(ssl?.mode == "required")
+        #expect(ssl?.mode == "Required")
         #expect(ssl?.caCertificatePath == "/path/to/ca.pem")
         #expect(ssl?.clientCertificatePath == "/path/to/client-cert.pem")
         #expect(ssl?.clientKeyPath == "/path/to/client-key.pem")
@@ -369,10 +369,10 @@ struct TablePlusImporterTests {
         let result = try importer.importConnections(includePasswords: false)
         let connections = result.envelope.connections
 
-        #expect(connections[0].color == "yellow")
-        #expect(connections[1].color == "red")
-        #expect(connections[2].color == "blue")
-        #expect(connections[3].color == "green")
+        #expect(connections[0].color == "Yellow")
+        #expect(connections[1].color == "Red")
+        #expect(connections[2].color == "Blue")
+        #expect(connections[3].color == "Green")
         #expect(connections[4].color == nil)
     }
 


### PR DESCRIPTION
## Summary

- TablePlus stores SSH key as bare filename (e.g. `id_ed25519`) in `ServerPrivateKeyName`, not a full path
- `analyzeImport` checks `FileManager.fileExists(atPath:)` on this bare name, which always fails
- Added `ForeignAppPathHelper.resolveKeyPath()` that prepends `~/.ssh/` to bare filenames
- Applied to all 3 importers (TablePlus, Sequel Ace, DBeaver) for consistency

## Test plan

- [ ] Import from TablePlus with SSH key auth: no "SSH private key not found" warning
- [ ] Keys with full paths (`~/path/to/key`) still work
- [ ] Keys with absolute paths (`/path/to/key`) still work