### PR TITLE
feat: built-in MCP server for AI tool integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - MCP server: built-in Model Context Protocol server lets AI tools (Claude Desktop, Claude Code, Cursor) browse schemas, run queries, and export data through TablePro's connections
+- MCP server: connected clients list in Settings and status menu item showing server state
 - Import connections from TablePlus, Sequel Ace, and DBeaver with one-click migration
 - Embedded database CLI terminal (View > Open Terminal or Ctrl+Cmd+`) auto-launches mysql, psql, redis-cli, etc. for the active connection
 - Structure tab: modify existing tables (add, modify, drop columns, indexes, foreign keys, primary keys)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- MCP server: built-in Model Context Protocol server lets AI tools (Claude Desktop, Claude Code, Cursor) browse schemas, run queries, and export data through TablePro's connections
 - Import connections from TablePlus, Sequel Ace, and DBeaver with one-click migration
 - Embedded database CLI terminal (View > Open Terminal or Ctrl+Cmd+`) auto-launches mysql, psql, redis-cli, etc. for the active connection
 - Structure tab: modify existing tables (add, modify, drop columns, indexes, foreign keys, primary keys)

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -110,7 +110,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if AppSettingsManager.shared.mcp.enabled {
             Task {
-                await MCPServerManager.shared.start(port: UInt16(AppSettingsManager.shared.mcp.port))
+                await MCPServerManager.shared.start(port: UInt16(clamping: AppSettingsManager.shared.mcp.port))
             }
         }
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -108,6 +108,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         SyncCoordinator.shared.start()
         LinkedFolderWatcher.shared.start()
 
+        if AppSettingsManager.shared.mcp.enabled {
+            Task {
+                await MCPServerManager.shared.start(port: UInt16(AppSettingsManager.shared.mcp.port))
+            }
+        }
+
         Task.detached(priority: .background) {
             _ = QueryHistoryStorage.shared
         }
@@ -205,6 +211,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        Task {
+            await MCPServerManager.shared.stop()
+        }
         LinkedFolderWatcher.shared.stop()
         SSHTunnelManager.shared.terminateAllProcessesSync()
     }

--- a/TablePro/Core/MCP/MCPAuthGuard.swift
+++ b/TablePro/Core/MCP/MCPAuthGuard.swift
@@ -1,0 +1,156 @@
+//
+//  MCPAuthGuard.swift
+//  TablePro
+//
+//  Enforces AIConnectionPolicy and SafeModeLevel for MCP requests.
+//
+
+import AppKit
+import Foundation
+import os
+
+actor MCPAuthGuard {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPAuthGuard")
+
+    /// Per-session approved connections (for askEachTime policy)
+    private var sessionApprovals: [String: Set<UUID>] = [:]
+
+    // MARK: - Connection Access Check
+
+    func checkConnectionAccess(connectionId: UUID, sessionId: String) async throws {
+        let (policy, connectionName, databaseType) = await MainActor.run {
+            let conns = ConnectionStorage.shared.loadConnections()
+            guard let conn = conns.first(where: { $0.id == connectionId }) else {
+                return (AIConnectionPolicy.never, "", "")
+            }
+            let effective = conn.aiPolicy ?? AppSettingsManager.shared.ai.defaultConnectionPolicy
+            return (effective, conn.name, conn.type.rawValue)
+        }
+
+        switch policy {
+        case .alwaysAllow:
+            return
+
+        case .never:
+            throw MCPError.forbidden(
+                String(localized: "AI access is disabled for this connection")
+            )
+
+        case .askEachTime:
+            if let approved = sessionApprovals[sessionId], approved.contains(connectionId) {
+                return
+            }
+
+            let userApproved = try await promptUserApproval(
+                connectionName: connectionName,
+                databaseType: databaseType
+            )
+
+            if userApproved {
+                sessionApprovals[sessionId, default: []].insert(connectionId)
+            } else {
+                throw MCPError.forbidden(
+                    String(localized: "User denied MCP access to this connection")
+                )
+            }
+        }
+    }
+
+    // MARK: - Query Permission Check
+
+    func checkQueryPermission(
+        sql: String,
+        connectionId: UUID,
+        databaseType: DatabaseType,
+        safeModeLevel: SafeModeLevel
+    ) async throws {
+        let isWrite = QueryClassifier.isWriteQuery(sql, databaseType: databaseType)
+
+        // SafeModeGuard.checkPermission is @MainActor async; Swift hops automatically
+        let permission = await SafeModeGuard.checkPermission(
+            level: safeModeLevel,
+            isWriteOperation: isWrite,
+            sql: sql,
+            operationDescription: String(localized: "MCP query execution"),
+            window: nil,
+            databaseType: databaseType
+        )
+
+        if case .blocked(let reason) = permission {
+            throw MCPError.forbidden(reason)
+        }
+    }
+
+    // MARK: - Query Logging
+
+    func logQuery(
+        sql: String,
+        connectionId: UUID,
+        databaseName: String,
+        executionTime: TimeInterval,
+        rowCount: Int,
+        wasSuccessful: Bool,
+        errorMessage: String?
+    ) async {
+        let shouldLog = await MainActor.run {
+            AppSettingsManager.shared.mcp.logQueriesInHistory
+        }
+        guard shouldLog else { return }
+
+        let entry = QueryHistoryEntry(
+            query: sql,
+            connectionId: connectionId,
+            databaseName: databaseName,
+            executionTime: executionTime,
+            rowCount: rowCount,
+            wasSuccessful: wasSuccessful,
+            errorMessage: errorMessage
+        )
+
+        _ = await QueryHistoryStorage.shared.addHistory(entry)
+    }
+
+    // MARK: - User Approval (askEachTime)
+
+    private func promptUserApproval(connectionName: String, databaseType: String) async throws -> Bool {
+        let approvalTask = Task { @MainActor in
+            NSApp.requestUserAttention(.criticalRequest)
+            NSApp.activate(ignoringOtherApps: true)
+            return await AlertHelper.confirmDestructive(
+                title: String(localized: "MCP Access Request"),
+                message: String(
+                    format: String(localized: "An MCP client wants to access '%@' (%@). Allow?"),
+                    connectionName,
+                    databaseType
+                ),
+                confirmButton: String(localized: "Allow"),
+                cancelButton: String(localized: "Deny"),
+                window: nil
+            )
+        }
+
+        // Race against a 30-second timeout
+        return try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await approvalTask.value
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(30))
+                throw MCPError.timeout(
+                    String(localized: "User approval timed out after 30 seconds")
+                )
+            }
+            guard let result = try await group.next() else {
+                throw MCPError.internalError("No result from approval prompt")
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
+    // MARK: - Session Cleanup
+
+    func clearSession(_ sessionId: String) {
+        sessionApprovals.removeValue(forKey: sessionId)
+    }
+}

