### PR TITLE
fix: preview tab double-click detection and promotion

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -332,11 +332,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                             previewCoordinator.promotePreviewTab()
                         } else {
                             previewCoordinator.promotePreviewTab()
-                            coordinator.openTableTab(table.name, isView: isView)
+                            coordinator.openTableTab(table.name, isView: isView, asPreview: false)
                         }
                     } else {
                         coordinator.promotePreviewTab()
-                        coordinator.openTableTab(table.name, isView: isView)
+                        coordinator.openTableTab(table.name, isView: isView, asPreview: false)
                     }
                 },
                 pendingTruncates: sessionPendingTruncatesBinding,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -15,7 +15,7 @@ private let navigationLogger = Logger(subsystem: "com.TablePro", category: "Main
 extension MainContentCoordinator {
     // MARK: - Table Tab Opening
 
-    func openTableTab(_ tableName: String, showStructure: Bool = false, isView: Bool = false) {
+    func openTableTab(_ tableName: String, showStructure: Bool = false, isView: Bool = false, asPreview: Bool? = nil) {
         let navigationModel = PluginMetadataRegistry.shared.snapshot(
             forTypeId: connection.type.pluginTypeId
         )?.navigationModel ?? .standard
@@ -73,8 +73,9 @@ extension MainContentCoordinator {
 
         // If no tabs exist (empty state), add a table tab directly.
         // In preview mode, mark it as preview so subsequent clicks replace it.
+        let usePreview = asPreview ?? AppSettingsManager.shared.tabs.enablePreviewTabs
         if tabManager.tabs.isEmpty {
-            if AppSettingsManager.shared.tabs.enablePreviewTabs {
+            if usePreview {
                 tabManager.addPreviewTableTab(
                     tableName: tableName,
                     databaseType: connection.type,
@@ -155,7 +156,7 @@ extension MainContentCoordinator {
         }
 
         // Preview tab mode: reuse or create a preview tab instead of a new native window
-        if AppSettingsManager.shared.tabs.enablePreviewTabs {
+        if usePreview {
             openPreviewTab(tableName, isView: isView, databaseName: currentDatabase, schemaName: currentSchema, showStructure: showStructure)
             return
         }

--- a/TablePro/Views/Sidebar/DoubleClickDetector.swift
+++ b/TablePro/Views/Sidebar/DoubleClickDetector.swift
@@ -84,13 +84,22 @@ private final class SharedDoubleClickMonitor {
     private func handleMouseDown(_ event: NSEvent) {
         guard event.clickCount == 2 else { return }
 
-        for view in registeredViews.allObjects {
+        let views = registeredViews.allObjects
+        guard !views.isEmpty else { return }
+
+        for view in views {
             guard let viewWindow = view.window,
                   event.window === viewWindow else { continue }
-            let locationInView = view.convert(event.locationInWindow, from: nil)
-            if view.bounds.contains(locationInView) {
+
+            var ancestor: NSView? = view.superview
+            while let current = ancestor, !(current is NSTableRowView) {
+                ancestor = current.superview
+            }
+            let hitView = ancestor ?? view
+            let locationInHitView = hitView.convert(event.locationInWindow, from: nil)
+            if hitView.bounds.contains(locationInHitView) {
                 view.onDoubleClick?()
-                break
+                return
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fix `DoubleClickDetector` bounds check: walk up to `NSTableRowView` instead of checking tiny overlay text bounds
- Add `asPreview` parameter to `openTableTab` so double-click can force non-preview mode
- Double-click now correctly promotes existing preview or opens permanent tab

## Root Cause

The `SharedDoubleClickMonitor` detected `clickCount == 2` events correctly, but the bounds check failed because the `SidebarDoubleClickView` overlay was sized to the text label width (67-156px), not the full row width. Clicks in the right portion of the row fell outside the overlay bounds.

## Changes

**`DoubleClickDetector.swift`**: Walk up the view hierarchy to the nearest `NSTableRowView` and check bounds against the full row, not the overlay.

**`MainContentCoordinator+Navigation.swift`**: Added `asPreview: Bool? = nil` parameter. `nil` = use setting (default), `false` = force permanent (double-click).

**`MainSplitViewController.swift`**: Double-click handler passes `asPreview: false`.

## Test plan

- [ ] Single-click table: opens as preview (subtitle shows "Preview")
- [ ] Single-click another table: replaces preview (still 1 tab)
- [ ] Double-click table: promotes preview to permanent (subtitle drops "Preview")
- [ ] Double-click different table from permanent: opens new permanent tab
- [ ] Edit/sort/filter in preview: auto-promotes to permanent
- [ ] Query tabs are never preview
- [ ] Preview tabs not persisted on close
- [ ] "Enable preview tabs" OFF: all clicks open permanent tabs