### PR TITLE
fix: Account settings sync section layout overlap

### DIFF
--- a/TablePro/Views/Settings/LinkedFoldersSection.swift
+++ b/TablePro/Views/Settings/LinkedFoldersSection.swift
@@ -126,7 +126,7 @@ struct LinkedFoldersSection: View {
 
 // MARK: - Pro Badge
 
-private struct ProBadge: View {
+struct ProBadge: View {
     var body: some View {
         Text("PRO")
             .font(.system(size: 9, weight: .bold))

--- a/TablePro/Views/Settings/Sections/SyncSection.swift
+++ b/TablePro/Views/Settings/Sections/SyncSection.swift
@@ -9,8 +9,12 @@ struct SyncSection: View {
     @Bindable private var settingsManager = AppSettingsManager.shared
     @Bindable private var syncCoordinator = SyncCoordinator.shared
 
+    private var isProAvailable: Bool {
+        LicenseManager.shared.isFeatureAvailable(.iCloudSync)
+    }
+
     var body: some View {
-        Section("iCloud Sync") {
+        Section {
             Toggle("iCloud Sync:", isOn: $settingsManager.sync.enabled)
                 .onChange(of: settingsManager.sync.enabled) { _, newValue in
                     updatePasswordSyncFlag()
@@ -21,10 +25,17 @@ struct SyncSection: View {
                     }
                 }
                 .help("Syncs connections, settings, and SSH profiles across your Macs via iCloud.")
+                .disabled(!isProAvailable)
+        } header: {
+            HStack(spacing: 6) {
+                Text("iCloud Sync")
+                if !isProAvailable {
+                    ProBadge()
+                }
+            }
         }
-        .requiresPro(.iCloudSync)
 
-        if settingsManager.sync.enabled {
+        if settingsManager.sync.enabled && isProAvailable {
             statusSection
             categoriesSection
         }


### PR DESCRIPTION
## Summary
- Replace `requiresPro(.iCloudSync)` overlay modifier on SyncSection with direct license check — the overlay's `.ultraThinMaterial` rectangle spilled over adjacent Form sections, causing layout corruption on the Account settings tab
- Gate Sync Status and Sync Categories sections behind `isProAvailable` so they don't appear for unlicensed users (previously only gated by `sync.enabled` UserDefaults value)
- Make `ProBadge` internal (was private to LinkedFoldersSection) for reuse in SyncSection header

## Test plan
- [ ] Open Settings > Account without a Pro license — iCloud Sync toggle should be disabled with a PRO badge, no blurred overlay, no status/categories sections visible
- [ ] Activate a Pro license — toggle becomes enabled, toggling on shows Sync Status and Sync Categories
- [ ] Verify LinkedFoldersSection still shows PRO badge correctly when unlicensed