### PR TITLE
feat: add SQL operator symbols to filter menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Filter operator picker shows SQL symbols alongside names for quick visual recognition
 - SQL autocomplete now suggests column names before a FROM clause is written, using all cached schema columns as fallback
 - Eager column cache warming after schema load for faster autocomplete
 - MCP query safety: three-tier classification with server-side confirmation for write and destructive queries

--- a/TablePro/Core/Storage/FilterSettingsStorage.swift
+++ b/TablePro/Core/Storage/FilterSettingsStorage.swift
@@ -33,10 +33,9 @@ enum FilterDefaultOperator: String, CaseIterable, Identifiable, Codable {
     var id: String { rawValue }
 
     var displayName: String {
-        switch self {
-        case .equal: return "Equal (=)"
-        case .contains: return "Contains"
-        }
+        let op = toFilterOperator()
+        if op.symbol.isEmpty { return op.displayName }
+        return "\(op.symbol)  \(op.displayName)"
     }
 
     func toFilterOperator() -> FilterOperator {

--- a/TablePro/Models/Database/TableFilter.swift
+++ b/TablePro/Models/Database/TableFilter.swift
@@ -68,6 +68,27 @@ enum FilterOperator: String, CaseIterable, Identifiable, Codable {
         case .regex: return String(localized: "matches regex")
         }
     }
+
+    /// SQL operator symbol for visual recognition in menus
+    var symbol: String {
+        switch self {
+        case .equal: return "="
+        case .notEqual: return "!="
+        case .greaterThan: return ">"
+        case .greaterOrEqual: return ">="
+        case .lessThan: return "<"
+        case .lessOrEqual: return "<="
+        case .contains: return "LIKE %..%"
+        case .notContains: return "NOT LIKE %..%"
+        case .startsWith: return "LIKE ..%"
+        case .endsWith: return "LIKE %.."
+        case .inList: return "IN (..)"
+        case .notInList: return "NOT IN (..)"
+        case .between: return "BETWEEN"
+        case .regex: return "~"
+        case .isNull, .isNotNull, .isEmpty, .isNotEmpty: return ""
+        }
+    }
 }
 
 /// Represents a single table filter condition

--- a/TablePro/Views/Filter/FilterRowView.swift
+++ b/TablePro/Views/Filter/FilterRowView.swift
@@ -71,7 +71,7 @@ struct FilterRowView: View {
     private var operatorPicker: some View {
         Picker("", selection: $filter.filterOperator) {
             ForEach(FilterOperator.allCases) { op in
-                Text(op.displayName).tag(op)
+                OperatorMenuLabel(op: op).tag(op)
             }
         }
         .pickerStyle(.menu)
@@ -130,7 +130,7 @@ struct FilterRowView: View {
             Text("—")
                 .font(.callout)
                 .foregroundStyle(.tertiary)
-                .frame(minWidth: 80, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -180,6 +180,17 @@ struct FilterRowView: View {
             onRemove()
         } label: {
             Label(String(localized: "Remove Filter"), systemImage: "trash")
+        }
+    }
+
+    // MARK: - Operator Menu Label
+
+    private struct OperatorMenuLabel: View {
+        let op: FilterOperator
+
+        var body: some View {
+            Text(op.symbol.isEmpty ? op.displayName : "\(op.symbol)  \(op.displayName)")
+                .accessibilityLabel(op.displayName)
         }
     }
 }

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -13,7 +13,7 @@ Filters are per-tab. Tables with active filters open in a new tab when you click
 
 ## Operators
 
-18 operators: `=`, `!=`, contains, not contains, starts with, ends with, `>`, `>=`, `<`, `<=`, IS NULL, IS NOT NULL, IS EMPTY, IS NOT EMPTY, IN, NOT IN, BETWEEN, REGEX.
+18 operators with SQL symbols shown inline: `=`, `!=`, `LIKE %..%`, `NOT LIKE %..%`, `LIKE ..%`, `LIKE %..`, `>`, `>=`, `<`, `<=`, IS NULL, IS NOT NULL, IS EMPTY, IS NOT EMPTY, `IN (..)`, `NOT IN (..)`, `BETWEEN`, `~` (regex).
 
 BETWEEN shows two value fields. IN/NOT IN takes comma-separated values.
 


### PR DESCRIPTION
## Summary

- Add `symbol` computed property to `FilterOperator` with SQL operator symbols (`=`, `!=`, `LIKE %..%`, `>`, `>=`, etc.)
- Filter operator picker now shows symbols alongside localized names (e.g. `=  equals`, `LIKE %..%  contains`)
- `FilterDefaultOperator.displayName` delegates to `FilterOperator` for consistent formatting
- Fix layout bug where no-value operators (IS NULL, IS EMPTY) caused the filter row to center

Closes #834

## Test plan

- [ ] Open filter panel (Cmd+Shift+F), click operator dropdown — verify symbols appear with correct format
- [ ] Select "is NULL" / "is not NULL" — verify no symbol prefix, row stays left-aligned
- [ ] Open filter settings (⋯ > Filter Settings) — verify default operator picker shows consistent symbol format
- [ ] Switch to a non-English language — verify symbols remain while text is translated
- [ ] Enable VoiceOver, navigate to operator picker — verify it reads display names not symbols