### PR TITLE
fix: terminal process management, SSH resolution, and input handling

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -215,6 +215,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await MCPServerManager.shared.stop()
         }
         LinkedFolderWatcher.shared.stop()
+        TerminalProcessManager.registry.terminateAllSync()
         SSHTunnelManager.shared.terminateAllProcessesSync()
     }
 

--- a/TablePro/Core/Terminal/CLICommandResolver.swift
+++ b/TablePro/Core/Terminal/CLICommandResolver.swift
@@ -26,26 +26,26 @@ enum CLICommandResolver {
         effectiveConnection: DatabaseConnection? = nil
     ) -> CLILaunchSpec? {
         let sshConfig = extractSSHConfig(from: connection)
-        if sshConfig != nil {
-            // For SSH-tunneled connections, prefer local CLI via the existing tunnel.
-            // This handles Docker/container setups where CLI isn't on the remote host.
+        if let sshConfig {
+            // Prefer running the CLI on the remote host via SSH — the server
+            // that runs the database almost always has the CLI binary installed.
+            if let spec = resolveViaSSH(
+                connection: connection,
+                password: password,
+                activeDatabase: activeDatabase,
+                sshConfig: sshConfig
+            ) {
+                return spec
+            }
+
+            // Fall back to local CLI through the existing SSH tunnel
+            // (e.g. Docker setups where the SSH host doesn't have the CLI).
             if let effective = effectiveConnection {
-                let localSpec = resolveLocal(
+                return resolveLocal(
                     connection: effective,
                     password: password,
                     activeDatabase: activeDatabase,
                     customCliPath: customCliPath
-                )
-                if localSpec != nil { return localSpec }
-            }
-
-            // Fall back to SSH remote if local CLI not available
-            if let sshConfig {
-                return resolveViaSSH(
-                    connection: connection,
-                    password: password,
-                    activeDatabase: activeDatabase,
-                    sshConfig: sshConfig
                 )
             }
         }
@@ -165,10 +165,12 @@ enum CLICommandResolver {
             : "\(sshConfig.username)@\(sshConfig.host)"
         sshArgs.append(userHost)
 
-        // Source common profile files inline so the remote PATH is loaded.
-        // Avoids bash -l -c '...' which causes nested single-quote issues
-        // when remoteCommand already contains single-quoted shell-escaped values.
-        sshArgs.append(". ~/.profile 2>/dev/null; . ~/.bashrc 2>/dev/null; " + remoteCommand)
+        // Source common profile files so the remote PATH includes CLI binaries.
+        // Covers bash (.bash_profile, .bashrc, .profile) and zsh (.zshrc).
+        let sourceChain = [".profile", ".bash_profile", ".bashrc", ".zshrc"]
+            .map { ". ~/\($0) 2>/dev/null" }
+            .joined(separator: "; ")
+        sshArgs.append(sourceChain + "; " + remoteCommand)
 
         return CLILaunchSpec(executablePath: sshPath, arguments: sshArgs, environment: [:])
     }
@@ -243,13 +245,13 @@ enum CLICommandResolver {
             if !database.isEmpty { cmd += " --database \(shellEscape(database))" }
 
         case .oracle:
-            // sqlplus requires password in connect string (no env var support).
-            // Visible in ps output — accepted industry limitation for Oracle CLI.
             let serviceName = connection.additionalFields["oracleServiceName"] ?? database
             let pass = password ?? ""
             var connectString: String
             if !connection.username.isEmpty {
-                connectString = "\(connection.username)/\(pass)@\(host):\(connection.port)/\(serviceName)"
+                // Double-quote the password so sqlplus doesn't split on @ or /
+                let quotedPass = "\"" + pass.replacingOccurrences(of: "\"", with: "\\\"") + "\""
+                connectString = "\(connection.username)/\(quotedPass)@\(host):\(connection.port)/\(serviceName)"
             } else {
                 connectString = "@\(host):\(connection.port)/\(serviceName)"
             }
@@ -263,11 +265,16 @@ enum CLICommandResolver {
     }
 
     /// Escapes a string for safe use in a shell command.
+    /// Strips null bytes and newlines which cannot be safely quoted in POSIX single-quote strings.
     private static func shellEscape(_ value: String) -> String {
-        if value.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/" }) {
-            return value
+        let sanitized = value
+            .replacingOccurrences(of: "\0", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "\r", with: "")
+        if sanitized.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/" }) {
+            return sanitized
         }
-        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        return "'" + sanitized.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     @MainActor
@@ -546,12 +553,12 @@ enum CLICommandResolver {
         let host = connection.host.isEmpty ? "127.0.0.1" : connection.host
         let serviceName = connection.additionalFields["oracleServiceName"] ?? database
 
-        // sqlplus requires password in connect string (no env var support).
-        // Visible in ps output — accepted industry limitation for Oracle CLI.
         var connectString: String
         if !connection.username.isEmpty {
             let pass = password ?? ""
-            connectString = "\(connection.username)/\(pass)@\(host):\(connection.port)/\(serviceName)"
+            // Double-quote the password so sqlplus doesn't split on @ or /
+            let quotedPass = "\"" + pass.replacingOccurrences(of: "\"", with: "\\\"") + "\""
+            connectString = "\(connection.username)/\(quotedPass)@\(host):\(connection.port)/\(serviceName)"
         } else {
             connectString = "@\(host):\(connection.port)/\(serviceName)"
         }

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -11,8 +11,6 @@ import os
 final class TerminalProcessManager {
     private static let logger = Logger(subsystem: "com.TablePro", category: "TerminalProcessManager")
 
-    /// File descriptor for the PTY. Set once during launch, read from any thread
-    /// (POSIX fd operations are thread-safe). Stored separately for nonisolated access.
     private let fdLock = NSLock()
     private nonisolated(unsafe) var _ptyFD: Int32 = -1
 
@@ -21,14 +19,17 @@ final class TerminalProcessManager {
         set { fdLock.withLock { _ptyFD = newValue } }
     }
 
-    private var childPID: pid_t = 0
-    private nonisolated(unsafe) var readSource: DispatchSourceRead?
-    private nonisolated(unsafe) var processMonitor: DispatchSourceProcess?
+    private let stateLock = NSLock()
+    private nonisolated(unsafe) var _childPID: pid_t = 0
+    private nonisolated(unsafe) var _readSource: DispatchSourceRead?
+    private nonisolated(unsafe) var _processMonitor: DispatchSourceProcess?
 
     var onData: ((Data) -> Void)?
     var onExit: ((Int32) -> Void)?
 
-    private var isRunning: Bool { childPID > 0 }
+    private var isRunning: Bool { _childPID > 0 }
+
+    static let registry = TerminalProcessRegistry()
 
     // MARK: - Launch
 
@@ -73,11 +74,12 @@ final class TerminalProcessManager {
         for ptr in cArgs { ptr.map { free($0) } }
         for ptr in cEnv { ptr.map { free($0) } }
         self.ptyFD = ptyFDValue
-        self.childPID = pid
+        self._childPID = pid
 
         let fullCmd = ([spec.executablePath] + spec.arguments).joined(separator: " ")
         Self.logger.info("Launched: \(fullCmd, privacy: .public) pid=\(pid)")
 
+        Self.registry.register(self)
         startReadingOutput()
         monitorChildExit()
     }
@@ -119,8 +121,8 @@ final class TerminalProcessManager {
         let fd = fdLock.withLock { _ptyFD }
         guard fd >= 0 else { return }
         var size = winsize(
-            ws_row: UInt16(rows),
-            ws_col: UInt16(cols),
+            ws_row: UInt16(clamping: max(0, rows)),
+            ws_col: UInt16(clamping: max(0, cols)),
             ws_xpixel: 0,
             ws_ypixel: 0
         )
@@ -130,36 +132,76 @@ final class TerminalProcessManager {
     // MARK: - Terminate
 
     func terminate() {
-        // Kill and reap the child BEFORE cancelling sources so the monitor can still reap.
-        if childPID > 0 {
-            kill(childPID, SIGHUP)
-            var status: Int32 = 0
-            // Give the process a moment to exit, then force-kill
-            if waitpid(childPID, &status, WNOHANG) == 0 {
-                kill(childPID, SIGKILL)
-                waitpid(childPID, &status, 0) // blocking — child is SIGKILL'd, returns immediately
-            }
-            Self.logger.info("Terminated child pid=\(self.childPID)")
-            childPID = 0
+        let pid = stateLock.withLock {
+            let p = _childPID
+            _childPID = 0
+            return p
         }
 
-        readSource?.cancel()
-        readSource = nil
-        processMonitor?.cancel()
-        processMonitor = nil
+        if pid > 0 {
+            kill(pid, SIGHUP)
+            var status: Int32 = 0
+            if waitpid(pid, &status, WNOHANG) == 0 {
+                kill(pid, SIGKILL)
+                waitpid(pid, &status, 0)
+            }
+            Self.logger.info("Terminated child pid=\(pid)")
+        }
+
+        stateLock.withLock {
+            _readSource?.cancel()
+            _readSource = nil
+            _processMonitor?.cancel()
+            _processMonitor = nil
+        }
 
         if ptyFD >= 0 {
             close(ptyFD)
             ptyFD = -1
         }
+
+        Self.registry.unregister(self)
+    }
+
+    nonisolated func terminateSync() {
+        let pid = stateLock.withLock {
+            let p = _childPID
+            _childPID = 0
+            return p
+        }
+
+        if pid > 0 {
+            kill(pid, SIGHUP)
+            var status: Int32 = 0
+            if waitpid(pid, &status, WNOHANG) == 0 {
+                kill(pid, SIGKILL)
+                waitpid(pid, &status, 0)
+            }
+        }
+
+        stateLock.withLock {
+            _readSource?.cancel()
+            _readSource = nil
+            _processMonitor?.cancel()
+            _processMonitor = nil
+        }
+
+        let fd = fdLock.withLock { _ptyFD }
+        if fd >= 0 {
+            Darwin.close(fd)
+            fdLock.withLock { _ptyFD = -1 }
+        }
     }
 
     deinit {
-        readSource?.cancel()
-        processMonitor?.cancel()
+        stateLock.withLock {
+            _readSource?.cancel()
+            _processMonitor?.cancel()
+        }
         let fd = fdLock.withLock { _ptyFD }
-        if fd >= 0 { close(fd) }
-        if childPID > 0 { kill(childPID, SIGKILL) }
+        if fd >= 0 { Darwin.close(fd) }
+        let pid = stateLock.withLock { _childPID }
+        if pid > 0 { kill(pid, SIGKILL) }
     }
 
     // MARK: - Private
@@ -182,11 +224,11 @@ final class TerminalProcessManager {
         }
 
         source.resume()
-        self.readSource = source
+        stateLock.withLock { _readSource = source }
     }
 
     private func monitorChildExit() {
-        let pid = childPID
+        let pid = stateLock.withLock { _childPID }
         let source = DispatchSource.makeProcessSource(
             identifier: pid,
             eventMask: .exit,
@@ -195,23 +237,52 @@ final class TerminalProcessManager {
 
         source.setEventHandler { [weak self] in
             var status: Int32 = 0
-            waitpid(pid, &status, WNOHANG)
-            let exitStatus = status
+            // Process source guarantees exit — blocking waitpid returns immediately
+            let ret = waitpid(pid, &status, 0)
+            guard ret == pid else { return }
+            let exitCode: Int32 = (status & 0x7F) == 0 ? (status >> 8) & 0xFF : -1
             Task { @MainActor [weak self] in
-                self?.handleProcessExit(status: exitStatus)
+                self?.handleProcessExit(exitCode: exitCode)
             }
         }
 
         source.resume()
-        self.processMonitor = source
+        stateLock.withLock { _processMonitor = source }
     }
 
-    private func handleProcessExit(status: Int32 = 0) {
-        guard childPID > 0 else { return }
-        let exitCode = (status & 0x7F) == 0 ? (status >> 8) & 0xFF : -1
+    private func handleProcessExit(exitCode: Int32) {
+        let wasRunning = stateLock.withLock {
+            guard _childPID > 0 else { return false }
+            _childPID = 0
+            return true
+        }
+        guard wasRunning else { return }
         Self.logger.info("Child process exited status=\(exitCode)")
-        childPID = 0
+        Self.registry.unregister(self)
         onExit?(exitCode)
+    }
+}
+
+// MARK: - Registry
+
+final class TerminalProcessRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var managers: [ObjectIdentifier: TerminalProcessManager] = [:]
+
+    func register(_ manager: TerminalProcessManager) {
+        lock.withLock { managers[ObjectIdentifier(manager)] = manager }
+    }
+
+    func unregister(_ manager: TerminalProcessManager) {
+        lock.withLock { managers.removeValue(forKey: ObjectIdentifier(manager)) }
+    }
+
+    func terminateAllSync() {
+        let snapshot = lock.withLock { Array(managers.values) }
+        for manager in snapshot {
+            manager.terminateSync()
+        }
+        lock.withLock { managers.removeAll() }
     }
 }
 

--- a/TablePro/Core/Terminal/TerminalProcessManager.swift
+++ b/TablePro/Core/Terminal/TerminalProcessManager.swift
@@ -132,28 +132,8 @@ final class TerminalProcessManager {
     // MARK: - Terminate
 
     func terminate() {
-        let pid = stateLock.withLock {
-            let p = _childPID
-            _childPID = 0
-            return p
-        }
-
-        if pid > 0 {
-            kill(pid, SIGHUP)
-            var status: Int32 = 0
-            if waitpid(pid, &status, WNOHANG) == 0 {
-                kill(pid, SIGKILL)
-                waitpid(pid, &status, 0)
-            }
-            Self.logger.info("Terminated child pid=\(pid)")
-        }
-
-        stateLock.withLock {
-            _readSource?.cancel()
-            _readSource = nil
-            _processMonitor?.cancel()
-            _processMonitor = nil
-        }
+        killAndReap()
+        cancelSources()
 
         if ptyFD >= 0 {
             close(ptyFD)
@@ -164,32 +144,37 @@ final class TerminalProcessManager {
     }
 
     nonisolated func terminateSync() {
-        let pid = stateLock.withLock {
-            let p = _childPID
-            _childPID = 0
-            return p
-        }
-
-        if pid > 0 {
-            kill(pid, SIGHUP)
-            var status: Int32 = 0
-            if waitpid(pid, &status, WNOHANG) == 0 {
-                kill(pid, SIGKILL)
-                waitpid(pid, &status, 0)
-            }
-        }
-
-        stateLock.withLock {
-            _readSource?.cancel()
-            _readSource = nil
-            _processMonitor?.cancel()
-            _processMonitor = nil
-        }
+        killAndReap()
+        cancelSources()
 
         let fd = fdLock.withLock { _ptyFD }
         if fd >= 0 {
             Darwin.close(fd)
             fdLock.withLock { _ptyFD = -1 }
+        }
+    }
+
+    private nonisolated func killAndReap() {
+        let pid = stateLock.withLock {
+            let p = _childPID
+            _childPID = 0
+            return p
+        }
+        guard pid > 0 else { return }
+        kill(pid, SIGHUP)
+        var status: Int32 = 0
+        if waitpid(pid, &status, WNOHANG) == 0 {
+            kill(pid, SIGKILL)
+            waitpid(pid, &status, 0)
+        }
+    }
+
+    private nonisolated func cancelSources() {
+        stateLock.withLock {
+            _readSource?.cancel()
+            _readSource = nil
+            _processMonitor?.cancel()
+            _processMonitor = nil
         }
     }
 

--- a/TablePro/Core/Terminal/TerminalSessionState.swift
+++ b/TablePro/Core/Terminal/TerminalSessionState.swift
@@ -18,7 +18,7 @@ final class TerminalSessionState: Identifiable {
 
     var terminalViewState: TerminalViewState
     var session: InMemoryTerminalSession?
-    nonisolated(unsafe) var processManager: TerminalProcessManager?
+    private(set) var processManager: TerminalProcessManager?
     var isConnected: Bool = false
     var isDisconnected: Bool = false
     var exitCode: Int32 = 0
@@ -127,10 +127,7 @@ final class TerminalSessionState: Identifiable {
             builder.withWindowPaddingX(4)
             builder.withWindowPaddingY(4)
 
-            // libghostty-spm embedded mode has broken key mapping for
-            // apostrophe (sends TAB instead of 0x27). Clear default
-            // keybindings and explicitly remap affected keys.
-            builder.withCustom("keybind", "clear")
+            // libghostty-spm embedded mode sends TAB for apostrophe — override it.
             builder.withCustom("keybind", "apostrophe=text:\\x27")
             builder.withCustom("keybind", "shift+apostrophe=text:\\x22")
         }
@@ -159,9 +156,7 @@ final class TerminalSessionState: Identifiable {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.applySettingsToTerminal()
-            }
+            self?.applySettingsToTerminal()
         }
     }
 

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -152,6 +152,10 @@ final class QueryTabManager {
     }
 
     func addTerminalTab(databaseName: String = "") {
+        if let existing = tabs.first(where: { $0.tabType == .terminal }) {
+            selectedTabId = existing.id
+            return
+        }
         let tabTitle = String(localized: "Terminal")
         var newTab = QueryTab(title: tabTitle, tabType: .terminal)
         newTab.databaseName = databaseName

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Terminal.swift
@@ -7,19 +7,13 @@ import AppKit
 
 extension MainContentCoordinator {
     func openTerminal() {
-        let session = DatabaseManager.shared.session(for: connectionId)
-        let dbName = session?.activeDatabase ?? connection.database
-
-        if tabManager.tabs.isEmpty {
-            tabManager.addTerminalTab(databaseName: dbName)
+        if let existing = tabManager.tabs.first(where: { $0.tabType == .terminal }) {
+            tabManager.selectedTabId = existing.id
             return
         }
 
-        let payload = EditorTabPayload(
-            connectionId: connection.id,
-            tabType: .terminal,
-            databaseName: dbName
-        )
-        WindowManager.shared.openTab(payload: payload)
+        let session = DatabaseManager.shared.session(for: connectionId)
+        let dbName = session?.activeDatabase ?? connection.database
+        tabManager.addTerminalTab(databaseName: dbName)
     }
 }

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -12,6 +12,7 @@ struct TerminalTabContentView: View {
     let connectionId: UUID
 
     @State private var sessionState: TerminalSessionState?
+    @State private var configuredSessionId: ObjectIdentifier?
 
     var body: some View {
         ZStack {
@@ -30,12 +31,16 @@ struct TerminalTabContentView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task { await connectWhenReady() }
-        .onDisappear {
-            let state = sessionState
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(300))
-                state?.disconnect()
+        .task {
+            await connectWhenReady()
+            await withTaskCancellationHandler {
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(86_400))
+                }
+            } onCancel: { [sessionState] in
+                Task { @MainActor in
+                    sessionState?.disconnect()
+                }
             }
         }
     }
@@ -47,11 +52,13 @@ struct TerminalTabContentView: View {
                 TerminalFocusHelper(processManager: state.processManager)
             }
             .onAppear {
-                if let session = state.session {
-                    state.terminalViewState.configuration = TerminalSurfaceOptions(
-                        backend: .inMemory(session)
-                    )
-                }
+                guard let session = state.session else { return }
+                let sessionId = ObjectIdentifier(session)
+                guard configuredSessionId != sessionId else { return }
+                state.terminalViewState.configuration = TerminalSurfaceOptions(
+                    backend: .inMemory(session)
+                )
+                configuredSessionId = sessionId
             }
     }
 
@@ -77,6 +84,8 @@ struct TerminalTabContentView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    // MARK: - Connection Lifecycle
+
     private func connectWhenReady() async {
         guard sessionState == nil else { return }
 
@@ -84,13 +93,36 @@ struct TerminalTabContentView: View {
         let tunnelReady = DatabaseManager.shared.session(for: connectionId)?.effectiveConnection != nil
 
         if hasSSH, !tunnelReady {
-            for await _ in NotificationCenter.default.notifications(named: .databaseDidConnect) {
-                guard DatabaseManager.shared.session(for: connectionId)?.effectiveConnection != nil else { continue }
-                break
+            let connected = await waitForSSHTunnel(timeout: .seconds(30))
+            guard connected else {
+                let state = TerminalSessionState(connectionId: connectionId, databaseType: connection.type)
+                state.error = String(localized: "SSH tunnel did not connect within 30 seconds")
+                self.sessionState = state
+                return
             }
         }
 
         launchTerminalSession()
+    }
+
+    private func waitForSSHTunnel(timeout: Duration) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in NotificationCenter.default.notifications(named: .databaseDidConnect) {
+                    if DatabaseManager.shared.session(for: self.connectionId)?.effectiveConnection != nil {
+                        return true
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
     }
 
     private func launchTerminalSession() {
@@ -113,13 +145,10 @@ struct TerminalTabContentView: View {
 
         state.reconnect(connection: connection, password: password, activeDatabase: activeDatabase)
     }
-
 }
 
-// MARK: - Focus Helper
+// MARK: - Focus & Input Helper
 
-/// Makes the terminal surface first responder when it appears.
-/// Follows the same pattern as SQLEditorCoordinator's auto-focus (50ms delay + makeFirstResponder).
 private struct TerminalFocusHelper: NSViewRepresentable {
     weak var processManager: TerminalProcessManager?
 
@@ -134,20 +163,25 @@ private struct TerminalFocusHelper: NSViewRepresentable {
     }
 }
 
+/// Bridges AppKit input handling for the embedded Ghostty terminal:
+/// - Auto-focuses the terminal surface on appear
+/// - Intercepts Cmd+V (paste) before AppKit's Edit menu captures it
+/// - Provides right-click context menu for copy/paste
+///
+/// Cmd+C copy works natively via Ghostty's responder chain.
+/// Cmd+A select-all is not supported by libghostty embedded mode.
 private final class TerminalFocusHelperView: NSView {
     private weak var terminalView: NSView?
     weak var processManager: TerminalProcessManager?
+    private var keyDownMonitor: Any?
     private var rightClickMonitor: Any?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard let window else {
-            removeMonitor()
+            removeMonitors()
             return
         }
-        // Walk up from the .background {} NSView to find the terminal's key view.
-        // The superview chain (self -> hosting view -> TerminalSurfaceView container)
-        // is determined by SwiftUI's .background {} modifier — stable since macOS 14.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self else { return }
             var ancestor: NSView? = self.superview?.superview
@@ -155,7 +189,7 @@ private final class TerminalFocusHelperView: NSView {
                 if let keyView = Self.firstKeyView(in: current, excluding: self) {
                     window.makeFirstResponder(keyView)
                     self.terminalView = keyView
-                    self.installRightClickMonitor()
+                    self.installMonitors()
                     return
                 }
                 ancestor = current.superview
@@ -164,63 +198,72 @@ private final class TerminalFocusHelperView: NSView {
     }
 
     override func removeFromSuperview() {
-        removeMonitor()
+        removeMonitors()
         super.removeFromSuperview()
     }
 
-    // MARK: - Right-Click Context Menu
+    // MARK: - Event Monitors
 
-    private func installRightClickMonitor() {
-        removeMonitor()
+    private func installMonitors() {
+        removeMonitors()
+
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, let terminal = self.terminalView,
+                  event.modifierFlags.contains(.command),
+                  !event.modifierFlags.contains(.shift),
+                  !event.modifierFlags.contains(.option),
+                  terminal.window?.firstResponder === terminal
+            else { return event }
+
+            if event.charactersIgnoringModifiers == "v" {
+                self.pasteFromClipboard()
+                return nil
+            }
+            return event
+        }
+
         rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
-            guard let self, let terminal = self.terminalView else { return event }
-            // Only handle right-clicks when this terminal's window is key (multi-terminal safety)
-            guard terminal.window?.isKeyWindow == true else { return event }
-            let locationInTerminal = terminal.convert(event.locationInWindow, from: nil)
-            guard terminal.bounds.contains(locationInTerminal) else { return event }
+            guard let self, let terminal = self.terminalView,
+                  terminal.window?.isKeyWindow == true
+            else { return event }
+            let point = terminal.convert(event.locationInWindow, from: nil)
+            guard terminal.bounds.contains(point) else { return event }
 
-            let menu = self.buildContextMenu()
-            NSMenu.popUpContextMenu(menu, with: event, for: terminal)
+            NSMenu.popUpContextMenu(self.buildContextMenu(), with: event, for: terminal)
             return nil
         }
     }
 
-    private func removeMonitor() {
+    private func removeMonitors() {
+        if let monitor = keyDownMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyDownMonitor = nil
+        }
         if let monitor = rightClickMonitor {
             NSEvent.removeMonitor(monitor)
             rightClickMonitor = nil
         }
     }
 
+    // MARK: - Context Menu
+
     private func buildContextMenu() -> NSMenu {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(handleCopy), keyEquivalent: "")
+        let copy = NSMenuItem(title: String(localized: "Copy"), action: #selector(copySelection), keyEquivalent: "")
         copy.target = self
-        copy.isEnabled = true
         menu.addItem(copy)
 
-        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(handlePaste), keyEquivalent: "")
+        let paste = NSMenuItem(title: String(localized: "Paste"), action: #selector(pasteFromClipboard), keyEquivalent: "")
         paste.target = self
         paste.isEnabled = NSPasteboard.general.string(forType: .string) != nil
         menu.addItem(paste)
 
-        menu.addItem(.separator())
-
-        let selectAll = NSMenuItem(title: String(localized: "Select All"), action: #selector(handleSelectAll), keyEquivalent: "")
-        selectAll.target = self
-        selectAll.isEnabled = true
-        menu.addItem(selectAll)
-
         return menu
     }
 
-    // Ghostty handles clipboard through key events, not NSResponder actions.
-    // Cmd+C copies selected text (no-op if nothing selected).
-    // Paste writes clipboard content directly to PTY input.
-
-    @objc private func handleCopy() {
+    @objc private func copySelection() {
         guard let terminal = terminalView, let window = terminal.window else { return }
         guard let event = NSEvent.keyEvent(
             with: .keyDown, location: .zero, modifierFlags: .command,
@@ -232,28 +275,9 @@ private final class TerminalFocusHelperView: NSView {
         terminal.keyDown(with: event)
     }
 
-    @objc private func handlePaste() {
+    @objc private func pasteFromClipboard() {
         guard let text = NSPasteboard.general.string(forType: .string) else { return }
-        // Bracket paste mode: wrap pasted text so the shell knows it's pasted content
-        // and doesn't execute commands on newlines
-        let bracketStart = Data([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]) // \e[200~
-        let bracketEnd = Data([0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E])   // \e[201~
-        var pasteData = bracketStart
-        pasteData.append(Data(text.utf8))
-        pasteData.append(bracketEnd)
-        processManager?.write(pasteData)
-    }
-
-    @objc private func handleSelectAll() {
-        guard let terminal = terminalView, let window = terminal.window else { return }
-        guard let event = NSEvent.keyEvent(
-            with: .keyDown, location: .zero, modifierFlags: .command,
-            timestamp: ProcessInfo.processInfo.systemUptime,
-            windowNumber: window.windowNumber, context: nil,
-            characters: "a", charactersIgnoringModifiers: "a",
-            isARepeat: false, keyCode: 0
-        ) else { return }
-        terminal.keyDown(with: event)
+        processManager?.write(Data(text.utf8))
     }
 
     // MARK: - Key View Discovery


### PR DESCRIPTION
## Summary

Deep review and fix of the embedded terminal feature. Addresses process lifecycle bugs, concurrency races, SSH CLI resolution issues, and input handling.

### Process Management (`TerminalProcessManager.swift`)
- **Fix zombie processes**: `waitpid` now uses blocking call (process source guarantees exit), checks return value before reporting exit code
- **Fix double-reap race**: All access to `childPID`, `readSource`, `processMonitor` goes through `stateLock` — `terminate()` and `monitorChildExit` can no longer race on the same PID
- **Fix app-quit orphans**: New `TerminalProcessRegistry` tracks all active managers; `applicationWillTerminate` calls `terminateAllSync()` (mirrors `SSHTunnelManager` pattern)
- **Fix UInt16 overflow trap**: `resize()` uses `UInt16(clamping:)` for cols/rows (matches port validation pattern from commit 52f928c3)
- **Fix `nonisolated(unsafe)` data race in `deinit`**: All field access uses locks

### SSH Resolution (`CLICommandResolver.swift`)
- **SSH remote first**: Prefer running CLI on the remote host (where the DB is installed) over local CLI through tunnel
- **Source more shell configs**: `.profile`, `.bash_profile`, `.bashrc`, `.zshrc` for bash and zsh servers
- **Fix shell injection**: `shellEscape` strips `\0`, `\n`, `\r` before quoting
- **Fix Oracle `@` in password**: Double-quote password in sqlplus connect string (both local and SSH paths)

### Terminal View (`TerminalTabContentView.swift`)
- **Fix disconnect timing hack**: Replace 300ms `onDisappear` timer with `.task` cancellation — SwiftUI cancels on real view removal, ignores transient disappears
- **Fix reconnect blank terminal**: Use `ObjectIdentifier(session)` instead of boolean flag for `onAppear` backend guard — correctly re-configures on reconnect
- **Fix Cmd+V paste**: Key event monitor intercepts before AppKit Edit menu; writes directly to PTY without bracket paste sequences (DB CLIs don't support them)
- **Fix SSH tunnel timeout**: `connectWhenReady` races notification listener against 30-second timeout instead of hanging forever

### Other
- **Terminal tab deduplication**: `addTerminalTab` and `openTerminal()` reuse existing terminal tab (mirrors `addServerDashboardTab` pattern)
- **`processManager` isolation**: Changed from `nonisolated(unsafe)` to `private(set)` on `TerminalSessionState`
- **Settings observer**: Removed redundant `Task { @MainActor }` inside `.main`-queue callback
- **Keybind cleanup**: Removed `keybind = clear` that was wiping all Ghostty defaults; only override broken apostrophe keys

### Known Limitation
- Cmd+A (Select All) does not work in libghostty embedded mode — `select_all` action is not supported by the in-memory backend

## Test plan

- [ ] Open terminal via Ctrl+Cmd+` — verify CLI connects to active database
- [ ] SSH connection: verify terminal runs CLI on remote server (not local)
- [ ] Cmd+V paste into terminal — verify text appears without escape sequences
- [ ] Cmd+C copy from terminal — verify selected text copies to clipboard
- [ ] Close terminal tab while process running — verify no zombie process (`ps aux | grep mysql`)
- [ ] Quit app with terminal open — verify child process is killed
- [ ] Reconnect from disconnected view — verify terminal connects to DB (not blank shell)
- [ ] Open terminal twice (Ctrl+Cmd+` x2) — verify it selects existing tab, not duplicate
- [ ] SSH connection with tunnel failure — verify 30s timeout with error message
- [ ] Tab group merge/split — verify terminal survives without disconnect