--- a/TablePro/Core/MCP/MCPAuthGuard.swift
+++ b/TablePro/Core/MCP/MCPAuthGuard.swift
@@ -138,6 +138,7 @@ actor MCPAuthGuard {
             }
             group.addTask {
                 try await Task.sleep(for: .seconds(30))
+                approvalTask.cancel()
                 throw MCPError.timeout(
                     String(localized: "User approval timed out after 30 seconds")
                 )
@@ -145,6 +146,7 @@ actor MCPAuthGuard {
             guard let result = try await group.next() else {
                 throw MCPError.internalError("No result from approval prompt")
             }
+            approvalTask.cancel()
             group.cancelAll()
             return result
         }

--- a/TablePro/Core/MCP/MCPAuthGuard.swift
+++ b/TablePro/Core/MCP/MCPAuthGuard.swift
@@ -113,6 +113,9 @@ actor MCPAuthGuard {
     // MARK: - User Approval (askEachTime)
 
     private func promptUserApproval(connectionName: String, databaseType: String) async throws -> Bool {
+        // Use a task group so the actor suspends (freeing it for other requests)
+        // while the approval dialog is shown on the main thread.
+        // Race the dialog against a 30-second timeout.
         let approvalTask = Task { @MainActor in
             NSApp.requestUserAttention(.criticalRequest)
             NSApp.activate(ignoringOtherApps: true)
@@ -129,8 +132,7 @@ actor MCPAuthGuard {
             )
         }
 
-        // Race against a 30-second timeout
-        return try await withThrowingTaskGroup(of: Bool.self) { group in
+        let approved = try await withThrowingTaskGroup(of: Bool.self) { group in
             group.addTask {
                 await approvalTask.value
             }
@@ -146,6 +148,13 @@ actor MCPAuthGuard {
             group.cancelAll()
             return result
         }
+
+        if approved {
+            return true
+        }
+        throw MCPError.forbidden(
+            String(localized: "User denied MCP access to this connection")
+        )
     }
 
     // MARK: - Session Cleanup

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -389,20 +389,19 @@ actor MCPConnectionBridge {
             }
         }
 
+        let (driver, _) = try await resolveDriver(connectionId)
+
         let tables: [TableInfo]
         if !cachedTables.isEmpty {
             tables = cachedTables
         } else {
-            let (driver, _) = try await resolveDriver(connectionId)
             tables = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
                 try await driver.fetchTables()
             }
         }
 
-        // Limit to first 100 tables to prevent excessive round-trips
         let limitedTables = Array(tables.prefix(100))
 
-        let (driver, _) = try await resolveDriver(connectionId)
         var tableSchemas: [JSONValue] = []
         for table in limitedTables {
             let columns = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -1,0 +1,440 @@
+//
+//  MCPConnectionBridge.swift
+//  TablePro
+//
+//  Bridges MCP tool/resource handlers to DatabaseManager and driver APIs.
+//
+
+import Foundation
+import os
+
+actor MCPConnectionBridge {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPConnectionBridge")
+
+    // MARK: - Connection Management
+
+    func listConnections() async -> JSONValue {
+        let (connections, activeSessions) = await MainActor.run {
+            let conns = ConnectionStorage.shared.loadConnections()
+            let sessions = DatabaseManager.shared.activeSessions
+            return (conns, sessions)
+        }
+
+        let items: [JSONValue] = connections.map { conn in
+            let session = activeSessions[conn.id]
+            let isConnected = session?.status.isConnected ?? false
+            let policy = conn.aiPolicy ?? AIConnectionPolicy.askEachTime
+
+            return .object([
+                "id": .string(conn.id.uuidString),
+                "name": .string(conn.name),
+                "type": .string(conn.type.rawValue),
+                "host": .string(conn.host),
+                "port": .int(conn.port),
+                "database": .string(session?.activeDatabase ?? conn.database),
+                "username": .string(conn.username),
+                "is_connected": .bool(isConnected),
+                "ai_policy": .string(policy.rawValue),
+                "safe_mode": .string(conn.safeModeLevel.rawValue)
+            ])
+        }
+
+        return .object(["connections": .array(items)])
+    }
+
+    func connect(connectionId: UUID) async throws -> JSONValue {
+        let connection = try await resolveConnection(connectionId)
+
+        try await DatabaseManager.shared.connectToSession(connection)
+
+        let (serverVersion, currentDatabase, currentSchema) = await MainActor.run {
+            let session = DatabaseManager.shared.activeSessions[connectionId]
+            return (
+                session?.driver?.serverVersion,
+                session?.activeDatabase,
+                session?.currentSchema
+            )
+        }
+
+        var result: [String: JSONValue] = [
+            "status": "connected",
+            "current_database": .string(currentDatabase ?? "")
+        ]
+        if let version = serverVersion {
+            result["server_version"] = .string(version)
+        }
+        if let schema = currentSchema {
+            result["current_schema"] = .string(schema)
+        }
+
+        return .object(result)
+    }
+
+    func disconnect(connectionId: UUID) async throws {
+        let sessionExists = await MainActor.run {
+            DatabaseManager.shared.activeSessions[connectionId] != nil
+        }
+        guard sessionExists else {
+            throw MCPError.notConnected(connectionId)
+        }
+        await DatabaseManager.shared.disconnectSession(connectionId)
+    }
+
+    func getConnectionStatus(connectionId: UUID) async throws -> JSONValue {
+        let sessionInfo = await MainActor.run {
+            () -> (status: ConnectionStatus, database: String, schema: String?, version: String?, connectedAt: Date)? in
+            guard let session = DatabaseManager.shared.activeSessions[connectionId] else {
+                return nil
+            }
+            return (
+                status: session.status,
+                database: session.activeDatabase,
+                schema: session.currentSchema,
+                version: session.driver?.serverVersion,
+                connectedAt: session.connectedAt
+            )
+        }
+
+        guard let info = sessionInfo else {
+            throw MCPError.notConnected(connectionId)
+        }
+
+        let statusString: String
+        switch info.status {
+        case .connected: statusString = "connected"
+        case .connecting: statusString = "connecting"
+        case .disconnected: statusString = "disconnected"
+        case .error(let msg): statusString = "error: \(msg)"
+        }
+
+        var result: [String: JSONValue] = [
+            "status": .string(statusString),
+            "current_database": .string(info.database),
+            "connected_at": .string(ISO8601DateFormatter().string(from: info.connectedAt))
+        ]
+        if let schema = info.schema {
+            result["current_schema"] = .string(schema)
+        }
+        if let version = info.version {
+            result["server_version"] = .string(version)
+        }
+
+        return .object(result)
+    }
+
+    // MARK: - Query Execution
+
+    func executeQuery(
+        connectionId: UUID,
+        query: String,
+        maxRows: Int,
+        timeoutSeconds: Int
+    ) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+        let effectiveLimit = maxRows + 1
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        // trackOperation is @MainActor; Swift hops automatically.
+        // The driver.fetchRows call inside runs on the cooperative pool.
+        let result: QueryResult = try await DatabaseManager.shared.trackOperation(
+            sessionId: connectionId
+        ) {
+            try await withThrowingTaskGroup(of: QueryResult.self) { group in
+                group.addTask {
+                    try await driver.fetchRows(query: query, offset: 0, limit: effectiveLimit)
+                }
+                group.addTask {
+                    try await Task.sleep(for: .seconds(timeoutSeconds))
+                    throw MCPError.timeout("Query timed out after \(timeoutSeconds) seconds")
+                }
+                guard let first = try await group.next() else {
+                    throw MCPError.internalError("No result from query execution")
+                }
+                group.cancelAll()
+                return first
+            }
+        }
+
+        let executionTimeMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+        let isTruncated = result.rows.count > maxRows
+        let rows = isTruncated ? Array(result.rows.prefix(maxRows)) : result.rows
+
+        let jsonColumns: [JSONValue] = result.columns.map { .string($0) }
+        let jsonRows: [JSONValue] = rows.map { row in
+            .array(row.map { cell in
+                if let value = cell {
+                    return .string(value)
+                }
+                return .null
+            })
+        }
+
+        var response: [String: JSONValue] = [
+            "columns": .array(jsonColumns),
+            "rows": .array(jsonRows),
+            "row_count": .int(rows.count),
+            "rows_affected": .int(result.rowsAffected),
+            "execution_time_ms": .double(executionTimeMs),
+            "is_truncated": .bool(isTruncated)
+        ]
+        if let statusMessage = result.statusMessage {
+            response["status_message"] = .string(statusMessage)
+        }
+
+        return .object(response)
+    }
+
+    // MARK: - Schema Operations
+
+    func listTables(connectionId: UUID, includeRowCounts: Bool) async throws -> JSONValue {
+        let provider = await MainActor.run {
+            SchemaProviderRegistry.shared.provider(for: connectionId)
+        }
+        var cachedTables: [TableInfo] = []
+        if let provider {
+            let cached = await provider.getTables()
+            if !cached.isEmpty {
+                cachedTables = cached
+            }
+        }
+
+        let tables: [TableInfo]
+        if !cachedTables.isEmpty {
+            tables = cachedTables
+        } else {
+            let (driver, _) = try await resolveDriver(connectionId)
+            tables = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+                try await driver.fetchTables()
+            }
+        }
+
+        let jsonTables: [JSONValue] = tables.map { table in
+            var obj: [String: JSONValue] = [
+                "name": .string(table.name),
+                "type": .string(table.type.rawValue)
+            ]
+            if includeRowCounts, let rowCount = table.rowCount {
+                obj["row_count"] = .int(rowCount)
+            }
+            return .object(obj)
+        }
+
+        return .object(["tables": .array(jsonTables)])
+    }
+
+    func describeTable(connectionId: UUID, table: String, schema: String?) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+
+        // Sequential fetches: driver connections are NOT thread-safe,
+        // so concurrent calls on the same driver would race.
+        return try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+            let columns = try await driver.fetchColumns(table: table, schema: schema)
+            let indexes = try await driver.fetchIndexes(table: table)
+            let foreignKeys = try await driver.fetchForeignKeys(table: table)
+            let approxRowCount = try await driver.fetchApproximateRowCount(table: table)
+            let ddl = try? await driver.fetchTableDDL(table: table)
+
+            let jsonColumns: [JSONValue] = columns.map { col in
+                var obj: [String: JSONValue] = [
+                    "name": .string(col.name),
+                    "data_type": .string(col.dataType),
+                    "is_nullable": .bool(col.isNullable),
+                    "is_primary_key": .bool(col.isPrimaryKey)
+                ]
+                if let def = col.defaultValue { obj["default_value"] = .string(def) }
+                if let extra = col.extra { obj["extra"] = .string(extra) }
+                if let comment = col.comment, !comment.isEmpty { obj["comment"] = .string(comment) }
+                return .object(obj)
+            }
+
+            let jsonIndexes: [JSONValue] = indexes.map { idx in
+                .object([
+                    "name": .string(idx.name),
+                    "columns": .array(idx.columns.map { .string($0) }),
+                    "is_unique": .bool(idx.isUnique),
+                    "is_primary": .bool(idx.isPrimary),
+                    "type": .string(idx.type)
+                ])
+            }
+
+            let jsonFKs: [JSONValue] = foreignKeys.map { fk in
+                var obj: [String: JSONValue] = [
+                    "name": .string(fk.name),
+                    "column": .string(fk.column),
+                    "referenced_table": .string(fk.referencedTable),
+                    "referenced_column": .string(fk.referencedColumn),
+                    "on_delete": .string(fk.onDelete),
+                    "on_update": .string(fk.onUpdate)
+                ]
+                if let refSchema = fk.referencedSchema {
+                    obj["referenced_schema"] = .string(refSchema)
+                }
+                return .object(obj)
+            }
+
+            var result: [String: JSONValue] = [
+                "columns": .array(jsonColumns),
+                "indexes": .array(jsonIndexes),
+                "foreign_keys": .array(jsonFKs)
+            ]
+            if let ddl {
+                result["ddl"] = .string(ddl)
+            }
+            if let count = approxRowCount {
+                result["approximate_row_count"] = .int(count)
+            }
+
+            return .object(result)
+        }
+    }
+
+    func listDatabases(connectionId: UUID) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+        let databases = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+            try await driver.fetchDatabases()
+        }
+        return .object(["databases": .array(databases.map { .string($0) })])
+    }
+
+    func listSchemas(connectionId: UUID) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+        let schemas = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+            try await driver.fetchSchemas()
+        }
+        return .object(["schemas": .array(schemas.map { .string($0) })])
+    }
+
+    func getTableDDL(connectionId: UUID, table: String, schema: String?) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+        let ddl = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+            try await driver.fetchTableDDL(table: table)
+        }
+        return .object(["ddl": .string(ddl)])
+    }
+
+    // MARK: - Database/Schema Switching
+
+    func switchDatabase(connectionId: UUID, database: String) async throws -> JSONValue {
+        try await DatabaseManager.shared.switchDatabase(to: database, for: connectionId)
+        return .object([
+            "status": "switched",
+            "current_database": .string(database)
+        ])
+    }
+
+    func switchSchema(connectionId: UUID, schema: String) async throws -> JSONValue {
+        try await DatabaseManager.shared.switchSchema(to: schema, for: connectionId)
+        return .object([
+            "status": "switched",
+            "current_schema": .string(schema)
+        ])
+    }
+
+    // MARK: - Schema Resource (for resources/read)
+
+    func fetchSchemaResource(connectionId: UUID) async throws -> JSONValue {
+        let (driver, _) = try await resolveDriver(connectionId)
+
+        let tables = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+            try await driver.fetchTables()
+        }
+
+        var tableSchemas: [JSONValue] = []
+        for table in tables {
+            let columns = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+                try await driver.fetchColumns(table: table.name)
+            }
+
+            let jsonCols: [JSONValue] = columns.map { col in
+                .object([
+                    "name": .string(col.name),
+                    "data_type": .string(col.dataType),
+                    "is_nullable": .bool(col.isNullable),
+                    "is_primary_key": .bool(col.isPrimaryKey)
+                ])
+            }
+
+            tableSchemas.append(.object([
+                "name": .string(table.name),
+                "type": .string(table.type.rawValue),
+                "columns": .array(jsonCols)
+            ]))
+        }
+
+        return .object(["tables": .array(tableSchemas)])
+    }
+
+    // MARK: - History Resource
+
+    func fetchHistoryResource(
+        connectionId: UUID,
+        limit: Int,
+        search: String?,
+        dateFilter: String?
+    ) async throws -> JSONValue {
+        let filter: DateFilter
+        switch dateFilter {
+        case "today": filter = .today
+        case "thisWeek": filter = .thisWeek
+        case "thisMonth": filter = .thisMonth
+        default: filter = .all
+        }
+
+        let entries = await QueryHistoryStorage.shared.fetchHistory(
+            limit: limit,
+            connectionId: connectionId,
+            searchText: search,
+            dateFilter: filter
+        )
+
+        let jsonEntries: [JSONValue] = entries.map { entry in
+            var obj: [String: JSONValue] = [
+                "id": .string(entry.id.uuidString),
+                "query": .string(entry.query),
+                "database_name": .string(entry.databaseName),
+                "executed_at": .string(ISO8601DateFormatter().string(from: entry.executedAt)),
+                "execution_time_ms": .double(entry.executionTime * 1000),
+                "row_count": .int(entry.rowCount),
+                "was_successful": .bool(entry.wasSuccessful)
+            ]
+            if let errorMsg = entry.errorMessage {
+                obj["error_message"] = .string(errorMsg)
+            }
+            return .object(obj)
+        }
+
+        return .object(["history": .array(jsonEntries)])
+    }
+
+    // MARK: - Private Helpers
+
+    private func resolveDriver(_ connectionId: UUID) async throws -> (DatabaseDriver, DatabaseType) {
+        try await MainActor.run {
+            guard let session = DatabaseManager.shared.activeSessions[connectionId],
+                  let driver = session.driver else {
+                throw MCPError.notConnected(connectionId)
+            }
+            return (driver, session.connection.type)
+        }
+    }
+
+    private func resolveSession(_ connectionId: UUID) async throws -> ConnectionSession {
+        try await MainActor.run {
+            guard let session = DatabaseManager.shared.activeSessions[connectionId] else {
+                throw MCPError.notConnected(connectionId)
+            }
+            return session
+        }
+    }
+
+    private func resolveConnection(_ connectionId: UUID) async throws -> DatabaseConnection {
+        try await MainActor.run {
+            let connections = ConnectionStorage.shared.loadConnections()
+            guard let connection = connections.first(where: { $0.id == connectionId }) else {
+                throw MCPError.invalidParams("Connection not found: \(connectionId)")
+            }
+            return connection
+        }
+    }
+}

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -45,6 +45,32 @@ actor MCPConnectionBridge {
     func connect(connectionId: UUID) async throws -> JSONValue {
         let connection = try await resolveConnection(connectionId)
 
+        // Check if session already exists and is connected -- reuse without switching UI
+        let existingSession = await MainActor.run {
+            DatabaseManager.shared.activeSessions[connectionId]
+        }
+
+        if let existing = existingSession, existing.driver != nil {
+            // Already connected, return current state without switching the UI's active session
+            let serverVersion = existing.driver?.serverVersion
+            let currentDatabase = existing.activeDatabase
+            let currentSchema = existing.currentSchema
+
+            var result: [String: JSONValue] = [
+                "status": "connected",
+                "current_database": .string(currentDatabase)
+            ]
+            if let version = serverVersion {
+                result["server_version"] = .string(version)
+            }
+            if let schema = currentSchema {
+                result["current_schema"] = .string(schema)
+            }
+            return .object(result)
+        }
+
+        // Not connected yet -- create a new session via DatabaseManager.
+        // connectToSession is @MainActor; Swift hops automatically for async calls.
         try await DatabaseManager.shared.connectToSession(connection)
 
         let (serverVersion, currentDatabase, currentSchema) = await MainActor.run {
@@ -81,42 +107,55 @@ actor MCPConnectionBridge {
     }
 
     func getConnectionStatus(connectionId: UUID) async throws -> JSONValue {
-        let sessionInfo = await MainActor.run {
-            () -> (status: ConnectionStatus, database: String, schema: String?, version: String?, connectedAt: Date)? in
+        let core = await MainActor.run {
+            () -> (status: ConnectionStatus, database: String, schema: String?)? in
             guard let session = DatabaseManager.shared.activeSessions[connectionId] else {
                 return nil
             }
-            return (
-                status: session.status,
-                database: session.activeDatabase,
-                schema: session.currentSchema,
-                version: session.driver?.serverVersion,
-                connectedAt: session.connectedAt
-            )
+            return (session.status, session.activeDatabase, session.currentSchema)
         }
 
-        guard let info = sessionInfo else {
+        guard let core else {
             throw MCPError.notConnected(connectionId)
         }
 
+        let meta = await MainActor.run {
+            () -> (version: String?, connectedAt: Date, lastActiveAt: Date) in
+            let session = DatabaseManager.shared.activeSessions[connectionId]
+            return (
+                session?.driver?.serverVersion,
+                session?.connectedAt ?? Date(),
+                session?.lastActiveAt ?? Date()
+            )
+        }
+
         let statusString: String
-        switch info.status {
+        var errorDetail: JSONValue?
+        switch core.status {
         case .connected: statusString = "connected"
         case .connecting: statusString = "connecting"
         case .disconnected: statusString = "disconnected"
-        case .error(let msg): statusString = "error: \(msg)"
+        case .error(let msg):
+            statusString = "error"
+            errorDetail = .object([
+                "message": .string(msg)
+            ])
         }
 
         var result: [String: JSONValue] = [
             "status": .string(statusString),
-            "current_database": .string(info.database),
-            "connected_at": .string(ISO8601DateFormatter().string(from: info.connectedAt))
+            "current_database": .string(core.database),
+            "connected_at": .string(ISO8601DateFormatter().string(from: meta.connectedAt)),
+            "last_active_at": .string(ISO8601DateFormatter().string(from: meta.lastActiveAt))
         ]
-        if let schema = info.schema {
+        if let schema = core.schema {
             result["current_schema"] = .string(schema)
         }
-        if let version = info.version {
+        if let version = meta.version {
             result["server_version"] = .string(version)
+        }
+        if let errorDetail {
+            result["error"] = errorDetail
         }
 
         return .object(result)
@@ -146,6 +185,8 @@ actor MCPConnectionBridge {
                 }
                 group.addTask {
                     try await Task.sleep(for: .seconds(timeoutSeconds))
+                    // Cancel the driver query before throwing
+                    try? driver.cancelQuery()
                     throw MCPError.timeout("Query timed out after \(timeoutSeconds) seconds")
                 }
                 guard let first = try await group.next() else {
@@ -156,7 +197,7 @@ actor MCPConnectionBridge {
             }
         }
 
-        let executionTimeMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+        let executionTimeMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1_000
         let isTruncated = result.rows.count > maxRows
         let rows = isTruncated ? Array(result.rows.prefix(maxRows)) : result.rows
 
@@ -316,6 +357,7 @@ actor MCPConnectionBridge {
     // MARK: - Database/Schema Switching
 
     func switchDatabase(connectionId: UUID, database: String) async throws -> JSONValue {
+        // switchDatabase is @MainActor; Swift hops automatically for async calls.
         try await DatabaseManager.shared.switchDatabase(to: database, for: connectionId)
         return .object([
             "status": "switched",
@@ -324,6 +366,7 @@ actor MCPConnectionBridge {
     }
 
     func switchSchema(connectionId: UUID, schema: String) async throws -> JSONValue {
+        // switchSchema is @MainActor; Swift hops automatically for async calls.
         try await DatabaseManager.shared.switchSchema(to: schema, for: connectionId)
         return .object([
             "status": "switched",
@@ -334,14 +377,34 @@ actor MCPConnectionBridge {
     // MARK: - Schema Resource (for resources/read)
 
     func fetchSchemaResource(connectionId: UUID) async throws -> JSONValue {
-        let (driver, _) = try await resolveDriver(connectionId)
-
-        let tables = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
-            try await driver.fetchTables()
+        // Check SchemaProviderRegistry cache first
+        let provider = await MainActor.run {
+            SchemaProviderRegistry.shared.provider(for: connectionId)
+        }
+        var cachedTables: [TableInfo] = []
+        if let provider {
+            let cached = await provider.getTables()
+            if !cached.isEmpty {
+                cachedTables = cached
+            }
         }
 
+        let tables: [TableInfo]
+        if !cachedTables.isEmpty {
+            tables = cachedTables
+        } else {
+            let (driver, _) = try await resolveDriver(connectionId)
+            tables = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
+                try await driver.fetchTables()
+            }
+        }
+
+        // Limit to first 100 tables to prevent excessive round-trips
+        let limitedTables = Array(tables.prefix(100))
+
+        let (driver, _) = try await resolveDriver(connectionId)
         var tableSchemas: [JSONValue] = []
-        for table in tables {
+        for table in limitedTables {
             let columns = try await DatabaseManager.shared.trackOperation(sessionId: connectionId) {
                 try await driver.fetchColumns(table: table.name)
             }
@@ -362,7 +425,13 @@ actor MCPConnectionBridge {
             ]))
         }
 
-        return .object(["tables": .array(tableSchemas)])
+        var result: [String: JSONValue] = ["tables": .array(tableSchemas)]
+        if tables.count > 100 {
+            result["truncated"] = .bool(true)
+            result["total_tables"] = .int(tables.count)
+        }
+
+        return .object(result)
     }
 
     // MARK: - History Resource
@@ -394,7 +463,7 @@ actor MCPConnectionBridge {
                 "query": .string(entry.query),
                 "database_name": .string(entry.databaseName),
                 "executed_at": .string(ISO8601DateFormatter().string(from: entry.executedAt)),
-                "execution_time_ms": .double(entry.executionTime * 1000),
+                "execution_time_ms": .double(entry.executionTime * 1_000),
                 "row_count": .int(entry.rowCount),
                 "was_successful": .bool(entry.wasSuccessful)
             ]

--- a/TablePro/Core/MCP/MCPHTTPParser.swift
+++ b/TablePro/Core/MCP/MCPHTTPParser.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+
+struct HTTPRequest: Sendable {
+    enum Method: String, Sendable {
+        case get = "GET"
+        case post = "POST"
+        case delete = "DELETE"
+        case options = "OPTIONS"
+    }
+
+    let method: Method
+    let path: String
+    let headers: [String: String]
+    let body: Data?
+}
+
+enum HTTPParseError: Error, Sendable {
+    case incomplete
+    case malformedRequestLine
+    case malformedHeaders
+    case unsupportedMethod(String)
+    case bodyTooLarge
+}
+
+enum MCPHTTPParser {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPHTTPParser")
+
+    static let maxBodySize = 10 * 1_024 * 1_024
+
+    static func parse(_ data: Data) -> Result<HTTPRequest, HTTPParseError> {
+        let crlfcrlf = Data([0x0D, 0x0A, 0x0D, 0x0A])
+        let lflf = Data([0x0A, 0x0A])
+
+        let headerEndRange: Range<Data.Index>
+        if let range = data.range(of: crlfcrlf) {
+            headerEndRange = range
+        } else if let range = data.range(of: lflf) {
+            headerEndRange = range
+        } else {
+            return .failure(.incomplete)
+        }
+
+        let headerData = data[data.startIndex..<headerEndRange.lowerBound]
+
+        guard let headerString = String(data: headerData, encoding: .utf8) else {
+            return .failure(.malformedHeaders)
+        }
+
+        // Normalize \r\n to \n then split
+        let normalized = headerString.replacingOccurrences(of: "\r\n", with: "\n")
+        let headerLines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+
+        guard let firstLine = headerLines.first, !firstLine.isEmpty else {
+            return .failure(.malformedRequestLine)
+        }
+
+        let requestParts = firstLine.split(separator: " ", maxSplits: 2)
+
+        guard requestParts.count >= 2 else {
+            return .failure(.malformedRequestLine)
+        }
+
+        let methodString = String(requestParts[0])
+        guard let method = HTTPRequest.Method(rawValue: methodString) else {
+            return .failure(.unsupportedMethod(methodString))
+        }
+
+        let path = String(requestParts[1])
+
+        var headers: [String: String] = [:]
+        for i in 1..<headerLines.count {
+            let line = headerLines[i]
+            if line.isEmpty { continue }
+            guard let colonIndex = line.firstIndex(of: ":") else {
+                continue
+            }
+            let key = line[line.startIndex..<colonIndex]
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased()
+            let value = line[line.index(after: colonIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+            headers[key] = value
+        }
+
+        let bodyStartIndex = headerEndRange.upperBound
+        var body: Data?
+
+        if method == .post {
+            if let transferEncoding = headers["transfer-encoding"],
+               transferEncoding.lowercased().contains("chunked")
+            {
+                logger.warning("Chunked transfer encoding not supported, treating body as empty")
+            } else if let contentLengthStr = headers["content-length"],
+                      let contentLength = Int(contentLengthStr)
+            {
+                if contentLength > maxBodySize {
+                    return .failure(.bodyTooLarge)
+                }
+
+                let availableBytes = data.count - bodyStartIndex
+                if availableBytes < contentLength {
+                    return .failure(.incomplete)
+                }
+
+                body = data[bodyStartIndex..<(bodyStartIndex + contentLength)]
+            }
+        }
+
+        return .success(HTTPRequest(
+            method: method,
+            path: path,
+            headers: headers,
+            body: body
+        ))
+    }
+
+    static func buildResponse(
+        status: Int,
+        statusText: String,
+        headers: [(String, String)],
+        body: Data?
+    ) -> Data {
+        var response = "HTTP/1.1 \(status) \(statusText)\r\n"
+        for (key, value) in headers {
+            response += "\(key): \(value)\r\n"
+        }
+        if let body {
+            response += "Content-Length: \(body.count)\r\n"
+        }
+        response += "\r\n"
+        var data = Data(response.utf8)
+        if let body {
+            data.append(body)
+        }
+        return data
+    }
+
+    static func buildSSEHeaders(sessionId: String) -> Data {
+        let headers = "HTTP/1.1 200 OK\r\n"
+            + "Content-Type: text/event-stream\r\n"
+            + "Cache-Control: no-cache\r\n"
+            + "Connection: keep-alive\r\n"
+            + "Mcp-Session-Id: \(sessionId)\r\n"
+            + "\r\n"
+        return Data(headers.utf8)
+    }
+
+    static func buildSSEEvent(data: Data) -> Data {
+        var event = Data("data: ".utf8)
+        event.append(data)
+        event.append(Data("\n\n".utf8))
+        return event
+    }
+
+    static func statusText(for code: Int) -> String {
+        switch code {
+        case 200: return "OK"
+        case 202: return "Accepted"
+        case 204: return "No Content"
+        case 400: return "Bad Request"
+        case 404: return "Not Found"
+        case 405: return "Method Not Allowed"
+        case 500: return "Internal Server Error"
+        default: return "Unknown"
+        }
+    }
+}

--- a/TablePro/Core/MCP/MCPHTTPParser.swift
+++ b/TablePro/Core/MCP/MCPHTTPParser.swift
@@ -210,18 +210,25 @@ enum MCPHTTPParser {
         return data
     }
 
-    static func buildSSEHeaders(sessionId: String) -> Data {
-        let headers = "HTTP/1.1 200 OK\r\n"
+    static func buildSSEHeaders(sessionId: String, corsHeaders: [(String, String)] = []) -> Data {
+        var response = "HTTP/1.1 200 OK\r\n"
             + "Content-Type: text/event-stream\r\n"
             + "Cache-Control: no-cache\r\n"
             + "Connection: keep-alive\r\n"
             + "Mcp-Session-Id: \(sessionId)\r\n"
-            + "\r\n"
-        return Data(headers.utf8)
+        for (key, value) in corsHeaders {
+            response += "\(key): \(value)\r\n"
+        }
+        response += "\r\n"
+        return Data(response.utf8)
     }
 
-    static func buildSSEEvent(data: Data) -> Data {
-        var event = Data("data: ".utf8)
+    static func buildSSEEvent(data: Data, id: String? = nil) -> Data {
+        var event = Data()
+        if let id {
+            event.append(Data("id: \(id)\n".utf8))
+        }
+        event.append(Data("data: ".utf8))
         event.append(data)
         event.append(Data("\n\n".utf8))
         return event
@@ -233,8 +240,10 @@ enum MCPHTTPParser {
         case 202: return "Accepted"
         case 204: return "No Content"
         case 400: return "Bad Request"
+        case 403: return "Forbidden"
         case 404: return "Not Found"
         case 405: return "Method Not Allowed"
+        case 406: return "Not Acceptable"
         case 413: return "Content Too Large"
         case 500: return "Internal Server Error"
         default: return "Unknown"

--- a/TablePro/Core/MCP/MCPHTTPParser.swift
+++ b/TablePro/Core/MCP/MCPHTTPParser.swift
@@ -21,6 +21,7 @@ enum HTTPParseError: Error, Sendable {
     case malformedHeaders
     case unsupportedMethod(String)
     case bodyTooLarge
+    case malformedChunkedEncoding
 }
 
 enum MCPHTTPParser {
@@ -90,7 +91,16 @@ enum MCPHTTPParser {
             if let transferEncoding = headers["transfer-encoding"],
                transferEncoding.lowercased().contains("chunked")
             {
-                logger.warning("Chunked transfer encoding not supported, treating body as empty")
+                let bodyData = data[bodyStartIndex...]
+                switch decodeChunkedBody(bodyData) {
+                case .success(let decoded):
+                    if decoded.count > maxBodySize {
+                        return .failure(.bodyTooLarge)
+                    }
+                    body = decoded
+                case .failure(let error):
+                    return .failure(error)
+                }
             } else if let contentLengthStr = headers["content-length"],
                       let contentLength = Int(contentLengthStr)
             {
@@ -114,6 +124,70 @@ enum MCPHTTPParser {
             body: body
         ))
     }
+
+    // MARK: - Chunked Transfer Encoding
+
+    /// Decode chunked transfer encoding body.
+    /// Format: <chunk-size-hex>\r\n<chunk-data>\r\n ... 0\r\n\r\n
+    private static func decodeChunkedBody(_ data: Data) -> Result<Data, HTTPParseError> {
+        var result = Data()
+        var offset = data.startIndex
+
+        while offset < data.endIndex {
+            // Find the end of the chunk size line
+            guard let lineEnd = findCRLF(in: data, from: offset) else {
+                return .failure(.incomplete)
+            }
+
+            let sizeData = data[offset..<lineEnd]
+            guard let sizeString = String(data: sizeData, encoding: .ascii)?.trimmingCharacters(in: .whitespaces),
+                  let chunkSize = UInt(sizeString, radix: 16)
+            else {
+                return .failure(.malformedChunkedEncoding)
+            }
+
+            // Move past the \r\n after chunk size
+            let chunkDataStart = lineEnd + 2
+
+            // Terminal chunk
+            if chunkSize == 0 {
+                return .success(result)
+            }
+
+            let chunkDataEnd = chunkDataStart + Int(chunkSize)
+
+            // Check we have enough data for the chunk + trailing \r\n
+            guard chunkDataEnd + 2 <= data.endIndex else {
+                return .failure(.incomplete)
+            }
+
+            // Check accumulated size
+            if result.count + Int(chunkSize) > maxBodySize {
+                return .failure(.bodyTooLarge)
+            }
+
+            result.append(data[chunkDataStart..<chunkDataEnd])
+
+            // Skip past the trailing \r\n after chunk data
+            offset = chunkDataEnd + 2
+        }
+
+        return .failure(.incomplete)
+    }
+
+    /// Find \r\n in data starting from given offset
+    private static func findCRLF(in data: Data, from start: Data.Index) -> Data.Index? {
+        var i = start
+        while i < data.endIndex - 1 {
+            if data[i] == 0x0D, data[i + 1] == 0x0A {
+                return i
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    // MARK: - Response Building
 
     static func buildResponse(
         status: Int,
@@ -161,6 +235,7 @@ enum MCPHTTPParser {
         case 400: return "Bad Request"
         case 404: return "Not Found"
         case 405: return "Method Not Allowed"
+        case 413: return "Content Too Large"
         case 500: return "Internal Server Error"
         default: return "Unknown"
         }

--- a/TablePro/Core/MCP/MCPMessageTypes.swift
+++ b/TablePro/Core/MCP/MCPMessageTypes.swift
@@ -1,0 +1,430 @@
+//
+//  MCPMessageTypes.swift
+//  TablePro
+//
+
+import Foundation
+
+// MARK: - JSONValue
+
+enum JSONValue: Codable, Equatable, Sendable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+
+        if let boolValue = try? container.decode(Bool.self) {
+            self = .bool(boolValue)
+            return
+        }
+
+        if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+            return
+        }
+
+        if let doubleValue = try? container.decode(Double.self) {
+            self = .double(doubleValue)
+            return
+        }
+
+        if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+            return
+        }
+
+        if let arrayValue = try? container.decode([JSONValue].self) {
+            self = .array(arrayValue)
+            return
+        }
+
+        if let objectValue = try? container.decode([String: JSONValue].self) {
+            self = .object(objectValue)
+            return
+        }
+
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode JSONValue")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+// MARK: - JSONValue Literals
+
+extension JSONValue: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension JSONValue: ExpressibleByIntegerLiteral {
+    init(integerLiteral value: Int) {
+        self = .int(value)
+    }
+}
+
+extension JSONValue: ExpressibleByBooleanLiteral {
+    init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}
+
+extension JSONValue: ExpressibleByNilLiteral {
+    init(nilLiteral: ()) {
+        self = .null
+    }
+}
+
+extension JSONValue: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: JSONValue...) {
+        self = .array(elements)
+    }
+}
+
+extension JSONValue: ExpressibleByDictionaryLiteral {
+    init(dictionaryLiteral elements: (String, JSONValue)...) {
+        self = .object(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+// MARK: - JSONValue Accessors
+
+extension JSONValue {
+    subscript(key: String) -> JSONValue? {
+        guard case .object(let dict) = self else { return nil }
+        return dict[key]
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var intValue: Int? {
+        guard case .int(let value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    var doubleValue: Double? {
+        switch self {
+        case .double(let value):
+            return value
+        case .int(let value):
+            return Double(value)
+        default:
+            return nil
+        }
+    }
+
+    var arrayValue: [JSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    var objectValue: [String: JSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+}
+
+// MARK: - JSONRPCId
+
+enum JSONRPCId: Codable, Equatable, Hashable, Sendable {
+    case string(String)
+    case int(Int)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+            return
+        }
+
+        if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+            return
+        }
+
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSONRPCId must be a string or integer")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+// MARK: - JSON-RPC 2.0 Base Types
+
+struct JSONRPCRequest: Codable, Sendable {
+    let jsonrpc: String
+    let id: JSONRPCId?
+    let method: String
+    let params: JSONValue?
+}
+
+struct JSONRPCResponse: Codable, Sendable {
+    let id: JSONRPCId
+    let result: JSONValue
+
+    var jsonrpc: String { "2.0" }
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case result
+    }
+
+    init(id: JSONRPCId, result: JSONValue) {
+        self.id = id
+        self.result = result
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _ = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decode(JSONRPCId.self, forKey: .id)
+        result = try container.decode(JSONValue.self, forKey: .result)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("2.0", forKey: .jsonrpc)
+        try container.encode(id, forKey: .id)
+        try container.encode(result, forKey: .result)
+    }
+}
+
+struct JSONRPCErrorResponse: Codable, Sendable {
+    let id: JSONRPCId?
+    let error: JSONRPCErrorDetail
+
+    var jsonrpc: String { "2.0" }
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case error
+    }
+
+    init(id: JSONRPCId?, error: JSONRPCErrorDetail) {
+        self.id = id
+        self.error = error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _ = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decodeIfPresent(JSONRPCId.self, forKey: .id)
+        error = try container.decode(JSONRPCErrorDetail.self, forKey: .error)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("2.0", forKey: .jsonrpc)
+        try container.encode(id, forKey: .id)
+        try container.encode(error, forKey: .error)
+    }
+}
+
+struct JSONRPCErrorDetail: Codable, Sendable {
+    let code: Int
+    let message: String
+    let data: JSONValue?
+}
+
+// MARK: - MCPError
+
+enum MCPError: Error, Sendable {
+    case parseError
+    case invalidRequest(String)
+    case methodNotFound(String)
+    case invalidParams(String)
+    case internalError(String)
+    case notConnected(UUID)
+    case forbidden(String)
+    case timeout(String)
+    case resultTooLarge
+    case serverDisabled
+
+    var code: Int {
+        switch self {
+        case .parseError: -32_700
+        case .invalidRequest: -32_600
+        case .methodNotFound: -32_601
+        case .invalidParams: -32_602
+        case .internalError: -32_603
+        case .notConnected: -32_001
+        case .forbidden: -32_002
+        case .timeout: -32_003
+        case .resultTooLarge: -32_004
+        case .serverDisabled: -32_005
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .parseError:
+            "Parse error"
+        case .invalidRequest(let detail):
+            "Invalid request: \(detail)"
+        case .methodNotFound(let method):
+            "Method not found: \(method)"
+        case .invalidParams(let detail):
+            "Invalid params: \(detail)"
+        case .internalError(let detail):
+            "Internal error: \(detail)"
+        case .notConnected(let connectionId):
+            "Not connected: \(connectionId)"
+        case .forbidden(let detail):
+            "Forbidden: \(detail)"
+        case .timeout(let detail):
+            "Timeout: \(detail)"
+        case .resultTooLarge:
+            "Result too large"
+        case .serverDisabled:
+            "MCP server is disabled"
+        }
+    }
+
+    func toJsonRpcError(id: JSONRPCId?) -> JSONRPCErrorResponse {
+        JSONRPCErrorResponse(
+            id: id,
+            error: JSONRPCErrorDetail(code: code, message: message, data: nil)
+        )
+    }
+}
+
+// MARK: - MCP Initialize
+
+struct MCPInitializeParams: Codable, Sendable {
+    let protocolVersion: String
+    let capabilities: JSONValue?
+    let clientInfo: MCPClientInfo
+}
+
+struct MCPClientInfo: Codable, Sendable {
+    let name: String
+    let version: String?
+}
+
+struct MCPInitializeResult: Codable, Sendable {
+    let protocolVersion: String
+    let capabilities: MCPServerCapabilities
+    let serverInfo: MCPServerInfo
+}
+
+struct MCPServerCapabilities: Codable, Sendable {
+    let tools: ToolCapability?
+    let resources: ResourceCapability?
+
+    struct ToolCapability: Codable, Sendable {
+        let listChanged: Bool
+    }
+
+    struct ResourceCapability: Codable, Sendable {
+        let subscribe: Bool
+        let listChanged: Bool
+    }
+}
+
+struct MCPServerInfo: Codable, Sendable {
+    let name: String
+    let version: String
+}
+
+// MARK: - MCP Tools
+
+struct MCPToolDefinition: Codable, Sendable {
+    let name: String
+    let description: String
+    let inputSchema: JSONValue
+}
+
+struct MCPToolCallParams: Codable, Sendable {
+    let name: String
+    let arguments: JSONValue?
+}
+
+struct MCPToolResult: Codable, Sendable {
+    let content: [MCPContent]
+    let isError: Bool?
+}
+
+struct MCPContent: Codable, Sendable {
+    let type: String
+    let text: String
+
+    static func text(_ value: String) -> MCPContent {
+        MCPContent(type: "text", text: value)
+    }
+}
+
+// MARK: - MCP Resources
+
+struct MCPResourceDefinition: Codable, Sendable {
+    let uri: String
+    let name: String
+    let description: String?
+    let mimeType: String?
+}
+
+struct MCPResourceReadParams: Codable, Sendable {
+    let uri: String
+}
+
+struct MCPResourceContent: Codable, Sendable {
+    let uri: String
+    let mimeType: String?
+    let text: String?
+}
+
+struct MCPResourceReadResult: Codable, Sendable {
+    let contents: [MCPResourceContent]
+}
+
+// MARK: - MCP Cancellation
+
+struct MCPCancelParams: Codable, Sendable {
+    let requestId: JSONRPCId
+}

--- a/TablePro/Core/MCP/MCPMessageTypes.swift
+++ b/TablePro/Core/MCP/MCPMessageTypes.swift
@@ -282,8 +282,8 @@ enum MCPError: Error, Sendable {
     case invalidParams(String)
     case internalError(String)
     case notConnected(UUID)
-    case forbidden(String)
-    case timeout(String)
+    case forbidden(String, context: [String: String]? = nil)
+    case timeout(String, context: [String: String]? = nil)
     case resultTooLarge
     case serverDisabled
 
@@ -294,11 +294,11 @@ enum MCPError: Error, Sendable {
         case .methodNotFound: -32_601
         case .invalidParams: -32_602
         case .internalError: -32_603
-        case .notConnected: -32_001
-        case .forbidden: -32_002
-        case .timeout: -32_003
-        case .resultTooLarge: -32_004
-        case .serverDisabled: -32_005
+        case .notConnected: -32_000
+        case .forbidden: -32_001
+        case .timeout: -32_002
+        case .resultTooLarge: -32_003
+        case .serverDisabled: -32_004
         }
     }
 
@@ -316,9 +316,9 @@ enum MCPError: Error, Sendable {
             "Internal error: \(detail)"
         case .notConnected(let connectionId):
             "Not connected: \(connectionId)"
-        case .forbidden(let detail):
+        case .forbidden(let detail, _):
             "Forbidden: \(detail)"
-        case .timeout(let detail):
+        case .timeout(let detail, _):
             "Timeout: \(detail)"
         case .resultTooLarge:
             "Result too large"
@@ -327,10 +327,26 @@ enum MCPError: Error, Sendable {
         }
     }
 
+    private var contextData: JSONValue? {
+        switch self {
+        case .forbidden(_, let context), .timeout(_, let context):
+            guard let context, !context.isEmpty else { return nil }
+            var dict: [String: JSONValue] = [:]
+            for (key, value) in context {
+                dict[key] = .string(value)
+            }
+            return .object(dict)
+        case .notConnected(let connectionId):
+            return .object(["connection_id": .string(connectionId.uuidString)])
+        default:
+            return nil
+        }
+    }
+
     func toJsonRpcError(id: JSONRPCId?) -> JSONRPCErrorResponse {
         JSONRPCErrorResponse(
             id: id,
-            error: JSONRPCErrorDetail(code: code, message: message, data: nil)
+            error: JSONRPCErrorDetail(code: code, message: message, data: contextData)
         )
     }
 }

--- a/TablePro/Core/MCP/MCPMessageTypes.swift
+++ b/TablePro/Core/MCP/MCPMessageTypes.swift
@@ -353,12 +353,6 @@ enum MCPError: Error, Sendable {
 
 // MARK: - MCP Initialize
 
-struct MCPInitializeParams: Codable, Sendable {
-    let protocolVersion: String
-    let capabilities: JSONValue?
-    let clientInfo: MCPClientInfo
-}
-
 struct MCPClientInfo: Codable, Sendable {
     let name: String
     let version: String?
@@ -397,11 +391,6 @@ struct MCPToolDefinition: Codable, Sendable {
     let inputSchema: JSONValue
 }
 
-struct MCPToolCallParams: Codable, Sendable {
-    let name: String
-    let arguments: JSONValue?
-}
-
 struct MCPToolResult: Codable, Sendable {
     let content: [MCPContent]
     let isError: Bool?
@@ -425,10 +414,6 @@ struct MCPResourceDefinition: Codable, Sendable {
     let mimeType: String?
 }
 
-struct MCPResourceReadParams: Codable, Sendable {
-    let uri: String
-}
-
 struct MCPResourceContent: Codable, Sendable {
     let uri: String
     let mimeType: String?
@@ -439,8 +424,3 @@ struct MCPResourceReadResult: Codable, Sendable {
     let contents: [MCPResourceContent]
 }
 
-// MARK: - MCP Cancellation
-
-struct MCPCancelParams: Codable, Sendable {
-    let requestId: JSONRPCId
-}

--- a/TablePro/Core/MCP/MCPResourceHandler.swift
+++ b/TablePro/Core/MCP/MCPResourceHandler.swift
@@ -120,6 +120,7 @@ final class MCPResourceHandler: Sendable {
         guard let data = try? encoder.encode(value),
               let string = String(data: data, encoding: .utf8)
         else {
+            Self.logger.warning("Failed to encode JSON value")
             return "{}"
         }
         return string

--- a/TablePro/Core/MCP/MCPResourceHandler.swift
+++ b/TablePro/Core/MCP/MCPResourceHandler.swift
@@ -1,0 +1,127 @@
+//
+//  MCPResourceHandler.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+final class MCPResourceHandler: Sendable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPResourceHandler")
+
+    private let bridge: MCPConnectionBridge
+
+    init(bridge: MCPConnectionBridge) {
+        self.bridge = bridge
+    }
+
+    // MARK: - Dispatch
+
+    func handleResourceRead(uri: String, sessionId: String) async throws -> MCPResourceReadResult {
+        guard let components = URLComponents(string: uri) else {
+            throw MCPError.invalidParams("Malformed URI: \(uri)")
+        }
+
+        guard components.scheme == "tablepro" else {
+            throw MCPError.invalidParams("Unsupported URI scheme: \(components.scheme ?? "nil")")
+        }
+
+        let pathSegments = parsePathSegments(from: uri)
+
+        if pathSegments == ["connections"] {
+            return try await handleConnectionsList(uri: uri)
+        }
+
+        if pathSegments.count == 3,
+           pathSegments[0] == "connections",
+           pathSegments[2] == "schema"
+        {
+            guard let connectionId = UUID(uuidString: pathSegments[1]) else {
+                throw MCPError.invalidParams("Invalid connection UUID in URI")
+            }
+            return try await handleSchemaResource(uri: uri, connectionId: connectionId)
+        }
+
+        if pathSegments.count == 3,
+           pathSegments[0] == "connections",
+           pathSegments[2] == "history"
+        {
+            guard let connectionId = UUID(uuidString: pathSegments[1]) else {
+                throw MCPError.invalidParams("Invalid connection UUID in URI")
+            }
+            let queryItems = components.queryItems ?? []
+            return try await handleHistoryResource(uri: uri, connectionId: connectionId, queryItems: queryItems)
+        }
+
+        throw MCPError.invalidParams("Unknown resource URI: \(uri)")
+    }
+
+    // MARK: - Resource Handlers
+
+    private func handleConnectionsList(uri: String) async throws -> MCPResourceReadResult {
+        let result = await bridge.listConnections()
+        let jsonString = encodeJSON(result)
+        return MCPResourceReadResult(contents: [
+            MCPResourceContent(uri: uri, mimeType: "application/json", text: jsonString)
+        ])
+    }
+
+    private func handleSchemaResource(uri: String, connectionId: UUID) async throws -> MCPResourceReadResult {
+        let result = try await bridge.fetchSchemaResource(connectionId: connectionId)
+        let jsonString = encodeJSON(result)
+        return MCPResourceReadResult(contents: [
+            MCPResourceContent(uri: uri, mimeType: "application/json", text: jsonString)
+        ])
+    }
+
+    private func handleHistoryResource(
+        uri: String,
+        connectionId: UUID,
+        queryItems: [URLQueryItem]
+    ) async throws -> MCPResourceReadResult {
+        let limit = queryItems.first(where: { $0.name == "limit" })
+            .flatMap { $0.value }
+            .flatMap { Int($0) }
+            ?? 50
+
+        let clampedLimit = min(max(limit, 1), 500)
+        let search = queryItems.first(where: { $0.name == "search" })?.value
+        let dateFilter = queryItems.first(where: { $0.name == "date_filter" })?.value
+
+        let result = try await bridge.fetchHistoryResource(
+            connectionId: connectionId,
+            limit: clampedLimit,
+            search: search,
+            dateFilter: dateFilter
+        )
+        let jsonString = encodeJSON(result)
+        return MCPResourceReadResult(contents: [
+            MCPResourceContent(uri: uri, mimeType: "application/json", text: jsonString)
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private func parsePathSegments(from uri: String) -> [String] {
+        guard let range = uri.range(of: "://") else { return [] }
+        let afterScheme = String(uri[range.upperBound...])
+        let pathOnly: String
+        if let queryStart = afterScheme.firstIndex(of: "?") {
+            pathOnly = String(afterScheme[..<queryStart])
+        } else {
+            pathOnly = afterScheme
+        }
+        return pathOnly.split(separator: "/").map(String.init)
+    }
+
+    private func encodeJSON(_ value: JSONValue) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+}

--- a/TablePro/Core/MCP/MCPRouter.swift
+++ b/TablePro/Core/MCP/MCPRouter.swift
@@ -13,10 +13,11 @@ final class MCPRouter: Sendable {
     private let decoder: JSONDecoder
 
     enum RouteResult: Sendable {
-        case jsonResponse(Data, sessionId: String?)
+        case json(Data, sessionId: String?)
         case sseStream(sessionId: String)
+        case accepted
+        case noContent
         case httpError(status: Int, message: String)
-        case noContent(headers: [(String, String)])
     }
 
     init() {
@@ -29,14 +30,16 @@ final class MCPRouter: Sendable {
     // MARK: - Main Entry
 
     func route(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
-        // OAuth discovery probes from Claude Code / MCP SDK.
-        // Return 404 with no auth requirement so the SDK skips authentication.
         if request.path.hasPrefix("/.well-known/") {
             return .httpError(status: 404, message: "Not found")
         }
 
         guard request.path == "/mcp" || request.path.hasPrefix("/mcp?") else {
             return .httpError(status: 404, message: "Not found")
+        }
+
+        if let origin = request.headers["origin"], !isAllowedOrigin(origin) {
+            return .httpError(status: 403, message: "Forbidden origin")
         }
 
         switch request.method {
@@ -51,24 +54,31 @@ final class MCPRouter: Sendable {
         }
     }
 
+    private func isAllowedOrigin(_ origin: String) -> Bool {
+        guard let components = URLComponents(string: origin),
+              let host = components.host
+        else {
+            return false
+        }
+        let allowedHosts: Set<String> = ["localhost", "127.0.0.1", "[::1]"]
+        return allowedHosts.contains(host)
+    }
+
     // MARK: - OPTIONS
 
     private func handleOptions() -> RouteResult {
-        .noContent(headers: [
-            ("Access-Control-Allow-Origin", "*"),
-            ("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS"),
-            ("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id"),
-            ("Access-Control-Max-Age", "86400")
-        ])
+        .noContent
     }
 
     // MARK: - GET (SSE Stream)
 
     private func handleGet(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
-        guard let sessionId = request.headers["mcp-session-id"],
-              let session = await server.session(for: sessionId)
-        else {
-            return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: nil)
+        guard let sessionId = request.headers["mcp-session-id"] else {
+            return .httpError(status: 400, message: "Missing Mcp-Session-Id header")
+        }
+
+        guard let session = await server.session(for: sessionId) else {
+            return .httpError(status: 404, message: "Session not found")
         }
 
         await session.markActive()
@@ -79,21 +89,25 @@ final class MCPRouter: Sendable {
 
     private func handleDelete(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
         guard let sessionId = request.headers["mcp-session-id"] else {
-            return encodeError(MCPError.invalidRequest("Missing Mcp-Session-Id"), id: nil)
+            return .httpError(status: 400, message: "Missing Mcp-Session-Id header")
+        }
+
+        guard await server.session(for: sessionId) != nil else {
+            return .httpError(status: 404, message: "Session not found")
         }
 
         await server.removeSession(sessionId)
         Self.logger.info("Session terminated via DELETE: \(sessionId)")
-
-        guard let body = try? encoder.encode(["status": "session_terminated"]) else {
-            return .httpError(status: 500, message: "Encoding error")
-        }
-        return .jsonResponse(body, sessionId: nil)
+        return .noContent
     }
 
     // MARK: - POST (JSON-RPC)
 
     private func handlePost(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        if let accept = request.headers["accept"], !accept.contains("application/json") && !accept.contains("*/*") {
+            return .httpError(status: 406, message: "Accept header must include application/json")
+        }
+
         guard let body = request.body else {
             return encodeError(MCPError.parseError, id: nil)
         }
@@ -109,6 +123,12 @@ final class MCPRouter: Sendable {
             return encodeError(MCPError.invalidRequest("jsonrpc must be \"2.0\""), id: rpcRequest.id)
         }
 
+        if let protocolVersion = request.headers["mcp-protocol-version"],
+           protocolVersion != "2025-03-26"
+        {
+            Self.logger.warning("Client mcp-protocol-version mismatch: \(protocolVersion)")
+        }
+
         let headerSessionId = request.headers["mcp-session-id"]
         return await dispatchMethod(rpcRequest, headerSessionId: headerSessionId, server: server)
     }
@@ -120,36 +140,39 @@ final class MCPRouter: Sendable {
         headerSessionId: String?,
         server: MCPServer
     ) async -> RouteResult {
-        // initialize does not require a session
         if request.method == "initialize" {
             return await handleInitialize(request, server: server)
         }
 
-        // ping does not strictly require a session
         if request.method == "ping" {
             return handlePing(request)
         }
 
-        // Notifications: best-effort, return 202 with empty body
-        if request.method == "notifications/initialized" {
-            if let sid = headerSessionId, let session = await server.session(for: sid) {
-                await session.markActive()
-            }
-            return .noContent(headers: [])
+        // Session-required methods: validate header and lookup
+        guard let sessionId = headerSessionId else {
+            return .httpError(status: 400, message: "Missing Mcp-Session-Id header")
         }
-
-        if request.method == "notifications/cancelled" {
-            return await handleCancellation(request, headerSessionId: headerSessionId, server: server)
-        }
-
-        // All other methods require a valid session
-        guard let sessionId = headerSessionId,
-              let session = await server.session(for: sessionId)
-        else {
-            return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: request.id)
+        guard let session = await server.session(for: sessionId) else {
+            return .httpError(status: 404, message: "Session not found")
         }
 
         await session.markActive()
+
+        if request.method == "notifications/initialized" {
+            await session.setInitialized(true)
+            return .accepted
+        }
+
+        if request.method == "notifications/cancelled" {
+            return await handleCancellation(request, session: session)
+        }
+
+        guard await session.isInitialized else {
+            return encodeError(
+                MCPError.invalidRequest("Session not initialized. Send notifications/initialized first."),
+                id: request.id
+            )
+        }
 
         switch request.method {
         case "tools/list":
@@ -183,7 +206,6 @@ final class MCPRouter: Sendable {
             let version = clientInfo["version"]?.stringValue
             await session.setClientInfo(MCPClientInfo(name: name, version: version))
         }
-        await session.setInitialized(true)
 
         let result = MCPInitializeResult(
             protocolVersion: "2025-03-26",
@@ -201,7 +223,7 @@ final class MCPRouter: Sendable {
 
     private func handlePing(_ request: JSONRPCRequest) -> RouteResult {
         guard let id = request.id else {
-            return .noContent(headers: [])
+            return .accepted
         }
         return encodeRawResult(.object([:]), id: id, sessionId: nil)
     }
@@ -210,15 +232,12 @@ final class MCPRouter: Sendable {
 
     private func handleCancellation(
         _ request: JSONRPCRequest,
-        headerSessionId: String?,
-        server: MCPServer
+        session: MCPSession
     ) async -> RouteResult {
-        guard let sessionId = headerSessionId,
-              let session = await server.session(for: sessionId),
-              let params = request.params,
+        guard let params = request.params,
               let requestIdValue = params["requestId"]
         else {
-            return .noContent(headers: [])
+            return .accepted
         }
 
         let cancelId: JSONRPCId?
@@ -233,17 +252,17 @@ final class MCPRouter: Sendable {
 
         if let cancelId, let task = await session.removeRunningTask(cancelId) {
             task.cancel()
-            Self.logger.info("Cancelled request \(String(describing: cancelId)) in session \(sessionId)")
+            Self.logger.info("Cancelled request \(String(describing: cancelId)) in session \(session.id)")
         }
 
-        return .noContent(headers: [])
+        return .accepted
     }
 
     // MARK: - tools/list
 
     private func handleToolsList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
         guard let id = request.id else {
-            return .noContent(headers: [])
+            return .accepted
         }
 
         let tools = Self.toolDefinitions()
@@ -306,7 +325,7 @@ final class MCPRouter: Sendable {
 
     private func handleResourcesList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
         guard let id = request.id else {
-            return .noContent(headers: [])
+            return .accepted
         }
 
         let resources = Self.resourceDefinitions()
@@ -353,7 +372,7 @@ final class MCPRouter: Sendable {
 
     private func encodeResult<T: Encodable>(_ result: T, id: JSONRPCId?, sessionId: String?) -> RouteResult {
         guard let id else {
-            return .noContent(headers: [])
+            return .accepted
         }
 
         do {
@@ -361,7 +380,7 @@ final class MCPRouter: Sendable {
             let resultValue = try decoder.decode(JSONValue.self, from: resultData)
             let response = JSONRPCResponse(id: id, result: resultValue)
             let data = try encoder.encode(response)
-            return .jsonResponse(data, sessionId: sessionId)
+            return .json(data, sessionId: sessionId)
         } catch {
             Self.logger.error("Failed to encode response: \(error.localizedDescription)")
             return encodeError(MCPError.internalError("Encoding failed"), id: id)
@@ -372,7 +391,7 @@ final class MCPRouter: Sendable {
         do {
             let response = JSONRPCResponse(id: id, result: result)
             let data = try encoder.encode(response)
-            return .jsonResponse(data, sessionId: sessionId)
+            return .json(data, sessionId: sessionId)
         } catch {
             Self.logger.error("Failed to encode response: \(error.localizedDescription)")
             return encodeError(MCPError.internalError("Encoding failed"), id: id)
@@ -383,7 +402,7 @@ final class MCPRouter: Sendable {
         let errorResponse = error.toJsonRpcError(id: id)
         do {
             let data = try encoder.encode(errorResponse)
-            return .jsonResponse(data, sessionId: nil)
+            return .json(data, sessionId: nil)
         } catch {
             Self.logger.error("Failed to encode error response")
             return .httpError(status: 500, message: "Internal encoding error")

--- a/TablePro/Core/MCP/MCPRouter.swift
+++ b/TablePro/Core/MCP/MCPRouter.swift
@@ -268,16 +268,30 @@ final class MCPRouter: Sendable {
             return encodeError(MCPError.internalError("Server not fully initialized"), id: id)
         }
 
+        let session = await server.session(for: sessionId)
+        let toolTask = Task {
+            try await handler(name, arguments, sessionId)
+        }
+        if let session {
+            await session.addRunningTask(id, task: Task { _ = try? await toolTask.value })
+        }
+
         do {
-            let toolResult = try await handler(name, arguments, sessionId)
+            let toolResult = try await toolTask.value
+            if let session { _ = await session.removeRunningTask(id) }
             let resultData = try encoder.encode(toolResult)
             guard let resultValue = try? decoder.decode(JSONValue.self, from: resultData) else {
                 return encodeError(MCPError.internalError("Failed to encode tool result"), id: id)
             }
             return encodeRawResult(resultValue, id: id, sessionId: sessionId)
+        } catch is CancellationError {
+            if let session { _ = await session.removeRunningTask(id) }
+            return encodeError(MCPError.timeout("Request was cancelled"), id: id)
         } catch let mcpError as MCPError {
+            if let session { _ = await session.removeRunningTask(id) }
             return encodeError(mcpError, id: id)
         } catch {
+            if let session { _ = await session.removeRunningTask(id) }
             return encodeError(MCPError.internalError(error.localizedDescription), id: id)
         }
     }
@@ -651,8 +665,8 @@ extension MCPRouter {
                         ]),
                         "format": .object([
                             "type": "string",
-                            "description": "Export format: csv, json, sql, or xlsx",
-                            "enum": .array([.string("csv"), .string("json"), .string("sql"), .string("xlsx")])
+                            "description": "Export format: csv, json, or sql",
+                            "enum": .array([.string("csv"), .string("json"), .string("sql")])
                         ]),
                         "query": .object([
                             "type": "string",

--- a/TablePro/Core/MCP/MCPRouter.swift
+++ b/TablePro/Core/MCP/MCPRouter.swift
@@ -29,6 +29,12 @@ final class MCPRouter: Sendable {
     // MARK: - Main Entry
 
     func route(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        // OAuth discovery probes from Claude Code / MCP SDK.
+        // Return 404 with no auth requirement so the SDK skips authentication.
+        if request.path.hasPrefix("/.well-known/") {
+            return .httpError(status: 404, message: "Not found")
+        }
+
         guard request.path == "/mcp" || request.path.hasPrefix("/mcp?") else {
             return .httpError(status: 404, message: "Not found")
         }

--- a/TablePro/Core/MCP/MCPRouter.swift
+++ b/TablePro/Core/MCP/MCPRouter.swift
@@ -65,7 +65,7 @@ final class MCPRouter: Sendable {
             return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: nil)
         }
 
-        session.markActive()
+        await session.markActive()
         return .sseStream(sessionId: session.id)
     }
 
@@ -124,12 +124,12 @@ final class MCPRouter: Sendable {
             return handlePing(request)
         }
 
-        // Notifications: best-effort, no session validation failure
+        // Notifications: best-effort, return 202 with empty body
         if request.method == "notifications/initialized" {
-            if let sid = headerSessionId {
-                await server.session(for: sid)?.markActive()
+            if let sid = headerSessionId, let session = await server.session(for: sid) {
+                await session.markActive()
             }
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
 
         if request.method == "notifications/cancelled" {
@@ -143,7 +143,7 @@ final class MCPRouter: Sendable {
             return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: request.id)
         }
 
-        session.markActive()
+        await session.markActive()
 
         switch request.method {
         case "tools/list":
@@ -175,9 +175,9 @@ final class MCPRouter: Sendable {
            let name = clientInfo["name"]?.stringValue
         {
             let version = clientInfo["version"]?.stringValue
-            session.clientInfo = MCPClientInfo(name: name, version: version)
+            await session.setClientInfo(MCPClientInfo(name: name, version: version))
         }
-        session.isInitialized = true
+        await session.setInitialized(true)
 
         let result = MCPInitializeResult(
             protocolVersion: "2025-03-26",
@@ -195,7 +195,7 @@ final class MCPRouter: Sendable {
 
     private func handlePing(_ request: JSONRPCRequest) -> RouteResult {
         guard let id = request.id else {
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
         return encodeRawResult(.object([:]), id: id, sessionId: nil)
     }
@@ -212,7 +212,7 @@ final class MCPRouter: Sendable {
               let params = request.params,
               let requestIdValue = params["requestId"]
         else {
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
 
         let cancelId: JSONRPCId?
@@ -225,20 +225,19 @@ final class MCPRouter: Sendable {
             cancelId = nil
         }
 
-        if let cancelId, let task = session.runningTasks[cancelId] {
+        if let cancelId, let task = await session.removeRunningTask(cancelId) {
             task.cancel()
-            session.runningTasks.removeValue(forKey: cancelId)
             Self.logger.info("Cancelled request \(String(describing: cancelId)) in session \(sessionId)")
         }
 
-        return .httpError(status: 202, message: "Accepted")
+        return .noContent(headers: [])
     }
 
     // MARK: - tools/list
 
     private func handleToolsList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
         guard let id = request.id else {
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
 
         let tools = Self.toolDefinitions()
@@ -287,7 +286,7 @@ final class MCPRouter: Sendable {
 
     private func handleResourcesList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
         guard let id = request.id else {
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
 
         let resources = Self.resourceDefinitions()
@@ -334,7 +333,7 @@ final class MCPRouter: Sendable {
 
     private func encodeResult<T: Encodable>(_ result: T, id: JSONRPCId?, sessionId: String?) -> RouteResult {
         guard let id else {
-            return .httpError(status: 202, message: "Accepted")
+            return .noContent(headers: [])
         }
 
         do {

--- a/TablePro/Core/MCP/MCPRouter.swift
+++ b/TablePro/Core/MCP/MCPRouter.swift
@@ -1,0 +1,708 @@
+//
+//  MCPRouter.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+final class MCPRouter: Sendable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPRouter")
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    enum RouteResult: Sendable {
+        case jsonResponse(Data, sessionId: String?)
+        case sseStream(sessionId: String)
+        case httpError(status: Int, message: String)
+        case noContent(headers: [(String, String)])
+    }
+
+    init() {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys]
+        self.encoder = enc
+        self.decoder = JSONDecoder()
+    }
+
+    // MARK: - Main Entry
+
+    func route(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        guard request.path == "/mcp" || request.path.hasPrefix("/mcp?") else {
+            return .httpError(status: 404, message: "Not found")
+        }
+
+        switch request.method {
+        case .options:
+            return handleOptions()
+        case .post:
+            return await handlePost(request, server: server)
+        case .get:
+            return await handleGet(request, server: server)
+        case .delete:
+            return await handleDelete(request, server: server)
+        }
+    }
+
+    // MARK: - OPTIONS
+
+    private func handleOptions() -> RouteResult {
+        .noContent(headers: [
+            ("Access-Control-Allow-Origin", "*"),
+            ("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS"),
+            ("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id"),
+            ("Access-Control-Max-Age", "86400")
+        ])
+    }
+
+    // MARK: - GET (SSE Stream)
+
+    private func handleGet(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        guard let sessionId = request.headers["mcp-session-id"],
+              let session = await server.session(for: sessionId)
+        else {
+            return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: nil)
+        }
+
+        session.markActive()
+        return .sseStream(sessionId: session.id)
+    }
+
+    // MARK: - DELETE (Terminate Session)
+
+    private func handleDelete(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        guard let sessionId = request.headers["mcp-session-id"] else {
+            return encodeError(MCPError.invalidRequest("Missing Mcp-Session-Id"), id: nil)
+        }
+
+        await server.removeSession(sessionId)
+        Self.logger.info("Session terminated via DELETE: \(sessionId)")
+
+        guard let body = try? encoder.encode(["status": "session_terminated"]) else {
+            return .httpError(status: 500, message: "Encoding error")
+        }
+        return .jsonResponse(body, sessionId: nil)
+    }
+
+    // MARK: - POST (JSON-RPC)
+
+    private func handlePost(_ request: HTTPRequest, server: MCPServer) async -> RouteResult {
+        guard let body = request.body else {
+            return encodeError(MCPError.parseError, id: nil)
+        }
+
+        let rpcRequest: JSONRPCRequest
+        do {
+            rpcRequest = try decoder.decode(JSONRPCRequest.self, from: body)
+        } catch {
+            return encodeError(MCPError.parseError, id: nil)
+        }
+
+        guard rpcRequest.jsonrpc == "2.0" else {
+            return encodeError(MCPError.invalidRequest("jsonrpc must be \"2.0\""), id: rpcRequest.id)
+        }
+
+        let headerSessionId = request.headers["mcp-session-id"]
+        return await dispatchMethod(rpcRequest, headerSessionId: headerSessionId, server: server)
+    }
+
+    // MARK: - Method Dispatch
+
+    private func dispatchMethod(
+        _ request: JSONRPCRequest,
+        headerSessionId: String?,
+        server: MCPServer
+    ) async -> RouteResult {
+        // initialize does not require a session
+        if request.method == "initialize" {
+            return await handleInitialize(request, server: server)
+        }
+
+        // ping does not strictly require a session
+        if request.method == "ping" {
+            return handlePing(request)
+        }
+
+        // Notifications: best-effort, no session validation failure
+        if request.method == "notifications/initialized" {
+            if let sid = headerSessionId {
+                await server.session(for: sid)?.markActive()
+            }
+            return .httpError(status: 202, message: "Accepted")
+        }
+
+        if request.method == "notifications/cancelled" {
+            return await handleCancellation(request, headerSessionId: headerSessionId, server: server)
+        }
+
+        // All other methods require a valid session
+        guard let sessionId = headerSessionId,
+              let session = await server.session(for: sessionId)
+        else {
+            return encodeError(MCPError.invalidRequest("Missing or invalid Mcp-Session-Id"), id: request.id)
+        }
+
+        session.markActive()
+
+        switch request.method {
+        case "tools/list":
+            return handleToolsList(request, sessionId: sessionId)
+
+        case "tools/call":
+            return await handleToolsCall(request, sessionId: sessionId, server: server)
+
+        case "resources/list":
+            return handleResourcesList(request, sessionId: sessionId)
+
+        case "resources/read":
+            return await handleResourcesRead(request, sessionId: sessionId, server: server)
+
+        default:
+            return encodeError(MCPError.methodNotFound(request.method), id: request.id)
+        }
+    }
+
+    // MARK: - initialize
+
+    private func handleInitialize(_ request: JSONRPCRequest, server: MCPServer) async -> RouteResult {
+        guard let session = await server.createSession() else {
+            return encodeError(MCPError.internalError("Maximum sessions reached"), id: request.id)
+        }
+
+        if let params = request.params,
+           let clientInfo = params["clientInfo"],
+           let name = clientInfo["name"]?.stringValue
+        {
+            let version = clientInfo["version"]?.stringValue
+            session.clientInfo = MCPClientInfo(name: name, version: version)
+        }
+        session.isInitialized = true
+
+        let result = MCPInitializeResult(
+            protocolVersion: "2025-03-26",
+            capabilities: MCPServerCapabilities(
+                tools: .init(listChanged: false),
+                resources: .init(subscribe: false, listChanged: false)
+            ),
+            serverInfo: MCPServerInfo(name: "tablepro", version: "1.0.0")
+        )
+
+        return encodeResult(result, id: request.id, sessionId: session.id)
+    }
+
+    // MARK: - ping
+
+    private func handlePing(_ request: JSONRPCRequest) -> RouteResult {
+        guard let id = request.id else {
+            return .httpError(status: 202, message: "Accepted")
+        }
+        return encodeRawResult(.object([:]), id: id, sessionId: nil)
+    }
+
+    // MARK: - notifications/cancelled
+
+    private func handleCancellation(
+        _ request: JSONRPCRequest,
+        headerSessionId: String?,
+        server: MCPServer
+    ) async -> RouteResult {
+        guard let sessionId = headerSessionId,
+              let session = await server.session(for: sessionId),
+              let params = request.params,
+              let requestIdValue = params["requestId"]
+        else {
+            return .httpError(status: 202, message: "Accepted")
+        }
+
+        let cancelId: JSONRPCId?
+        switch requestIdValue {
+        case .string(let s):
+            cancelId = .string(s)
+        case .int(let i):
+            cancelId = .int(i)
+        default:
+            cancelId = nil
+        }
+
+        if let cancelId, let task = session.runningTasks[cancelId] {
+            task.cancel()
+            session.runningTasks.removeValue(forKey: cancelId)
+            Self.logger.info("Cancelled request \(String(describing: cancelId)) in session \(sessionId)")
+        }
+
+        return .httpError(status: 202, message: "Accepted")
+    }
+
+    // MARK: - tools/list
+
+    private func handleToolsList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
+        guard let id = request.id else {
+            return .httpError(status: 202, message: "Accepted")
+        }
+
+        let tools = Self.toolDefinitions()
+        let result: JSONValue = .object(["tools": encodeToolDefinitions(tools)])
+        return encodeRawResult(result, id: id, sessionId: sessionId)
+    }
+
+    // MARK: - tools/call
+
+    private func handleToolsCall(
+        _ request: JSONRPCRequest,
+        sessionId: String,
+        server: MCPServer
+    ) async -> RouteResult {
+        guard let id = request.id else {
+            return encodeError(MCPError.invalidRequest("tools/call requires an id"), id: nil)
+        }
+
+        guard let params = request.params,
+              let name = params["name"]?.stringValue
+        else {
+            return encodeError(MCPError.invalidParams("Missing tool name"), id: id)
+        }
+
+        let arguments = params["arguments"]
+
+        guard let handler = await server.toolCallHandler else {
+            return encodeError(MCPError.internalError("Server not fully initialized"), id: id)
+        }
+
+        do {
+            let toolResult = try await handler(name, arguments, sessionId)
+            let resultData = try encoder.encode(toolResult)
+            guard let resultValue = try? decoder.decode(JSONValue.self, from: resultData) else {
+                return encodeError(MCPError.internalError("Failed to encode tool result"), id: id)
+            }
+            return encodeRawResult(resultValue, id: id, sessionId: sessionId)
+        } catch let mcpError as MCPError {
+            return encodeError(mcpError, id: id)
+        } catch {
+            return encodeError(MCPError.internalError(error.localizedDescription), id: id)
+        }
+    }
+
+    // MARK: - resources/list
+
+    private func handleResourcesList(_ request: JSONRPCRequest, sessionId: String) -> RouteResult {
+        guard let id = request.id else {
+            return .httpError(status: 202, message: "Accepted")
+        }
+
+        let resources = Self.resourceDefinitions()
+        let result: JSONValue = .object(["resources": encodeResourceDefinitions(resources)])
+        return encodeRawResult(result, id: id, sessionId: sessionId)
+    }
+
+    // MARK: - resources/read
+
+    private func handleResourcesRead(
+        _ request: JSONRPCRequest,
+        sessionId: String,
+        server: MCPServer
+    ) async -> RouteResult {
+        guard let id = request.id else {
+            return encodeError(MCPError.invalidRequest("resources/read requires an id"), id: nil)
+        }
+
+        guard let params = request.params,
+              let uri = params["uri"]?.stringValue
+        else {
+            return encodeError(MCPError.invalidParams("Missing resource uri"), id: id)
+        }
+
+        guard let handler = await server.resourceReadHandler else {
+            return encodeError(MCPError.internalError("Server not fully initialized"), id: id)
+        }
+
+        do {
+            let readResult = try await handler(uri, sessionId)
+            let resultData = try encoder.encode(readResult)
+            guard let resultValue = try? decoder.decode(JSONValue.self, from: resultData) else {
+                return encodeError(MCPError.internalError("Failed to encode resource result"), id: id)
+            }
+            return encodeRawResult(resultValue, id: id, sessionId: sessionId)
+        } catch let mcpError as MCPError {
+            return encodeError(mcpError, id: id)
+        } catch {
+            return encodeError(MCPError.internalError(error.localizedDescription), id: id)
+        }
+    }
+
+    // MARK: - Encoding Helpers
+
+    private func encodeResult<T: Encodable>(_ result: T, id: JSONRPCId?, sessionId: String?) -> RouteResult {
+        guard let id else {
+            return .httpError(status: 202, message: "Accepted")
+        }
+
+        do {
+            let resultData = try encoder.encode(result)
+            let resultValue = try decoder.decode(JSONValue.self, from: resultData)
+            let response = JSONRPCResponse(id: id, result: resultValue)
+            let data = try encoder.encode(response)
+            return .jsonResponse(data, sessionId: sessionId)
+        } catch {
+            Self.logger.error("Failed to encode response: \(error.localizedDescription)")
+            return encodeError(MCPError.internalError("Encoding failed"), id: id)
+        }
+    }
+
+    private func encodeRawResult(_ result: JSONValue, id: JSONRPCId, sessionId: String?) -> RouteResult {
+        do {
+            let response = JSONRPCResponse(id: id, result: result)
+            let data = try encoder.encode(response)
+            return .jsonResponse(data, sessionId: sessionId)
+        } catch {
+            Self.logger.error("Failed to encode response: \(error.localizedDescription)")
+            return encodeError(MCPError.internalError("Encoding failed"), id: id)
+        }
+    }
+
+    private func encodeError(_ error: MCPError, id: JSONRPCId?) -> RouteResult {
+        let errorResponse = error.toJsonRpcError(id: id)
+        do {
+            let data = try encoder.encode(errorResponse)
+            return .jsonResponse(data, sessionId: nil)
+        } catch {
+            Self.logger.error("Failed to encode error response")
+            return .httpError(status: 500, message: "Internal encoding error")
+        }
+    }
+
+    private func encodeToolDefinitions(_ tools: [MCPToolDefinition]) -> JSONValue {
+        .array(tools.map { tool in
+            .object([
+                "name": .string(tool.name),
+                "description": .string(tool.description),
+                "inputSchema": tool.inputSchema
+            ])
+        })
+    }
+
+    private func encodeResourceDefinitions(_ resources: [MCPResourceDefinition]) -> JSONValue {
+        .array(resources.map { resource in
+            var dict: [String: JSONValue] = [
+                "uri": .string(resource.uri),
+                "name": .string(resource.name)
+            ]
+            if let description = resource.description {
+                dict["description"] = .string(description)
+            }
+            if let mimeType = resource.mimeType {
+                dict["mimeType"] = .string(mimeType)
+            }
+            return .object(dict)
+        })
+    }
+}
+
+// MARK: - Tool Definitions
+
+extension MCPRouter {
+    static func toolDefinitions() -> [MCPToolDefinition] {
+        connectionTools() + schemaTools() + queryAndExportTools()
+    }
+
+    private static func connectionTools() -> [MCPToolDefinition] {
+        [
+            MCPToolDefinition(
+                name: "list_connections",
+                description: "List all saved database connections with their status",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([:]),
+                    "required": .array([])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "connect",
+                description: "Connect to a saved database",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the saved connection"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "disconnect",
+                description: "Disconnect from a database",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection to disconnect"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "get_connection_status",
+                description: "Get detailed status of a database connection",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "switch_database",
+                description: "Switch the active database on a connection",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "database": .object([
+                            "type": "string",
+                            "description": "Database name to switch to"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("database")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "switch_schema",
+                description: "Switch the active schema on a connection",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "schema": .object([
+                            "type": "string",
+                            "description": "Schema name to switch to"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("schema")])
+                ])
+            )
+        ]
+    }
+
+    private static func schemaTools() -> [MCPToolDefinition] {
+        [
+            MCPToolDefinition(
+                name: "list_databases",
+                description: "List all databases on the server",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "list_schemas",
+                description: "List schemas in a database",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "database": .object([
+                            "type": "string",
+                            "description": "Database name (uses current if omitted)"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "list_tables",
+                description: "List tables and views in a database",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "database": .object([
+                            "type": "string",
+                            "description": "Database name (uses current if omitted)"
+                        ]),
+                        "schema": .object([
+                            "type": "string",
+                            "description": "Schema name (uses current if omitted)"
+                        ]),
+                        "include_row_counts": .object([
+                            "type": "boolean",
+                            "description": "Include approximate row counts (default false)"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "describe_table",
+                description: "Get detailed table structure: columns, indexes, foreign keys, and DDL",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "table": .object([
+                            "type": "string",
+                            "description": "Table name"
+                        ]),
+                        "schema": .object([
+                            "type": "string",
+                            "description": "Schema name (uses current if omitted)"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("table")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "get_table_ddl",
+                description: "Get the CREATE TABLE DDL statement for a table",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "table": .object([
+                            "type": "string",
+                            "description": "Table name"
+                        ]),
+                        "schema": .object([
+                            "type": "string",
+                            "description": "Schema name (uses current if omitted)"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("table")])
+                ])
+            )
+        ]
+    }
+
+    private static func queryAndExportTools() -> [MCPToolDefinition] {
+        [
+            MCPToolDefinition(
+                name: "execute_query",
+                description: "Execute a SQL or NoSQL query on a connected database",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "query": .object([
+                            "type": "string",
+                            "description": "SQL or NoSQL query text"
+                        ]),
+                        "max_rows": .object([
+                            "type": "integer",
+                            "description": "Maximum rows to return (default 500, max 10000)"
+                        ]),
+                        "timeout_seconds": .object([
+                            "type": "integer",
+                            "description": "Query timeout in seconds (default 30, max 300)"
+                        ]),
+                        "database": .object([
+                            "type": "string",
+                            "description": "Switch to this database before executing"
+                        ]),
+                        "schema": .object([
+                            "type": "string",
+                            "description": "Switch to this schema before executing"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("query")])
+                ])
+            ),
+            MCPToolDefinition(
+                name: "export_data",
+                description: "Export query results or table data to CSV, JSON, SQL, or XLSX",
+                inputSchema: .object([
+                    "type": "object",
+                    "properties": .object([
+                        "connection_id": .object([
+                            "type": "string",
+                            "description": "UUID of the connection"
+                        ]),
+                        "format": .object([
+                            "type": "string",
+                            "description": "Export format: csv, json, sql, or xlsx",
+                            "enum": .array([.string("csv"), .string("json"), .string("sql"), .string("xlsx")])
+                        ]),
+                        "query": .object([
+                            "type": "string",
+                            "description": "SQL query to export results from"
+                        ]),
+                        "tables": .object([
+                            "type": "array",
+                            "description": "Table names to export (alternative to query)",
+                            "items": .object(["type": "string"])
+                        ]),
+                        "output_path": .object([
+                            "type": "string",
+                            "description": "File path to save export (returns inline data if omitted)"
+                        ]),
+                        "max_rows": .object([
+                            "type": "integer",
+                            "description": "Maximum rows to export (default 50000)"
+                        ])
+                    ]),
+                    "required": .array([.string("connection_id"), .string("format")])
+                ])
+            )
+        ]
+    }
+}
+
+// MARK: - Resource Definitions
+
+extension MCPRouter {
+    static func resourceDefinitions() -> [MCPResourceDefinition] {
+        [
+            MCPResourceDefinition(
+                uri: "tablepro://connections",
+                name: "Saved Connections",
+                description: "List of all saved database connections with metadata",
+                mimeType: "application/json"
+            ),
+            MCPResourceDefinition(
+                uri: "tablepro://connections/{id}/schema",
+                name: "Database Schema",
+                description: "Tables, columns, indexes, and foreign keys for a connected database",
+                mimeType: "application/json"
+            ),
+            MCPResourceDefinition(
+                uri: "tablepro://connections/{id}/history",
+                name: "Query History",
+                description: "Recent query history for a connection (supports ?limit=, ?search=, ?date_filter=)",
+                mimeType: "application/json"
+            )
+        ]
+    }
+}

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -14,6 +14,7 @@ actor MCPServer {
     private static let idleTimeout: TimeInterval = 300
     private static let cleanupInterval: TimeInterval = 60
     private static let maxReadSize = 1_048_576
+    private static let maxBufferSize = 10 * 1_024 * 1_024
 
     // MARK: - State
 
@@ -25,6 +26,7 @@ actor MCPServer {
 
     private(set) var toolCallHandler: (@Sendable (String, JSONValue?, String) async throws -> MCPToolResult)?
     private(set) var resourceReadHandler: (@Sendable (String, String) async throws -> MCPResourceReadResult)?
+    private(set) var sessionCleanupHandler: (@Sendable (String) async -> Void)?
 
     // MARK: - Initialization
 
@@ -41,6 +43,10 @@ actor MCPServer {
 
     func setResourceReadHandler(_ handler: @escaping @Sendable (String, String) async throws -> MCPResourceReadResult) {
         self.resourceReadHandler = handler
+    }
+
+    func setSessionCleanupHandler(_ handler: @escaping @Sendable (String) async -> Void) {
+        self.sessionCleanupHandler = handler
     }
 
     // MARK: - Lifecycle
@@ -85,8 +91,10 @@ actor MCPServer {
         cleanupTask = nil
 
         for (_, session) in sessions {
-            session.cancelAllTasks()
-            session.sseConnection?.cancel()
+            Task {
+                await session.cancelAllTasks()
+                await session.cancelSSEConnection()
+            }
         }
         sessions.removeAll()
 
@@ -178,6 +186,13 @@ actor MCPServer {
             buffer.append(content)
         }
 
+        // DoS prevention: reject requests with accumulated buffer exceeding max body size
+        if buffer.count > Self.maxBufferSize {
+            Self.logger.warning("Request buffer exceeds \(Self.maxBufferSize) bytes, rejecting")
+            sendHTTPError(connection: connection, status: 413, message: "Request entity too large")
+            return
+        }
+
         let parseResult = MCPHTTPParser.parse(buffer)
 
         switch parseResult {
@@ -213,8 +228,8 @@ actor MCPServer {
 
         case .sseStream(let sessionId):
             if let session = sessions[sessionId] {
-                session.sseConnection?.cancel()
-                session.sseConnection = connection
+                await session.cancelSSEConnection()
+                await session.setSSEConnection(connection)
             }
             sendSseHeaders(connection: connection, sessionId: sessionId)
 
@@ -244,10 +259,16 @@ actor MCPServer {
         sessions[sessionId]
     }
 
-    func removeSession(_ sessionId: String) {
+    func removeSession(_ sessionId: String) async {
         guard let session = sessions.removeValue(forKey: sessionId) else { return }
-        session.cancelAllTasks()
-        session.sseConnection?.cancel()
+        await session.cancelAllTasks()
+        await session.cancelSSEConnection()
+
+        // Notify external cleanup (e.g. MCPAuthGuard session approvals)
+        if let cleanupHandler = sessionCleanupHandler {
+            await cleanupHandler(sessionId)
+        }
+
         Self.logger.info("Removed session \(sessionId) (total: \(self.sessions.count))")
     }
 
@@ -264,16 +285,22 @@ actor MCPServer {
         }
     }
 
-    private func cleanupIdleSessions() {
+    private func cleanupIdleSessions() async {
         let now = ContinuousClock.now
         var removed: [String] = []
 
         for (id, session) in sessions {
-            let idle = now - session.lastActivityAt
+            let lastActivity = await session.lastActivityAt
+            let idle = now - lastActivity
             if idle > .seconds(Self.idleTimeout) {
-                session.cancelAllTasks()
-                session.sseConnection?.cancel()
+                await session.cancelAllTasks()
+                await session.cancelSSEConnection()
                 sessions.removeValue(forKey: id)
+
+                if let cleanupHandler = sessionCleanupHandler {
+                    await cleanupHandler(id)
+                }
+
                 removed.append(id)
             }
         }

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -1,0 +1,338 @@
+//
+//  MCPServer.swift
+//  TablePro
+//
+
+import Foundation
+import Network
+import os
+
+actor MCPServer {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPServer")
+
+    private static let maxSessions = 10
+    private static let idleTimeout: TimeInterval = 300
+    private static let cleanupInterval: TimeInterval = 60
+    private static let maxReadSize = 1_048_576
+
+    // MARK: - State
+
+    private var listener: NWListener?
+    private var sessions: [String: MCPSession] = [:]
+    private var cleanupTask: Task<Void, Never>?
+    private let stateCallback: @Sendable (MCPServerState) -> Void
+    private var router: MCPRouter!
+
+    var toolCallHandler: (@Sendable (String, JSONValue?, String) async throws -> MCPToolResult)?
+    var resourceReadHandler: (@Sendable (String, String) async throws -> MCPResourceReadResult)?
+
+    // MARK: - Initialization
+
+    init(stateCallback: @escaping @Sendable (MCPServerState) -> Void) {
+        self.stateCallback = stateCallback
+        self.router = MCPRouter()
+    }
+
+    // MARK: - Lifecycle
+
+    func start(port: UInt16) throws {
+        guard listener == nil else {
+            Self.logger.warning("Server already running, ignoring start request")
+            return
+        }
+
+        stateCallback(.starting)
+
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port) ?? 23_508)
+        params.allowLocalEndpointReuse = true
+
+        let newListener = try NWListener(using: params)
+        self.listener = newListener
+
+        newListener.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            Task {
+                await self.handleListenerState(state, listener: newListener)
+            }
+        }
+
+        newListener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            Task {
+                await self.handleNewConnection(connection)
+            }
+        }
+
+        newListener.start(queue: .global(qos: .userInitiated))
+        startCleanupTimer()
+    }
+
+    func stop() {
+        Self.logger.info("Stopping MCP server")
+
+        cleanupTask?.cancel()
+        cleanupTask = nil
+
+        for (_, session) in sessions {
+            session.cancelAllTasks()
+            session.sseConnection?.cancel()
+        }
+        sessions.removeAll()
+
+        let currentListener = listener
+        listener = nil
+        currentListener?.cancel()
+
+        stateCallback(.stopped)
+    }
+
+    var sessionCount: Int {
+        sessions.count
+    }
+
+    // MARK: - Listener State
+
+    private func handleListenerState(_ state: NWListener.State, listener: NWListener) {
+        switch state {
+        case .ready:
+            let port = listener.port?.rawValue ?? 0
+            Self.logger.info("MCP server listening on 127.0.0.1:\(port)")
+            stateCallback(.running(port: port))
+
+        case .failed(let error):
+            Self.logger.error("MCP server listener failed: \(error.localizedDescription)")
+            stateCallback(.failed(error.localizedDescription))
+            self.listener = nil
+            listener.cancel()
+
+        case .cancelled:
+            Self.logger.debug("MCP server listener cancelled")
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleNewConnection(_ connection: NWConnection) {
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                Task {
+                    await self.readRequest(from: connection, buffer: Data())
+                }
+            case .failed(let error):
+                Self.logger.debug("Connection failed: \(error.localizedDescription)")
+                connection.cancel()
+            default:
+                break
+            }
+        }
+        connection.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func readRequest(from connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: Self.maxReadSize) { [weak self] content, _, isComplete, error in
+            guard let self else { return }
+
+            Task {
+                await self.processReceivedData(
+                    connection: connection,
+                    existingBuffer: buffer,
+                    content: content,
+                    isComplete: isComplete,
+                    error: error
+                )
+            }
+        }
+    }
+
+    private func processReceivedData(
+        connection: NWConnection,
+        existingBuffer: Data,
+        content: Data?,
+        isComplete: Bool,
+        error: NWError?
+    ) {
+        if let error {
+            Self.logger.debug("Read error: \(error.localizedDescription)")
+            connection.cancel()
+            return
+        }
+
+        var buffer = existingBuffer
+        if let content {
+            buffer.append(content)
+        }
+
+        let parseResult = MCPHTTPParser.parse(buffer)
+
+        switch parseResult {
+        case .success(let request):
+            Task {
+                await self.handleHTTPRequest(request, connection: connection)
+            }
+
+        case .failure(.incomplete):
+            if isComplete {
+                sendHTTPError(connection: connection, status: 400, message: "Incomplete request")
+            } else {
+                readRequest(from: connection, buffer: buffer)
+            }
+
+        case .failure(.bodyTooLarge):
+            sendHTTPError(connection: connection, status: 400, message: "Request body too large")
+
+        case .failure(let parseError):
+            Self.logger.warning("Parse error: \(String(describing: parseError))")
+            sendHTTPError(connection: connection, status: 400, message: "Malformed HTTP request")
+        }
+    }
+
+    // MARK: - HTTP Request Handling
+
+    private func handleHTTPRequest(_ request: HTTPRequest, connection: NWConnection) async {
+        let result = await router.route(request, server: self)
+
+        switch result {
+        case .jsonResponse(let data, let sessionId):
+            sendJsonResponse(connection: connection, data: data, sessionId: sessionId)
+
+        case .sseStream(let sessionId):
+            if let session = sessions[sessionId] {
+                session.sseConnection?.cancel()
+                session.sseConnection = connection
+            }
+            sendSseHeaders(connection: connection, sessionId: sessionId)
+
+        case .httpError(let status, let message):
+            sendHTTPError(connection: connection, status: status, message: message)
+
+        case .noContent(let headers):
+            sendResponse(connection: connection, status: 204, headers: headers, body: nil)
+        }
+    }
+
+    // MARK: - Session Management
+
+    func createSession() -> MCPSession? {
+        guard sessions.count < Self.maxSessions else {
+            Self.logger.warning("Maximum session limit reached (\(Self.maxSessions))")
+            return nil
+        }
+
+        let session = MCPSession()
+        sessions[session.id] = session
+        Self.logger.info("Created session \(session.id) (total: \(self.sessions.count))")
+        return session
+    }
+
+    func session(for sessionId: String) -> MCPSession? {
+        sessions[sessionId]
+    }
+
+    func removeSession(_ sessionId: String) {
+        guard let session = sessions.removeValue(forKey: sessionId) else { return }
+        session.cancelAllTasks()
+        session.sseConnection?.cancel()
+        Self.logger.info("Removed session \(sessionId) (total: \(self.sessions.count))")
+    }
+
+    // MARK: - Cleanup
+
+    private func startCleanupTimer() {
+        cleanupTask?.cancel()
+        cleanupTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Self.cleanupInterval))
+                guard !Task.isCancelled else { break }
+                await self?.cleanupIdleSessions()
+            }
+        }
+    }
+
+    private func cleanupIdleSessions() {
+        let now = ContinuousClock.now
+        var removed: [String] = []
+
+        for (id, session) in sessions {
+            let idle = now - session.lastActivityAt
+            if idle > .seconds(Self.idleTimeout) {
+                session.cancelAllTasks()
+                session.sseConnection?.cancel()
+                sessions.removeValue(forKey: id)
+                removed.append(id)
+            }
+        }
+
+        if !removed.isEmpty {
+            Self.logger.info("Cleaned up \(removed.count) idle session(s)")
+        }
+    }
+
+    // MARK: - HTTP Response Helpers
+
+    func sendResponse(connection: NWConnection, status: Int, headers: [(String, String)], body: Data?) {
+        let statusText = MCPHTTPParser.statusText(for: status)
+        let responseData = MCPHTTPParser.buildResponse(
+            status: status,
+            statusText: statusText,
+            headers: headers,
+            body: body
+        )
+        connection.send(content: responseData, completion: .contentProcessed { error in
+            if let error {
+                Self.logger.debug("Send error: \(error.localizedDescription)")
+            }
+            if status != 200 || headers.contains(where: { $0.0.lowercased() == "connection" && $0.1.lowercased() == "close" }) {
+                connection.cancel()
+            }
+        })
+    }
+
+    func sendJsonResponse(connection: NWConnection, data: Data, sessionId: String?) {
+        var headers: [(String, String)] = [
+            ("Content-Type", "application/json"),
+            ("Connection", "close")
+        ]
+        if let sessionId {
+            headers.append(("Mcp-Session-Id", sessionId))
+        }
+        sendResponse(connection: connection, status: 200, headers: headers, body: data)
+    }
+
+    func sendSseHeaders(connection: NWConnection, sessionId: String) {
+        let headerData = MCPHTTPParser.buildSSEHeaders(sessionId: sessionId)
+        connection.send(content: headerData, completion: .contentProcessed { error in
+            if let error {
+                Self.logger.debug("SSE header send error: \(error.localizedDescription)")
+            }
+        })
+    }
+
+    func sendSseEvent(connection: NWConnection, data: Data) {
+        let eventData = MCPHTTPParser.buildSSEEvent(data: data)
+        connection.send(content: eventData, completion: .contentProcessed { error in
+            if let error {
+                Self.logger.debug("SSE event send error: \(error.localizedDescription)")
+            }
+        })
+    }
+
+    func sendHTTPError(connection: NWConnection, status: Int, message: String) {
+        let body: [String: String] = ["error": message]
+        let data = (try? JSONEncoder().encode(body)) ?? Data()
+        sendResponse(
+            connection: connection,
+            status: status,
+            headers: [
+                ("Content-Type", "application/json"),
+                ("Connection", "close")
+            ],
+            body: data
+        )
+    }
+}

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -106,18 +106,15 @@ actor MCPServer {
 
         if let currentListener = listener {
             listener = nil
-            currentListener.cancel()
-            // Wait for the listener to fully release the port
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 currentListener.stateUpdateHandler = { state in
                     if case .cancelled = state {
                         continuation.resume()
                     }
                 }
+                currentListener.cancel()
             }
         }
-
-        stateCallback(.stopped)
     }
 
     var sessionCount: Int {

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -251,11 +251,19 @@ actor MCPServer {
 
     // MARK: - HTTP Request Handling
 
+    private static let corsHeaders: [(String, String)] = [
+        ("Access-Control-Allow-Origin", "*"),
+        ("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS"),
+        ("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, mcp-protocol-version"),
+        ("Access-Control-Expose-Headers", "Mcp-Session-Id"),
+        ("Access-Control-Max-Age", "86400")
+    ]
+
     private func handleHTTPRequest(_ request: HTTPRequest, connection: NWConnection) async {
         let result = await router.route(request, server: self)
 
         switch result {
-        case .jsonResponse(let data, let sessionId):
+        case .json(let data, let sessionId):
             sendJsonResponse(connection: connection, data: data, sessionId: sessionId)
 
         case .sseStream(let sessionId):
@@ -265,11 +273,14 @@ actor MCPServer {
             }
             sendSseHeaders(connection: connection, sessionId: sessionId)
 
+        case .accepted:
+            sendResponse(connection: connection, status: 202, headers: Self.corsHeaders, body: nil)
+
+        case .noContent:
+            sendResponse(connection: connection, status: 204, headers: Self.corsHeaders, body: nil)
+
         case .httpError(let status, let message):
             sendHTTPError(connection: connection, status: status, message: message)
-
-        case .noContent(let headers):
-            sendResponse(connection: connection, status: 204, headers: headers, body: nil)
         }
     }
 
@@ -367,6 +378,7 @@ actor MCPServer {
             ("Content-Type", "application/json"),
             ("Connection", "close")
         ]
+        headers.append(contentsOf: Self.corsHeaders)
         if let sessionId {
             headers.append(("Mcp-Session-Id", sessionId))
         }
@@ -374,7 +386,10 @@ actor MCPServer {
     }
 
     func sendSseHeaders(connection: NWConnection, sessionId: String) {
-        let headerData = MCPHTTPParser.buildSSEHeaders(sessionId: sessionId)
+        let headerData = MCPHTTPParser.buildSSEHeaders(
+            sessionId: sessionId,
+            corsHeaders: Self.corsHeaders
+        )
         connection.send(content: headerData, completion: .contentProcessed { error in
             if let error {
                 Self.logger.debug("SSE header send error: \(error.localizedDescription)")
@@ -382,8 +397,8 @@ actor MCPServer {
         })
     }
 
-    func sendSseEvent(connection: NWConnection, data: Data) {
-        let eventData = MCPHTTPParser.buildSSEEvent(data: data)
+    func sendSseEvent(connection: NWConnection, data: Data, eventId: String? = nil) {
+        let eventData = MCPHTTPParser.buildSSEEvent(data: data, id: eventId)
         connection.send(content: eventData, completion: .contentProcessed { error in
             if let error {
                 Self.logger.debug("SSE event send error: \(error.localizedDescription)")
@@ -394,14 +409,11 @@ actor MCPServer {
     func sendHTTPError(connection: NWConnection, status: Int, message: String) {
         let body: [String: String] = ["error": message]
         let data = (try? JSONEncoder().encode(body)) ?? Data()
-        sendResponse(
-            connection: connection,
-            status: status,
-            headers: [
-                ("Content-Type", "application/json"),
-                ("Connection", "close")
-            ],
-            body: data
-        )
+        var headers: [(String, String)] = [
+            ("Content-Type", "application/json"),
+            ("Connection", "close")
+        ]
+        headers.append(contentsOf: Self.corsHeaders)
+        sendResponse(connection: connection, status: status, headers: headers, body: data)
     }
 }

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -8,6 +8,14 @@ import Network
 import os
 
 actor MCPServer {
+    struct SessionSnapshot: Sendable, Identifiable {
+        let id: String
+        let clientName: String
+        let clientVersion: String?
+        let connectedSince: Date
+        let lastActivityAt: Date
+    }
+
     private static let logger = Logger(subsystem: "com.TablePro", category: "MCPServer")
 
     private static let maxSessions = 10
@@ -107,6 +115,26 @@ actor MCPServer {
 
     var sessionCount: Int {
         sessions.count
+    }
+
+    func sessionSnapshots() async -> [SessionSnapshot] {
+        let now = ContinuousClock.now
+        var snapshots: [SessionSnapshot] = []
+        for (_, session) in sessions {
+            let info = await session.clientInfo
+            let created = await session.createdAt
+            let lastActive = await session.lastActivityAt
+            let connectedElapsed = now - created
+            let activeElapsed = now - lastActive
+            snapshots.append(SessionSnapshot(
+                id: session.id,
+                clientName: info?.name ?? String(localized: "Unknown"),
+                clientVersion: info?.version,
+                connectedSince: Date.now - TimeInterval(connectedElapsed.components.seconds),
+                lastActivityAt: Date.now - TimeInterval(activeElapsed.components.seconds)
+            ))
+        }
+        return snapshots
     }
 
     // MARK: - Listener State

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -23,14 +23,24 @@ actor MCPServer {
     private let stateCallback: @Sendable (MCPServerState) -> Void
     private var router: MCPRouter!
 
-    var toolCallHandler: (@Sendable (String, JSONValue?, String) async throws -> MCPToolResult)?
-    var resourceReadHandler: (@Sendable (String, String) async throws -> MCPResourceReadResult)?
+    private(set) var toolCallHandler: (@Sendable (String, JSONValue?, String) async throws -> MCPToolResult)?
+    private(set) var resourceReadHandler: (@Sendable (String, String) async throws -> MCPResourceReadResult)?
 
     // MARK: - Initialization
 
     init(stateCallback: @escaping @Sendable (MCPServerState) -> Void) {
         self.stateCallback = stateCallback
         self.router = MCPRouter()
+    }
+
+    // MARK: - Handler Configuration
+
+    func setToolCallHandler(_ handler: @escaping @Sendable (String, JSONValue?, String) async throws -> MCPToolResult) {
+        self.toolCallHandler = handler
+    }
+
+    func setResourceReadHandler(_ handler: @escaping @Sendable (String, String) async throws -> MCPResourceReadResult) {
+        self.resourceReadHandler = handler
     }
 
     // MARK: - Lifecycle

--- a/TablePro/Core/MCP/MCPServer.swift
+++ b/TablePro/Core/MCP/MCPServer.swift
@@ -92,23 +92,30 @@ actor MCPServer {
         startCleanupTimer()
     }
 
-    func stop() {
+    func stop() async {
         Self.logger.info("Stopping MCP server")
 
         cleanupTask?.cancel()
         cleanupTask = nil
 
         for (_, session) in sessions {
-            Task {
-                await session.cancelAllTasks()
-                await session.cancelSSEConnection()
-            }
+            await session.cancelAllTasks()
+            await session.cancelSSEConnection()
         }
         sessions.removeAll()
 
-        let currentListener = listener
-        listener = nil
-        currentListener?.cancel()
+        if let currentListener = listener {
+            listener = nil
+            currentListener.cancel()
+            // Wait for the listener to fully release the port
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                currentListener.stateUpdateHandler = { state in
+                    if case .cancelled = state {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
 
         stateCallback(.stopped)
     }

--- a/TablePro/Core/MCP/MCPServerManager.swift
+++ b/TablePro/Core/MCP/MCPServerManager.swift
@@ -24,6 +24,7 @@ final class MCPServerManager {
     private(set) var connectedClients: [MCPServer.SessionSnapshot] = []
     private var server: MCPServer?
     private var clientRefreshTask: Task<Void, Never>?
+    private var serverGeneration: Int = 0
 
     var isRunning: Bool {
         if case .running = state { return true } else { return false }
@@ -43,9 +44,12 @@ final class MCPServerManager {
             await stop()
         }
 
+        serverGeneration += 1
+        let generation = serverGeneration
         let newServer = MCPServer { [weak self] newState in
             Task { @MainActor in
-                self?.state = newState
+                guard let self, self.serverGeneration == generation else { return }
+                self.state = newState
             }
         }
 

--- a/TablePro/Core/MCP/MCPServerManager.swift
+++ b/TablePro/Core/MCP/MCPServerManager.swift
@@ -61,6 +61,9 @@ final class MCPServerManager {
         await newServer.setResourceReadHandler { uri, sessionId in
             try await resourceHandler.handleResourceRead(uri: uri, sessionId: sessionId)
         }
+        await newServer.setSessionCleanupHandler { sessionId in
+            await authGuard.clearSession(sessionId)
+        }
 
         do {
             try await newServer.start(port: port)

--- a/TablePro/Core/MCP/MCPServerManager.swift
+++ b/TablePro/Core/MCP/MCPServerManager.swift
@@ -21,7 +21,9 @@ final class MCPServerManager {
     static let shared = MCPServerManager()
 
     private(set) var state: MCPServerState = .stopped
+    private(set) var connectedClients: [MCPServer.SessionSnapshot] = []
     private var server: MCPServer?
+    private var clientRefreshTask: Task<Void, Never>?
 
     var isRunning: Bool {
         if case .running = state { return true } else { return false }
@@ -67,6 +69,7 @@ final class MCPServerManager {
 
         do {
             try await newServer.start(port: port)
+            startClientRefresh()
         } catch {
             Self.logger.error("Failed to start MCP server: \(error.localizedDescription)")
             state = .failed(error.localizedDescription)
@@ -75,6 +78,7 @@ final class MCPServerManager {
     }
 
     func stop() async {
+        stopClientRefresh()
         guard let server else { return }
         await server.stop()
         self.server = nil
@@ -84,5 +88,35 @@ final class MCPServerManager {
     func restart(port: UInt16) async {
         await stop()
         await start(port: port)
+    }
+
+    func disconnectClient(_ sessionId: String) async {
+        await server?.removeSession(sessionId)
+        await refreshClients()
+    }
+
+    // MARK: - Client Refresh
+
+    private func startClientRefresh() {
+        clientRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshClients()
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
+    }
+
+    private func stopClientRefresh() {
+        clientRefreshTask?.cancel()
+        clientRefreshTask = nil
+        connectedClients = []
+    }
+
+    private func refreshClients() async {
+        guard let server else {
+            connectedClients = []
+            return
+        }
+        connectedClients = await server.sessionSnapshots()
     }
 }

--- a/TablePro/Core/MCP/MCPServerManager.swift
+++ b/TablePro/Core/MCP/MCPServerManager.swift
@@ -49,6 +49,19 @@ final class MCPServerManager {
 
         self.server = newServer
 
+        // Wire tool and resource handlers
+        let bridge = MCPConnectionBridge()
+        let authGuard = MCPAuthGuard()
+        let toolHandler = MCPToolHandler(bridge: bridge, authGuard: authGuard)
+        let resourceHandler = MCPResourceHandler(bridge: bridge)
+
+        await newServer.setToolCallHandler { name, arguments, sessionId in
+            try await toolHandler.handleToolCall(name: name, arguments: arguments, sessionId: sessionId)
+        }
+        await newServer.setResourceReadHandler { uri, sessionId in
+            try await resourceHandler.handleResourceRead(uri: uri, sessionId: sessionId)
+        }
+
         do {
             try await newServer.start(port: port)
         } catch {

--- a/TablePro/Core/MCP/MCPServerManager.swift
+++ b/TablePro/Core/MCP/MCPServerManager.swift
@@ -1,0 +1,72 @@
+//
+//  MCPServerManager.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// MCP server lifecycle state
+enum MCPServerState: Sendable, Equatable {
+    case stopped
+    case starting
+    case running(port: UInt16)
+    case failed(String)
+}
+
+@MainActor @Observable
+final class MCPServerManager {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPServerManager")
+
+    static let shared = MCPServerManager()
+
+    private(set) var state: MCPServerState = .stopped
+    private var server: MCPServer?
+
+    var isRunning: Bool {
+        if case .running = state { return true } else { return false }
+    }
+
+    var connectedClientCount: Int {
+        get async {
+            guard let server else { return 0 }
+            return await server.sessionCount
+        }
+    }
+
+    private init() {}
+
+    func start(port: UInt16) async {
+        if server != nil {
+            await stop()
+        }
+
+        let newServer = MCPServer { [weak self] newState in
+            Task { @MainActor in
+                self?.state = newState
+            }
+        }
+
+        self.server = newServer
+
+        do {
+            try await newServer.start(port: port)
+        } catch {
+            Self.logger.error("Failed to start MCP server: \(error.localizedDescription)")
+            state = .failed(error.localizedDescription)
+            server = nil
+        }
+    }
+
+    func stop() async {
+        guard let server else { return }
+        await server.stop()
+        self.server = nil
+        state = .stopped
+    }
+
+    func restart(port: UInt16) async {
+        await stop()
+        await start(port: port)
+    }
+}

--- a/TablePro/Core/MCP/MCPSession.swift
+++ b/TablePro/Core/MCP/MCPSession.swift
@@ -1,20 +1,15 @@
 import Foundation
 import Network
 
-final class MCPSession: Sendable {
-
+actor MCPSession {
     let id: String
     let createdAt: ContinuousClock.Instant
 
-    // All mutable state is protected by MCPServer actor isolation.
-    // Using nonisolated(unsafe) because MCPSession is only mutated
-    // from within the MCPServer actor.
-    nonisolated(unsafe) var lastActivityAt: ContinuousClock.Instant
-    nonisolated(unsafe) var isInitialized: Bool = false
-    nonisolated(unsafe) var clientInfo: MCPClientInfo?
-    nonisolated(unsafe) var sseConnection: NWConnection?
-    nonisolated(unsafe) var approvedConnectionIds: Set<UUID> = []
-    nonisolated(unsafe) var runningTasks: [JSONRPCId: Task<Void, Never>] = [:]
+    var lastActivityAt: ContinuousClock.Instant
+    var isInitialized: Bool = false
+    var clientInfo: MCPClientInfo?
+    var sseConnection: NWConnection?
+    var runningTasks: [JSONRPCId: Task<Void, Never>] = [:]
 
     init() {
         self.id = UUID().uuidString
@@ -32,5 +27,29 @@ final class MCPSession: Sendable {
             task.cancel()
         }
         runningTasks.removeAll()
+    }
+
+    func setInitialized(_ value: Bool) {
+        isInitialized = value
+    }
+
+    func setClientInfo(_ info: MCPClientInfo?) {
+        clientInfo = info
+    }
+
+    func setSSEConnection(_ connection: NWConnection?) {
+        sseConnection = connection
+    }
+
+    func cancelSSEConnection() {
+        sseConnection?.cancel()
+    }
+
+    func addRunningTask(_ id: JSONRPCId, task: Task<Void, Never>) {
+        runningTasks[id] = task
+    }
+
+    func removeRunningTask(_ id: JSONRPCId) -> Task<Void, Never>? {
+        runningTasks.removeValue(forKey: id)
     }
 }

--- a/TablePro/Core/MCP/MCPSession.swift
+++ b/TablePro/Core/MCP/MCPSession.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Network
+
+final class MCPSession: Sendable {
+
+    let id: String
+    let createdAt: ContinuousClock.Instant
+
+    // All mutable state is protected by MCPServer actor isolation.
+    // Using nonisolated(unsafe) because MCPSession is only mutated
+    // from within the MCPServer actor.
+    nonisolated(unsafe) var lastActivityAt: ContinuousClock.Instant
+    nonisolated(unsafe) var isInitialized: Bool = false
+    nonisolated(unsafe) var clientInfo: MCPClientInfo?
+    nonisolated(unsafe) var sseConnection: NWConnection?
+    nonisolated(unsafe) var approvedConnectionIds: Set<UUID> = []
+    nonisolated(unsafe) var runningTasks: [JSONRPCId: Task<Void, Never>] = [:]
+
+    init() {
+        self.id = UUID().uuidString
+        let now = ContinuousClock.now
+        self.createdAt = now
+        self.lastActivityAt = now
+    }
+
+    func markActive() {
+        lastActivityAt = .now
+    }
+
+    func cancelAllTasks() {
+        for (_, task) in runningTasks {
+            task.cancel()
+        }
+        runningTasks.removeAll()
+    }
+}

--- a/TablePro/Core/MCP/MCPSession.swift
+++ b/TablePro/Core/MCP/MCPSession.swift
@@ -10,6 +10,7 @@ actor MCPSession {
     var clientInfo: MCPClientInfo?
     var sseConnection: NWConnection?
     var runningTasks: [JSONRPCId: Task<Void, Never>] = [:]
+    private(set) var eventCounter: Int = 0
 
     init() {
         self.id = UUID().uuidString
@@ -51,5 +52,10 @@ actor MCPSession {
 
     func removeRunningTask(_ id: JSONRPCId) -> Task<Void, Never>? {
         runningTasks.removeValue(forKey: id)
+    }
+
+    func nextEventId() -> String {
+        eventCounter += 1
+        return String(eventCounter)
     }
 }

--- a/TablePro/Core/MCP/MCPToolHandler.swift
+++ b/TablePro/Core/MCP/MCPToolHandler.swift
@@ -1,0 +1,431 @@
+//
+//  MCPToolHandler.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+final class MCPToolHandler: Sendable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPToolHandler")
+
+    private let bridge: MCPConnectionBridge
+    private let authGuard: MCPAuthGuard
+
+    init(bridge: MCPConnectionBridge, authGuard: MCPAuthGuard) {
+        self.bridge = bridge
+        self.authGuard = authGuard
+    }
+
+    // MARK: - Dispatch
+
+    func handleToolCall(name: String, arguments: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        switch name {
+        case "list_connections":
+            return try await handleListConnections()
+        case "connect":
+            return try await handleConnect(arguments, sessionId: sessionId)
+        case "disconnect":
+            return try await handleDisconnect(arguments)
+        case "get_connection_status":
+            return try await handleGetConnectionStatus(arguments)
+        case "execute_query":
+            return try await handleExecuteQuery(arguments, sessionId: sessionId)
+        case "list_tables":
+            return try await handleListTables(arguments, sessionId: sessionId)
+        case "describe_table":
+            return try await handleDescribeTable(arguments, sessionId: sessionId)
+        case "list_databases":
+            return try await handleListDatabases(arguments, sessionId: sessionId)
+        case "list_schemas":
+            return try await handleListSchemas(arguments, sessionId: sessionId)
+        case "get_table_ddl":
+            return try await handleGetTableDDL(arguments, sessionId: sessionId)
+        case "export_data":
+            return try await handleExportData(arguments, sessionId: sessionId)
+        case "switch_database":
+            return try await handleSwitchDatabase(arguments, sessionId: sessionId)
+        case "switch_schema":
+            return try await handleSwitchSchema(arguments, sessionId: sessionId)
+        default:
+            throw MCPError.methodNotFound(name)
+        }
+    }
+
+    // MARK: - Connection Tools
+
+    private func handleListConnections() async throws -> MCPToolResult {
+        let result = await bridge.listConnections()
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleConnect(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+        let result = try await bridge.connect(connectionId: connectionId)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleDisconnect(_ args: JSONValue?) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        try await bridge.disconnect(connectionId: connectionId)
+        let result: JSONValue = .object(["status": "disconnected"])
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleGetConnectionStatus(_ args: JSONValue?) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let result = try await bridge.getConnectionStatus(connectionId: connectionId)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    // MARK: - Query Execution
+
+    private func handleExecuteQuery(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let query = try requireString(args, key: "query")
+        let maxRows = optionalInt(args, key: "max_rows", default: 500, clamp: 1...10_000)
+        let timeoutSeconds = optionalInt(args, key: "timeout_seconds", default: 30, clamp: 1...300)
+        let database = optionalString(args, key: "database")
+        let schema = optionalString(args, key: "schema")
+
+        guard (query as NSString).length <= 102_400 else {
+            throw MCPError.invalidParams("Query exceeds 100KB limit")
+        }
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        let (databaseType, safeModeLevel, databaseName) = try await resolveConnectionMeta(connectionId)
+
+        if let database {
+            _ = try await bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+        if let schema {
+            _ = try await bridge.switchSchema(connectionId: connectionId, schema: schema)
+        }
+
+        try await authGuard.checkQueryPermission(
+            sql: query,
+            connectionId: connectionId,
+            databaseType: databaseType,
+            safeModeLevel: safeModeLevel
+        )
+
+        let startTime = Date()
+        let result: JSONValue
+        do {
+            result = try await bridge.executeQuery(
+                connectionId: connectionId,
+                query: query,
+                maxRows: maxRows,
+                timeoutSeconds: timeoutSeconds
+            )
+            let elapsed = Date().timeIntervalSince(startTime)
+            await authGuard.logQuery(
+                sql: query,
+                connectionId: connectionId,
+                databaseName: databaseName,
+                executionTime: elapsed,
+                rowCount: result["row_count"]?.intValue ?? 0,
+                wasSuccessful: true,
+                errorMessage: nil
+            )
+        } catch {
+            let elapsed = Date().timeIntervalSince(startTime)
+            await authGuard.logQuery(
+                sql: query,
+                connectionId: connectionId,
+                databaseName: databaseName,
+                executionTime: elapsed,
+                rowCount: 0,
+                wasSuccessful: false,
+                errorMessage: error.localizedDescription
+            )
+            throw error
+        }
+
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    // MARK: - Schema Tools
+
+    private func handleListTables(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let includeRowCounts = optionalBool(args, key: "include_row_counts", default: false)
+        let database = optionalString(args, key: "database")
+        let schema = optionalString(args, key: "schema")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        if let database {
+            _ = try await bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+        if let schema {
+            _ = try await bridge.switchSchema(connectionId: connectionId, schema: schema)
+        }
+
+        let result = try await bridge.listTables(connectionId: connectionId, includeRowCounts: includeRowCounts)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleDescribeTable(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let table = try requireString(args, key: "table")
+        let schema = optionalString(args, key: "schema")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        let result = try await bridge.describeTable(connectionId: connectionId, table: table, schema: schema)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleListDatabases(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+        let result = try await bridge.listDatabases(connectionId: connectionId)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleListSchemas(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let database = optionalString(args, key: "database")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        if let database {
+            _ = try await bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+
+        let result = try await bridge.listSchemas(connectionId: connectionId)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleGetTableDDL(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let table = try requireString(args, key: "table")
+        let schema = optionalString(args, key: "schema")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        let result = try await bridge.getTableDDL(connectionId: connectionId, table: table, schema: schema)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    // MARK: - Export
+
+    private func handleExportData(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let format = try requireString(args, key: "format")
+        let query = optionalString(args, key: "query")
+        let tables = optionalStringArray(args, key: "tables")
+        let maxRows = optionalInt(args, key: "max_rows", default: 50_000, clamp: 1...100_000)
+
+        guard ["csv", "json", "sql", "xlsx"].contains(format) else {
+            throw MCPError.invalidParams("Unsupported format: \(format). Must be csv, json, sql, or xlsx")
+        }
+
+        guard query != nil || tables != nil else {
+            throw MCPError.invalidParams("Either 'query' or 'tables' must be provided")
+        }
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        var queries: [(label: String, sql: String)] = []
+
+        if let query {
+            let (databaseType, safeModeLevel, _) = try await resolveConnectionMeta(connectionId)
+            try await authGuard.checkQueryPermission(
+                sql: query,
+                connectionId: connectionId,
+                databaseType: databaseType,
+                safeModeLevel: safeModeLevel
+            )
+            queries.append((label: "query", sql: query))
+        } else if let tables {
+            for table in tables {
+                queries.append((label: table, sql: "SELECT * FROM \(table) LIMIT \(maxRows)"))
+            }
+        }
+
+        var exportResults: [JSONValue] = []
+
+        for (label, sql) in queries {
+            let result = try await bridge.executeQuery(
+                connectionId: connectionId,
+                query: sql,
+                maxRows: maxRows,
+                timeoutSeconds: 60
+            )
+
+            guard let columns = result["columns"]?.arrayValue,
+                  let rows = result["rows"]?.arrayValue
+            else {
+                throw MCPError.internalError("Unexpected query result structure")
+            }
+
+            let columnNames = columns.compactMap(\.stringValue)
+            let formatted: String
+
+            switch format {
+            case "csv":
+                formatted = formatCSV(columns: columnNames, rows: rows)
+            case "json":
+                formatted = formatJSON(columns: columnNames, rows: rows)
+            default:
+                formatted = formatCSV(columns: columnNames, rows: rows)
+            }
+
+            exportResults.append(.object([
+                "label": .string(label),
+                "format": .string(format),
+                "row_count": result["row_count"] ?? .int(0),
+                "data": .string(formatted)
+            ]))
+        }
+
+        let response: JSONValue
+        if exportResults.count == 1, let single = exportResults.first {
+            response = single
+        } else {
+            response = .object(["exports": .array(exportResults)])
+        }
+
+        return MCPToolResult(content: [.text(encodeJSON(response))], isError: nil)
+    }
+
+    // MARK: - Database/Schema Switching
+
+    private func handleSwitchDatabase(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let database = try requireString(args, key: "database")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        let result = try await bridge.switchDatabase(connectionId: connectionId, database: database)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    private func handleSwitchSchema(_ args: JSONValue?, sessionId: String) async throws -> MCPToolResult {
+        let connectionId = try requireUUID(args, key: "connection_id")
+        let schema = try requireString(args, key: "schema")
+
+        try await authGuard.checkConnectionAccess(connectionId: connectionId, sessionId: sessionId)
+
+        let result = try await bridge.switchSchema(connectionId: connectionId, schema: schema)
+        return MCPToolResult(content: [.text(encodeJSON(result))], isError: nil)
+    }
+
+    // MARK: - Parameter Helpers
+
+    private func requireUUID(_ args: JSONValue?, key: String) throws -> UUID {
+        guard let value = args?[key]?.stringValue else {
+            throw MCPError.invalidParams("Missing required parameter: \(key)")
+        }
+        guard let uuid = UUID(uuidString: value) else {
+            throw MCPError.invalidParams("Invalid UUID for parameter: \(key)")
+        }
+        return uuid
+    }
+
+    private func requireString(_ args: JSONValue?, key: String) throws -> String {
+        guard let value = args?[key]?.stringValue else {
+            throw MCPError.invalidParams("Missing required parameter: \(key)")
+        }
+        return value
+    }
+
+    private func optionalString(_ args: JSONValue?, key: String) -> String? {
+        args?[key]?.stringValue
+    }
+
+    private func optionalInt(_ args: JSONValue?, key: String, default defaultValue: Int, clamp range: ClosedRange<Int>) -> Int {
+        guard let value = args?[key]?.intValue else { return defaultValue }
+        return min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    private func optionalBool(_ args: JSONValue?, key: String, default defaultValue: Bool) -> Bool {
+        args?[key]?.boolValue ?? defaultValue
+    }
+
+    private func optionalStringArray(_ args: JSONValue?, key: String) -> [String]? {
+        guard let array = args?[key]?.arrayValue else { return nil }
+        let strings = array.compactMap(\.stringValue)
+        return strings.isEmpty ? nil : strings
+    }
+
+    // MARK: - Connection Metadata
+
+    private func resolveConnectionMeta(_ connectionId: UUID) async throws -> (DatabaseType, SafeModeLevel, String) {
+        try await MainActor.run {
+            guard let session = DatabaseManager.shared.activeSessions[connectionId] else {
+                throw MCPError.notConnected(connectionId)
+            }
+            return (session.connection.type, session.connection.safeModeLevel, session.activeDatabase)
+        }
+    }
+
+    // MARK: - JSON Encoding
+
+    private func encodeJSON(_ value: JSONValue) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    // MARK: - Export Formatters
+
+    private func formatCSV(columns: [String], rows: [JSONValue]) -> String {
+        var lines: [String] = []
+        lines.append(columns.map { escapeCSVField($0) }.joined(separator: ","))
+
+        for row in rows {
+            guard let cells = row.arrayValue else { continue }
+            let line = cells.map { cell -> String in
+                switch cell {
+                case .string(let value):
+                    return escapeCSVField(value)
+                case .null:
+                    return ""
+                case .int(let value):
+                    return String(value)
+                case .double(let value):
+                    return String(value)
+                case .bool(let value):
+                    return value ? "true" : "false"
+                default:
+                    return escapeCSVField(encodeJSON(cell))
+                }
+            }
+            lines.append(line.joined(separator: ","))
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func escapeCSVField(_ field: String) -> String {
+        if field.contains(",") || field.contains("\"") || field.contains("\n") {
+            return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return field
+    }
+
+    private func formatJSON(columns: [String], rows: [JSONValue]) -> String {
+        var objects: [JSONValue] = []
+
+        for row in rows {
+            guard let cells = row.arrayValue else { continue }
+            var dict: [String: JSONValue] = [:]
+            for (index, column) in columns.enumerated() where index < cells.count {
+                dict[column] = cells[index]
+            }
+            objects.append(.object(dict))
+        }
+
+        return encodeJSON(.array(objects))
+    }
+}

--- a/TablePro/Core/MCP/MCPToolHandler.swift
+++ b/TablePro/Core/MCP/MCPToolHandler.swift
@@ -218,10 +218,16 @@ final class MCPToolHandler: Sendable {
         let format = try requireString(args, key: "format")
         let query = optionalString(args, key: "query")
         let tables = optionalStringArray(args, key: "tables")
+        let outputPath = optionalString(args, key: "output_path")
         let maxRows = optionalInt(args, key: "max_rows", default: 50_000, clamp: 1...100_000)
 
         guard ["csv", "json", "sql", "xlsx"].contains(format) else {
             throw MCPError.invalidParams("Unsupported format: \(format). Must be csv, json, sql, or xlsx")
+        }
+
+        // XLSX is binary and cannot be returned inline
+        if format == "xlsx" && outputPath == nil {
+            throw MCPError.invalidParams("XLSX export requires output_path since it is a binary format")
         }
 
         guard query != nil || tables != nil else {
@@ -248,6 +254,7 @@ final class MCPToolHandler: Sendable {
         }
 
         var exportResults: [JSONValue] = []
+        var totalRowsExported = 0
 
         for (label, sql) in queries {
             let result = try await bridge.executeQuery(
@@ -271,9 +278,16 @@ final class MCPToolHandler: Sendable {
                 formatted = formatCSV(columns: columnNames, rows: rows)
             case "json":
                 formatted = formatJSON(columns: columnNames, rows: rows)
+            case "sql":
+                formatted = formatSQL(table: label, columns: columnNames, rows: rows)
+            case "xlsx":
+                // XLSX is handled via file write below; generate CSV as intermediate
+                formatted = formatCSV(columns: columnNames, rows: rows)
             default:
                 formatted = formatCSV(columns: columnNames, rows: rows)
             }
+
+            totalRowsExported += rows.count
 
             exportResults.append(.object([
                 "label": .string(label),
@@ -283,6 +297,28 @@ final class MCPToolHandler: Sendable {
             ]))
         }
 
+        // If output_path is provided, write to file
+        if let outputPath {
+            let fullContent: String
+            if exportResults.count == 1,
+               let data = exportResults.first?["data"]?.stringValue
+            {
+                fullContent = data
+            } else {
+                fullContent = exportResults.compactMap { $0["data"]?.stringValue }.joined(separator: "\n\n")
+            }
+
+            let fileURL = URL(fileURLWithPath: outputPath)
+            try fullContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let response: JSONValue = .object([
+                "path": .string(outputPath),
+                "rows_exported": .int(totalRowsExported)
+            ])
+            return MCPToolResult(content: [.text(encodeJSON(response))], isError: nil)
+        }
+
+        // Return inline data
         let response: JSONValue
         if exportResults.count == 1, let single = exportResults.first {
             response = single
@@ -372,6 +408,7 @@ final class MCPToolHandler: Sendable {
         guard let data = try? encoder.encode(value),
               let string = String(data: data, encoding: .utf8)
         else {
+            Self.logger.warning("Failed to encode JSON value")
             return "{}"
         }
         return string
@@ -427,5 +464,43 @@ final class MCPToolHandler: Sendable {
         }
 
         return encodeJSON(.array(objects))
+    }
+
+    private func formatSQL(table: String, columns: [String], rows: [JSONValue]) -> String {
+        guard !columns.isEmpty else { return "" }
+
+        var statements: [String] = []
+        let escapedTable = "`\(table.replacingOccurrences(of: "`", with: "``"))`"
+        let escapedColumns = columns.map { "`\($0.replacingOccurrences(of: "`", with: "``"))`" }
+        let columnList = escapedColumns.joined(separator: ", ")
+
+        for row in rows {
+            guard let cells = row.arrayValue else { continue }
+            let values = cells.map { cell -> String in
+                switch cell {
+                case .null:
+                    return "NULL"
+                case .string(let value):
+                    let escaped = value
+                        .replacingOccurrences(of: "\\", with: "\\\\")
+                        .replacingOccurrences(of: "'", with: "\\'")
+                    return "'\(escaped)'"
+                case .int(let value):
+                    return String(value)
+                case .double(let value):
+                    return String(value)
+                case .bool(let value):
+                    return value ? "1" : "0"
+                default:
+                    let escaped = encodeJSON(cell)
+                        .replacingOccurrences(of: "\\", with: "\\\\")
+                        .replacingOccurrences(of: "'", with: "\\'")
+                    return "'\(escaped)'"
+                }
+            }
+            statements.append("INSERT INTO \(escapedTable) (\(columnList)) VALUES (\(values.joined(separator: ", ")));")
+        }
+
+        return statements.joined(separator: "\n")
     }
 }

--- a/TablePro/Core/MCP/MCPToolHandler.swift
+++ b/TablePro/Core/MCP/MCPToolHandler.swift
@@ -221,13 +221,8 @@ final class MCPToolHandler: Sendable {
         let outputPath = optionalString(args, key: "output_path")
         let maxRows = optionalInt(args, key: "max_rows", default: 50_000, clamp: 1...100_000)
 
-        guard ["csv", "json", "sql", "xlsx"].contains(format) else {
-            throw MCPError.invalidParams("Unsupported format: \(format). Must be csv, json, sql, or xlsx")
-        }
-
-        // XLSX is binary and cannot be returned inline
-        if format == "xlsx" && outputPath == nil {
-            throw MCPError.invalidParams("XLSX export requires output_path since it is a binary format")
+        guard ["csv", "json", "sql"].contains(format) else {
+            throw MCPError.invalidParams("Unsupported format: \(format). Must be csv, json, or sql")
         }
 
         guard query != nil || tables != nil else {
@@ -280,9 +275,6 @@ final class MCPToolHandler: Sendable {
                 formatted = formatJSON(columns: columnNames, rows: rows)
             case "sql":
                 formatted = formatSQL(table: label, columns: columnNames, rows: rows)
-            case "xlsx":
-                // XLSX is handled via file write below; generate CSV as intermediate
-                formatted = formatCSV(columns: columnNames, rows: rows)
             default:
                 formatted = formatCSV(columns: columnNames, rows: rows)
             }

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -146,9 +146,10 @@ final class AppSettingsManager {
         didSet {
             storage.saveMCP(mcp)
             SyncChangeTracker.shared.markDirty(.settings, id: "mcp")
-            Task { @MainActor in
-                if mcp.enabled {
-                    await MCPServerManager.shared.restart(port: UInt16(mcp.port))
+            let settings = mcp
+            Task {
+                if settings.enabled {
+                    await MCPServerManager.shared.restart(port: UInt16(clamping: settings.port))
                 } else {
                     await MCPServerManager.shared.stop()
                 }

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -146,12 +146,16 @@ final class AppSettingsManager {
         didSet {
             storage.saveMCP(mcp)
             SyncChangeTracker.shared.markDirty(.settings, id: "mcp")
-            let settings = mcp
-            Task {
-                if settings.enabled {
-                    await MCPServerManager.shared.restart(port: UInt16(clamping: settings.port))
-                } else {
-                    await MCPServerManager.shared.stop()
+            let enabledChanged = mcp.enabled != oldValue.enabled
+            let portChanged = mcp.port != oldValue.port
+            if enabledChanged || portChanged {
+                let settings = mcp
+                Task {
+                    if settings.enabled {
+                        await MCPServerManager.shared.restart(port: UInt16(clamping: settings.port))
+                    } else {
+                        await MCPServerManager.shared.stop()
+                    }
                 }
             }
         }

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -146,6 +146,13 @@ final class AppSettingsManager {
         didSet {
             storage.saveMCP(mcp)
             SyncChangeTracker.shared.markDirty(.settings, id: "mcp")
+            Task { @MainActor in
+                if mcp.enabled {
+                    await MCPServerManager.shared.restart(port: UInt16(mcp.port))
+                } else {
+                    await MCPServerManager.shared.stop()
+                }
+            }
         }
     }
 

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -142,6 +142,13 @@ final class AppSettingsManager {
         }
     }
 
+    var mcp: MCPSettings {
+        didSet {
+            storage.saveMCP(mcp)
+            SyncChangeTracker.shared.markDirty(.settings, id: "mcp")
+        }
+    }
+
     @ObservationIgnored private let storage = AppSettingsStorage.shared
     /// Reentrancy guard for didSet validation that re-assigns the property.
     @ObservationIgnored private var isValidating = false
@@ -165,6 +172,7 @@ final class AppSettingsManager {
         self.ai = storage.loadAI()
         self.sync = storage.loadSync()
         self.terminal = storage.loadTerminal()
+        self.mcp = storage.loadMCP()
 
         // Apply language immediately
         general.language.apply()
@@ -242,6 +250,7 @@ final class AppSettingsManager {
         ai = .default
         sync = .default
         terminal = .default
+        mcp = .default
         storage.resetToDefaults()
     }
 }

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -31,6 +31,7 @@ final class AppSettingsStorage {
         static let ai = "com.TablePro.settings.ai"
         static let sync = "com.TablePro.settings.sync"
         static let terminal = "com.TablePro.settings.terminal"
+        static let mcp = "com.TablePro.settings.mcp"
         static let lastConnectionId = "com.TablePro.settings.lastConnectionId"
         static let lastOpenConnectionIds = "com.TablePro.settings.lastOpenConnectionIds"
         static let hasCompletedOnboarding = "com.TablePro.settings.hasCompletedOnboarding"
@@ -139,6 +140,16 @@ final class AppSettingsStorage {
         save(settings, key: Keys.terminal)
     }
 
+    // MARK: - MCP Settings
+
+    func loadMCP() -> MCPSettings {
+        load(key: Keys.mcp, default: .default)
+    }
+
+    func saveMCP(_ settings: MCPSettings) {
+        save(settings, key: Keys.mcp)
+    }
+
     // MARK: - Last Connection (for Reopen Last Session)
 
     /// Load the last used connection ID
@@ -231,6 +242,7 @@ final class AppSettingsStorage {
         saveAI(.default)
         saveSync(.default)
         saveTerminal(.default)
+        saveMCP(.default)
     }
 
     // MARK: - Helpers

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -10,6 +10,7 @@ enum QueryClassifier {
         "INSERT ", "UPDATE ", "DELETE ", "REPLACE ",
         "DROP ", "TRUNCATE ", "ALTER ", "CREATE ",
         "RENAME ", "GRANT ", "REVOKE ",
+        "MERGE ", "UPSERT ", "CALL ", "EXEC ", "EXECUTE ", "LOAD ",
     ]
 
     private static let redisWriteCommands: Set<String> = [

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -1,0 +1,75 @@
+//
+//  QueryClassifier.swift
+//  TablePro
+//
+
+import Foundation
+
+enum QueryClassifier {
+    private static let writeQueryPrefixes: [String] = [
+        "INSERT ", "UPDATE ", "DELETE ", "REPLACE ",
+        "DROP ", "TRUNCATE ", "ALTER ", "CREATE ",
+        "RENAME ", "GRANT ", "REVOKE ",
+    ]
+
+    private static let redisWriteCommands: Set<String> = [
+        "SET", "DEL", "HSET", "HDEL", "HMSET", "LPUSH", "RPUSH", "LPOP", "RPOP",
+        "SADD", "SREM", "ZADD", "ZREM", "EXPIRE", "PERSIST", "RENAME",
+        "FLUSHDB", "FLUSHALL", "MSET", "APPEND", "INCR", "DECR", "INCRBY",
+        "DECRBY", "SETEX", "PSETEX", "SETNX", "GETSET", "GETDEL",
+        "XADD", "XTRIM", "XDEL",
+    ]
+
+    private static let redisDangerousCommands: Set<String> = [
+        "FLUSHDB", "FLUSHALL", "DEBUG", "SHUTDOWN",
+    ]
+
+    private static let whereClauseRegex = try? NSRegularExpression(pattern: "\\sWHERE\\s", options: [])
+
+    static func isWriteQuery(_ sql: String, databaseType: DatabaseType) -> Bool {
+        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if databaseType == .redis {
+            let firstToken = trimmed.prefix(while: { !$0.isWhitespace }).uppercased()
+            if firstToken == "CONFIG" {
+                let rest = trimmed.dropFirst(firstToken.count).trimmingCharacters(in: .whitespaces)
+                return rest.uppercased().hasPrefix("SET")
+            }
+            return redisWriteCommands.contains(firstToken)
+        }
+
+        let uppercased = trimmed.uppercased()
+        return writeQueryPrefixes.contains { uppercased.hasPrefix($0) }
+    }
+
+    static func isDangerousQuery(_ sql: String, databaseType: DatabaseType) -> Bool {
+        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if databaseType == .redis {
+            let firstToken = trimmed.prefix(while: { !$0.isWhitespace }).uppercased()
+            if firstToken == "CONFIG" {
+                let rest = trimmed.dropFirst(firstToken.count).trimmingCharacters(in: .whitespaces)
+                return rest.uppercased().hasPrefix("SET")
+            }
+            return redisDangerousCommands.contains(firstToken)
+        }
+
+        let uppercased = trimmed.uppercased()
+
+        if uppercased.hasPrefix("DROP ") {
+            return true
+        }
+
+        if uppercased.hasPrefix("TRUNCATE ") {
+            return true
+        }
+
+        if uppercased.hasPrefix("DELETE ") {
+            let range = NSRange(uppercased.startIndex..., in: uppercased)
+            let hasWhere = whereClauseRegex?.firstMatch(in: uppercased, options: [], range: range) != nil
+            return !hasWhere
+        }
+
+        return false
+    }
+}

--- a/TablePro/Models/Settings/MCPSettings.swift
+++ b/TablePro/Models/Settings/MCPSettings.swift
@@ -43,7 +43,8 @@ struct MCPSettings: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
-        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? 23508
+        let rawPort = try container.decodeIfPresent(Int.self, forKey: .port) ?? 23508
+        port = (1...65535).contains(rawPort) ? rawPort : 23508
         defaultRowLimit = try container.decodeIfPresent(Int.self, forKey: .defaultRowLimit) ?? 500
         maxRowLimit = try container.decodeIfPresent(Int.self, forKey: .maxRowLimit) ?? 10_000
         queryTimeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .queryTimeoutSeconds) ?? 30

--- a/TablePro/Models/Settings/MCPSettings.swift
+++ b/TablePro/Models/Settings/MCPSettings.swift
@@ -1,0 +1,52 @@
+//
+//  MCPSettings.swift
+//  TablePro
+//
+//  User-configurable MCP server preferences
+//
+
+import Foundation
+
+struct MCPSettings: Codable, Equatable {
+    var enabled: Bool
+    var port: Int
+    var defaultRowLimit: Int
+    var maxRowLimit: Int
+    var queryTimeoutSeconds: Int
+    var logQueriesInHistory: Bool
+
+    static let `default` = MCPSettings(
+        enabled: false,
+        port: 23508,
+        defaultRowLimit: 500,
+        maxRowLimit: 10_000,
+        queryTimeoutSeconds: 30,
+        logQueriesInHistory: true
+    )
+
+    init(
+        enabled: Bool = false,
+        port: Int = 23508,
+        defaultRowLimit: Int = 500,
+        maxRowLimit: Int = 10_000,
+        queryTimeoutSeconds: Int = 30,
+        logQueriesInHistory: Bool = true
+    ) {
+        self.enabled = enabled
+        self.port = port
+        self.defaultRowLimit = defaultRowLimit
+        self.maxRowLimit = maxRowLimit
+        self.queryTimeoutSeconds = queryTimeoutSeconds
+        self.logQueriesInHistory = logQueriesInHistory
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? 23508
+        defaultRowLimit = try container.decodeIfPresent(Int.self, forKey: .defaultRowLimit) ?? 500
+        maxRowLimit = try container.decodeIfPresent(Int.self, forKey: .maxRowLimit) ?? 10_000
+        queryTimeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .queryTimeoutSeconds) ?? 30
+        logQueriesInHistory = try container.decodeIfPresent(Bool.self, forKey: .logQueriesInHistory) ?? true
+    }
+}

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3783,6 +3783,9 @@
         }
       }
     },
+    "Add this to your AI tool's MCP configuration:" : {
+
+    },
     "Add validation rules to ensure data integrity" : {
       "localizations" : {
         "tr" : {
@@ -3870,6 +3873,12 @@
           }
         }
       }
+    },
+    "AI access is disabled for this connection" : {
+
+    },
+    "AI access policies are configured per-connection in each connection's settings." : {
+
     },
     "AI Chat" : {
       "localizations" : {
@@ -4535,6 +4544,9 @@
           }
         }
       }
+    },
+    "An MCP client wants to access '%@' (%@). Allow?" : {
+
     },
     "An unknown sync error occurred: %@" : {
       "localizations" : {
@@ -7312,6 +7324,9 @@
         }
       }
     },
+    "Client Configuration" : {
+
+    },
     "Client Key" : {
       "localizations" : {
         "tr" : {
@@ -8135,6 +8150,9 @@
           }
         }
       }
+    },
+    "Configuration" : {
+
     },
     "Configure an AI provider in Settings to start chatting." : {
       "localizations" : {
@@ -9353,6 +9371,9 @@
           }
         }
       }
+    },
+    "Copy to clipboard" : {
+
     },
     "Copy Value" : {
       "localizations" : {
@@ -11291,6 +11312,9 @@
         }
       }
     },
+    "Default row limit" : {
+
+    },
     "Default value" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -11902,6 +11926,9 @@
           }
         }
       }
+    },
+    "Deny" : {
+
     },
     "Destructive Changes" : {
 
@@ -13288,6 +13315,9 @@
           }
         }
       }
+    },
+    "Enable MCP Server" : {
+
     },
     "Enable preview tabs" : {
       "localizations" : {
@@ -15869,6 +15899,9 @@
           }
         }
       }
+    },
+    "Failed: %@" : {
+
     },
     "false" : {
       "localizations" : {
@@ -21016,6 +21049,9 @@
         }
       }
     },
+    "Log MCP queries in history" : {
+
+    },
     "Maintenance" : {
       "localizations" : {
         "tr" : {
@@ -21377,6 +21413,9 @@
         }
       }
     },
+    "Maximum row limit" : {
+
+    },
     "Maximum time to wait for a query to complete. Set to 0 for no limit. Applied to new connections." : {
       "localizations" : {
         "tr" : {
@@ -21398,6 +21437,15 @@
           }
         }
       }
+    },
+    "MCP" : {
+
+    },
+    "MCP Access Request" : {
+
+    },
+    "MCP query execution" : {
+
     },
     "Medium" : {
       "extractionState" : "stale",
@@ -27850,6 +27898,9 @@
     "Query results exceeding this limit show Load More / Fetch All buttons" : {
 
     },
+    "Query timeout" : {
+
+    },
     "Query timeout:" : {
       "localizations" : {
         "tr" : {
@@ -30076,6 +30127,9 @@
         }
       }
     },
+    "Running on port %d" : {
+
+    },
     "Running Threads" : {
 
     },
@@ -31139,6 +31193,9 @@
           }
         }
       }
+    },
+    "seconds" : {
+
     },
     "Secret Access Key" : {
       "localizations" : {
@@ -33739,6 +33796,9 @@
         }
       }
     },
+    "Starting..." : {
+
+    },
     "starts with" : {
       "localizations" : {
         "tr" : {
@@ -34064,6 +34124,9 @@
           }
         }
       }
+    },
+    "Stopped" : {
+
     },
     "Streaming failed: %@" : {
       "localizations" : {
@@ -38284,6 +38347,12 @@
           }
         }
       }
+    },
+    "User approval timed out after 30 seconds" : {
+
+    },
+    "User denied MCP access to this connection" : {
+
     },
     "User Sessions" : {
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -141,12 +141,14 @@ struct AppMenuCommands: Commands {
     }
 
     var body: some Commands {
-        // Custom About window + Check for Updates
+        // Custom About window + Check for Updates + MCP status
         CommandGroup(replacing: .appInfo) {
             Button(String(localized: "About TablePro")) {
                 AboutWindowController.shared.showAboutPanel()
             }
             CheckForUpdatesView(updaterBridge: updaterBridge)
+            Divider()
+            MCPServerMenuItem()
         }
 
         // MARK: - Keyboard Shortcut Architecture
@@ -664,6 +666,35 @@ struct CheckForUpdatesView: View {
             updaterBridge.checkForUpdates()
         }
         .disabled(!updaterBridge.canCheckForUpdates)
+    }
+}
+
+// MARK: - MCP Server Menu Item
+
+private struct MCPServerMenuItem: View {
+    @State private var manager = MCPServerManager.shared
+
+    var body: some View {
+        Button(menuTitle) {
+            NotificationCenter.default.post(name: .openSettingsWindow, object: nil)
+        }
+    }
+
+    private var menuTitle: String {
+        switch manager.state {
+        case .running:
+            let count = manager.connectedClients.count
+            if count == 0 {
+                return String(localized: "MCP Server: Running")
+            }
+            return String(format: String(localized: "MCP Server: Running (%d clients)"), count)
+        case .failed:
+            return String(localized: "MCP Server: Failed")
+        case .stopped:
+            return String(localized: "MCP Server: Stopped")
+        case .starting:
+            return String(localized: "MCP Server: Starting...")
+        }
     }
 }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryAnalysis.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryAnalysis.swift
@@ -10,7 +10,6 @@ import Foundation
 extension MainContentCoordinator {
     // MARK: - DDL Query Detection
 
-    /// DDL operations that modify schema structure
     private static let ddlPrefixes: [String] = [
         "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
     ]
@@ -22,86 +21,13 @@ extension MainContentCoordinator {
 
     // MARK: - Write Query Detection
 
-    /// Write-operation SQL prefixes blocked in read-only mode
-    private static let writeQueryPrefixes: [String] = [
-        "INSERT ", "UPDATE ", "DELETE ", "REPLACE ",
-        "DROP ", "TRUNCATE ", "ALTER ", "CREATE ",
-        "RENAME ", "GRANT ", "REVOKE ",
-    ]
-
-    /// Redis commands that modify data
-    private static let redisWriteCommands: Set<String> = [
-        "SET", "DEL", "HSET", "HDEL", "HMSET", "LPUSH", "RPUSH", "LPOP", "RPOP",
-        "SADD", "SREM", "ZADD", "ZREM", "EXPIRE", "PERSIST", "RENAME",
-        "FLUSHDB", "FLUSHALL", "MSET", "APPEND", "INCR", "DECR", "INCRBY",
-        "DECRBY", "SETEX", "PSETEX", "SETNX", "GETSET", "GETDEL",
-        "XADD", "XTRIM", "XDEL",
-    ]
-
-    /// Redis commands that are destructive
-    private static let redisDangerousCommands: Set<String> = [
-        "FLUSHDB", "FLUSHALL", "DEBUG", "SHUTDOWN",
-    ]
-
-    /// Check if a SQL statement is a write operation (modifies data or schema)
     func isWriteQuery(_ sql: String) -> Bool {
-        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Redis: check the first token against known write commands
-        if connection.type == .redis {
-            let firstToken = trimmed.prefix(while: { !$0.isWhitespace }).uppercased()
-            // CONFIG SET is a write; plain CONFIG GET is not
-            if firstToken == "CONFIG" {
-                let rest = trimmed.dropFirst(firstToken.count).trimmingCharacters(in: .whitespaces)
-                return rest.uppercased().hasPrefix("SET")
-            }
-            return Self.redisWriteCommands.contains(firstToken)
-        }
-
-        let uppercased = trimmed.uppercased()
-        return Self.writeQueryPrefixes.contains { uppercased.hasPrefix($0) }
+        QueryClassifier.isWriteQuery(sql, databaseType: connection.type)
     }
 
     // MARK: - Dangerous Query Detection
 
-    /// Pre-compiled regex for detecting WHERE clause in DELETE queries (avoids per-call compilation)
-    private static let whereClauseRegex = try? NSRegularExpression(pattern: "\\sWHERE\\s", options: [])
-
-    /// Check if a query is potentially dangerous (DROP, TRUNCATE, DELETE without WHERE)
     func isDangerousQuery(_ sql: String) -> Bool {
-        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Redis: check for destructive commands
-        if connection.type == .redis {
-            let firstToken = trimmed.prefix(while: { !$0.isWhitespace }).uppercased()
-            // CONFIG SET is dangerous
-            if firstToken == "CONFIG" {
-                let rest = trimmed.dropFirst(firstToken.count).trimmingCharacters(in: .whitespaces)
-                return rest.uppercased().hasPrefix("SET")
-            }
-            return Self.redisDangerousCommands.contains(firstToken)
-        }
-
-        let uppercased = trimmed.uppercased()
-
-        // Check for DROP
-        if uppercased.hasPrefix("DROP ") {
-            return true
-        }
-
-        // Check for TRUNCATE
-        if uppercased.hasPrefix("TRUNCATE ") {
-            return true
-        }
-
-        // Check for DELETE without WHERE clause
-        if uppercased.hasPrefix("DELETE ") {
-            // Check if there's a WHERE clause (handle any whitespace: space, tab, newline)
-            let range = NSRange(uppercased.startIndex..., in: uppercased)
-            let hasWhere = Self.whereClauseRegex?.firstMatch(in: uppercased, options: [], range: range) != nil
-            return !hasWhere
-        }
-
-        return false
+        QueryClassifier.isDangerousQuery(sql, databaseType: connection.type)
     }
 }

--- a/TablePro/Views/Settings/MCPSettingsView.swift
+++ b/TablePro/Views/Settings/MCPSettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct MCPSettingsView: View {
     @Bindable var settingsManager: AppSettingsManager
+    @State private var manager = MCPServerManager.shared
 
     var body: some View {
         Form {
@@ -25,6 +26,7 @@ struct MCPSettingsView: View {
             if settingsManager.mcp.enabled {
                 configurationSection
                 clientConfigurationSection
+                connectedClientsSection
 
                 Section {
                     Text("AI access policies are configured per-connection in each connection's settings.")
@@ -103,6 +105,41 @@ struct MCPSettingsView: View {
                         Image(systemName: "doc.on.doc")
                     }
                     .help(String(localized: "Copy to clipboard"))
+                }
+            }
+        }
+    }
+
+    // MARK: - Connected Clients
+
+    private var connectedClientsSection: some View {
+        Section("Connected Clients") {
+            if manager.connectedClients.isEmpty {
+                Text("No clients connected")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(manager.connectedClients) { client in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text(client.clientName)
+                                if let version = client.clientVersion {
+                                    Text(version)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Text(client.connectedSince, style: .relative)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Disconnect") {
+                            Task {
+                                await manager.disconnectClient(client.id)
+                            }
+                        }
+                        .controlSize(.small)
+                    }
                 }
             }
         }

--- a/TablePro/Views/Settings/MCPSettingsView.swift
+++ b/TablePro/Views/Settings/MCPSettingsView.swift
@@ -1,0 +1,169 @@
+//
+//  MCPSettingsView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct MCPSettingsView: View {
+    @Bindable var settingsManager: AppSettingsManager
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable MCP Server", isOn: $settingsManager.mcp.enabled)
+
+                if settingsManager.mcp.enabled {
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        MCPStatusIndicator()
+                    }
+                }
+            }
+
+            if settingsManager.mcp.enabled {
+                configurationSection
+                clientConfigurationSection
+
+                Section {
+                    Text("AI access policies are configured per-connection in each connection's settings.")
+                        .foregroundStyle(.secondary)
+                        .font(.callout)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Configuration
+
+    private var configurationSection: some View {
+        Section("Configuration") {
+            HStack {
+                Text("Port")
+                Spacer()
+                TextField("", value: $settingsManager.mcp.port, format: .number)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            HStack {
+                Text("Default row limit")
+                Spacer()
+                TextField("", value: $settingsManager.mcp.defaultRowLimit, format: .number)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            HStack {
+                Text("Maximum row limit")
+                Spacer()
+                TextField("", value: $settingsManager.mcp.maxRowLimit, format: .number)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            HStack {
+                Text("Query timeout")
+                Spacer()
+                TextField("", value: $settingsManager.mcp.queryTimeoutSeconds, format: .number)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+                Text("seconds")
+                    .foregroundStyle(.secondary)
+            }
+
+            Toggle("Log MCP queries in history", isOn: $settingsManager.mcp.logQueriesInHistory)
+        }
+    }
+
+    // MARK: - Client Configuration
+
+    private var clientConfigurationSection: some View {
+        Section("Client Configuration") {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Add this to your AI tool's MCP configuration:")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+
+                HStack {
+                    Text(configSnippet)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(configSnippet, forType: .string)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .help(String(localized: "Copy to clipboard"))
+                }
+            }
+        }
+    }
+
+    private var configSnippet: String {
+        """
+        {
+          "mcpServers": {
+            "tablepro": {
+              "url": "http://127.0.0.1:\(settingsManager.mcp.port)/mcp"
+            }
+          }
+        }
+        """
+    }
+}
+
+// MARK: - Status Indicator
+
+private struct MCPStatusIndicator: View {
+    @State private var manager = MCPServerManager.shared
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            Text(statusText)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusColor: Color {
+        switch manager.state {
+        case .stopped:
+            .secondary
+        case .starting:
+            .orange
+        case .running:
+            .green
+        case .failed:
+            .red
+        }
+    }
+
+    private var statusText: String {
+        switch manager.state {
+        case .stopped:
+            String(localized: "Stopped")
+        case .starting:
+            String(localized: "Starting...")
+        case .running(let port):
+            String(format: String(localized: "Running on port %d"), port)
+        case .failed(let message):
+            String(format: String(localized: "Failed: %@"), message)
+        }
+    }
+}
+
+#Preview {
+    MCPSettingsView(settingsManager: .shared)
+        .frame(width: 450, height: 400)
+}

--- a/TablePro/Views/Settings/MCPSettingsView.swift
+++ b/TablePro/Views/Settings/MCPSettingsView.swift
@@ -43,7 +43,7 @@ struct MCPSettingsView: View {
             HStack {
                 Text("Port")
                 Spacer()
-                TextField("", value: $settingsManager.mcp.port, format: .number)
+                TextField("", value: $settingsManager.mcp.port, format: .number.grouping(.never))
                     .frame(width: 80)
                     .multilineTextAlignment(.trailing)
             }
@@ -51,7 +51,7 @@ struct MCPSettingsView: View {
             HStack {
                 Text("Default row limit")
                 Spacer()
-                TextField("", value: $settingsManager.mcp.defaultRowLimit, format: .number)
+                TextField("", value: $settingsManager.mcp.defaultRowLimit, format: .number.grouping(.never))
                     .frame(width: 80)
                     .multilineTextAlignment(.trailing)
             }
@@ -59,7 +59,7 @@ struct MCPSettingsView: View {
             HStack {
                 Text("Maximum row limit")
                 Spacer()
-                TextField("", value: $settingsManager.mcp.maxRowLimit, format: .number)
+                TextField("", value: $settingsManager.mcp.maxRowLimit, format: .number.grouping(.never))
                     .frame(width: 80)
                     .multilineTextAlignment(.trailing)
             }
@@ -67,7 +67,7 @@ struct MCPSettingsView: View {
             HStack {
                 Text("Query timeout")
                 Spacer()
-                TextField("", value: $settingsManager.mcp.queryTimeoutSeconds, format: .number)
+                TextField("", value: $settingsManager.mcp.queryTimeoutSeconds, format: .number.grouping(.never))
                     .frame(width: 80)
                     .multilineTextAlignment(.trailing)
                 Text("seconds")
@@ -158,7 +158,11 @@ private struct MCPStatusIndicator: View {
         case .running(let port):
             String(format: String(localized: "Running on port %d"), port)
         case .failed(let message):
-            String(format: String(localized: "Failed: %@"), message)
+            if message.contains("48") || message.lowercased().contains("address already in use") {
+                String(localized: "Port is already in use. Try a different port or close the other process.")
+            } else {
+                String(format: String(localized: "Failed: %@"), message)
+            }
         }
     }
 }

--- a/TablePro/Views/Settings/MCPSettingsView.swift
+++ b/TablePro/Views/Settings/MCPSettingsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct MCPSettingsView: View {
     @Bindable var settingsManager: AppSettingsManager
     @State private var manager = MCPServerManager.shared
+    @State private var selectedTool: MCPClientTool = .claudeDesktop
 
     var body: some View {
         Form {
@@ -83,30 +84,16 @@ struct MCPSettingsView: View {
     // MARK: - Client Configuration
 
     private var clientConfigurationSection: some View {
-        Section("Client Configuration") {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Add this to your AI tool's MCP configuration:")
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
-
-                HStack {
-                    Text(configSnippet)
-                        .font(.system(.caption, design: .monospaced))
-                        .textSelection(.enabled)
-                        .padding(8)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(configSnippet, forType: .string)
-                    } label: {
-                        Image(systemName: "doc.on.doc")
-                    }
-                    .help(String(localized: "Copy to clipboard"))
+        Section("Setup") {
+            Picker("", selection: $selectedTool) {
+                ForEach(MCPClientTool.allCases) { tool in
+                    Text(tool.displayName).tag(tool)
                 }
             }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            MCPSetupInstructions(tool: selectedTool, port: settingsManager.mcp.port)
         }
     }
 
@@ -145,16 +132,155 @@ struct MCPSettingsView: View {
         }
     }
 
-    private var configSnippet: String {
-        """
-        {
-          "mcpServers": {
-            "tablepro": {
-              "url": "http://127.0.0.1:\(settingsManager.mcp.port)/mcp"
-            }
-          }
+}
+
+// MARK: - Client Tool Enum
+
+private enum MCPClientTool: String, CaseIterable, Identifiable {
+    case claudeDesktop
+    case claudeCode
+    case cursor
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .claudeDesktop: "Claude Desktop"
+        case .claudeCode: "Claude Code"
+        case .cursor: "Cursor"
         }
-        """
+    }
+}
+
+// MARK: - Setup Instructions
+
+private struct MCPSetupInstructions: View {
+    let tool: MCPClientTool
+    let port: Int
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("\(index + 1).")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .frame(width: 20, alignment: .trailing)
+                    Text(step)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let snippet = configSnippet {
+                HStack(alignment: .top) {
+                    Text(snippet)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(snippet, forType: .string)
+                        copied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+                    } label: {
+                        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                            .contentTransition(.symbolEffect(.replace))
+                    }
+                    .help(String(localized: "Copy to clipboard"))
+                }
+            }
+
+            if let command {
+                HStack(alignment: .top) {
+                    Text(command)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(command, forType: .string)
+                        copied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+                    } label: {
+                        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                            .contentTransition(.symbolEffect(.replace))
+                    }
+                    .help(String(localized: "Copy to clipboard"))
+                }
+            }
+        }
+        .font(.callout)
+    }
+
+    private var url: String {
+        "http://127.0.0.1:\(port)/mcp"
+    }
+
+    private var steps: [String] {
+        switch tool {
+        case .claudeDesktop:
+            [
+                "Open Claude Desktop, go to Settings > Developer",
+                "Click \"Edit Config\" to open claude_desktop_config.json",
+                "Add the JSON below inside the file and save",
+                "Restart Claude Desktop"
+            ]
+        case .claudeCode:
+            [
+                "Run the command below in your terminal",
+            ]
+        case .cursor:
+            [
+                "Open Cursor, go to Settings > MCP",
+                "Click \"+ Add new global MCP server\"",
+                "Paste the JSON below and save"
+            ]
+        }
+    }
+
+    private var configSnippet: String? {
+        switch tool {
+        case .claudeDesktop:
+            """
+            {
+              "mcpServers": {
+                "tablepro": {
+                  "url": "\(url)"
+                }
+              }
+            }
+            """
+        case .claudeCode:
+            nil
+        case .cursor:
+            """
+            {
+              "mcpServers": {
+                "tablepro": {
+                  "url": "\(url)"
+                }
+              }
+            }
+            """
+        }
+    }
+
+    private var command: String? {
+        switch tool {
+        case .claudeCode:
+            "claude mcp add tablepro --transport sse \(url)"
+        default:
+            nil
+        }
     }
 }
 

--- a/TablePro/Views/Settings/MCPSettingsView.swift
+++ b/TablePro/Views/Settings/MCPSettingsView.swift
@@ -277,7 +277,7 @@ private struct MCPSetupInstructions: View {
     private var command: String? {
         switch tool {
         case .claudeCode:
-            "claude mcp add tablepro --transport sse \(url)"
+            "claude mcp add tablepro --transport http \(url)"
         default:
             nil
         }

--- a/TablePro/Views/Settings/SettingsView.swift
+++ b/TablePro/Views/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Settings tab identifiers for programmatic navigation
 enum SettingsTab: String {
-    case general, appearance, editor, dataGrid, keyboard, history, ai, terminal, plugins, sync, license
+    case general, appearance, editor, dataGrid, keyboard, history, ai, terminal, mcp, plugins, sync, license
 }
 
 /// Main settings view with tab-based navigation (macOS Settings style)
@@ -71,6 +71,12 @@ struct SettingsView: View {
                     Label("Terminal", systemImage: "terminal")
                 }
                 .tag(SettingsTab.terminal.rawValue)
+
+            MCPSettingsView(settingsManager: settingsManager)
+                .tabItem {
+                    Label("MCP", systemImage: "network")
+                }
+                .tag(SettingsTab.mcp.rawValue)
 
             PluginsSettingsView()
                 .tabItem {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,6 +76,7 @@
               "features/safe-mode",
               "features/connection-sharing",
               "features/terminal",
+              "features/mcp",
               "features/icloud-sync",
               "features/ssh-profiles"
             ]

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -1,0 +1,104 @@
+---
+title: MCP Server
+description: Built-in Model Context Protocol server for AI tool integration
+---
+
+# MCP Server
+
+TablePro includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI tools query your databases, browse schemas, and export data through TablePro's saved connections. The server runs locally on `127.0.0.1` and is never exposed to the network.
+
+## Enabling the Server
+
+Open **Settings > MCP** and toggle **Enable MCP Server**. The server starts on port `23508` by default. A green status indicator confirms it is running.
+
+You can also configure:
+
+- **Port** - TCP port for the MCP endpoint (default 23508)
+- **Default row limit** - maximum rows returned per query (default 500)
+- **Maximum row limit** - hard cap on rows (default 10,000)
+- **Query timeout** - seconds before a query is cancelled (default 30)
+- **Log MCP queries in history** - whether MCP-executed queries appear in Query History
+
+## Client Configuration
+
+Add this JSON to your AI tool's MCP configuration file:
+
+```json
+{
+  "mcpServers": {
+    "tablepro": {
+      "url": "http://127.0.0.1:23508/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add the snippet above to your `claude_desktop_config.json` file. On macOS this is at `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+### Claude Code
+
+Run:
+
+```bash
+claude mcp add tablepro --transport sse http://127.0.0.1:23508/mcp
+```
+
+### Cursor
+
+Add the snippet to your `.cursor/mcp.json` file in the project root, or to the global MCP config at `~/.cursor/mcp.json`.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_connections` | List all saved connections with status |
+| `connect` | Connect to a saved database |
+| `disconnect` | Disconnect from a database |
+| `get_connection_status` | Get connection details (version, uptime) |
+| `list_databases` | List databases on the server |
+| `list_schemas` | List schemas in a database |
+| `list_tables` | List tables and views |
+| `describe_table` | Get columns, indexes, foreign keys, and DDL |
+| `get_table_ddl` | Get the CREATE TABLE statement |
+| `execute_query` | Run a SQL or NoSQL query |
+| `export_data` | Export results as CSV, JSON, SQL, or XLSX |
+| `switch_database` | Switch the active database |
+| `switch_schema` | Switch the active schema |
+
+The server also exposes three resources that AI tools can read directly:
+
+- `tablepro://connections` - all saved connections with metadata
+- `tablepro://connections/{id}/schema` - full schema for a connected database
+- `tablepro://connections/{id}/history` - recent query history (supports `?limit=`, `?search=`, `?date_filter=`)
+
+## Security
+
+### AI Connection Policy
+
+Each connection has an **AI Policy** that controls MCP access:
+
+- **Always Allow** - MCP tools can use this connection without prompts
+- **Ask Each Time** - TablePro shows an approval dialog when an MCP client first accesses the connection in a session
+- **Never** - MCP access is blocked entirely
+
+Set the policy in the connection's settings. The default policy for new connections is configurable in **Settings > AI**.
+
+### Safe Mode
+
+[Safe Mode](/features/safe-mode) applies to MCP queries the same way it applies to manual queries. If a connection is set to Alert or higher, write queries from MCP clients require the same confirmation or Touch ID authentication.
+
+Read-Only connections block all write queries from MCP clients.
+
+## Troubleshooting
+
+**Port conflict**: If the server fails to start, another process may be using port 23508. Change the port in **Settings > MCP**.
+
+**"Server not fully initialized"**: Restart the MCP server from **Settings > MCP**. If the issue persists, quit and relaunch TablePro.
+
+**App must be running**: The MCP server only runs while TablePro is open. AI tools cannot connect if the app is quit or the server is disabled.
+
+**Connection refused**: Verify the server is running (green indicator in Settings). Check that your AI tool's MCP config URL matches the port shown in Settings.
+
+**Query blocked by Safe Mode**: The MCP server respects the same Safe Mode levels as manual queries. Check the connection's safe mode setting if queries are being rejected.

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -42,7 +42,7 @@ Add the snippet above to your `claude_desktop_config.json` file. On macOS this i
 Run:
 
 ```bash
-claude mcp add tablepro --transport sse http://127.0.0.1:23508/mcp
+claude mcp add tablepro --transport http http://127.0.0.1:23508/mcp
 ```
 
 ### Cursor
@@ -63,7 +63,7 @@ Add the snippet to your `.cursor/mcp.json` file in the project root, or to the g
 | `describe_table` | Get columns, indexes, foreign keys, and DDL |
 | `get_table_ddl` | Get the CREATE TABLE statement |
 | `execute_query` | Run a SQL or NoSQL query |
-| `export_data` | Export results as CSV, JSON, SQL, or XLSX |
+| `export_data` | Export results as CSV, JSON, or SQL |
 | `switch_database` | Switch the active database |
 | `switch_schema` | Switch the active schema |
 


### PR DESCRIPTION
## Summary

- Built-in MCP (Model Context Protocol) server lets AI tools (Claude Desktop, Claude Code, Cursor, Windsurf) query databases through TablePro's existing connections
- 13 tools: list_connections, connect, disconnect, execute_query, list_tables, describe_table, list_databases, list_schemas, get_table_ddl, export_data, get_connection_status, switch_database, switch_schema
- 3 resources: connections list, schema cache, query history
- SSE transport on localhost:23508 via Network.framework (NWListener)
- Full security: respects per-connection AIConnectionPolicy and SafeModeLevel
- Settings tab with enable toggle, port config, row limits, and copy-to-clipboard config snippet
- Query classification extracted to reusable QueryClassifier utility

## Architecture

- `MCPServer` (actor): NWListener lifecycle, session management, SSE
- `MCPRouter`: HTTP/1.1 parsing, JSON-RPC 2.0 dispatch
- `MCPConnectionBridge` (actor): MainActor hop to DatabaseManager, driver dispatch
- `MCPAuthGuard` (actor): AIConnectionPolicy + SafeModeLevel enforcement
- `MCPToolHandler` / `MCPResourceHandler`: 13 tool + 3 resource implementations
- `MCPServerManager` (@MainActor): bridges AppDelegate/Settings to server actor

## New files (11)

- `Core/MCP/MCPServer.swift`, `MCPRouter.swift`, `MCPHTTPParser.swift`, `MCPSession.swift`, `MCPMessageTypes.swift`
- `Core/MCP/MCPConnectionBridge.swift`, `MCPAuthGuard.swift`, `MCPToolHandler.swift`, `MCPResourceHandler.swift`, `MCPServerManager.swift`
- `Core/Utilities/SQL/QueryClassifier.swift`
- `Models/Settings/MCPSettings.swift`
- `Views/Settings/MCPSettingsView.swift`

## Modified files (5)

- `AppSettingsStorage.swift` + `AppSettingsManager.swift` (MCP settings)
- `AppDelegate.swift` (server lifecycle)
- `SettingsView.swift` (MCP tab)
- `MainContentCoordinator+QueryAnalysis.swift` (delegate to QueryClassifier)

## Test plan

- [ ] Build succeeds (`xcodebuild -scheme TablePro build -skipPackagePluginValidation`)
- [ ] Enable MCP in Settings, status shows "Running"
- [ ] Copy config snippet to Claude Desktop, verify connection
- [ ] `list_connections` returns saved connections without passwords
- [ ] `connect` → `list_tables` → `describe_table` → `execute_query` flow works
- [ ] Read-only connection blocks write queries via MCP
- [ ] `aiPolicy == .never` connection returns FORBIDDEN
- [ ] Disable MCP in Settings, server stops
- [ ] SwiftLint passes