### PR TITLE
feat: embedded database CLI terminal with libghostty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Import connections from TablePlus, Sequel Ace, and DBeaver with one-click migration
+- Embedded database CLI terminal (View > Open Terminal or Ctrl+Cmd+`) auto-launches mysql, psql, redis-cli, etc. for the active connection
 - Structure tab: modify existing tables (add, modify, drop columns, indexes, foreign keys, primary keys)
 
 ### Changed

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -59,6 +59,8 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             defaultTitle = String(localized: "ER Diagram")
         } else if payload?.tabType == .createTable {
             defaultTitle = String(localized: "Create Table")
+        } else if payload?.tabType == .terminal {
+            defaultTitle = String(localized: "Terminal")
         } else if let tabTitle = payload?.tabTitle {
             defaultTitle = tabTitle
         } else if let tableName = payload?.tableName {

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -121,6 +121,10 @@ enum SessionStateFactory {
                     )
                 case .serverDashboard:
                     tabMgr.addServerDashboardTab()
+                case .terminal:
+                    tabMgr.addTerminalTab(
+                        databaseName: payload.databaseName ?? connection.database
+                    )
                 }
             case .newEmptyTab:
                 let allTabs = MainContentCoordinator.allTabs(for: connection.id)

--- a/TablePro/Core/Services/Infrastructure/SettingsNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/SettingsNotifications.swift
@@ -24,4 +24,8 @@ extension Notification.Name {
     /// Posted when the active theme changes (colors, fonts, or entire theme switch).
     /// Used by AppKit components that cannot observe @Observable directly.
     static let themeDidChange = Notification.Name("themeDidChange")
+
+    /// Posted when terminal settings change (font, theme, cursor, etc.)
+    /// Used by terminal views to live-update configuration.
+    static let terminalSettingsDidChange = Notification.Name("terminalSettingsDidChange")
 }

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -134,6 +134,14 @@ final class AppSettingsManager {
         }
     }
 
+    var terminal: TerminalSettings {
+        didSet {
+            storage.saveTerminal(terminal)
+            notifyChange(.terminalSettingsDidChange)
+            SyncChangeTracker.shared.markDirty(.settings, id: "terminal")
+        }
+    }
+
     @ObservationIgnored private let storage = AppSettingsStorage.shared
     /// Reentrancy guard for didSet validation that re-assigns the property.
     @ObservationIgnored private var isValidating = false
@@ -156,6 +164,7 @@ final class AppSettingsManager {
         self.keyboard = storage.loadKeyboard()
         self.ai = storage.loadAI()
         self.sync = storage.loadSync()
+        self.terminal = storage.loadTerminal()
 
         // Apply language immediately
         general.language.apply()
@@ -232,6 +241,7 @@ final class AppSettingsManager {
         keyboard = .default
         ai = .default
         sync = .default
+        terminal = .default
         storage.resetToDefaults()
     }
 }

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -30,6 +30,7 @@ final class AppSettingsStorage {
         static let keyboard = "com.TablePro.settings.keyboard"
         static let ai = "com.TablePro.settings.ai"
         static let sync = "com.TablePro.settings.sync"
+        static let terminal = "com.TablePro.settings.terminal"
         static let lastConnectionId = "com.TablePro.settings.lastConnectionId"
         static let lastOpenConnectionIds = "com.TablePro.settings.lastOpenConnectionIds"
         static let hasCompletedOnboarding = "com.TablePro.settings.hasCompletedOnboarding"
@@ -128,6 +129,16 @@ final class AppSettingsStorage {
         save(settings, key: Keys.sync)
     }
 
+    // MARK: - Terminal Settings
+
+    func loadTerminal() -> TerminalSettings {
+        load(key: Keys.terminal, default: .default)
+    }
+
+    func saveTerminal(_ settings: TerminalSettings) {
+        save(settings, key: Keys.terminal)
+    }
+
     // MARK: - Last Connection (for Reopen Last Session)
 
     /// Load the last used connection ID
@@ -219,6 +230,7 @@ final class AppSettingsStorage {
         saveKeyboard(.default)
         saveAI(.default)
         saveSync(.default)
+        saveTerminal(.default)
     }
 
     // MARK: - Helpers

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -53,8 +53,10 @@ enum CLICommandResolver {
         let type = connection.type
 
         switch type {
-        case .mysql, .mariadb:
+        case .mysql:
             return resolveMysql(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
+        case .mariadb:
+            return resolveMariadbOrMysql(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .postgresql, .redshift:
             return resolvePsql(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .redis:
@@ -285,7 +287,8 @@ enum CLICommandResolver {
 
     static func binaryName(for databaseType: DatabaseType) -> String {
         switch databaseType {
-        case .mysql, .mariadb: return "mysql"
+        case .mysql: return "mysql"
+        case .mariadb: return "mariadb"
         case .postgresql, .redshift: return "psql"
         case .redis: return "redis-cli"
         case .mongodb: return "mongosh"
@@ -300,8 +303,10 @@ enum CLICommandResolver {
 
     static func installInstructions(for databaseType: DatabaseType) -> String {
         switch databaseType {
-        case .mysql, .mariadb:
-            return "brew install mysql"
+        case .mysql:
+            return "brew install mysql-client"
+        case .mariadb:
+            return "brew install mariadb"
         case .postgresql, .redshift:
             return "brew install libpq"
         case .redis:
@@ -332,6 +337,34 @@ enum CLICommandResolver {
         customCliPath: String? = nil
     ) -> CLILaunchSpec? {
         guard let path = findExecutable("mysql", customPath: customCliPath) else { return nil }
+
+        var args: [String] = []
+        if !connection.username.isEmpty {
+            args += ["-u", connection.username]
+        }
+        args += ["-h", connection.host.isEmpty ? "127.0.0.1" : connection.host]
+        args += ["-P", String(connection.port)]
+        if !database.isEmpty {
+            args.append(database)
+        }
+
+        var env: [String: String] = [:]
+        if let password, !password.isEmpty {
+            env["MYSQL_PWD"] = password
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolveMariadbOrMysql(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String,
+        customCliPath: String? = nil
+    ) -> CLILaunchSpec? {
+        let path = findExecutable("mariadb", customPath: customCliPath)
+            ?? findExecutable("mysql", customPath: nil)
+        guard let path else { return nil }
 
         var args: [String] = []
         if !connection.username.isEmpty {

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -149,8 +149,9 @@ enum CLICommandResolver {
             : "\(sshConfig.username)@\(sshConfig.host)"
         sshArgs.append(userHost)
 
-        // Remote command (the CLI invocation on the remote host)
-        sshArgs.append(remoteCommand)
+        // Wrap in login shell so the remote user's PATH is loaded
+        // (non-login SSH commands don't source .bashrc/.profile)
+        sshArgs += ["bash", "-l", "-c", remoteCommand]
 
         return CLILaunchSpec(executablePath: sshPath, arguments: sshArgs, environment: [:])
     }

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -130,9 +130,6 @@ enum CLICommandResolver {
             sshArgs += ["-J", jumpSpec]
         }
 
-        // Disable strict host key checking for non-interactive use
-        sshArgs += ["-o", "StrictHostKeyChecking=accept-new"]
-
         // Request TTY for interactive CLI
         sshArgs.append("-t")
 
@@ -189,11 +186,15 @@ enum CLICommandResolver {
 
         case .mongodb:
             let db = database.isEmpty ? "test" : database
+            var uri: String
             if !connection.username.isEmpty, let password, !password.isEmpty {
-                cmd += " 'mongodb://\(connection.username):\(password)@\(host):\(connection.port)/\(db)'"
+                let encodedUser = connection.username.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed) ?? connection.username
+                let encodedPass = password.addingPercentEncoding(withAllowedCharacters: .urlPasswordAllowed) ?? password
+                uri = "mongodb://\(encodedUser):\(encodedPass)@\(host):\(connection.port)/\(db)"
             } else {
-                cmd += " 'mongodb://\(host):\(connection.port)/\(db)'"
+                uri = "mongodb://\(host):\(connection.port)/\(db)"
             }
+            cmd += " \(shellEscape(uri))"
 
         case .mssql:
             if let password, !password.isEmpty {
@@ -214,11 +215,13 @@ enum CLICommandResolver {
         case .oracle:
             let serviceName = connection.additionalFields["oracleServiceName"] ?? database
             let pass = password ?? ""
+            var connectString: String
             if !connection.username.isEmpty {
-                cmd += " \(shellEscape(connection.username))/\(shellEscape(pass))@\(host):\(connection.port)/\(serviceName)"
+                connectString = "\(connection.username)/\(pass)@\(host):\(connection.port)/\(serviceName)"
             } else {
-                cmd += " @\(host):\(connection.port)/\(serviceName)"
+                connectString = "@\(host):\(connection.port)/\(serviceName)"
             }
+            cmd += " \(shellEscape(connectString))"
 
         default:
             return ""

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -20,7 +20,9 @@ enum CLICommandResolver {
     static func resolve(
         connection: DatabaseConnection,
         password: String?,
-        activeDatabase: String?
+        activeDatabase: String?,
+        databaseType: DatabaseType? = nil,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
         let sshConfig = extractSSHConfig(from: connection)
         if let sshConfig {
@@ -31,7 +33,12 @@ enum CLICommandResolver {
                 sshConfig: sshConfig
             )
         }
-        return resolveLocal(connection: connection, password: password, activeDatabase: activeDatabase)
+        return resolveLocal(
+            connection: connection,
+            password: password,
+            activeDatabase: activeDatabase,
+            customCliPath: customCliPath
+        )
     }
 
     // MARK: - Local Resolution
@@ -39,30 +46,31 @@ enum CLICommandResolver {
     private static func resolveLocal(
         connection: DatabaseConnection,
         password: String?,
-        activeDatabase: String?
+        activeDatabase: String?,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
         let dbName = activeDatabase ?? connection.database
         let type = connection.type
 
         switch type {
         case .mysql, .mariadb:
-            return resolveMysql(connection: connection, password: password, database: dbName)
+            return resolveMysql(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .postgresql, .redshift:
-            return resolvePsql(connection: connection, password: password, database: dbName)
+            return resolvePsql(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .redis:
-            return resolveRedisCli(connection: connection, password: password)
+            return resolveRedisCli(connection: connection, password: password, customCliPath: customCliPath)
         case .mongodb:
-            return resolveMongosh(connection: connection, password: password, database: dbName)
+            return resolveMongosh(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .sqlite:
-            return resolveSqlite3(connection: connection)
+            return resolveSqlite3(connection: connection, customCliPath: customCliPath)
         case .mssql:
-            return resolveSqlcmd(connection: connection, password: password, database: dbName)
+            return resolveSqlcmd(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .clickhouse:
-            return resolveClickhouseClient(connection: connection, password: password, database: dbName)
+            return resolveClickhouseClient(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         case .duckdb:
-            return resolveDuckdb(connection: connection)
+            return resolveDuckdb(connection: connection, customCliPath: customCliPath)
         case .oracle:
-            return resolveSqlplus(connection: connection, password: password, database: dbName)
+            return resolveSqlplus(connection: connection, password: password, database: dbName, customCliPath: customCliPath)
         default:
             logger.warning("No CLI mapping for database type: \(type.rawValue, privacy: .public)")
             return nil
@@ -238,14 +246,27 @@ enum CLICommandResolver {
         return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
-    static func findExecutable(_ name: String) -> String? {
-        // 1. System PATH via /usr/bin/which
+    @MainActor
+    static func userConfiguredPath(for databaseType: DatabaseType) -> String? {
+        let customPath = AppSettingsManager.shared.terminal.cliPaths[databaseType.rawValue] ?? ""
+        guard !customPath.isEmpty else { return nil }
+        return customPath
+    }
+
+    static func findExecutable(_ name: String, customPath: String? = nil) -> String? {
+        // 1. User-configured path
+        if let customPath, !customPath.isEmpty,
+           FileManager.default.isExecutableFile(atPath: customPath) {
+            return customPath
+        }
+
+        // 2. System PATH via /usr/bin/which
         let whichResult = shell("/usr/bin/which", arguments: [name])
         if let path = whichResult, !path.isEmpty {
             return path
         }
 
-        // 2. Common locations
+        // 3. Common locations
         let commonPaths = [
             "/opt/homebrew/bin/\(name)",
             "/usr/local/bin/\(name)",
@@ -307,9 +328,10 @@ enum CLICommandResolver {
     private static func resolveMysql(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("mysql") else { return nil }
+        guard let path = findExecutable("mysql", customPath: customCliPath) else { return nil }
 
         var args: [String] = []
         if !connection.username.isEmpty {
@@ -332,9 +354,10 @@ enum CLICommandResolver {
     private static func resolvePsql(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("psql") else { return nil }
+        guard let path = findExecutable("psql", customPath: customCliPath) else { return nil }
 
         var args: [String] = []
         if !connection.username.isEmpty {
@@ -356,9 +379,10 @@ enum CLICommandResolver {
 
     private static func resolveRedisCli(
         connection: DatabaseConnection,
-        password: String?
+        password: String?,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("redis-cli") else { return nil }
+        guard let path = findExecutable("redis-cli", customPath: customCliPath) else { return nil }
 
         var args: [String] = []
         args += ["-h", connection.host.isEmpty ? "127.0.0.1" : connection.host]
@@ -378,9 +402,10 @@ enum CLICommandResolver {
     private static func resolveMongosh(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("mongosh") else { return nil }
+        guard let path = findExecutable("mongosh", customPath: customCliPath) else { return nil }
 
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         let port = connection.port
@@ -398,8 +423,8 @@ enum CLICommandResolver {
         return CLILaunchSpec(executablePath: path, arguments: [uri], environment: [:])
     }
 
-    private static func resolveSqlite3(connection: DatabaseConnection) -> CLILaunchSpec? {
-        guard let path = findExecutable("sqlite3") else { return nil }
+    private static func resolveSqlite3(connection: DatabaseConnection, customCliPath: String? = nil) -> CLILaunchSpec? {
+        guard let path = findExecutable("sqlite3", customPath: customCliPath) else { return nil }
 
         let dbPath = connection.database
         return CLILaunchSpec(executablePath: path, arguments: [dbPath], environment: [:])
@@ -408,9 +433,10 @@ enum CLICommandResolver {
     private static func resolveSqlcmd(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("sqlcmd") else { return nil }
+        guard let path = findExecutable("sqlcmd", customPath: customCliPath) else { return nil }
 
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         var args: [String] = ["-S", "\(host),\(connection.port)"]
@@ -432,9 +458,10 @@ enum CLICommandResolver {
     private static func resolveClickhouseClient(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("clickhouse-client") else { return nil }
+        guard let path = findExecutable("clickhouse-client", customPath: customCliPath) else { return nil }
 
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         var args: [String] = ["--host", host, "--port", String(connection.port)]
@@ -455,9 +482,10 @@ enum CLICommandResolver {
     private static func resolveSqlplus(
         connection: DatabaseConnection,
         password: String?,
-        database: String
+        database: String,
+        customCliPath: String? = nil
     ) -> CLILaunchSpec? {
-        guard let path = findExecutable("sqlplus") else { return nil }
+        guard let path = findExecutable("sqlplus", customPath: customCliPath) else { return nil }
 
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         let serviceName = connection.additionalFields["oracleServiceName"] ?? database
@@ -474,8 +502,8 @@ enum CLICommandResolver {
         return CLILaunchSpec(executablePath: path, arguments: [connectString], environment: [:])
     }
 
-    private static func resolveDuckdb(connection: DatabaseConnection) -> CLILaunchSpec? {
-        guard let path = findExecutable("duckdb") else { return nil }
+    private static func resolveDuckdb(connection: DatabaseConnection, customCliPath: String? = nil) -> CLILaunchSpec? {
+        guard let path = findExecutable("duckdb", customPath: customCliPath) else { return nil }
 
         let dbPath = connection.database
         return CLILaunchSpec(executablePath: path, arguments: [dbPath], environment: [:])

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -165,10 +165,10 @@ enum CLICommandResolver {
             : "\(sshConfig.username)@\(sshConfig.host)"
         sshArgs.append(userHost)
 
-        // Wrap in login shell so the remote user's PATH is loaded.
-        // Must be a single argument — bash -c takes one string.
-        let bashEscaped = remoteCommand.replacingOccurrences(of: "'", with: "'\\''")
-        sshArgs.append("bash -l -c '\(bashEscaped)'")
+        // Source common profile files inline so the remote PATH is loaded.
+        // Avoids bash -l -c '...' which causes nested single-quote issues
+        // when remoteCommand already contains single-quoted shell-escaped values.
+        sshArgs.append(". ~/.profile 2>/dev/null; . ~/.bashrc 2>/dev/null; " + remoteCommand)
 
         return CLILaunchSpec(executablePath: sshPath, arguments: sshArgs, environment: [:])
     }
@@ -243,6 +243,8 @@ enum CLICommandResolver {
             if !database.isEmpty { cmd += " --database \(shellEscape(database))" }
 
         case .oracle:
+            // sqlplus requires password in connect string (no env var support).
+            // Visible in ps output — accepted industry limitation for Oracle CLI.
             let serviceName = connection.additionalFields["oracleServiceName"] ?? database
             let pass = password ?? ""
             var connectString: String
@@ -323,6 +325,7 @@ enum CLICommandResolver {
 
     static func installInstructions(for databaseType: DatabaseType) -> String {
         switch databaseType {
+        // brew commands are not localized — they are technical shell commands
         case .mysql:
             return "brew install mysql-client"
         case .mariadb:
@@ -334,7 +337,7 @@ enum CLICommandResolver {
         case .mongodb:
             return "brew install mongosh"
         case .sqlite:
-            return "sqlite3 is included with macOS"
+            return String(localized: "sqlite3 is included with macOS")
         case .mssql:
             return "brew install sqlcmd"
         case .clickhouse:
@@ -344,7 +347,7 @@ enum CLICommandResolver {
         case .oracle:
             return "brew install instantclient-sqlplus"
         default:
-            return "Install the CLI client for \(databaseType.displayName)"
+            return String(format: String(localized: "Install the CLI client for %@"), databaseType.displayName)
         }
     }
 
@@ -543,7 +546,8 @@ enum CLICommandResolver {
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         let serviceName = connection.additionalFields["oracleServiceName"] ?? database
 
-        // sqlplus user/password@host:port/service_name
+        // sqlplus requires password in connect string (no env var support).
+        // Visible in ps output — accepted industry limitation for Oracle CLI.
         var connectString: String
         if !connection.username.isEmpty {
             let pass = password ?? ""
@@ -564,6 +568,8 @@ enum CLICommandResolver {
 
     // MARK: - Shell Helper
 
+    // Note: shell() and findExecutable() perform synchronous I/O. They are called
+    // from Task.detached in TerminalSessionState.connect() to avoid blocking MainActor.
     private static func shell(_ path: String, arguments: [String]) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: path)

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -2,9 +2,6 @@
 //  CLICommandResolver.swift
 //  TablePro
 //
-//  Maps DatabaseType to CLI binary, arguments, and environment variables
-//  for launching an interactive database shell in the terminal tab.
-//
 
 import Foundation
 import os
@@ -73,6 +70,20 @@ enum CLICommandResolver {
         }
 
         return nil
+    }
+
+    static func binaryName(for databaseType: DatabaseType) -> String {
+        switch databaseType {
+        case .mysql, .mariadb: return "mysql"
+        case .postgresql, .redshift: return "psql"
+        case .redis: return "redis-cli"
+        case .mongodb: return "mongosh"
+        case .sqlite: return "sqlite3"
+        case .mssql: return "sqlcmd"
+        case .clickhouse: return "clickhouse-client"
+        case .duckdb: return "duckdb"
+        default: return databaseType.rawValue.lowercased()
+        }
     }
 
     static func installInstructions(for databaseType: DatabaseType) -> String {
@@ -240,11 +251,12 @@ enum CLICommandResolver {
         if !database.isEmpty {
             args += ["--database", database]
         }
+        var env: [String: String] = [:]
         if let password, !password.isEmpty {
-            args += ["--password", password]
+            env["CLICKHOUSE_PASSWORD"] = password
         }
 
-        return CLILaunchSpec(executablePath: path, arguments: args, environment: [:])
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
     }
 
     private static func resolveDuckdb(connection: DatabaseConnection) -> CLILaunchSpec? {

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -149,9 +149,10 @@ enum CLICommandResolver {
             : "\(sshConfig.username)@\(sshConfig.host)"
         sshArgs.append(userHost)
 
-        // Wrap in login shell so the remote user's PATH is loaded
-        // (non-login SSH commands don't source .bashrc/.profile)
-        sshArgs += ["bash", "-l", "-c", remoteCommand]
+        // Wrap in login shell so the remote user's PATH is loaded.
+        // Must be a single argument — bash -c takes one string.
+        let bashEscaped = remoteCommand.replacingOccurrences(of: "'", with: "'\\''")
+        sshArgs.append("bash -l -c '\(bashEscaped)'")
 
         return CLILaunchSpec(executablePath: sshPath, arguments: sshArgs, environment: [:])
     }

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -22,16 +22,32 @@ enum CLICommandResolver {
         password: String?,
         activeDatabase: String?,
         databaseType: DatabaseType? = nil,
-        customCliPath: String? = nil
+        customCliPath: String? = nil,
+        effectiveConnection: DatabaseConnection? = nil
     ) -> CLILaunchSpec? {
         let sshConfig = extractSSHConfig(from: connection)
-        if let sshConfig {
-            return resolveViaSSH(
-                connection: connection,
-                password: password,
-                activeDatabase: activeDatabase,
-                sshConfig: sshConfig
-            )
+        if sshConfig != nil {
+            // For SSH-tunneled connections, prefer local CLI via the existing tunnel.
+            // This handles Docker/container setups where CLI isn't on the remote host.
+            if let effective = effectiveConnection {
+                let localSpec = resolveLocal(
+                    connection: effective,
+                    password: password,
+                    activeDatabase: activeDatabase,
+                    customCliPath: customCliPath
+                )
+                if localSpec != nil { return localSpec }
+            }
+
+            // Fall back to SSH remote if local CLI not available
+            if let sshConfig {
+                return resolveViaSSH(
+                    connection: connection,
+                    password: password,
+                    activeDatabase: activeDatabase,
+                    sshConfig: sshConfig
+                )
+            }
         }
         return resolveLocal(
             connection: connection,

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -22,6 +22,25 @@ enum CLICommandResolver {
         password: String?,
         activeDatabase: String?
     ) -> CLILaunchSpec? {
+        let sshConfig = extractSSHConfig(from: connection)
+        if let sshConfig {
+            return resolveViaSSH(
+                connection: connection,
+                password: password,
+                activeDatabase: activeDatabase,
+                sshConfig: sshConfig
+            )
+        }
+        return resolveLocal(connection: connection, password: password, activeDatabase: activeDatabase)
+    }
+
+    // MARK: - Local Resolution
+
+    private static func resolveLocal(
+        connection: DatabaseConnection,
+        password: String?,
+        activeDatabase: String?
+    ) -> CLILaunchSpec? {
         let dbName = activeDatabase ?? connection.database
         let type = connection.type
 
@@ -48,6 +67,172 @@ enum CLICommandResolver {
             logger.warning("No CLI mapping for database type: \(type.rawValue, privacy: .public)")
             return nil
         }
+    }
+
+    // MARK: - SSH Resolution
+
+    private static func extractSSHConfig(from connection: DatabaseConnection) -> SSHConfiguration? {
+        switch connection.sshTunnelMode {
+        case .disabled:
+            return nil
+        case .inline(let config):
+            return config
+        case .profile(_, let snapshot):
+            return snapshot
+        }
+    }
+
+    private static func resolveViaSSH(
+        connection: DatabaseConnection,
+        password: String?,
+        activeDatabase: String?,
+        sshConfig: SSHConfiguration
+    ) -> CLILaunchSpec? {
+        guard let sshPath = findExecutable("ssh") else {
+            logger.error("ssh binary not found")
+            return nil
+        }
+
+        let cliName = binaryName(for: connection.type)
+        let dbName = activeDatabase ?? connection.database
+
+        // Build the remote CLI command
+        var remoteCommand = buildRemoteCommand(
+            connection: connection,
+            password: password,
+            database: dbName,
+            cliName: cliName
+        )
+        guard !remoteCommand.isEmpty else { return nil }
+
+        // Build ssh args
+        var sshArgs: [String] = []
+
+        // SSH port
+        if sshConfig.port != 22 {
+            sshArgs += ["-p", String(sshConfig.port)]
+        }
+
+        // Private key
+        if sshConfig.authMethod == .privateKey, let keyPath = sshConfig.privateKeyPath, !keyPath.isEmpty {
+            let expanded = (keyPath as NSString).expandingTildeInPath
+            sshArgs += ["-i", expanded]
+        }
+
+        // Jump hosts
+        if !sshConfig.jumpHosts.isEmpty {
+            let jumpSpec = sshConfig.jumpHosts.map { jump -> String in
+                if jump.port != 22 {
+                    return "\(jump.username.isEmpty ? "" : "\(jump.username)@")\(jump.host):\(jump.port)"
+                }
+                return "\(jump.username.isEmpty ? "" : "\(jump.username)@")\(jump.host)"
+            }.joined(separator: ",")
+            sshArgs += ["-J", jumpSpec]
+        }
+
+        // Disable strict host key checking for non-interactive use
+        sshArgs += ["-o", "StrictHostKeyChecking=accept-new"]
+
+        // Request TTY for interactive CLI
+        sshArgs.append("-t")
+
+        // user@host
+        let userHost = sshConfig.username.isEmpty
+            ? sshConfig.host
+            : "\(sshConfig.username)@\(sshConfig.host)"
+        sshArgs.append(userHost)
+
+        // Remote command (the CLI invocation on the remote host)
+        sshArgs.append(remoteCommand)
+
+        return CLILaunchSpec(executablePath: sshPath, arguments: sshArgs, environment: [:])
+    }
+
+    /// Builds the remote shell command string to run the database CLI on the SSH host.
+    /// The DB connects to localhost on the remote (or the configured host from there).
+    private static func buildRemoteCommand(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String,
+        cliName: String
+    ) -> String {
+        let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
+        var envPrefix = ""
+        var cmd = cliName
+        let type = connection.type
+
+        switch type {
+        case .mysql, .mariadb:
+            if let password, !password.isEmpty {
+                envPrefix = "MYSQL_PWD=\(shellEscape(password)) "
+            }
+            cmd += " -h \(host) -P \(connection.port)"
+            if !connection.username.isEmpty { cmd += " -u \(shellEscape(connection.username))" }
+            if !database.isEmpty { cmd += " \(shellEscape(database))" }
+
+        case .postgresql, .redshift:
+            if let password, !password.isEmpty {
+                envPrefix = "PGPASSWORD=\(shellEscape(password)) "
+            }
+            cmd += " -h \(host) -p \(connection.port)"
+            if !connection.username.isEmpty { cmd += " -U \(shellEscape(connection.username))" }
+            if !database.isEmpty { cmd += " \(shellEscape(database))" }
+
+        case .redis:
+            if let password, !password.isEmpty {
+                envPrefix = "REDISCLI_AUTH=\(shellEscape(password)) "
+            }
+            cmd += " -h \(host) -p \(connection.port)"
+            if let dbIndex = connection.redisDatabase, dbIndex > 0 {
+                cmd += " -n \(dbIndex)"
+            }
+
+        case .mongodb:
+            let db = database.isEmpty ? "test" : database
+            if !connection.username.isEmpty, let password, !password.isEmpty {
+                cmd += " 'mongodb://\(connection.username):\(password)@\(host):\(connection.port)/\(db)'"
+            } else {
+                cmd += " 'mongodb://\(host):\(connection.port)/\(db)'"
+            }
+
+        case .mssql:
+            if let password, !password.isEmpty {
+                envPrefix = "SQLCMDPASSWORD=\(shellEscape(password)) "
+            }
+            cmd += " -S \(host),\(connection.port)"
+            if !connection.username.isEmpty { cmd += " -U \(shellEscape(connection.username))" }
+            if !database.isEmpty { cmd += " -d \(shellEscape(database))" }
+
+        case .clickhouse:
+            if let password, !password.isEmpty {
+                envPrefix = "CLICKHOUSE_PASSWORD=\(shellEscape(password)) "
+            }
+            cmd += " --host \(host) --port \(connection.port)"
+            if !connection.username.isEmpty { cmd += " --user \(shellEscape(connection.username))" }
+            if !database.isEmpty { cmd += " --database \(shellEscape(database))" }
+
+        case .oracle:
+            let serviceName = connection.additionalFields["oracleServiceName"] ?? database
+            let pass = password ?? ""
+            if !connection.username.isEmpty {
+                cmd += " \(shellEscape(connection.username))/\(shellEscape(pass))@\(host):\(connection.port)/\(serviceName)"
+            } else {
+                cmd += " @\(host):\(connection.port)/\(serviceName)"
+            }
+
+        default:
+            return ""
+        }
+
+        return "\(envPrefix)\(cmd)"
+    }
+
+    /// Escapes a string for safe use in a shell command.
+    private static func shellEscape(_ value: String) -> String {
+        if value.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/" }) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     static func findExecutable(_ name: String) -> String? {

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -1,0 +1,279 @@
+//
+//  CLICommandResolver.swift
+//  TablePro
+//
+//  Maps DatabaseType to CLI binary, arguments, and environment variables
+//  for launching an interactive database shell in the terminal tab.
+//
+
+import Foundation
+import os
+
+struct CLILaunchSpec {
+    let executablePath: String
+    let arguments: [String]
+    let environment: [String: String]
+}
+
+enum CLICommandResolver {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "CLICommandResolver")
+
+    // MARK: - Public API
+
+    static func resolve(
+        connection: DatabaseConnection,
+        password: String?,
+        activeDatabase: String?
+    ) -> CLILaunchSpec? {
+        let dbName = activeDatabase ?? connection.database
+        let type = connection.type
+
+        switch type {
+        case .mysql, .mariadb:
+            return resolveMysql(connection: connection, password: password, database: dbName)
+        case .postgresql, .redshift:
+            return resolvePsql(connection: connection, password: password, database: dbName)
+        case .redis:
+            return resolveRedisCli(connection: connection, password: password)
+        case .mongodb:
+            return resolveMongosh(connection: connection, password: password, database: dbName)
+        case .sqlite:
+            return resolveSqlite3(connection: connection)
+        case .mssql:
+            return resolveSqlcmd(connection: connection, password: password, database: dbName)
+        case .clickhouse:
+            return resolveClickhouseClient(connection: connection, password: password, database: dbName)
+        case .duckdb:
+            return resolveDuckdb(connection: connection)
+        default:
+            logger.warning("No CLI mapping for database type: \(type.rawValue, privacy: .public)")
+            return nil
+        }
+    }
+
+    static func findExecutable(_ name: String) -> String? {
+        // 1. System PATH via /usr/bin/which
+        let whichResult = shell("/usr/bin/which", arguments: [name])
+        if let path = whichResult, !path.isEmpty {
+            return path
+        }
+
+        // 2. Common locations
+        let commonPaths = [
+            "/opt/homebrew/bin/\(name)",
+            "/usr/local/bin/\(name)",
+            "/usr/local/mysql/bin/\(name)",
+            "/Applications/Postgres.app/Contents/Versions/latest/bin/\(name)"
+        ]
+
+        for path in commonPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+
+        return nil
+    }
+
+    static func installInstructions(for databaseType: DatabaseType) -> String {
+        switch databaseType {
+        case .mysql, .mariadb:
+            return "brew install mysql"
+        case .postgresql, .redshift:
+            return "brew install libpq"
+        case .redis:
+            return "brew install redis"
+        case .mongodb:
+            return "brew install mongosh"
+        case .sqlite:
+            return "sqlite3 is included with macOS"
+        case .mssql:
+            return "brew install sqlcmd"
+        case .clickhouse:
+            return "brew install clickhouse"
+        case .duckdb:
+            return "brew install duckdb"
+        default:
+            return "Install the CLI client for \(databaseType.displayName)"
+        }
+    }
+
+    // MARK: - Private Resolvers
+
+    private static func resolveMysql(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("mysql") else { return nil }
+
+        var args: [String] = []
+        if !connection.username.isEmpty {
+            args += ["-u", connection.username]
+        }
+        args += ["-h", connection.host.isEmpty ? "127.0.0.1" : connection.host]
+        args += ["-P", String(connection.port)]
+        if !database.isEmpty {
+            args.append(database)
+        }
+
+        var env: [String: String] = [:]
+        if let password, !password.isEmpty {
+            env["MYSQL_PWD"] = password
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolvePsql(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("psql") else { return nil }
+
+        var args: [String] = []
+        if !connection.username.isEmpty {
+            args += ["-U", connection.username]
+        }
+        args += ["-h", connection.host.isEmpty ? "127.0.0.1" : connection.host]
+        args += ["-p", String(connection.port)]
+        if !database.isEmpty {
+            args.append(database)
+        }
+
+        var env: [String: String] = [:]
+        if let password, !password.isEmpty {
+            env["PGPASSWORD"] = password
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolveRedisCli(
+        connection: DatabaseConnection,
+        password: String?
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("redis-cli") else { return nil }
+
+        var args: [String] = []
+        args += ["-h", connection.host.isEmpty ? "127.0.0.1" : connection.host]
+        args += ["-p", String(connection.port)]
+        if let dbIndex = connection.redisDatabase, dbIndex > 0 {
+            args += ["-n", String(dbIndex)]
+        }
+
+        var env: [String: String] = [:]
+        if let password, !password.isEmpty {
+            env["REDISCLI_AUTH"] = password
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolveMongosh(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("mongosh") else { return nil }
+
+        let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
+        let port = connection.port
+        let db = database.isEmpty ? "test" : database
+
+        var uri: String
+        if !connection.username.isEmpty, let password, !password.isEmpty {
+            let encodedUser = connection.username.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed) ?? connection.username
+            let encodedPass = password.addingPercentEncoding(withAllowedCharacters: .urlPasswordAllowed) ?? password
+            uri = "mongodb://\(encodedUser):\(encodedPass)@\(host):\(port)/\(db)"
+        } else {
+            uri = "mongodb://\(host):\(port)/\(db)"
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: [uri], environment: [:])
+    }
+
+    private static func resolveSqlite3(connection: DatabaseConnection) -> CLILaunchSpec? {
+        guard let path = findExecutable("sqlite3") else { return nil }
+
+        let dbPath = connection.database
+        return CLILaunchSpec(executablePath: path, arguments: [dbPath], environment: [:])
+    }
+
+    private static func resolveSqlcmd(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("sqlcmd") else { return nil }
+
+        let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
+        var args: [String] = ["-S", "\(host),\(connection.port)"]
+        if !connection.username.isEmpty {
+            args += ["-U", connection.username]
+        }
+        if !database.isEmpty {
+            args += ["-d", database]
+        }
+
+        var env: [String: String] = [:]
+        if let password, !password.isEmpty {
+            env["SQLCMDPASSWORD"] = password
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolveClickhouseClient(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("clickhouse-client") else { return nil }
+
+        let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
+        var args: [String] = ["--host", host, "--port", String(connection.port)]
+        if !connection.username.isEmpty {
+            args += ["--user", connection.username]
+        }
+        if !database.isEmpty {
+            args += ["--database", database]
+        }
+        if let password, !password.isEmpty {
+            args += ["--password", password]
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: args, environment: [:])
+    }
+
+    private static func resolveDuckdb(connection: DatabaseConnection) -> CLILaunchSpec? {
+        guard let path = findExecutable("duckdb") else { return nil }
+
+        let dbPath = connection.database
+        return CLILaunchSpec(executablePath: path, arguments: [dbPath], environment: [:])
+    }
+
+    // MARK: - Shell Helper
+
+    private static func shell(_ path: String, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -42,6 +42,8 @@ enum CLICommandResolver {
             return resolveClickhouseClient(connection: connection, password: password, database: dbName)
         case .duckdb:
             return resolveDuckdb(connection: connection)
+        case .oracle:
+            return resolveSqlplus(connection: connection, password: password, database: dbName)
         default:
             logger.warning("No CLI mapping for database type: \(type.rawValue, privacy: .public)")
             return nil
@@ -82,6 +84,7 @@ enum CLICommandResolver {
         case .mssql: return "sqlcmd"
         case .clickhouse: return "clickhouse-client"
         case .duckdb: return "duckdb"
+        case .oracle: return "sqlplus"
         default: return databaseType.rawValue.lowercased()
         }
     }
@@ -104,6 +107,8 @@ enum CLICommandResolver {
             return "brew install clickhouse"
         case .duckdb:
             return "brew install duckdb"
+        case .oracle:
+            return "brew install instantclient-sqlplus"
         default:
             return "Install the CLI client for \(databaseType.displayName)"
         }
@@ -257,6 +262,28 @@ enum CLICommandResolver {
         }
 
         return CLILaunchSpec(executablePath: path, arguments: args, environment: env)
+    }
+
+    private static func resolveSqlplus(
+        connection: DatabaseConnection,
+        password: String?,
+        database: String
+    ) -> CLILaunchSpec? {
+        guard let path = findExecutable("sqlplus") else { return nil }
+
+        let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
+        let serviceName = connection.additionalFields["oracleServiceName"] ?? database
+
+        // sqlplus user/password@host:port/service_name
+        var connectString: String
+        if !connection.username.isEmpty {
+            let pass = password ?? ""
+            connectString = "\(connection.username)/\(pass)@\(host):\(connection.port)/\(serviceName)"
+        } else {
+            connectString = "@\(host):\(connection.port)/\(serviceName)"
+        }
+
+        return CLILaunchSpec(executablePath: path, arguments: [connectString], environment: [:])
     }
 
     private static func resolveDuckdb(connection: DatabaseConnection) -> CLILaunchSpec? {

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -170,6 +170,8 @@ enum CLICommandResolver {
 
         switch type {
         case .mysql, .mariadb:
+            // Use "mysql" for SSH — universally available on both MySQL and MariaDB servers
+            cmd = "mysql"
             if let password, !password.isEmpty {
                 envPrefix = "MYSQL_PWD=\(shellEscape(password)) "
             }

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -114,8 +114,8 @@ enum CLICommandResolver {
         }
 
         // Private key
-        if sshConfig.authMethod == .privateKey, let keyPath = sshConfig.privateKeyPath, !keyPath.isEmpty {
-            let expanded = (keyPath as NSString).expandingTildeInPath
+        if sshConfig.authMethod == .privateKey, !sshConfig.privateKeyPath.isEmpty {
+            let expanded = (sshConfig.privateKeyPath as NSString).expandingTildeInPath
             sshArgs += ["-i", expanded]
         }
 

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -191,14 +191,11 @@ final class TerminalProcessManager {
 
 enum TerminalError: LocalizedError {
     case forkFailed(errno: Int32)
-    case executableNotFound(String)
 
     var errorDescription: String? {
         switch self {
         case .forkFailed(let code):
             return String(format: String(localized: "Failed to create terminal process (errno: %d)"), code)
-        case .executableNotFound(let name):
-            return String(format: String(localized: "CLI tool not found: %@"), name)
         }
     }
 }

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -1,0 +1,213 @@
+//
+//  TerminalProcessManager.swift
+//  TablePro
+//
+//  PTY lifecycle management for the embedded terminal.
+//  Uses forkpty() to create a pseudo-terminal and manages
+//  the child process I/O via DispatchSource.
+//
+
+import Darwin
+import Foundation
+import os
+
+@MainActor
+final class TerminalProcessManager {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalProcessManager")
+
+    /// File descriptor for the PTY. Set once during launch, read from any thread
+    /// (POSIX fd operations are thread-safe). Stored separately for nonisolated access.
+    private let fdLock = NSLock()
+    private var _ptyFD: Int32 = -1
+
+    private var ptyFD: Int32 {
+        get { fdLock.withLock { _ptyFD } }
+        set { fdLock.withLock { _ptyFD = newValue } }
+    }
+
+    private var childPID: pid_t = 0
+    private var readSource: DispatchSourceRead?
+    private var processMonitor: DispatchSourceProcess?
+
+    var onData: ((Data) -> Void)?
+    var onExit: ((Int32) -> Void)?
+
+    private var isRunning: Bool { childPID > 0 }
+
+    // MARK: - Launch
+
+    func launch(spec: CLILaunchSpec) throws {
+        guard !isRunning else {
+            Self.logger.warning("Process already running, ignoring launch request")
+            return
+        }
+
+        var ptyFDValue: Int32 = -1
+        var winSize = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
+
+        let pid = forkpty(&ptyFDValue, nil, nil, &winSize)
+
+        if pid < 0 {
+            throw TerminalError.forkFailed(errno: errno)
+        }
+
+        if pid == 0 {
+            // Child process
+            var env = ProcessInfo.processInfo.environment
+            for (key, value) in spec.environment {
+                env[key] = value
+            }
+
+            env["TERM"] = "xterm-256color"
+
+            let envArray = env.map { "\($0.key)=\($0.value)" }
+            let cArgs = ([spec.executablePath] + spec.arguments).map { strdup($0) } + [nil]
+            let cEnv = envArray.map { strdup($0) } + [nil]
+
+            execve(spec.executablePath, cArgs, cEnv)
+            _exit(127)
+        }
+
+        // Parent process
+        self.ptyFD = ptyFDValue
+        self.childPID = pid
+
+        Self.logger.info("Launched \(spec.executablePath, privacy: .public) pid=\(pid)")
+
+        startReadingOutput()
+        monitorChildExit()
+    }
+
+    // MARK: - Write (called from libghostty threads)
+
+    nonisolated func write(_ data: Data) {
+        guard !data.isEmpty else { return }
+        let fd = fdLock.withLock { _ptyFD }
+        guard fd >= 0 else { return }
+        data.withUnsafeBytes { buffer in
+            guard let ptr = buffer.baseAddress else { return }
+            var remaining = data.count
+            var offset = 0
+            while remaining > 0 {
+                let written = Darwin.write(fd, ptr.advanced(by: offset), remaining)
+                if written <= 0 { break }
+                offset += written
+                remaining -= written
+            }
+        }
+    }
+
+    // MARK: - Resize (called from libghostty threads)
+
+    nonisolated func resize(cols: Int, rows: Int) {
+        let fd = fdLock.withLock { _ptyFD }
+        guard fd >= 0 else { return }
+        var size = winsize(
+            ws_row: UInt16(rows),
+            ws_col: UInt16(cols),
+            ws_xpixel: 0,
+            ws_ypixel: 0
+        )
+        _ = ioctl(fd, TIOCSWINSZ, &size)
+    }
+
+    // MARK: - Terminate
+
+    func terminate() {
+        readSource?.cancel()
+        readSource = nil
+        processMonitor?.cancel()
+        processMonitor = nil
+
+        if childPID > 0 {
+            kill(childPID, SIGHUP)
+            var status: Int32 = 0
+            waitpid(childPID, &status, WNOHANG)
+            Self.logger.info("Terminated child pid=\(self.childPID)")
+            childPID = 0
+        }
+
+        if ptyFD >= 0 {
+            close(ptyFD)
+            ptyFD = -1
+        }
+    }
+
+    deinit {
+        let fd = _ptyFD
+        let pid = childPID
+        if fd >= 0 {
+            close(fd)
+        }
+        if pid > 0 {
+            kill(pid, SIGHUP)
+        }
+    }
+
+    // MARK: - Private
+
+    private func startReadingOutput() {
+        let fd = ptyFD
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .global(qos: .userInteractive))
+
+        source.setEventHandler { [weak self] in
+            var buffer = [UInt8](repeating: 0, count: 8_192)
+            let bytesRead = read(fd, &buffer, buffer.count)
+            if bytesRead > 0 {
+                let data = Data(buffer[0..<bytesRead])
+                Task { @MainActor [weak self] in
+                    self?.onData?(data)
+                }
+            } else if bytesRead <= 0 {
+                source.cancel()
+            }
+        }
+
+        source.setCancelHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleProcessExit()
+            }
+        }
+
+        source.resume()
+        self.readSource = source
+    }
+
+    private func monitorChildExit() {
+        let pid = childPID
+        let source = DispatchSource.makeProcessSource(identifier: pid, eventMask: .exit, queue: .main)
+
+        source.setEventHandler { [weak self] in
+            var status: Int32 = 0
+            waitpid(pid, &status, 0)
+            self?.handleProcessExit(status: status)
+        }
+
+        source.resume()
+        self.processMonitor = source
+    }
+
+    private func handleProcessExit(status: Int32 = 0) {
+        guard childPID > 0 else { return }
+        let exitStatus = WIFEXITED(status) ? WEXITSTATUS(status) : -1
+        Self.logger.info("Child process exited status=\(exitStatus)")
+        childPID = 0
+        onExit?(exitStatus)
+    }
+}
+
+// MARK: - Error
+
+enum TerminalError: LocalizedError {
+    case forkFailed(errno: Int32)
+    case executableNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .forkFailed(let code):
+            return String(format: String(localized: "Failed to create terminal process (errno: %d)"), code)
+        case .executableNotFound(let name):
+            return String(format: String(localized: "CLI tool not found: %@"), name)
+        }
+    }
+}

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -48,7 +48,8 @@ final class TerminalProcessManager {
         env["TERM"] = "xterm-256color"
 
         let cArgs: [UnsafeMutablePointer<CChar>?] = allArgs.map { strdup($0) } + [nil]
-        let cEnv: [UnsafeMutablePointer<CChar>?] = env.map { "\($0.key)=\($0.value)" }.map { strdup($0) } + [nil]
+        let envStrings = env.map { "\($0.key)=\($0.value)" }
+        let cEnv: [UnsafeMutablePointer<CChar>?] = envStrings.map { strdup($0) } + [nil]
 
         var ptyFDValue: Int32 = -1
         var winSize = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -22,8 +22,8 @@ final class TerminalProcessManager {
     }
 
     private var childPID: pid_t = 0
-    private var readSource: DispatchSourceRead?
-    private var processMonitor: DispatchSourceProcess?
+    private nonisolated(unsafe) var readSource: DispatchSourceRead?
+    private nonisolated(unsafe) var processMonitor: DispatchSourceProcess?
 
     var onData: ((Data) -> Void)?
     var onExit: ((Int32) -> Void)?
@@ -38,33 +38,39 @@ final class TerminalProcessManager {
             return
         }
 
+        // Pre-build all C strings BEFORE fork. After fork, the child must only
+        // use async-signal-safe POSIX calls (execve, _exit) — no Swift allocations.
+        let allArgs = [spec.executablePath] + spec.arguments
+        var env = ProcessInfo.processInfo.environment
+        for (key, value) in spec.environment {
+            env[key] = value
+        }
+        env["TERM"] = "xterm-256color"
+
+        let cArgs: [UnsafeMutablePointer<CChar>?] = allArgs.map { strdup($0) } + [nil]
+        let cEnv: [UnsafeMutablePointer<CChar>?] = env.map { "\($0.key)=\($0.value)" }.map { strdup($0) } + [nil]
+
         var ptyFDValue: Int32 = -1
         var winSize = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
 
         let pid = forkpty(&ptyFDValue, nil, nil, &winSize)
 
         if pid < 0 {
-            throw TerminalError.forkFailed(errno: errno)
+            let forkErrno = errno
+            for ptr in cArgs { ptr.map { free($0) } }
+            for ptr in cEnv { ptr.map { free($0) } }
+            throw TerminalError.forkFailed(errno: forkErrno)
         }
 
         if pid == 0 {
-            // Child process
-            var env = ProcessInfo.processInfo.environment
-            for (key, value) in spec.environment {
-                env[key] = value
-            }
-
-            env["TERM"] = "xterm-256color"
-
-            let envArray = env.map { "\($0.key)=\($0.value)" }
-            let cArgs = ([spec.executablePath] + spec.arguments).map { strdup($0) } + [nil]
-            let cEnv = envArray.map { strdup($0) } + [nil]
-
-            execve(spec.executablePath, cArgs, cEnv)
+            // Child process: ONLY async-signal-safe POSIX calls, no Swift
+            execve(cArgs[0]!, cArgs, cEnv)
             _exit(127)
         }
 
-        // Parent process
+        // Parent process: free the strdup'd strings
+        for ptr in cArgs { ptr.map { free($0) } }
+        for ptr in cEnv { ptr.map { free($0) } }
         self.ptyFD = ptyFDValue
         self.childPID = pid
 
@@ -111,18 +117,23 @@ final class TerminalProcessManager {
     // MARK: - Terminate
 
     func terminate() {
+        // Kill and reap the child BEFORE cancelling sources so the monitor can still reap.
+        if childPID > 0 {
+            kill(childPID, SIGHUP)
+            var status: Int32 = 0
+            // Give the process a moment to exit, then force-kill
+            if waitpid(childPID, &status, WNOHANG) == 0 {
+                kill(childPID, SIGKILL)
+                waitpid(childPID, &status, 0) // blocking — child is SIGKILL'd, returns immediately
+            }
+            Self.logger.info("Terminated child pid=\(self.childPID)")
+            childPID = 0
+        }
+
         readSource?.cancel()
         readSource = nil
         processMonitor?.cancel()
         processMonitor = nil
-
-        if childPID > 0 {
-            kill(childPID, SIGHUP)
-            var status: Int32 = 0
-            waitpid(childPID, &status, WNOHANG)
-            Self.logger.info("Terminated child pid=\(self.childPID)")
-            childPID = 0
-        }
 
         if ptyFD >= 0 {
             close(ptyFD)
@@ -131,8 +142,11 @@ final class TerminalProcessManager {
     }
 
     deinit {
+        readSource?.cancel()
+        processMonitor?.cancel()
         let fd = fdLock.withLock { _ptyFD }
         if fd >= 0 { close(fd) }
+        if childPID > 0 { kill(childPID, SIGKILL) }
     }
 
     // MARK: - Private

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -68,7 +68,8 @@ final class TerminalProcessManager {
         self.ptyFD = ptyFDValue
         self.childPID = pid
 
-        Self.logger.info("Launched \(spec.executablePath, privacy: .public) pid=\(pid)")
+        let fullCmd = ([spec.executablePath] + spec.arguments).joined(separator: " ")
+        Self.logger.info("Launched: \(fullCmd, privacy: .public) pid=\(pid)")
 
         startReadingOutput()
         monitorChildExit()

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -2,10 +2,6 @@
 //  TerminalProcessManager.swift
 //  TablePro
 //
-//  PTY lifecycle management for the embedded terminal.
-//  Uses forkpty() to create a pseudo-terminal and manages
-//  the child process I/O via DispatchSource.
-//
 
 import Darwin
 import Foundation
@@ -18,7 +14,7 @@ final class TerminalProcessManager {
     /// File descriptor for the PTY. Set once during launch, read from any thread
     /// (POSIX fd operations are thread-safe). Stored separately for nonisolated access.
     private let fdLock = NSLock()
-    private var _ptyFD: Int32 = -1
+    private nonisolated(unsafe) var _ptyFD: Int32 = -1
 
     private var ptyFD: Int32 {
         get { fdLock.withLock { _ptyFD } }
@@ -134,14 +130,8 @@ final class TerminalProcessManager {
     }
 
     deinit {
-        let fd = _ptyFD
-        let pid = childPID
-        if fd >= 0 {
-            close(fd)
-        }
-        if pid > 0 {
-            kill(pid, SIGHUP)
-        }
+        let fd = fdLock.withLock { _ptyFD }
+        if fd >= 0 { close(fd) }
     }
 
     // MARK: - Private
@@ -158,14 +148,8 @@ final class TerminalProcessManager {
                 Task { @MainActor [weak self] in
                     self?.onData?(data)
                 }
-            } else if bytesRead <= 0 {
+            } else {
                 source.cancel()
-            }
-        }
-
-        source.setCancelHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.handleProcessExit()
             }
         }
 
@@ -175,12 +159,19 @@ final class TerminalProcessManager {
 
     private func monitorChildExit() {
         let pid = childPID
-        let source = DispatchSource.makeProcessSource(identifier: pid, eventMask: .exit, queue: .main)
+        let source = DispatchSource.makeProcessSource(
+            identifier: pid,
+            eventMask: .exit,
+            queue: .global(qos: .utility)
+        )
 
         source.setEventHandler { [weak self] in
             var status: Int32 = 0
-            waitpid(pid, &status, 0)
-            self?.handleProcessExit(status: status)
+            waitpid(pid, &status, WNOHANG)
+            let exitStatus = status
+            Task { @MainActor [weak self] in
+                self?.handleProcessExit(status: exitStatus)
+            }
         }
 
         source.resume()
@@ -189,10 +180,10 @@ final class TerminalProcessManager {
 
     private func handleProcessExit(status: Int32 = 0) {
         guard childPID > 0 else { return }
-        let exitStatus = WIFEXITED(status) ? WEXITSTATUS(status) : -1
-        Self.logger.info("Child process exited status=\(exitStatus)")
+        let exitCode = (status & 0x7F) == 0 ? (status >> 8) & 0xFF : -1
+        Self.logger.info("Child process exited status=\(exitCode)")
         childPID = 0
-        onExit?(exitStatus)
+        onExit?(exitCode)
     }
 }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -1,0 +1,113 @@
+//
+//  TerminalSessionState.swift
+//  TablePro
+//
+//  Observable state per terminal session, bridging PTY I/O
+//  to the libghostty terminal renderer.
+//
+
+import Foundation
+import GhosttyTerminal
+import os
+
+@MainActor @Observable
+final class TerminalSessionState: Identifiable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalSessionState")
+
+    let id: UUID
+    let connectionId: UUID
+    let databaseType: DatabaseType
+
+    var terminalViewState = TerminalViewState()
+    var session: InMemoryTerminalSession?
+    var processManager: TerminalProcessManager?
+    var isConnected: Bool = false
+    var error: String?
+
+    init(connectionId: UUID, databaseType: DatabaseType) {
+        self.id = UUID()
+        self.connectionId = connectionId
+        self.databaseType = databaseType
+    }
+
+    // MARK: - Connect
+
+    func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
+        let spec = CLICommandResolver.resolve(
+            connection: connection,
+            password: password,
+            activeDatabase: activeDatabase
+        )
+
+        guard let spec else {
+            let binaryName = cliBinaryName(for: connection.type)
+            error = String(
+                format: String(localized: "CLI tool \"%@\" not found in PATH"),
+                binaryName
+            )
+            Self.logger.warning("CLI not found for \(connection.type.rawValue, privacy: .public)")
+            return
+        }
+
+        let manager = TerminalProcessManager()
+        self.processManager = manager
+
+        let inMemorySession = InMemoryTerminalSession(
+            write: { [weak manager] data in
+                manager?.write(data)
+            },
+            resize: { [weak manager] viewport in
+                manager?.resize(cols: viewport.columns, rows: viewport.rows)
+            }
+        )
+        self.session = inMemorySession
+
+        manager.onData = { [weak inMemorySession] data in
+            inMemorySession?.receive(data)
+        }
+
+        manager.onExit = { [weak self] status in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isConnected = false
+                if status != 0 {
+                    Self.logger.info("Terminal process exited with status \(status)")
+                }
+            }
+        }
+
+        do {
+            try manager.launch(spec: spec)
+            isConnected = true
+            Self.logger.info("Terminal connected for \(connection.type.rawValue, privacy: .public)")
+        } catch {
+            self.error = error.localizedDescription
+            Self.logger.error("Failed to launch terminal: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Disconnect
+
+    func disconnect() {
+        processManager?.terminate()
+        processManager = nil
+        session = nil
+        isConnected = false
+    }
+
+    // MARK: - Private
+
+    private func cliBinaryName(for type: DatabaseType) -> String {
+        switch type {
+        case .mysql, .mariadb: return "mysql"
+        case .postgresql, .redshift: return "psql"
+        case .redis: return "redis-cli"
+        case .mongodb: return "mongosh"
+        case .sqlite: return "sqlite3"
+        case .mssql: return "sqlcmd"
+        case .clickhouse: return "clickhouse-client"
+        case .duckdb: return "duckdb"
+        default: return type.rawValue.lowercased()
+        }
+    }
+}

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -131,6 +131,9 @@ final class TerminalSessionState: Identifiable {
             builder.withCustom("keybind", "clear")
             builder.withCustom("keybind", "apostrophe=text:\\x27")
             builder.withCustom("keybind", "shift+apostrophe=text:\\x22")
+            builder.withCustom("keybind", "super+f=search_open")
+            builder.withCustom("keybind", "super+shift+g=search_navigate:previous")
+            builder.withCustom("keybind", "super+g=search_navigate:next")
         }
     }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -45,6 +45,7 @@ final class TerminalSessionState: Identifiable {
 
     func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
         let customCliPath = CLICommandResolver.userConfiguredPath(for: databaseType)
+        let effectiveConnection = DatabaseManager.shared.session(for: connectionId)?.effectiveConnection
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self else { return }
             let dbType = await self.databaseType
@@ -53,7 +54,8 @@ final class TerminalSessionState: Identifiable {
                 password: password,
                 activeDatabase: activeDatabase,
                 databaseType: dbType,
-                customCliPath: customCliPath
+                customCliPath: customCliPath,
+                effectiveConnection: effectiveConnection
             )
             await MainActor.run { [weak self] in
                 self?.launchProcess(spec: spec, connection: connection)

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -119,9 +119,12 @@ final class TerminalSessionState: Identifiable {
             builder.withWindowPaddingX(4)
             builder.withWindowPaddingY(4)
 
-            // Clear Ghostty's default keybindings to prevent interference
-            // with raw terminal key handling (e.g. ' mapped to TAB)
+            // libghostty-spm embedded mode has broken key mapping for
+            // apostrophe (sends TAB instead of 0x27). Clear default
+            // keybindings and explicitly remap affected keys.
             builder.withCustom("keybind", "clear")
+            builder.withCustom("keybind", "apostrophe=text:\\x27")
+            builder.withCustom("keybind", "shift+apostrophe=text:\\x22")
         }
     }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -19,6 +19,8 @@ final class TerminalSessionState: Identifiable {
     var session: InMemoryTerminalSession?
     var processManager: TerminalProcessManager?
     var isConnected: Bool = false
+    var isDisconnected: Bool = false
+    var exitCode: Int32 = 0
     var error: String?
 
     init(connectionId: UUID, databaseType: DatabaseType) {
@@ -40,6 +42,17 @@ final class TerminalSessionState: Identifiable {
                 self?.launchProcess(spec: spec, connection: connection)
             }
         }
+    }
+
+    // MARK: - Reconnect
+
+    func reconnect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
+        disconnect()
+        isDisconnected = false
+        exitCode = 0
+        error = nil
+        terminalViewState = TerminalViewState()
+        connect(connection: connection, password: password, activeDatabase: activeDatabase)
     }
 
     // MARK: - Disconnect
@@ -85,9 +98,9 @@ final class TerminalSessionState: Identifiable {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.isConnected = false
-                if status != 0 {
-                    Self.logger.info("Terminal process exited with status \(status)")
-                }
+                self.isDisconnected = true
+                self.exitCode = status
+                Self.logger.info("Terminal process exited with status \(status)")
             }
         }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -119,6 +119,10 @@ final class TerminalSessionState: Identifiable {
 
             builder.withWindowPaddingX(4)
             builder.withWindowPaddingY(4)
+
+            // Clear Ghostty's default keybindings to prevent interference
+            // with raw terminal key handling (e.g. ' mapped to TAB)
+            builder.withCustom("keybind", "clear")
         }
     }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -175,11 +175,6 @@ final class TerminalSessionState: Identifiable {
 
         let inMemorySession = InMemoryTerminalSession(
             write: { [weak manager] data in
-                let bytes = [UInt8](data)
-                let hex = bytes.map { String(format: "%02x", $0) }.joined(separator: " ")
-                let ascii = bytes.map { (0x20...0x7E).contains($0) ? String(UnicodeScalar($0)) : "." }.joined()
-                Logger(subsystem: "com.TablePro", category: "TerminalIO")
-                    .debug("WRITE \(bytes.count) bytes: [\(hex, privacy: .public)] ascii=[\(ascii, privacy: .public)]")
                 manager?.write(data)
             },
             resize: { [weak manager] viewport in

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -2,9 +2,6 @@
 //  TerminalSessionState.swift
 //  TablePro
 //
-//  Observable state per terminal session, bridging PTY I/O
-//  to the libghostty terminal renderer.
-//
 
 import Foundation
 import GhosttyTerminal
@@ -33,14 +30,33 @@ final class TerminalSessionState: Identifiable {
     // MARK: - Connect
 
     func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
-        let spec = CLICommandResolver.resolve(
-            connection: connection,
-            password: password,
-            activeDatabase: activeDatabase
-        )
+        let dbType = connection.type
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let spec = CLICommandResolver.resolve(
+                connection: connection,
+                password: password,
+                activeDatabase: activeDatabase
+            )
+            await MainActor.run { [weak self] in
+                self?.launchProcess(spec: spec, connection: connection)
+            }
+        }
+    }
 
+    // MARK: - Disconnect
+
+    func disconnect() {
+        processManager?.terminate()
+        processManager = nil
+        session = nil
+        isConnected = false
+    }
+
+    // MARK: - Private
+
+    private func launchProcess(spec: CLILaunchSpec?, connection: DatabaseConnection) {
         guard let spec else {
-            let binaryName = cliBinaryName(for: connection.type)
+            let binaryName = CLICommandResolver.binaryName(for: connection.type)
             error = String(
                 format: String(localized: "CLI tool \"%@\" not found in PATH"),
                 binaryName
@@ -57,7 +73,7 @@ final class TerminalSessionState: Identifiable {
                 manager?.write(data)
             },
             resize: { [weak manager] viewport in
-                manager?.resize(cols: viewport.columns, rows: viewport.rows)
+                manager?.resize(cols: Int(viewport.columns), rows: Int(viewport.rows))
             }
         )
         self.session = inMemorySession
@@ -83,31 +99,6 @@ final class TerminalSessionState: Identifiable {
         } catch {
             self.error = error.localizedDescription
             Self.logger.error("Failed to launch terminal: \(error.localizedDescription, privacy: .public)")
-        }
-    }
-
-    // MARK: - Disconnect
-
-    func disconnect() {
-        processManager?.terminate()
-        processManager = nil
-        session = nil
-        isConnected = false
-    }
-
-    // MARK: - Private
-
-    private func cliBinaryName(for type: DatabaseType) -> String {
-        switch type {
-        case .mysql, .mariadb: return "mysql"
-        case .postgresql, .redshift: return "psql"
-        case .redis: return "redis-cli"
-        case .mongodb: return "mongosh"
-        case .sqlite: return "sqlite3"
-        case .mssql: return "sqlcmd"
-        case .clickhouse: return "clickhouse-client"
-        case .duckdb: return "duckdb"
-        default: return type.rawValue.lowercased()
         }
     }
 }

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -18,7 +18,7 @@ final class TerminalSessionState: Identifiable {
 
     var terminalViewState: TerminalViewState
     var session: InMemoryTerminalSession?
-    var processManager: TerminalProcessManager?
+    nonisolated(unsafe) var processManager: TerminalProcessManager?
     var isConnected: Bool = false
     var isDisconnected: Bool = false
     var exitCode: Int32 = 0
@@ -39,6 +39,9 @@ final class TerminalSessionState: Identifiable {
         if let settingsObserver {
             NotificationCenter.default.removeObserver(settingsObserver)
         }
+        // TerminalProcessManager.deinit handles source cancellation, fd close, and child kill
+        // via nonisolated(unsafe) fields (see Issue 5 fix). Releasing our strong reference
+        // here triggers that cleanup if no other references remain.
     }
 
     // MARK: - Connect
@@ -46,9 +49,8 @@ final class TerminalSessionState: Identifiable {
     func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
         let customCliPath = CLICommandResolver.userConfiguredPath(for: databaseType)
         let effectiveConnection = DatabaseManager.shared.session(for: connectionId)?.effectiveConnection
+        let dbType = databaseType // Read immutable let before task to avoid unnecessary hop
         Task.detached(priority: .userInitiated) { [weak self] in
-            guard let self else { return }
-            let dbType = await self.databaseType
             let spec = CLICommandResolver.resolve(
                 connection: connection,
                 password: password,
@@ -117,6 +119,8 @@ final class TerminalSessionState: Identifiable {
             if settings.optionAsMeta {
                 builder.withCustom("macos-option-as-alt", "true")
             }
+
+            builder.withCustom("bell-feature", settings.bellEnabled ? "system" : "ignore")
 
             builder.withWindowPaddingX(4)
             builder.withWindowPaddingY(4)

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -30,7 +30,6 @@ final class TerminalSessionState: Identifiable {
     // MARK: - Connect
 
     func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
-        let dbType = connection.type
         Task.detached(priority: .userInitiated) { [weak self] in
             let spec = CLICommandResolver.resolve(
                 connection: connection,

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -169,6 +169,11 @@ final class TerminalSessionState: Identifiable {
 
         let inMemorySession = InMemoryTerminalSession(
             write: { [weak manager] data in
+                let bytes = [UInt8](data)
+                let hex = bytes.map { String(format: "%02x", $0) }.joined(separator: " ")
+                let ascii = bytes.map { (0x20...0x7E).contains($0) ? String(UnicodeScalar($0)) : "." }.joined()
+                Logger(subsystem: "com.TablePro", category: "TerminalIO")
+                    .debug("WRITE \(bytes.count) bytes: [\(hex, privacy: .public)] ascii=[\(ascii, privacy: .public)]")
                 manager?.write(data)
             },
             resize: { [weak manager] viewport in

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -131,9 +131,6 @@ final class TerminalSessionState: Identifiable {
             builder.withCustom("keybind", "clear")
             builder.withCustom("keybind", "apostrophe=text:\\x27")
             builder.withCustom("keybind", "shift+apostrophe=text:\\x22")
-            builder.withCustom("keybind", "super+f=search_open")
-            builder.withCustom("keybind", "super+shift+g=search_navigate:previous")
-            builder.withCustom("keybind", "super+g=search_navigate:next")
         }
     }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -88,7 +88,6 @@ final class TerminalSessionState: Identifiable {
         let config = buildTerminalConfiguration(from: settings)
         let theme = buildTerminalTheme(from: settings)
         return TerminalViewState(
-            configSource: .none,
             theme: theme,
             terminalConfiguration: config
         )

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import GhosttyTerminal
+import GhosttyTheme
 import os
 
 @MainActor @Observable
@@ -15,7 +16,7 @@ final class TerminalSessionState: Identifiable {
     let connectionId: UUID
     let databaseType: DatabaseType
 
-    var terminalViewState = TerminalViewState()
+    var terminalViewState: TerminalViewState
     var session: InMemoryTerminalSession?
     var processManager: TerminalProcessManager?
     var isConnected: Bool = false
@@ -23,20 +24,36 @@ final class TerminalSessionState: Identifiable {
     var exitCode: Int32 = 0
     var error: String?
 
+    @ObservationIgnored private var settingsObserver: NSObjectProtocol?
+
     init(connectionId: UUID, databaseType: DatabaseType) {
         self.id = UUID()
         self.connectionId = connectionId
         self.databaseType = databaseType
+        self.terminalViewState = Self.buildTerminalViewState()
+
+        observeSettingsChanges()
+    }
+
+    deinit {
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+        }
     }
 
     // MARK: - Connect
 
     func connect(connection: DatabaseConnection, password: String?, activeDatabase: String?) {
+        let customCliPath = CLICommandResolver.userConfiguredPath(for: databaseType)
         Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            let dbType = await self.databaseType
             let spec = CLICommandResolver.resolve(
                 connection: connection,
                 password: password,
-                activeDatabase: activeDatabase
+                activeDatabase: activeDatabase,
+                databaseType: dbType,
+                customCliPath: customCliPath
             )
             await MainActor.run { [weak self] in
                 self?.launchProcess(spec: spec, connection: connection)
@@ -51,7 +68,7 @@ final class TerminalSessionState: Identifiable {
         isDisconnected = false
         exitCode = 0
         error = nil
-        terminalViewState = TerminalViewState()
+        terminalViewState = Self.buildTerminalViewState()
         connect(connection: connection, password: password, activeDatabase: activeDatabase)
     }
 
@@ -62,6 +79,76 @@ final class TerminalSessionState: Identifiable {
         processManager = nil
         session = nil
         isConnected = false
+    }
+
+    // MARK: - Configuration
+
+    private static func buildTerminalViewState() -> TerminalViewState {
+        let settings = AppSettingsManager.shared.terminal
+        let config = buildTerminalConfiguration(from: settings)
+        let theme = buildTerminalTheme(from: settings)
+        return TerminalViewState(
+            configSource: .none,
+            theme: theme,
+            terminalConfiguration: config
+        )
+    }
+
+    private static func buildTerminalConfiguration(from settings: TerminalSettings) -> TerminalConfiguration {
+        TerminalConfiguration { builder in
+            builder.withFontFamily(settings.fontFamily)
+            builder.withFontSize(Float(settings.fontSize))
+
+            let cursorStyle: GhosttyTerminal.TerminalCursorStyle = switch settings.cursorStyle {
+            case .block: .block
+            case .bar: .bar
+            case .underline: .underline
+            }
+            builder.withCursorStyle(cursorStyle)
+            builder.withCursorStyleBlink(settings.cursorBlink)
+
+            if settings.scrollbackLines > 0 {
+                builder.withCustom("scrollback-limit", String(settings.scrollbackLines))
+            } else {
+                builder.withCustom("scrollback-limit", "unlimited")
+            }
+
+            if settings.optionAsMeta {
+                builder.withCustom("macos-option-as-alt", "true")
+            }
+
+            builder.withWindowPaddingX(4)
+            builder.withWindowPaddingY(4)
+        }
+    }
+
+    private static func buildTerminalTheme(from settings: TerminalSettings) -> TerminalTheme {
+        guard !settings.themeName.isEmpty,
+              let themeDef = GhosttyThemeCatalog.theme(named: settings.themeName)
+        else {
+            return .default
+        }
+        return themeDef.toTerminalTheme()
+    }
+
+    private func applySettingsToTerminal() {
+        let settings = AppSettingsManager.shared.terminal
+        let config = Self.buildTerminalConfiguration(from: settings)
+        let theme = Self.buildTerminalTheme(from: settings)
+        terminalViewState.setTheme(theme)
+        terminalViewState.setTerminalConfiguration(config)
+    }
+
+    private func observeSettingsChanges() {
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: .terminalSettingsDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.applySettingsToTerminal()
+            }
+        }
     }
 
     // MARK: - Private

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -151,6 +151,16 @@ final class QueryTabManager {
         selectedTabId = newTab.id
     }
 
+    func addTerminalTab(databaseName: String = "") {
+        let tabTitle = String(localized: "Terminal")
+        var newTab = QueryTab(title: tabTitle, tabType: .terminal)
+        newTab.databaseName = databaseName
+        newTab.isEditable = false
+        newTab.hasUserInteraction = true
+        tabs.append(newTab)
+        selectedTabId = newTab.id
+    }
+
     func addPreviewTableTab(
         tableName: String,
         databaseType: DatabaseType = .mysql,

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -12,6 +12,7 @@ enum TabType: Equatable, Codable, Hashable {
     case createTable      // Create new table tab
     case erDiagram        // ER diagram tab
     case serverDashboard  // Server dashboard tab
+    case terminal         // Embedded database CLI terminal tab
 }
 
 /// Minimal representation of a tab for persistence

--- a/TablePro/Models/Settings/AppSettings.swift
+++ b/TablePro/Models/Settings/AppSettings.swift
@@ -322,3 +322,70 @@ struct TabSettings: Codable, Equatable {
         groupAllConnectionTabs = try container.decodeIfPresent(Bool.self, forKey: .groupAllConnectionTabs) ?? false
     }
 }
+
+// MARK: - Terminal Settings
+
+enum TerminalCursorStyleOption: String, Codable, CaseIterable {
+    case block
+    case bar
+    case underline
+
+    var displayName: String {
+        switch self {
+        case .block: return String(localized: "Block")
+        case .bar: return String(localized: "Bar")
+        case .underline: return String(localized: "Underline")
+        }
+    }
+}
+
+struct TerminalSettings: Codable, Equatable {
+    var fontFamily: String = "Menlo"
+    var fontSize: Int = 13
+    var cursorStyle: TerminalCursorStyleOption = .block
+    var cursorBlink: Bool = true
+    var scrollbackLines: Int = 10_000
+    var optionAsMeta: Bool = true
+    var bellEnabled: Bool = true
+    var themeName: String = ""
+
+    /// Per-database CLI path overrides (empty = auto-detect)
+    var cliPaths: [String: String] = [:]
+
+    static let `default` = TerminalSettings()
+
+    init(
+        fontFamily: String = "Menlo",
+        fontSize: Int = 13,
+        cursorStyle: TerminalCursorStyleOption = .block,
+        cursorBlink: Bool = true,
+        scrollbackLines: Int = 10_000,
+        optionAsMeta: Bool = true,
+        bellEnabled: Bool = true,
+        themeName: String = "",
+        cliPaths: [String: String] = [:]
+    ) {
+        self.fontFamily = fontFamily
+        self.fontSize = fontSize
+        self.cursorStyle = cursorStyle
+        self.cursorBlink = cursorBlink
+        self.scrollbackLines = scrollbackLines
+        self.optionAsMeta = optionAsMeta
+        self.bellEnabled = bellEnabled
+        self.themeName = themeName
+        self.cliPaths = cliPaths
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        fontFamily = try container.decodeIfPresent(String.self, forKey: .fontFamily) ?? "Menlo"
+        fontSize = try container.decodeIfPresent(Int.self, forKey: .fontSize) ?? 13
+        cursorStyle = try container.decodeIfPresent(TerminalCursorStyleOption.self, forKey: .cursorStyle) ?? .block
+        cursorBlink = try container.decodeIfPresent(Bool.self, forKey: .cursorBlink) ?? true
+        scrollbackLines = try container.decodeIfPresent(Int.self, forKey: .scrollbackLines) ?? 10_000
+        optionAsMeta = try container.decodeIfPresent(Bool.self, forKey: .optionAsMeta) ?? true
+        bellEnabled = try container.decodeIfPresent(Bool.self, forKey: .bellEnabled) ?? true
+        themeName = try container.decodeIfPresent(String.self, forKey: .themeName) ?? ""
+        cliPaths = try container.decodeIfPresent([String: String].self, forKey: .cliPaths) ?? [:]
+    }
+}

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -53,6 +53,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case importData
     case quickSwitcher
 
+    case openTerminal
+
     // Navigation
     case previousPage
     case nextPage
@@ -99,7 +101,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .manageConnections, .newTab, .openDatabase, .openFile, .switchConnection,
              .saveChanges, .saveAs, .previewSQL, .closeTab, .refresh,
              .executeQuery, .explainQuery, .formatQuery, .export, .importData, .quickSwitcher,
-             .previousPage, .nextPage, .saveAsFavorite:
+             .previousPage, .nextPage, .saveAsFavorite, .openTerminal:
             return .file
         case .undo, .redo, .cut, .copy, .copyWithHeaders, .copyAsJson, .paste,
              .delete, .selectAll, .clearSelection, .addRow,
@@ -133,6 +135,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .export: return String(localized: "Export")
         case .importData: return String(localized: "Import")
         case .quickSwitcher: return String(localized: "Quick Switcher")
+        case .openTerminal: return String(localized: "Open Terminal")
         case .previousPage: return String(localized: "Previous Page")
         case .nextPage: return String(localized: "Next Page")
         case .undo: return String(localized: "Undo")
@@ -470,6 +473,7 @@ struct KeyboardSettings: Codable, Equatable {
         .export: KeyCombo(key: "e", command: true, shift: true),
         .importData: KeyCombo(key: "i", command: true, shift: true),
         .quickSwitcher: KeyCombo(key: "o", command: true, shift: true),
+        .openTerminal: KeyCombo(key: "`", command: true, control: true),
         .previousPage: KeyCombo(key: "[", command: true),
         .nextPage: KeyCombo(key: "]", command: true),
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -486,6 +486,12 @@ struct AppMenuCommands: Commands {
             }
             .disabled(!(actions?.isConnected ?? false) || !(actions?.supportsServerDashboard ?? false))
 
+            Button(String(localized: "Open Terminal")) {
+                actions?.openTerminal()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .openTerminal))
+            .disabled(!(actions?.isConnected ?? false))
+
             Divider()
 
             Button("Increase Text Size") {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -193,6 +193,8 @@ struct MainEditorContentView: View {
             erDiagramContent(tab: tab)
         case .serverDashboard:
             serverDashboardContent(tab: tab)
+        case .terminal:
+            terminalTabContent(tab: tab)
         }
     }
 
@@ -216,6 +218,18 @@ struct MainEditorContentView: View {
                     }
             }
         }
+        .id(tab.id)
+    }
+
+    // MARK: - Terminal Tab Content
+
+    @ViewBuilder
+    private func terminalTabContent(tab: QueryTab) -> some View {
+        TerminalTabContentView(
+            tab: tab,
+            connection: connection,
+            connectionId: connectionId
+        )
         .id(tab.id)
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
@@ -2,11 +2,8 @@
 //  MainContentCoordinator+Terminal.swift
 //  TablePro
 //
-//  Opens an embedded terminal tab for the current connection.
-//
 
 import AppKit
-import Foundation
 
 extension MainContentCoordinator {
     func openTerminal() {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
@@ -1,0 +1,28 @@
+//
+//  MainContentCoordinator+Terminal.swift
+//  TablePro
+//
+//  Opens an embedded terminal tab for the current connection.
+//
+
+import AppKit
+import Foundation
+
+extension MainContentCoordinator {
+    func openTerminal() {
+        let session = DatabaseManager.shared.session(for: connectionId)
+        let dbName = session?.activeDatabase ?? connection.database
+
+        if tabManager.tabs.isEmpty {
+            tabManager.addTerminalTab(databaseName: dbName)
+            return
+        }
+
+        let payload = EditorTabPayload(
+            connectionId: connection.id,
+            tabType: .terminal,
+            databaseName: dbName
+        )
+        WindowManager.shared.openTab(payload: payload)
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -189,6 +189,8 @@ extension MainContentView {
             windowTitle = String(localized: "Create Table")
         } else if selectedTab?.tabType == .erDiagram {
             windowTitle = String(localized: "ER Diagram")
+        } else if selectedTab?.tabType == .terminal {
+            windowTitle = String(localized: "Terminal")
         } else if let fileURL = selectedTab?.sourceFileURL {
             windowTitle = fileURL.deletingPathExtension().lastPathComponent
         } else {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -501,6 +501,10 @@ final class MainContentCommandActions {
         coordinator?.showServerDashboard()
     }
 
+    func openTerminal() {
+        coordinator?.openTerminal()
+    }
+
     var supportsServerDashboard: Bool {
         guard let type = coordinator?.connection.type else { return false }
         return ServerDashboardQueryProviderFactory.provider(for: type) != nil

--- a/TablePro/Views/Settings/SettingsView.swift
+++ b/TablePro/Views/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Settings tab identifiers for programmatic navigation
 enum SettingsTab: String {
-    case general, appearance, editor, dataGrid, keyboard, history, ai, plugins, sync, license
+    case general, appearance, editor, dataGrid, keyboard, history, ai, terminal, plugins, sync, license
 }
 
 /// Main settings view with tab-based navigation (macOS Settings style)
@@ -65,6 +65,12 @@ struct SettingsView: View {
                     Label("AI", systemImage: "sparkles")
                 }
                 .tag(SettingsTab.ai.rawValue)
+
+            TerminalSettingsView(settings: $settingsManager.terminal)
+                .tabItem {
+                    Label("Terminal", systemImage: "terminal")
+                }
+                .tag(SettingsTab.terminal.rawValue)
 
             PluginsSettingsView()
                 .tabItem {

--- a/TablePro/Views/Settings/TerminalSettingsView.swift
+++ b/TablePro/Views/Settings/TerminalSettingsView.swift
@@ -151,15 +151,24 @@ struct TerminalSettingsView: View {
     }
 
     private func resolveAllCliPaths() async {
-        var paths: [String: String] = [:]
-        for dbType in Self.terminalDatabaseTypes {
-            let name = CLICommandResolver.binaryName(for: dbType)
-            let resolved = await Task.detached(priority: .utility) {
-                CLICommandResolver.findExecutable(name)
-            }.value
-            paths[dbType.rawValue] = resolved ?? name
+        let dbTypes = Self.terminalDatabaseTypes
+        let results = await withTaskGroup(of: (String, String).self) { group in
+            for dbType in dbTypes {
+                group.addTask {
+                    let name = CLICommandResolver.binaryName(for: dbType)
+                    let resolved = await Task.detached(priority: .utility) {
+                        CLICommandResolver.findExecutable(name)
+                    }.value
+                    return (dbType.rawValue, resolved ?? name)
+                }
+            }
+            var paths: [String: String] = [:]
+            for await (key, value) in group {
+                paths[key] = value
+            }
+            return paths
         }
-        resolvedPaths = paths
+        resolvedPaths = results
     }
 
     // MARK: - Notifications

--- a/TablePro/Views/Settings/TerminalSettingsView.swift
+++ b/TablePro/Views/Settings/TerminalSettingsView.swift
@@ -106,7 +106,7 @@ struct TerminalSettingsView: View {
     @ViewBuilder
     private func colorSwatch(hex: String) -> some View {
         RoundedRectangle(cornerRadius: 2)
-            .fill(Color(hex: hex))
+            .fill(hex.swiftUIColor)
             .frame(width: 12, height: 12)
             .overlay(
                 RoundedRectangle(cornerRadius: 2)
@@ -165,26 +165,6 @@ struct TerminalSettingsView: View {
     }
 }
 
-// MARK: - Color Extension
-
-private extension Color {
-    init(hex: String) {
-        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
-        guard cleaned.count >= 6,
-              let r = UInt8(cleaned.prefix(2), radix: 16),
-              let g = UInt8(cleaned.dropFirst(2).prefix(2), radix: 16),
-              let b = UInt8(cleaned.dropFirst(4).prefix(2), radix: 16)
-        else {
-            self.init(.gray)
-            return
-        }
-        self.init(
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue: Double(b) / 255
-        )
-    }
-}
 
 #Preview {
     TerminalSettingsView(settings: .constant(.default))

--- a/TablePro/Views/Settings/TerminalSettingsView.swift
+++ b/TablePro/Views/Settings/TerminalSettingsView.swift
@@ -116,6 +116,8 @@ struct TerminalSettingsView: View {
 
     // MARK: - CLI Paths
 
+    @State private var resolvedPaths: [String: String] = [:]
+
     @ViewBuilder
     private var cliPathsSection: some View {
         Section {
@@ -127,6 +129,9 @@ struct TerminalSettingsView: View {
         } footer: {
             Text("Leave empty to auto-detect from system PATH.")
         }
+        .task {
+            await resolveAllCliPaths()
+        }
     }
 
     @ViewBuilder
@@ -135,15 +140,26 @@ struct TerminalSettingsView: View {
             get: { settings.cliPaths[dbType.rawValue] ?? "" },
             set: { settings.cliPaths[dbType.rawValue] = $0.isEmpty ? nil : $0 }
         )
-        let placeholder = CLICommandResolver.findExecutable(
-            CLICommandResolver.binaryName(for: dbType)
-        ) ?? CLICommandResolver.binaryName(for: dbType)
+        let binaryName = CLICommandResolver.binaryName(for: dbType)
+        let placeholder = resolvedPaths[dbType.rawValue] ?? binaryName
 
         LabeledContent(dbType.displayName) {
             TextField(placeholder, text: binding)
                 .textFieldStyle(.roundedBorder)
                 .frame(maxWidth: 300)
         }
+    }
+
+    private func resolveAllCliPaths() async {
+        var paths: [String: String] = [:]
+        for dbType in Self.terminalDatabaseTypes {
+            let name = CLICommandResolver.binaryName(for: dbType)
+            let resolved = await Task.detached(priority: .utility) {
+                CLICommandResolver.findExecutable(name)
+            }.value
+            paths[dbType.rawValue] = resolved ?? name
+        }
+        resolvedPaths = paths
     }
 
     // MARK: - Notifications

--- a/TablePro/Views/Settings/TerminalSettingsView.swift
+++ b/TablePro/Views/Settings/TerminalSettingsView.swift
@@ -1,0 +1,192 @@
+//
+//  TerminalSettingsView.swift
+//  TablePro
+//
+
+import GhosttyTheme
+import SwiftUI
+
+struct TerminalSettingsView: View {
+    @Binding var settings: TerminalSettings
+
+    private static let monospaceFonts = [
+        "Menlo", "SF Mono", "Monaco", "Courier New", "JetBrains Mono",
+        "Fira Code", "Source Code Pro", "Hack", "Inconsolata"
+    ]
+
+    private static let scrollbackOptions: [(String, Int)] = [
+        ("1,000", 1_000),
+        ("5,000", 5_000),
+        ("10,000", 10_000),
+        ("50,000", 50_000),
+        ("Unlimited", 0)
+    ]
+
+    private static let terminalDatabaseTypes: [DatabaseType] = [
+        .mysql, .mariadb, .postgresql, .redshift, .redis, .mongodb,
+        .sqlite, .mssql, .clickhouse, .duckdb, .oracle
+    ]
+
+    var body: some View {
+        Form {
+            displaySection
+            themeSection
+            cliPathsSection
+            notificationsSection
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+    }
+
+    // MARK: - Display
+
+    @ViewBuilder
+    private var displaySection: some View {
+        Section("Display") {
+            Picker("Font:", selection: $settings.fontFamily) {
+                ForEach(Self.availableFonts, id: \.self) { font in
+                    Text(font).tag(font)
+                }
+            }
+
+            Picker("Font size:", selection: $settings.fontSize) {
+                ForEach(9 ... 24, id: \.self) { size in
+                    Text("\(size)").tag(size)
+                }
+            }
+
+            Picker("Cursor style:", selection: $settings.cursorStyle) {
+                ForEach(TerminalCursorStyleOption.allCases, id: \.self) { style in
+                    Text(style.displayName).tag(style)
+                }
+            }
+
+            Toggle("Cursor blink", isOn: $settings.cursorBlink)
+
+            Picker("Scrollback lines:", selection: $settings.scrollbackLines) {
+                ForEach(Self.scrollbackOptions, id: \.1) { option in
+                    Text(option.0).tag(option.1)
+                }
+            }
+
+            Toggle("Option as Meta key", isOn: $settings.optionAsMeta)
+        }
+    }
+
+    // MARK: - Theme
+
+    @ViewBuilder
+    private var themeSection: some View {
+        Section("Theme") {
+            Picker("Theme:", selection: $settings.themeName) {
+                Text("Default").tag("")
+                ForEach(GhosttyThemeCatalog.allThemes) { theme in
+                    HStack(spacing: 6) {
+                        Text(theme.name)
+                        Spacer()
+                        themeSwatches(theme)
+                    }
+                    .tag(theme.name)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func themeSwatches(_ theme: GhosttyThemeDefinition) -> some View {
+        HStack(spacing: 2) {
+            colorSwatch(hex: theme.background)
+            colorSwatch(hex: theme.foreground)
+            if let cursor = theme.cursorColor {
+                colorSwatch(hex: cursor)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func colorSwatch(hex: String) -> some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(Color(hex: hex))
+            .frame(width: 12, height: 12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 2)
+                    .strokeBorder(.quaternary, lineWidth: 0.5)
+            )
+    }
+
+    // MARK: - CLI Paths
+
+    @ViewBuilder
+    private var cliPathsSection: some View {
+        Section {
+            ForEach(Self.terminalDatabaseTypes, id: \.rawValue) { dbType in
+                cliPathRow(for: dbType)
+            }
+        } header: {
+            Text("CLI Paths")
+        } footer: {
+            Text("Leave empty to auto-detect from system PATH.")
+        }
+    }
+
+    @ViewBuilder
+    private func cliPathRow(for dbType: DatabaseType) -> some View {
+        let binding = Binding<String>(
+            get: { settings.cliPaths[dbType.rawValue] ?? "" },
+            set: { settings.cliPaths[dbType.rawValue] = $0.isEmpty ? nil : $0 }
+        )
+        let placeholder = CLICommandResolver.findExecutable(
+            CLICommandResolver.binaryName(for: dbType)
+        ) ?? CLICommandResolver.binaryName(for: dbType)
+
+        LabeledContent(dbType.displayName) {
+            TextField(placeholder, text: binding)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 300)
+        }
+    }
+
+    // MARK: - Notifications
+
+    @ViewBuilder
+    private var notificationsSection: some View {
+        Section("Notifications") {
+            Toggle("Terminal bell", isOn: $settings.bellEnabled)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static var availableFonts: [String] {
+        let available = Set(
+            NSFontManager.shared.availableFontFamilies
+        )
+        return monospaceFonts.filter { available.contains($0) }
+    }
+}
+
+// MARK: - Color Extension
+
+private extension Color {
+    init(hex: String) {
+        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard cleaned.count >= 6,
+              let r = UInt8(cleaned.prefix(2), radix: 16),
+              let g = UInt8(cleaned.dropFirst(2).prefix(2), radix: 16),
+              let b = UInt8(cleaned.dropFirst(4).prefix(2), radix: 16)
+        else {
+            self.init(.gray)
+            return
+        }
+        self.init(
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255
+        )
+    }
+}
+
+#Preview {
+    TerminalSettingsView(settings: .constant(.default))
+        .frame(width: 600, height: 500)
+}

--- a/TablePro/Views/Terminal/TerminalErrorView.swift
+++ b/TablePro/Views/Terminal/TerminalErrorView.swift
@@ -2,9 +2,6 @@
 //  TerminalErrorView.swift
 //  TablePro
 //
-//  Displayed when the CLI binary for a database connection cannot be found.
-//  Shows the error message and installation instructions.
-//
 
 import SwiftUI
 

--- a/TablePro/Views/Terminal/TerminalErrorView.swift
+++ b/TablePro/Views/Terminal/TerminalErrorView.swift
@@ -1,0 +1,47 @@
+//
+//  TerminalErrorView.swift
+//  TablePro
+//
+//  Displayed when the CLI binary for a database connection cannot be found.
+//  Shows the error message and installation instructions.
+//
+
+import SwiftUI
+
+struct TerminalErrorView: View {
+    let error: String
+    let databaseType: DatabaseType
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "terminal")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Terminal Unavailable")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(error)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 8) {
+                Text("Install with:")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                let instructions = CLICommandResolver.installInstructions(for: databaseType)
+                Text(instructions)
+                    .font(.system(.body, design: .monospaced))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 6))
+                    .textSelection(.enabled)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+}

--- a/TablePro/Views/Terminal/TerminalErrorView.swift
+++ b/TablePro/Views/Terminal/TerminalErrorView.swift
@@ -10,35 +10,15 @@ struct TerminalErrorView: View {
     let databaseType: DatabaseType
 
     var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "terminal")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-
-            Text("Terminal Unavailable")
-                .font(.title2)
-                .fontWeight(.semibold)
-
+        ContentUnavailableView {
+            Label("Terminal Unavailable", systemImage: "terminal")
+        } description: {
             Text(error)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-
-            VStack(spacing: 8) {
-                Text("Install with:")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-
-                let instructions = CLICommandResolver.installInstructions(for: databaseType)
-                Text(instructions)
-                    .font(.system(.body, design: .monospaced))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 6))
-                    .textSelection(.enabled)
-            }
+        } actions: {
+            let instructions = CLICommandResolver.installInstructions(for: databaseType)
+            Text(instructions)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(40)
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -16,8 +16,8 @@ struct TerminalTabContentView: View {
     var body: some View {
         ZStack {
             if let state = sessionState {
-                if state.error != nil {
-                    TerminalErrorView(error: state.error!, databaseType: connection.type)
+                if let error = state.error {
+                    TerminalErrorView(error: error, databaseType: connection.type)
                 } else if state.isDisconnected {
                     disconnectedView(state: state)
                 } else if state.session != nil {
@@ -46,6 +46,9 @@ struct TerminalTabContentView: View {
             .background {
                 TerminalFocusHelper()
             }
+            .contextMenu {
+                terminalContextMenu(state: state)
+            }
             .onAppear {
                 if let session = state.session {
                     state.terminalViewState.configuration = TerminalSurfaceOptions(
@@ -53,6 +56,36 @@ struct TerminalTabContentView: View {
                     )
                 }
             }
+    }
+
+    @ViewBuilder
+    private func terminalContextMenu(state: TerminalSessionState) -> some View {
+        Button("Copy") {
+            NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+        }
+        .keyboardShortcut("c", modifiers: .command)
+
+        Button("Paste") {
+            NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)
+        }
+        .keyboardShortcut("v", modifiers: .command)
+
+        Divider()
+
+        Button("Select All") {
+            NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
+        }
+        .keyboardShortcut("a", modifiers: .command)
+
+        Button("Clear Terminal") {
+            clearTerminal(state: state)
+        }
+
+        Divider()
+
+        Button("Search") {}
+            .disabled(true)
+            .help("Coming soon")
     }
 
     private func disconnectedView(state: TerminalSessionState) -> some View {
@@ -96,6 +129,12 @@ struct TerminalTabContentView: View {
             ?? connection.database
 
         state.reconnect(connection: connection, password: password, activeDatabase: activeDatabase)
+    }
+
+    private func clearTerminal(state: TerminalSessionState) {
+        // Send Ctrl+L (form feed) to clear the terminal screen
+        let ctrlL = Data([0x0C])
+        state.processManager?.write(ctrlL)
     }
 }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -14,7 +14,7 @@ struct TerminalTabContentView: View {
     @State private var sessionState: TerminalSessionState?
 
     var body: some View {
-        Group {
+        ZStack {
             if let state = sessionState {
                 if state.error != nil {
                     TerminalErrorView(error: state.error!, databaseType: connection.type)
@@ -29,6 +29,7 @@ struct TerminalTabContentView: View {
                 connectingView
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { startTerminal() }
         .onDisappear {
             let state = sessionState

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -158,7 +158,7 @@ private final class TerminalFocusHelperView: NSView {
         menu.addItem(selectAll)
 
         terminalView.menu = menu
-        logger.info("menu installed, items=\(menu.items.count), menu identity=\(ObjectIdentifier(menu))")
+        logger.info("menu installed, items=\(menu.items.count)")
         logger.info("terminalView.menu after set: \(String(describing: terminalView.menu), privacy: .public)")
     }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -1,0 +1,60 @@
+//
+//  TerminalTabContentView.swift
+//  TablePro
+//
+//  SwiftUI view hosting the libghostty terminal surface for a database CLI session.
+//
+
+import GhosttyTerminal
+import SwiftUI
+
+struct TerminalTabContentView: View {
+    let tab: QueryTab
+    let connection: DatabaseConnection
+    let connectionId: UUID
+
+    @State private var sessionState: TerminalSessionState?
+
+    var body: some View {
+        Group {
+            if let state = sessionState, state.error == nil {
+                terminalView(state: state)
+            } else if let error = sessionState?.error {
+                TerminalErrorView(error: error, databaseType: connection.type)
+            } else {
+                ProgressView("Connecting...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear { startTerminal() }
+        .onDisappear { sessionState?.disconnect() }
+    }
+
+    @ViewBuilder
+    private func terminalView(state: TerminalSessionState) -> some View {
+        if let session = state.session {
+            TerminalSurfaceView(context: state.terminalViewState)
+                .onAppear {
+                    state.terminalViewState.configuration = TerminalSurfaceOptions(
+                        backend: .inMemory(session)
+                    )
+                }
+        } else {
+            ProgressView("Connecting...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func startTerminal() {
+        guard sessionState == nil else { return }
+
+        let state = TerminalSessionState(connectionId: connectionId, databaseType: connection.type)
+        self.sessionState = state
+
+        let password = ConnectionStorage.shared.loadPassword(for: connectionId)
+        let activeDatabase = DatabaseManager.shared.session(for: connectionId)?.activeDatabase
+            ?? connection.database
+
+        state.connect(connection: connection, password: password, activeDatabase: activeDatabase)
+    }
+}

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -52,30 +52,20 @@ struct TerminalTabContentView: View {
     }
 
     private func disconnectedView(state: TerminalSessionState) -> some View {
-        VStack(spacing: 16) {
-            Image(systemName: "terminal")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-
-            Text("Disconnected")
-                .font(.title2)
-                .fontWeight(.semibold)
-
+        ContentUnavailableView {
+            Label("Disconnected", systemImage: "terminal")
+        } description: {
             if state.exitCode != 0 {
                 Text(String(format: String(localized: "Process exited with code %d"), state.exitCode))
-                    .font(.body)
-                    .foregroundStyle(.secondary)
             }
-
+        } actions: {
             Button {
                 reconnect(state: state)
             } label: {
                 Label("Reconnect", systemImage: "arrow.clockwise")
             }
             .keyboardShortcut(.return, modifiers: [])
-            .controlSize(.large)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var connectingView: some View {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -166,55 +166,16 @@ private final class TerminalFocusHelperView: NSView {
 
     private func buildContextMenu() -> NSMenu {
         let menu = NSMenu()
-        menu.autoenablesItems = false
 
-        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(handleCopy), keyEquivalent: "")
-        copy.target = self
-        copy.isEnabled = true
-        menu.addItem(copy)
-
-        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(handlePaste), keyEquivalent: "")
-        paste.target = self
-        paste.isEnabled = true
-        menu.addItem(paste)
-
+        // Use standard responder chain actions — no custom targets.
+        // AppTerminalView inherits NSResponder which handles copy:/paste:/selectAll:
+        // via the responder chain. autoenablesItems (default true) validates each item.
+        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSResponder.copy(_:)), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSResponder.paste(_:)), keyEquivalent: ""))
         menu.addItem(.separator())
-
-        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(handleSelectAll), keyEquivalent: "")
-        selectAll.target = self
-        selectAll.isEnabled = true
-        menu.addItem(selectAll)
+        menu.addItem(NSMenuItem(title: String(localized: "Select All"), action: #selector(NSResponder.selectAll(_:)), keyEquivalent: ""))
 
         return menu
-    }
-
-    @objc private func handleCopy() {
-        simulateKeyEvent(characters: "c", modifiers: .command)
-    }
-
-    @objc private func handlePaste() {
-        simulateKeyEvent(characters: "v", modifiers: .command)
-    }
-
-    @objc private func handleSelectAll() {
-        simulateKeyEvent(characters: "a", modifiers: .command)
-    }
-
-    private func simulateKeyEvent(characters: String, modifiers: NSEvent.ModifierFlags) {
-        guard let terminal = terminalView, let window = terminal.window else { return }
-        guard let event = NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: modifiers,
-            timestamp: ProcessInfo.processInfo.systemUptime,
-            windowNumber: window.windowNumber,
-            context: nil,
-            characters: characters,
-            charactersIgnoringModifiers: characters,
-            isARepeat: false,
-            keyCode: 0
-        ) else { return }
-        terminal.keyDown(with: event)
     }
 
     // MARK: - Key View Discovery

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -46,9 +46,6 @@ struct TerminalTabContentView: View {
             .background {
                 TerminalFocusHelper()
             }
-            .contextMenu {
-                terminalContextMenu(state: state)
-            }
             .onAppear {
                 if let session = state.session {
                     state.terminalViewState.configuration = TerminalSurfaceOptions(
@@ -56,36 +53,6 @@ struct TerminalTabContentView: View {
                     )
                 }
             }
-    }
-
-    @ViewBuilder
-    private func terminalContextMenu(state: TerminalSessionState) -> some View {
-        Button("Copy") {
-            NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
-        }
-        .keyboardShortcut("c", modifiers: .command)
-
-        Button("Paste") {
-            NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)
-        }
-        .keyboardShortcut("v", modifiers: .command)
-
-        Divider()
-
-        Button("Select All") {
-            NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
-        }
-        .keyboardShortcut("a", modifiers: .command)
-
-        Button("Clear Terminal") {
-            clearTerminal(state: state)
-        }
-
-        Divider()
-
-        Button("Search") {}
-            .disabled(true)
-            .help("Coming soon")
     }
 
     private func disconnectedView(state: TerminalSessionState) -> some View {
@@ -131,11 +98,6 @@ struct TerminalTabContentView: View {
         state.reconnect(connection: connection, password: password, activeDatabase: activeDatabase)
     }
 
-    private func clearTerminal(state: TerminalSessionState) {
-        // Send Ctrl+L (form feed) to clear the terminal screen
-        let ctrlL = Data([0x0C])
-        state.processManager?.write(ctrlL)
-    }
 }
 
 // MARK: - Focus Helper

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -122,11 +122,33 @@ private final class TerminalFocusHelperView: NSView {
             while let current = ancestor {
                 if let keyView = Self.firstKeyView(in: current, excluding: self) {
                     window.makeFirstResponder(keyView)
+                    Self.installContextMenu(on: keyView)
                     return
                 }
                 ancestor = current.superview
             }
         }
+    }
+
+    private static func installContextMenu(on terminalView: NSView) {
+        guard terminalView.menu == nil else { return }
+        let menu = NSMenu()
+
+        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        copy.keyEquivalentModifierMask = .command
+        menu.addItem(copy)
+
+        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        paste.keyEquivalentModifierMask = .command
+        menu.addItem(paste)
+
+        menu.addItem(.separator())
+
+        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        selectAll.keyEquivalentModifierMask = .command
+        menu.addItem(selectAll)
+
+        terminalView.menu = menu
     }
 
     private static func firstKeyView(in view: NSView, excluding: NSView) -> NSView? {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,7 +4,6 @@
 //
 
 import GhosttyTerminal
-import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -113,24 +112,19 @@ private struct TerminalFocusHelper: NSViewRepresentable {
 }
 
 private final class TerminalFocusHelperView: NSView {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalFocus")
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard let window else { return }
-        Self.logger.info("viewDidMoveToWindow fired")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self else { return }
             var ancestor: NSView? = self.superview?.superview
             while let current = ancestor {
                 if let keyView = Self.firstKeyView(in: current, excluding: self) {
-                    let result = window.makeFirstResponder(keyView)
-                    Self.logger.info("makeFirstResponder → \(keyView.className, privacy: .public) result=\(result)")
+                    window.makeFirstResponder(keyView)
                     return
                 }
                 ancestor = current.superview
             }
-            Self.logger.warning("no focusable view found in ancestor chain")
         }
     }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -2,8 +2,6 @@
 //  TerminalTabContentView.swift
 //  TablePro
 //
-//  SwiftUI view hosting the libghostty terminal surface for a database CLI session.
-//
 
 import GhosttyTerminal
 import SwiftUI
@@ -22,12 +20,17 @@ struct TerminalTabContentView: View {
             } else if let error = sessionState?.error {
                 TerminalErrorView(error: error, databaseType: connection.type)
             } else {
-                ProgressView("Connecting...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                connectingView
             }
         }
         .onAppear { startTerminal() }
-        .onDisappear { sessionState?.disconnect() }
+        .onDisappear {
+            let state = sessionState
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(300))
+                state?.disconnect()
+            }
+        }
     }
 
     @ViewBuilder
@@ -40,9 +43,13 @@ struct TerminalTabContentView: View {
                     )
                 }
         } else {
-            ProgressView("Connecting...")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            connectingView
         }
+    }
+
+    private var connectingView: some View {
+        ProgressView("Connecting...")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func startTerminal() {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -44,7 +44,7 @@ struct TerminalTabContentView: View {
     private func terminalView(state: TerminalSessionState) -> some View {
         TerminalSurfaceView(context: state.terminalViewState)
             .background {
-                TerminalFocusHelper()
+                TerminalFocusHelper(processManager: state.processManager)
             }
             .onAppear {
                 if let session = state.session {
@@ -105,15 +105,22 @@ struct TerminalTabContentView: View {
 /// Makes the terminal surface first responder when it appears.
 /// Follows the same pattern as SQLEditorCoordinator's auto-focus (50ms delay + makeFirstResponder).
 private struct TerminalFocusHelper: NSViewRepresentable {
+    weak var processManager: TerminalProcessManager?
+
     func makeNSView(context: Context) -> TerminalFocusHelperView {
-        TerminalFocusHelperView()
+        let view = TerminalFocusHelperView()
+        view.processManager = processManager
+        return view
     }
 
-    func updateNSView(_ nsView: TerminalFocusHelperView, context: Context) {}
+    func updateNSView(_ nsView: TerminalFocusHelperView, context: Context) {
+        nsView.processManager = processManager
+    }
 }
 
 private final class TerminalFocusHelperView: NSView {
     private weak var terminalView: NSView?
+    weak var processManager: TerminalProcessManager?
     private var rightClickMonitor: Any?
 
     override func viewDidMoveToWindow() {
@@ -166,16 +173,59 @@ private final class TerminalFocusHelperView: NSView {
 
     private func buildContextMenu() -> NSMenu {
         let menu = NSMenu()
+        menu.autoenablesItems = false
 
-        // Use standard responder chain actions — no custom targets.
-        // AppTerminalView inherits NSResponder which handles copy:/paste:/selectAll:
-        // via the responder chain. autoenablesItems (default true) validates each item.
-        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: ""))
-        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: ""))
+        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(handleCopy), keyEquivalent: "")
+        copy.target = self
+        copy.isEnabled = true
+        menu.addItem(copy)
+
+        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(handlePaste), keyEquivalent: "")
+        paste.target = self
+        paste.isEnabled = NSPasteboard.general.string(forType: .string) != nil
+        menu.addItem(paste)
+
         menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: String(localized: "Select All"), action: #selector(NSResponder.selectAll(_:)), keyEquivalent: ""))
+
+        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(handleSelectAll), keyEquivalent: "")
+        selectAll.target = self
+        selectAll.isEnabled = true
+        menu.addItem(selectAll)
 
         return menu
+    }
+
+    // Ghostty handles clipboard through key events, not NSResponder actions.
+    // Cmd+C copies selected text (no-op if nothing selected).
+    // Paste writes clipboard content directly to PTY input.
+
+    @objc private func handleCopy() {
+        guard let terminal = terminalView, let window = terminal.window else { return }
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: .command,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber, context: nil,
+            characters: "c", charactersIgnoringModifiers: "c",
+            isARepeat: false, keyCode: 8
+        ) else { return }
+        terminal.keyDown(with: event)
+    }
+
+    @objc private func handlePaste() {
+        guard let text = NSPasteboard.general.string(forType: .string) else { return }
+        processManager?.write(Data(text.utf8))
+    }
+
+    @objc private func handleSelectAll() {
+        guard let terminal = terminalView, let window = terminal.window else { return }
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: .command,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber, context: nil,
+            characters: "a", charactersIgnoringModifiers: "a",
+            isARepeat: false, keyCode: 0
+        ) else { return }
+        terminal.keyDown(with: event)
     }
 
     // MARK: - Key View Discovery

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -43,6 +43,9 @@ struct TerminalTabContentView: View {
     @ViewBuilder
     private func terminalView(state: TerminalSessionState) -> some View {
         TerminalSurfaceView(context: state.terminalViewState)
+            .background {
+                TerminalFocusHelper()
+            }
             .onAppear {
                 if let session = state.session {
                     state.terminalViewState.configuration = TerminalSurfaceOptions(
@@ -93,5 +96,42 @@ struct TerminalTabContentView: View {
             ?? connection.database
 
         state.reconnect(connection: connection, password: password, activeDatabase: activeDatabase)
+    }
+}
+
+// MARK: - Focus Helper
+
+/// Makes the terminal surface first responder when it appears.
+/// Follows the same pattern as SQLEditorCoordinator's auto-focus (50ms delay + makeFirstResponder).
+private struct TerminalFocusHelper: NSViewRepresentable {
+    func makeNSView(context: Context) -> TerminalFocusHelperView {
+        TerminalFocusHelperView()
+    }
+
+    func updateNSView(_ nsView: TerminalFocusHelperView, context: Context) {}
+}
+
+private final class TerminalFocusHelperView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let window else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            guard let self, let parent = self.superview else { return }
+            if let keyView = Self.firstKeyView(in: parent, excluding: self) {
+                window.makeFirstResponder(keyView)
+            }
+        }
+    }
+
+    private static func firstKeyView(in view: NSView, excluding: NSView) -> NSView? {
+        for subview in view.subviews where subview !== excluding {
+            if subview.canBecomeKeyView {
+                return subview
+            }
+            if let found = firstKeyView(in: subview, excluding: excluding) {
+                return found
+            }
+        }
+        return nil
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -15,10 +15,16 @@ struct TerminalTabContentView: View {
 
     var body: some View {
         Group {
-            if let state = sessionState, state.error == nil {
-                terminalView(state: state)
-            } else if let error = sessionState?.error {
-                TerminalErrorView(error: error, databaseType: connection.type)
+            if let state = sessionState {
+                if state.error != nil {
+                    TerminalErrorView(error: state.error!, databaseType: connection.type)
+                } else if state.isDisconnected {
+                    disconnectedView(state: state)
+                } else if state.session != nil {
+                    terminalView(state: state)
+                } else {
+                    connectingView
+                }
             } else {
                 connectingView
             }
@@ -35,16 +41,41 @@ struct TerminalTabContentView: View {
 
     @ViewBuilder
     private func terminalView(state: TerminalSessionState) -> some View {
-        if let session = state.session {
-            TerminalSurfaceView(context: state.terminalViewState)
-                .onAppear {
+        TerminalSurfaceView(context: state.terminalViewState)
+            .onAppear {
+                if let session = state.session {
                     state.terminalViewState.configuration = TerminalSurfaceOptions(
                         backend: .inMemory(session)
                     )
                 }
-        } else {
-            connectingView
+            }
+    }
+
+    private func disconnectedView(state: TerminalSessionState) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "terminal")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Disconnected")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            if state.exitCode != 0 {
+                Text(String(format: String(localized: "Process exited with code %d"), state.exitCode))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button {
+                reconnect(state: state)
+            } label: {
+                Label("Reconnect", systemImage: "arrow.clockwise")
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .controlSize(.large)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var connectingView: some View {
@@ -63,5 +94,13 @@ struct TerminalTabContentView: View {
             ?? connection.database
 
         state.connect(connection: connection, password: password, activeDatabase: activeDatabase)
+    }
+
+    private func reconnect(state: TerminalSessionState) {
+        let password = ConnectionStorage.shared.loadPassword(for: connectionId)
+        let activeDatabase = DatabaseManager.shared.session(for: connectionId)?.activeDatabase
+            ?? connection.database
+
+        state.reconnect(connection: connection, password: password, activeDatabase: activeDatabase)
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,6 +4,7 @@
 //
 
 import GhosttyTerminal
+import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -112,13 +113,31 @@ private struct TerminalFocusHelper: NSViewRepresentable {
 }
 
 private final class TerminalFocusHelperView: NSView {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalFocus")
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard let window else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-            guard let self, let parent = self.superview else { return }
-            if let keyView = Self.firstKeyView(in: parent, excluding: self) {
-                window.makeFirstResponder(keyView)
+        guard let window else {
+            Self.logger.debug("viewDidMoveToWindow: no window")
+            return
+        }
+        Self.logger.debug("viewDidMoveToWindow: window=\(window.title, privacy: .public)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self else {
+                Self.logger.debug("focus: self deallocated")
+                return
+            }
+            Self.logger.debug("focus: superview=\(String(describing: self.superview?.className), privacy: .public)")
+            Self.dumpViewHierarchy(self.superview, depth: 0)
+
+            if let parent = self.superview,
+               let keyView = Self.firstKeyView(in: parent, excluding: self) {
+                Self.logger.info("focus: making firstResponder → \(keyView.className, privacy: .public)")
+                let success = window.makeFirstResponder(keyView)
+                Self.logger.info("focus: makeFirstResponder result=\(success)")
+            } else {
+                Self.logger.warning("focus: no keyView found, trying window.contentView")
+                Self.dumpViewHierarchy(window.contentView, depth: 0)
             }
         }
     }
@@ -133,5 +152,17 @@ private final class TerminalFocusHelperView: NSView {
             }
         }
         return nil
+    }
+
+    private static func dumpViewHierarchy(_ view: NSView?, depth: Int) {
+        guard let view, depth < 6 else { return }
+        let indent = String(repeating: "  ", count: depth)
+        let accepts = view.acceptsFirstResponder ? "✓FR" : ""
+        let canKey = view.canBecomeKeyView ? "✓KV" : ""
+        let frame = "(\(Int(view.frame.width))×\(Int(view.frame.height)))"
+        logger.debug("\(indent, privacy: .public)\(view.className, privacy: .public) \(frame, privacy: .public) \(accepts, privacy: .public) \(canKey, privacy: .public)")
+        for subview in view.subviews {
+            dumpViewHierarchy(subview, depth: depth + 1)
+        }
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -218,7 +218,14 @@ private final class TerminalFocusHelperView: NSView {
 
     @objc private func handlePaste() {
         guard let text = NSPasteboard.general.string(forType: .string) else { return }
-        processManager?.write(Data(text.utf8))
+        // Bracket paste mode: wrap pasted text so the shell knows it's pasted content
+        // and doesn't execute commands on newlines
+        let bracketStart = Data([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]) // \e[200~
+        let bracketEnd = Data([0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E])   // \e[201~
+        var pasteData = bracketStart
+        pasteData.append(Data(text.utf8))
+        pasteData.append(bracketEnd)
+        processManager?.write(pasteData)
     }
 
     @objc private func handleSelectAll() {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,6 +4,7 @@
 //
 
 import GhosttyTerminal
+import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -112,21 +113,24 @@ private struct TerminalFocusHelper: NSViewRepresentable {
 }
 
 private final class TerminalFocusHelperView: NSView {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalFocus")
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard let window else { return }
+        Self.logger.info("viewDidMoveToWindow fired")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self else { return }
-            // Walk up to the common ancestor (NSHostingView) that contains
-            // both this helper and the terminal surface as sibling subtrees.
             var ancestor: NSView? = self.superview?.superview
             while let current = ancestor {
                 if let keyView = Self.firstKeyView(in: current, excluding: self) {
-                    window.makeFirstResponder(keyView)
+                    let result = window.makeFirstResponder(keyView)
+                    Self.logger.info("makeFirstResponder → \(keyView.className, privacy: .public) result=\(result)")
                     return
                 }
                 ancestor = current.superview
             }
+            Self.logger.warning("no focusable view found in ancestor chain")
         }
     }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,7 +4,6 @@
 //
 
 import GhosttyTerminal
-import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -117,27 +116,18 @@ private final class TerminalFocusHelperView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard let window else {
-            Self.logger.debug("viewDidMoveToWindow: no window")
-            return
-        }
-        Self.logger.debug("viewDidMoveToWindow: window=\(window.title, privacy: .public)")
+        guard let window else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            guard let self else {
-                Self.logger.debug("focus: self deallocated")
-                return
-            }
-            Self.logger.debug("focus: superview=\(String(describing: self.superview?.className), privacy: .public)")
-            Self.dumpViewHierarchy(self.superview, depth: 0)
-
-            if let parent = self.superview,
-               let keyView = Self.firstKeyView(in: parent, excluding: self) {
-                Self.logger.info("focus: making firstResponder → \(keyView.className, privacy: .public)")
-                let success = window.makeFirstResponder(keyView)
-                Self.logger.info("focus: makeFirstResponder result=\(success)")
-            } else {
-                Self.logger.warning("focus: no keyView found, trying window.contentView")
-                Self.dumpViewHierarchy(window.contentView, depth: 0)
+            guard let self else { return }
+            // Walk up to the common ancestor (NSHostingView) that contains
+            // both this helper and the terminal surface as sibling subtrees.
+            var ancestor: NSView? = self.superview?.superview
+            while let current = ancestor {
+                if let keyView = Self.firstKeyView(in: current, excluding: self) {
+                    window.makeFirstResponder(keyView)
+                    return
+                }
+                ancestor = current.superview
             }
         }
     }
@@ -152,17 +142,5 @@ private final class TerminalFocusHelperView: NSView {
             }
         }
         return nil
-    }
-
-    private static func dumpViewHierarchy(_ view: NSView?, depth: Int) {
-        guard let view, depth < 6 else { return }
-        let indent = String(repeating: "  ", count: depth)
-        let accepts = view.acceptsFirstResponder ? "✓FR" : ""
-        let canKey = view.canBecomeKeyView ? "✓KV" : ""
-        let frame = "(\(Int(view.frame.width))×\(Int(view.frame.height)))"
-        logger.debug("\(indent, privacy: .public)\(view.className, privacy: .public) \(frame, privacy: .public) \(accepts, privacy: .public) \(canKey, privacy: .public)")
-        for subview in view.subviews {
-            dumpViewHierarchy(subview, depth: depth + 1)
-        }
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,7 +4,6 @@
 //
 
 import GhosttyTerminal
-import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -114,16 +113,23 @@ private struct TerminalFocusHelper: NSViewRepresentable {
 }
 
 private final class TerminalFocusHelperView: NSView {
+    private weak var terminalView: NSView?
+    private var rightClickMonitor: Any?
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard let window else { return }
+        guard let window else {
+            removeMonitor()
+            return
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self else { return }
             var ancestor: NSView? = self.superview?.superview
             while let current = ancestor {
                 if let keyView = Self.firstKeyView(in: current, excluding: self) {
                     window.makeFirstResponder(keyView)
-                    Self.installContextMenu(on: keyView)
+                    self.terminalView = keyView
+                    self.installRightClickMonitor()
                     return
                 }
                 ancestor = current.superview
@@ -131,36 +137,45 @@ private final class TerminalFocusHelperView: NSView {
         }
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalContextMenu")
+    override func removeFromSuperview() {
+        removeMonitor()
+        super.removeFromSuperview()
+    }
 
-    private static func installContextMenu(on terminalView: NSView) {
-        logger.info("installContextMenu on \(terminalView.className, privacy: .public) menu=\(String(describing: terminalView.menu), privacy: .public)")
+    // MARK: - Right-Click Context Menu
 
-        // Check if the terminal view overrides menu(for:) which would prevent our NSMenu from showing
-        let existingMenu = terminalView.menu
-        logger.info("existing menu: \(String(describing: existingMenu), privacy: .public), menuClass: \(String(describing: type(of: terminalView)), privacy: .public)")
-        logger.info("responds to menuForEvent: \(terminalView.responds(to: #selector(NSView.menu(for:))), privacy: .public)")
+    private func installRightClickMonitor() {
+        removeMonitor()
+        rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+            guard let self, let terminal = self.terminalView else { return event }
+            let locationInTerminal = terminal.convert(event.locationInWindow, from: nil)
+            guard terminal.bounds.contains(locationInTerminal) else { return event }
 
+            let menu = Self.buildContextMenu()
+            NSMenu.popUpContextMenu(menu, with: event, for: terminal)
+            return nil
+        }
+    }
+
+    private func removeMonitor() {
+        if let monitor = rightClickMonitor {
+            NSEvent.removeMonitor(monitor)
+            rightClickMonitor = nil
+        }
+    }
+
+    private static func buildContextMenu() -> NSMenu {
         let menu = NSMenu()
 
-        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: "c")
-        copy.keyEquivalentModifierMask = .command
-        menu.addItem(copy)
-
-        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: "v")
-        paste.keyEquivalentModifierMask = .command
-        menu.addItem(paste)
-
+        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: ""))
         menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: String(localized: "Select All"), action: #selector(NSText.selectAll(_:)), keyEquivalent: ""))
 
-        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
-        selectAll.keyEquivalentModifierMask = .command
-        menu.addItem(selectAll)
-
-        terminalView.menu = menu
-        logger.info("menu installed, items=\(menu.items.count)")
-        logger.info("terminalView.menu after set: \(String(describing: terminalView.menu), privacy: .public)")
+        return menu
     }
+
+    // MARK: - Key View Discovery
 
     private static func firstKeyView(in view: NSView, excluding: NSView) -> NSView? {
         for subview in view.subviews where subview !== excluding {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -129,6 +129,9 @@ private final class TerminalFocusHelperView: NSView {
             removeMonitor()
             return
         }
+        // Walk up from the .background {} NSView to find the terminal's key view.
+        // The superview chain (self -> hosting view -> TerminalSurfaceView container)
+        // is determined by SwiftUI's .background {} modifier — stable since macOS 14.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self else { return }
             var ancestor: NSView? = self.superview?.superview
@@ -155,6 +158,8 @@ private final class TerminalFocusHelperView: NSView {
         removeMonitor()
         rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
             guard let self, let terminal = self.terminalView else { return event }
+            // Only handle right-clicks when this terminal's window is key (multi-terminal safety)
+            guard terminal.window?.isKeyWindow == true else { return event }
             let locationInTerminal = terminal.convert(event.locationInWindow, from: nil)
             guard terminal.bounds.contains(locationInTerminal) else { return event }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -112,8 +112,6 @@ private struct TerminalFocusHelper: NSViewRepresentable {
 }
 
 private final class TerminalFocusHelperView: NSView {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalFocus")
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard let window else { return }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -170,8 +170,8 @@ private final class TerminalFocusHelperView: NSView {
         // Use standard responder chain actions — no custom targets.
         // AppTerminalView inherits NSResponder which handles copy:/paste:/selectAll:
         // via the responder chain. autoenablesItems (default true) validates each item.
-        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSResponder.copy(_:)), keyEquivalent: ""))
-        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSResponder.paste(_:)), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: ""))
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: String(localized: "Select All"), action: #selector(NSResponder.selectAll(_:)), keyEquivalent: ""))
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -4,6 +4,7 @@
 //
 
 import GhosttyTerminal
+import os
 import SwiftUI
 
 struct TerminalTabContentView: View {
@@ -130,8 +131,16 @@ private final class TerminalFocusHelperView: NSView {
         }
     }
 
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalContextMenu")
+
     private static func installContextMenu(on terminalView: NSView) {
-        guard terminalView.menu == nil else { return }
+        logger.info("installContextMenu on \(terminalView.className, privacy: .public) menu=\(String(describing: terminalView.menu), privacy: .public)")
+
+        // Check if the terminal view overrides menu(for:) which would prevent our NSMenu from showing
+        let existingMenu = terminalView.menu
+        logger.info("existing menu: \(String(describing: existingMenu), privacy: .public), menuClass: \(String(describing: type(of: terminalView)), privacy: .public)")
+        logger.info("responds to menuForEvent: \(terminalView.responds(to: #selector(NSView.menu(for:))), privacy: .public)")
+
         let menu = NSMenu()
 
         let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: "c")
@@ -149,6 +158,8 @@ private final class TerminalFocusHelperView: NSView {
         menu.addItem(selectAll)
 
         terminalView.menu = menu
+        logger.info("menu installed, items=\(menu.items.count), menu identity=\(ObjectIdentifier(menu))")
+        logger.info("terminalView.menu after set: \(String(describing: terminalView.menu), privacy: .public)")
     }
 
     private static func firstKeyView(in view: NSView, excluding: NSView) -> NSView? {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -151,7 +151,7 @@ private final class TerminalFocusHelperView: NSView {
             let locationInTerminal = terminal.convert(event.locationInWindow, from: nil)
             guard terminal.bounds.contains(locationInTerminal) else { return event }
 
-            let menu = Self.buildContextMenu()
+            let menu = self.buildContextMenu()
             NSMenu.popUpContextMenu(menu, with: event, for: terminal)
             return nil
         }
@@ -164,15 +164,57 @@ private final class TerminalFocusHelperView: NSView {
         }
     }
 
-    private static func buildContextMenu() -> NSMenu {
+    private func buildContextMenu() -> NSMenu {
         let menu = NSMenu()
+        menu.autoenablesItems = false
 
-        menu.addItem(NSMenuItem(title: String(localized: "Copy"), action: #selector(NSText.copy(_:)), keyEquivalent: ""))
-        menu.addItem(NSMenuItem(title: String(localized: "Paste"), action: #selector(NSText.paste(_:)), keyEquivalent: ""))
+        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(handleCopy), keyEquivalent: "")
+        copy.target = self
+        copy.isEnabled = true
+        menu.addItem(copy)
+
+        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(handlePaste), keyEquivalent: "")
+        paste.target = self
+        paste.isEnabled = true
+        menu.addItem(paste)
+
         menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: String(localized: "Select All"), action: #selector(NSText.selectAll(_:)), keyEquivalent: ""))
+
+        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(handleSelectAll), keyEquivalent: "")
+        selectAll.target = self
+        selectAll.isEnabled = true
+        menu.addItem(selectAll)
 
         return menu
+    }
+
+    @objc private func handleCopy() {
+        simulateKeyEvent(characters: "c", modifiers: .command)
+    }
+
+    @objc private func handlePaste() {
+        simulateKeyEvent(characters: "v", modifiers: .command)
+    }
+
+    @objc private func handleSelectAll() {
+        simulateKeyEvent(characters: "a", modifiers: .command)
+    }
+
+    private func simulateKeyEvent(characters: String, modifiers: NSEvent.ModifierFlags) {
+        guard let terminal = terminalView, let window = terminal.window else { return }
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: 0
+        ) else { return }
+        terminal.keyDown(with: event)
     }
 
     // MARK: - Key View Discovery

--- a/TableProTests/Core/Terminal/CLICommandResolverTests.swift
+++ b/TableProTests/Core/Terminal/CLICommandResolverTests.swift
@@ -1,0 +1,214 @@
+//
+//  CLICommandResolverTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("CLICommandResolver")
+struct CLICommandResolverTests {
+    // MARK: - binaryName(for:)
+
+    @Test("binaryName returns mysql for MySQL")
+    func testBinaryName_mysql() {
+        #expect(CLICommandResolver.binaryName(for: .mysql) == "mysql")
+    }
+
+    @Test("binaryName returns mariadb for MariaDB")
+    func testBinaryName_mariadb() {
+        #expect(CLICommandResolver.binaryName(for: .mariadb) == "mariadb")
+    }
+
+    @Test("binaryName returns psql for PostgreSQL")
+    func testBinaryName_postgresql() {
+        #expect(CLICommandResolver.binaryName(for: .postgresql) == "psql")
+    }
+
+    @Test("binaryName returns psql for Redshift")
+    func testBinaryName_redshift() {
+        #expect(CLICommandResolver.binaryName(for: .redshift) == "psql")
+    }
+
+    @Test("binaryName returns redis-cli for Redis")
+    func testBinaryName_redis() {
+        #expect(CLICommandResolver.binaryName(for: .redis) == "redis-cli")
+    }
+
+    @Test("binaryName returns mongosh for MongoDB")
+    func testBinaryName_mongodb() {
+        #expect(CLICommandResolver.binaryName(for: .mongodb) == "mongosh")
+    }
+
+    @Test("binaryName returns sqlite3 for SQLite")
+    func testBinaryName_sqlite() {
+        #expect(CLICommandResolver.binaryName(for: .sqlite) == "sqlite3")
+    }
+
+    @Test("binaryName returns sqlcmd for MSSQL")
+    func testBinaryName_mssql() {
+        #expect(CLICommandResolver.binaryName(for: .mssql) == "sqlcmd")
+    }
+
+    @Test("binaryName returns clickhouse-client for ClickHouse")
+    func testBinaryName_clickhouse() {
+        #expect(CLICommandResolver.binaryName(for: .clickhouse) == "clickhouse-client")
+    }
+
+    @Test("binaryName returns duckdb for DuckDB")
+    func testBinaryName_duckdb() {
+        #expect(CLICommandResolver.binaryName(for: .duckdb) == "duckdb")
+    }
+
+    @Test("binaryName returns sqlplus for Oracle")
+    func testBinaryName_oracle() {
+        #expect(CLICommandResolver.binaryName(for: .oracle) == "sqlplus")
+    }
+
+    @Test("binaryName returns lowercased rawValue for unknown type")
+    func testBinaryName_unknownType() {
+        let unknownType = DatabaseType(rawValue: "CockroachDB")
+        #expect(CLICommandResolver.binaryName(for: unknownType) == "cockroachdb")
+    }
+
+    // MARK: - installInstructions(for:)
+
+    @Test("installInstructions returns non-empty for all known terminal types")
+    func testInstallInstructions_allKnownTypes() {
+        let terminalTypes: [DatabaseType] = [
+            .mysql, .mariadb, .postgresql, .redshift, .redis, .mongodb,
+            .sqlite, .mssql, .clickhouse, .duckdb, .oracle
+        ]
+        for dbType in terminalTypes {
+            let instructions = CLICommandResolver.installInstructions(for: dbType)
+            #expect(!instructions.isEmpty, "Instructions should be non-empty for \(dbType.rawValue)")
+        }
+    }
+
+    @Test("installInstructions returns brew command for MySQL")
+    func testInstallInstructions_mysql() {
+        #expect(CLICommandResolver.installInstructions(for: .mysql) == "brew install mysql-client")
+    }
+
+    @Test("installInstructions returns generic message for unknown type")
+    func testInstallInstructions_unknownType() {
+        let unknownType = DatabaseType(rawValue: "CockroachDB")
+        let instructions = CLICommandResolver.installInstructions(for: unknownType)
+        #expect(instructions.contains("CockroachDB"))
+    }
+
+    // MARK: - resolve returns nil for unsupported type
+
+    @Test("resolve returns nil for a database type with no CLI mapping")
+    func testResolve_unknownType_returnsNil() {
+        let connection = DatabaseConnection(
+            name: "Test",
+            host: "localhost",
+            port: 9999,
+            type: DatabaseType(rawValue: "FakeDB"),
+            sshTunnelMode: .disabled
+        )
+        let result = CLICommandResolver.resolve(
+            connection: connection,
+            password: nil,
+            activeDatabase: nil
+        )
+        #expect(result == nil)
+    }
+
+    // MARK: - findExecutable
+
+    @Test("findExecutable returns nil for nonexistent binary")
+    func testFindExecutable_nonexistent() {
+        let result = CLICommandResolver.findExecutable("__tablepro_nonexistent_binary_xyz__")
+        #expect(result == nil)
+    }
+
+    @Test("findExecutable returns path for system binary")
+    func testFindExecutable_systemBinary() {
+        // /bin/ls exists on all macOS systems
+        let result = CLICommandResolver.findExecutable("ls")
+        #expect(result != nil)
+    }
+
+    // MARK: - SSH config extraction (tested through resolve)
+
+    @Test("resolve with disabled SSH does not use SSH path")
+    func testResolve_disabledSSH() {
+        // With SSH disabled, resolve should attempt local resolution.
+        // Since the CLI binary likely exists for sqlite3, this tests
+        // that disabled SSH doesn't trigger SSH resolution.
+        let connection = DatabaseConnection(
+            name: "Local SQLite",
+            host: "",
+            database: "/tmp/test.db",
+            type: .sqlite,
+            sshTunnelMode: .disabled
+        )
+        let result = CLICommandResolver.resolve(
+            connection: connection,
+            password: nil,
+            activeDatabase: nil
+        )
+        // sqlite3 should be found on macOS
+        if let spec = result {
+            #expect(spec.executablePath.contains("sqlite3"))
+            #expect(!spec.executablePath.contains("ssh"))
+        }
+    }
+
+    @Test("resolve with inline SSH uses SSH when local CLI unavailable")
+    func testResolve_inlineSSH() {
+        let sshConfig = SSHConfiguration(
+            enabled: true,
+            host: "bastion.example.com",
+            port: 22,
+            username: "deploy"
+        )
+        // Use a type that is unlikely to have a local CLI to force SSH path
+        let connection = DatabaseConnection(
+            name: "Remote Oracle",
+            host: "db.internal",
+            port: 1521,
+            type: .oracle,
+            sshTunnelMode: .inline(sshConfig)
+        )
+        let result = CLICommandResolver.resolve(
+            connection: connection,
+            password: "secret",
+            activeDatabase: "mydb"
+        )
+        // If ssh binary exists, we should get an SSH-based spec
+        if let spec = result {
+            #expect(spec.executablePath.hasSuffix("ssh"))
+        }
+    }
+
+    @Test("resolve with profile SSH uses snapshot config")
+    func testResolve_profileSSH() {
+        let snapshot = SSHConfiguration(
+            enabled: true,
+            host: "jump.example.com",
+            port: 2222,
+            username: "admin"
+        )
+        let connection = DatabaseConnection(
+            name: "Remote PG",
+            host: "db.internal",
+            port: 5432,
+            type: .postgresql,
+            sshTunnelMode: .profile(id: UUID(), snapshot: snapshot)
+        )
+        let result = CLICommandResolver.resolve(
+            connection: connection,
+            password: "pass",
+            activeDatabase: "mydb"
+        )
+        // Should attempt SSH-based resolution since profile SSH is set
+        if let spec = result {
+            // Either SSH path or local psql path (if psql found locally with effectiveConnection)
+            #expect(!spec.executablePath.isEmpty)
+        }
+    }
+}

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Settings Overview
-description: All settings categories - General, Appearance, Editor, Data Grid, Tabs, Keyboard, AI, History, Plugins, Sync, and License
+description: All settings categories - General, Appearance, Editor, Data Grid, Tabs, Keyboard, AI, Terminal, History, Plugins, Sync, and License
 ---
 
 # Settings Overview
@@ -44,6 +44,9 @@ Open settings via **TablePro** > **Settings** or `Cmd+,`.
   </Card>
   <Card title="AI" icon="sparkles" href="/features/ai-chat">
     AI provider setup
+  </Card>
+  <Card title="Terminal" icon="terminal" href="/features/terminal#settings">
+    Terminal font, theme, CLI paths
   </Card>
   <Card title="History" icon="clock-rotate-left">
     History retention
@@ -417,6 +420,22 @@ Disabling auto cleanup with unlimited entries may cause the history database to 
     alt="History settings"
   />
 </Frame>
+
+## Terminal Settings
+
+Configure the embedded database terminal. See [Database Terminal](/features/terminal) for full documentation.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Font** | Menlo | Monospace font for the terminal |
+| **Font size** | 13 | Font size (9-24 pt) |
+| **Cursor style** | Block | Block, bar, or underline |
+| **Cursor blink** | On | Animate the cursor |
+| **Scrollback lines** | 10,000 | Lines kept in scroll history (0 = unlimited) |
+| **Option as Meta** | On | Use Option key as Meta for terminal shortcuts |
+| **Theme** | Default | Terminal color theme (300+ built-in options) |
+| **CLI paths** | Auto-detect | Per-database override for CLI executable path |
+| **Terminal bell** | On | Play sound on bell character |
 
 ## Plugins Settings
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,6 +69,7 @@
               "features/deep-links",
               "features/safe-mode",
               "features/connection-sharing",
+              "features/terminal",
               "features/icloud-sync",
               "features/ssh-profiles"
             ]

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -178,6 +178,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Query History | `Cmd+Y` |
 | Toggle Cell Inspector | `Cmd+Option+I` |
 | Toggle Results | `Cmd+Opt+R` |
+| Open Terminal | `Ctrl+Cmd+`` |
 | Settings | `Cmd+,` |
 
 ### Results

--- a/docs/features/terminal.mdx
+++ b/docs/features/terminal.mdx
@@ -9,11 +9,8 @@ TablePro includes an embedded terminal that auto-launches the appropriate databa
 
 ## Opening the Terminal
 
-There are three ways to open a terminal:
-
 - **Menu**: View > Open Terminal
 - **Keyboard shortcut**: `Ctrl+Cmd+``
-- **Context menu**: Right-click a connection in the sidebar
 
 The terminal automatically detects which CLI tool to use based on the connection type and launches it with the correct host, port, username, and database arguments.
 
@@ -21,7 +18,8 @@ The terminal automatically detects which CLI tool to use based on the connection
 
 | Database | CLI Tool | Install Command |
 |----------|----------|-----------------|
-| MySQL / MariaDB | `mysql` | `brew install mysql` |
+| MySQL | `mysql` | `brew install mysql-client` |
+| MariaDB | `mariadb` (falls back to `mysql`) | `brew install mariadb` |
 | PostgreSQL / Redshift | `psql` | `brew install libpq` |
 | Redis | `redis-cli` | `brew install redis` |
 | MongoDB | `mongosh` | `brew install mongosh` |
@@ -35,13 +33,25 @@ If the CLI tool is not installed, TablePro shows an error with the install comma
 
 ## SSH Tunnel Support
 
-When your connection uses an SSH tunnel, the terminal launches `ssh` with the correct parameters (host, port, key, jump hosts) and runs the database CLI on the remote host. This works with:
+For SSH-tunneled connections, TablePro uses a two-step strategy:
+
+1. **Local CLI via tunnel** (preferred): Runs the CLI on your Mac, connecting through the existing SSH tunnel (`localhost:tunnelPort`). Works with Docker and containerized databases where the CLI isn't installed on the remote host.
+2. **Remote CLI via SSH** (fallback): If the CLI isn't installed locally, SSHs into the remote host and runs the CLI there.
+
+SSH remote mode supports:
 
 - Inline SSH configuration
 - SSH profiles (uses the resolved snapshot)
+- Private key authentication
 - Jump hosts (multi-hop tunnels)
 
 Password-based authentication for the database is passed through environment variables, keeping it out of the process argument list.
+
+## Docker and Container Support
+
+When the database runs inside a Docker container on the SSH host, the local CLI approach works automatically. The SSH tunnel forwards to the container's exposed port, and the CLI on your Mac connects through it. No need for `docker exec` or installing CLI tools on the Docker host.
+
+**Requirement**: The CLI tool must be installed on your Mac (e.g., `brew install mariadb` for MariaDB).
 
 ## Settings
 
@@ -58,7 +68,7 @@ Open **Settings > Terminal** to customize:
 
 ### Theme
 
-Pick from 300+ built-in Ghostty terminal themes. Color swatches preview the background, foreground, and cursor colors for each theme. The default theme follows system appearance (Alabaster for light, Afterglow for dark).
+Pick from 300+ built-in terminal themes. Color swatches preview the background, foreground, and cursor colors for each theme.
 
 ### CLI Paths
 
@@ -82,6 +92,7 @@ Right-click inside the terminal for:
 - If the CLI process exits, a "Disconnected" view appears with the exit code and a Reconnect button
 - Pressing Enter on the disconnected view reconnects
 - The terminal uses the active database from your current session, not just the connection default
+- Terminal tabs persist across app restarts and auto-reconnect on launch
 
 ## Keyboard Shortcuts
 
@@ -91,5 +102,11 @@ Right-click inside the terminal for:
 | Copy | `Cmd+C` |
 | Paste | `Cmd+V` |
 | Clear screen | `Ctrl+L` (in terminal) |
+| Reverse search history | `Ctrl+R` (readline) |
 
 Settings changes (font, theme, cursor style) apply immediately to all open terminals without reconnecting.
+
+## Known Limitations
+
+- **No Cmd+F search**: Scrollback search is not available in the embedded terminal. Use `Ctrl+R` for readline reverse search or pipe output through `grep`.
+- **Oracle passwords**: Oracle's `sqlplus` requires the password in the connect string (no environment variable support). The password may be visible in process listings.

--- a/docs/features/terminal.mdx
+++ b/docs/features/terminal.mdx
@@ -75,7 +75,6 @@ Right-click inside the terminal for:
 - **Copy** (`Cmd+C`)
 - **Paste** (`Cmd+V`)
 - **Select All** (`Cmd+A`)
-- **Clear Terminal**: Sends Ctrl+L to clear the screen
 
 ## Connection Handling
 

--- a/docs/features/terminal.mdx
+++ b/docs/features/terminal.mdx
@@ -1,0 +1,96 @@
+---
+title: Database Terminal
+description: Embedded database CLI terminal for direct command-line access to your connections
+---
+
+# Database Terminal
+
+TablePro includes an embedded terminal that auto-launches the appropriate database CLI tool for your active connection. Instead of switching to a separate terminal app, you get a native terminal right inside the database client.
+
+## Opening the Terminal
+
+There are three ways to open a terminal:
+
+- **Menu**: View > Open Terminal
+- **Keyboard shortcut**: `Ctrl+Cmd+``
+- **Context menu**: Right-click a connection in the sidebar
+
+The terminal automatically detects which CLI tool to use based on the connection type and launches it with the correct host, port, username, and database arguments.
+
+## Supported Databases
+
+| Database | CLI Tool | Install Command |
+|----------|----------|-----------------|
+| MySQL / MariaDB | `mysql` | `brew install mysql` |
+| PostgreSQL / Redshift | `psql` | `brew install libpq` |
+| Redis | `redis-cli` | `brew install redis` |
+| MongoDB | `mongosh` | `brew install mongosh` |
+| SQLite | `sqlite3` | Included with macOS |
+| SQL Server | `sqlcmd` | `brew install sqlcmd` |
+| ClickHouse | `clickhouse-client` | `brew install clickhouse` |
+| DuckDB | `duckdb` | `brew install duckdb` |
+| Oracle | `sqlplus` | `brew install instantclient-sqlplus` |
+
+If the CLI tool is not installed, TablePro shows an error with the install command.
+
+## SSH Tunnel Support
+
+When your connection uses an SSH tunnel, the terminal launches `ssh` with the correct parameters (host, port, key, jump hosts) and runs the database CLI on the remote host. This works with:
+
+- Inline SSH configuration
+- SSH profiles (uses the resolved snapshot)
+- Jump hosts (multi-hop tunnels)
+
+Password-based authentication for the database is passed through environment variables, keeping it out of the process argument list.
+
+## Settings
+
+Open **Settings > Terminal** to customize:
+
+### Display
+
+- **Font**: Choose from system monospace fonts (Menlo, SF Mono, Monaco, Courier New, JetBrains Mono)
+- **Font size**: 9 to 24 points (default: 13)
+- **Cursor style**: Block, bar, or underline
+- **Cursor blink**: Enable or disable cursor blinking
+- **Scrollback lines**: 1,000 to 50,000, or unlimited
+- **Option as Meta**: Use the Option key as Meta for terminal shortcuts like `Alt+B` (word back) and `Alt+F` (word forward)
+
+### Theme
+
+Pick from 300+ built-in Ghostty terminal themes. Color swatches preview the background, foreground, and cursor colors for each theme. The default theme follows system appearance (Alabaster for light, Afterglow for dark).
+
+### CLI Paths
+
+Override the auto-detected CLI path for any database type. Useful when you have multiple versions installed or the CLI is in a non-standard location. Leave empty to auto-detect from system PATH and common Homebrew locations.
+
+### Notifications
+
+- **Terminal bell**: Enable or disable the terminal bell sound
+
+## Context Menu
+
+Right-click inside the terminal for:
+
+- **Copy** (`Cmd+C`)
+- **Paste** (`Cmd+V`)
+- **Select All** (`Cmd+A`)
+- **Clear Terminal**: Sends Ctrl+L to clear the screen
+
+## Connection Handling
+
+- The terminal connects when the tab opens and disconnects when you close the tab
+- If the CLI process exits, a "Disconnected" view appears with the exit code and a Reconnect button
+- Pressing Enter on the disconnected view reconnects
+- The terminal uses the active database from your current session, not just the connection default
+
+## Keyboard Shortcuts
+
+| Action | Shortcut |
+|--------|----------|
+| Open Terminal | `Ctrl+Cmd+`` |
+| Copy | `Cmd+C` |
+| Paste | `Cmd+V` |
+| Clear screen | `Ctrl+L` (in terminal) |
+
+Settings changes (font, theme, cursor style) apply immediately to all open terminals without reconnecting.


### PR DESCRIPTION
## Summary

- Add embedded terminal tabs that auto-launch the appropriate database CLI tool (mysql, psql, redis-cli, mongosh, sqlite3, sqlcmd, clickhouse-client, duckdb) for the active connection
- Terminal rendering powered by [libghostty](https://github.com/Lakr233/libghostty-spm) (Metal GPU-accelerated, via GhosttyTerminal SPM package)
- PTY-based process management with `forkpty()` for real interactive CLI sessions
- CLI binary auto-discovery (PATH, Homebrew, common install locations) with user-friendly "not found" error and install instructions
- Password passed securely via environment variables (MYSQL_PWD, PGPASSWORD, REDISCLI_AUTH, etc.)
- New `.terminal` tab type integrated into the existing native macOS window tab system
- Menu item (View > Open Terminal) with customizable keyboard shortcut (Ctrl+Cmd+`)

## Technical Details

### New files (6)
- `Core/Terminal/CLICommandResolver.swift` — DatabaseType → CLI binary + args + env vars mapping
- `Core/Terminal/TerminalProcessManager.swift` — PTY lifecycle (forkpty, DispatchSource I/O, process monitoring)
- `Core/Terminal/TerminalSessionState.swift` — @Observable state bridging PTY ↔ InMemoryTerminalSession ↔ GhosttyTerminal
- `Views/Terminal/TerminalTabContentView.swift` — SwiftUI host for TerminalSurfaceView
- `Views/Terminal/TerminalErrorView.swift` — CLI not found error with brew install guidance
- `Views/Main/Extensions/MainContentCoordinator+Terminal.swift` — Coordinator extension (follows +ServerDashboard pattern)

### Modified files (10)
- TabType, QueryTabManager, SessionStateFactory, MainSplitViewController, MainEditorContentView, MainContentView+Setup, MainContentCommandActions, KeyboardShortcutModels, TableProApp, CHANGELOG

### Dependencies
- **libghostty-spm** (`GhosttyTerminal`) — must be added via Xcode (File → Add Package Dependencies → `https://github.com/Lakr233/libghostty-spm.git`)

## Remaining phases (future PRs)
- Phase 2: SSH tunneled connections + all CLI types
- Phase 3: Tab persistence + auto-reconnect
- Phase 4: Split terminal panes
- Phase 5: Search + copy/paste + context menu
- Phase 6: Terminal settings + themes
- Phase 7: Polish (shell integration, bell, accessibility)

## Test plan
- [ ] Add libghostty-spm SPM package to Xcode project (GhosttyTerminal → TablePro target)
- [ ] Build succeeds
- [ ] Connect to a MySQL/PostgreSQL database
- [ ] View → Open Terminal opens terminal tab with correct window title
- [ ] CLI auto-connects (verify with `SELECT 1;`)
- [ ] Ctrl+Cmd+` keyboard shortcut works
- [ ] Multiple terminal tabs work independently
- [ ] Close terminal tab terminates the process
- [ ] SQLite connection uses sqlite3 with file path
- [ ] CLI not found shows error view with brew install instructions