### PR TITLE
fix: address remaining non-native macOS UI patterns from #846

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,30 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace custom dropdown fields with native Picker(.menu) for boolean and enum cell editors
-- Replace confirmation dialogs with native alerts for delete actions (welcome screen, SSH profile)
-- Quit dialog defaults to Cancel on Return key instead of Quit Anyway
-- Table drop/truncate confirmation button now shows the operation name instead of generic "OK"
-- Database switcher uses native List selection highlighting instead of manual colors
-- Database switcher and drop database sheets use .navigationTitle instead of manual header text
-- Welcome screen uses native NSSearchField instead of hand-rolled search bar
-- Sidebar search field uses regular size instead of large
-- Single-clicking a dropdown column cell no longer triggers the dropdown menu
-- Welcome screen toolbar buttons use native borderless style instead of custom backgrounds
-- AI provider editor and URL import sheets use .navigationTitle instead of manual header text
-- Connection form delete button positioned at far left, separated from confirm/cancel cluster
-- SET field picker shows chevron disclosure indicator
-- SSH/SSL file browse panels show descriptive message text
-- Sidebar minimum width enforced by NSSplitViewItem instead of conflicting SwiftUI constraint
+- Native macOS UI patterns: Picker(.menu) for cell editors, native alerts, native List selection, .navigationTitle for sheets, NSSearchField for welcome search, borderless toolbar buttons, chevron indicator on SET picker
+- Quit dialog defaults to Cancel on Return key
+- Connection form delete button moved to far left
+- SSH/SSL browse panels show descriptive message text
 
 ### Fixed
 
 - Schema-qualified table names (e.g. `public.users`) now correctly resolve in autocomplete
-- Alert dialogs in ER diagram export and plugin rejection use sheet attachment instead of bare modal
-- Duplicate onExitCommand in table operation dialog
-- SQLEditorView duplicated onAppear initialization logic
-- Unlocalized metadata strings in query history panel
+- Alert dialogs use sheet attachment instead of bare modal
 - Terminal copy uses responder chain instead of synthetic NSEvent
+- Unlocalized metadata strings in query history panel
 
 ## [0.34.0] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Welcome screen uses native NSSearchField instead of hand-rolled search bar
 - Sidebar search field uses regular size instead of large
 - Single-clicking a dropdown column cell no longer triggers the dropdown menu
+- Welcome screen toolbar buttons use native borderless style instead of custom backgrounds
+- AI provider editor and URL import sheets use .navigationTitle instead of manual header text
+- Connection form delete button positioned at far left, separated from confirm/cancel cluster
+- SET field picker shows chevron disclosure indicator
+- SSH/SSL file browse panels show descriptive message text
+- Sidebar minimum width enforced by NSSplitViewItem instead of conflicting SwiftUI constraint
 
 ### Fixed
 
 - Schema-qualified table names (e.g. `public.users`) now correctly resolve in autocomplete
+- Alert dialogs in ER diagram export and plugin rejection use sheet attachment instead of bare modal
+- Duplicate onExitCommand in table operation dialog
+- SQLEditorView duplicated onAppear initialization logic
+- Unlocalized metadata strings in query history panel
+- Terminal copy uses responder chain instead of synthetic NSEvent
 
 ## [0.34.0] - 2026-04-22
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -188,7 +188,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             )
             alert.alertStyle = .warning
             alert.addButton(withTitle: String(localized: "OK"))
-            alert.runModal()
+            if let window = AlertHelper.resolveWindow(nil) {
+                alert.beginSheetModal(for: window)
+            } else {
+                alert.runModal()
+            }
         }
     }
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -121,7 +121,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         sidebarContainer = SidebarContainerViewController(rootView: AnyView(buildSidebarView()))
         sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarContainer)
         sidebarSplitItem.canCollapse = true
-        sidebarSplitItem.minimumThickness = 200
+        sidebarSplitItem.minimumThickness = 280
         sidebarSplitItem.maximumThickness = 600
         addSplitViewItem(sidebarSplitItem)
 

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -7600,6 +7600,9 @@
         }
       }
     },
+    "Choose a certificate or key file" : {
+
+    },
     "Choose a folder to watch for .tablepro connection files" : {
       "localizations" : {
         "tr" : {
@@ -7643,6 +7646,12 @@
           }
         }
       }
+    },
+    "Choose a private key file" : {
+
+    },
+    "Choose a private key file for the jump host" : {
+
     },
     "Choose a query from the list\nto see its full content here." : {
       "localizations" : {

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -32,9 +32,6 @@ extension ConnectionFormView {
                 }
                 .disabled(isTesting || isInstallingPlugin || !isValid)
 
-                Spacer()
-
-                // Delete button (edit mode only)
                 if !isNew {
                     Button("Delete", role: .destructive) {
                         Task {
@@ -50,6 +47,8 @@ extension ConnectionFormView {
                         }
                     }
                 }
+
+                Spacer()
 
                 // Cancel
                 Button("Cancel") {
@@ -89,9 +88,6 @@ extension ConnectionFormView {
 
     var connectionURLImportSheet: some View {
         VStack(spacing: 16) {
-            Text(String(localized: "Import from URL"))
-                .font(.headline)
-
             Text(String(localized: "Paste a connection URL to auto-fill the form fields."))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -129,6 +125,7 @@ extension ConnectionFormView {
                 .disabled(connectionURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
+        .navigationTitle(String(localized: "Import from URL"))
         .padding(20)
         .frame(width: 420)
     }

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -342,6 +342,7 @@ struct ConnectionSSHTunnelView: View {
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
             ".ssh")
         panel.showsHiddenFiles = true
+        panel.message = String(localized: "Choose a private key file")
 
         panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {
@@ -358,6 +359,7 @@ struct ConnectionSSHTunnelView: View {
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
             ".ssh")
         panel.showsHiddenFiles = true
+        panel.message = String(localized: "Choose a private key file for the jump host")
 
         panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -82,6 +82,7 @@ struct ConnectionSSLView: View {
         panel.canChooseDirectories = false
         panel.allowedContentTypes = [.data]
         panel.showsHiddenFiles = true
+        panel.message = String(localized: "Choose a certificate or key file")
 
         panel.beginSheetModal(for: window) { response in
             if response == .OK, let url = panel.url {

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -133,12 +133,8 @@ struct WelcomeWindowView: View {
                             width: 24,
                             height: 24
                         )
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(Color(nsColor: .quaternaryLabelColor))
-                        )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderless)
                 .help(String(localized: "New Connection (⌘N)"))
 
                 Button(action: { vm.pendingMoveToNewGroup = []; vm.activeSheet = .newGroup(parentId: nil) }) {
@@ -149,12 +145,8 @@ struct WelcomeWindowView: View {
                             width: 24,
                             height: 24
                         )
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(Color(nsColor: .quaternaryLabelColor))
-                        )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderless)
                 .help(String(localized: "New Group"))
 
                 NativeSearchField(

--- a/TablePro/Views/ERDiagram/ERDiagramView.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramView.swift
@@ -271,7 +271,11 @@ struct ERDiagramView: View {
             alert.messageText = String(localized: "Export Failed")
             alert.informativeText = String(localized: "Failed to render the diagram image.")
             alert.alertStyle = .warning
-            alert.runModal()
+            if let window = AlertHelper.resolveWindow(nil) {
+                alert.beginSheetModal(for: window)
+            } else {
+                alert.runModal()
+            }
             return
         }
 

--- a/TablePro/Views/Editor/HistoryPanelView.swift
+++ b/TablePro/Views/Editor/HistoryPanelView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 /// Query history panel with master-detail layout
 struct HistoryPanelView: View {
+    private static let dateFilterKey = "HistoryPanel.dateFilter"
+
     let connectionId: UUID
     // MARK: - State
 
@@ -283,7 +285,7 @@ private extension HistoryPanelView {
 
     func buildPrimaryMetadata(_ entry: QueryHistoryEntry) -> String {
         var parts: [String] = []
-        parts.append("Database: \(entry.databaseName)")
+        parts.append(String(format: String(localized: "Database: %@"), entry.databaseName))
         parts.append(entry.formattedExecutionTime)
 
         if entry.rowCount >= 0 {
@@ -298,7 +300,7 @@ private extension HistoryPanelView {
         var text = String(format: String(localized: "Executed: %@"), executedAt)
 
         if !entry.wasSuccessful, let error = entry.errorMessage {
-            text += "\nError: \(error)"
+            text += "\n" + String(format: String(localized: "Error: %@"), error)
         }
 
         return text
@@ -386,14 +388,14 @@ private extension HistoryPanelView {
     // MARK: - Filter State Persistence
 
     func restoreFilterState() {
-        let savedFilter = UserDefaults.standard.integer(forKey: "HistoryPanel.dateFilter")
+        let savedFilter = UserDefaults.standard.integer(forKey: Self.dateFilterKey)
         if let filter = UIDateFilter(rawValue: savedFilter) {
             dateFilter = filter
         }
     }
 
     func saveFilterState() {
-        UserDefaults.standard.set(dateFilter.rawValue, forKey: "HistoryPanel.dateFilter")
+        UserDefaults.standard.set(dateFilter.rawValue, forKey: Self.dateFilterKey)
     }
 }
 

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -108,24 +108,12 @@ struct SQLEditorView: View {
                 editorConfiguration = Self.makeConfiguration()
             }
             .onAppear {
-                if coordinator.isDestroyed {
-                    coordinator.revive()
-                }
-                if completionAdapter == nil {
-                    completionAdapter = SQLCompletionAdapter(schemaProvider: schemaProvider, databaseType: databaseType)
-                }
-                setupFavoritesObserver()
+                initializeEditor()
             }
         } else {
             Color(nsColor: .textBackgroundColor)
                 .onAppear {
-                    if coordinator.isDestroyed {
-                        coordinator.revive()
-                    }
-                    if completionAdapter == nil {
-                        completionAdapter = SQLCompletionAdapter(schemaProvider: schemaProvider, databaseType: databaseType)
-                    }
-                    setupFavoritesObserver()
+                    initializeEditor()
                     editorReady = true
                 }
             }
@@ -138,6 +126,18 @@ struct SQLEditorView: View {
         .onChange(of: coordinator.vimMode) { _, newMode in
             vimMode = newMode
         }
+    }
+
+    // MARK: - Initialization
+
+    private func initializeEditor() {
+        if coordinator.isDestroyed {
+            coordinator.revive()
+        }
+        if completionAdapter == nil {
+            completionAdapter = SQLCompletionAdapter(schemaProvider: schemaProvider, databaseType: databaseType)
+        }
+        setupFavoritesObserver()
     }
 
     // MARK: - Favorites

--- a/TablePro/Views/RightSidebar/FieldEditors/SetPickerView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/SetPickerView.swift
@@ -19,10 +19,16 @@ internal struct SetPickerView: View {
         Button {
             isSetPopoverPresented = true
         } label: {
-            Text(displayLabel)
-                .font(.subheadline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+            HStack(spacing: 4) {
+                Text(displayLabel)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 4)

--- a/TablePro/Views/Settings/AISettingsView.swift
+++ b/TablePro/Views/Settings/AISettingsView.swift
@@ -345,12 +345,11 @@ private struct AIProviderEditorSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            sheetHeader
-            Divider()
             sheetForm
             Divider()
             sheetFooter
         }
+        .navigationTitle(isNew ? String(localized: "Add Provider") : String(localized: "Edit Provider"))
         .frame(minWidth: 420, minHeight: 400)
         .onAppear {
             fetchModels()
@@ -359,14 +358,6 @@ private struct AIProviderEditorSheet: View {
             modelFetchTask?.cancel()
             testTask?.cancel()
         }
-    }
-
-    // MARK: - Header
-
-    private var sheetHeader: some View {
-        Text(isNew ? String(localized: "Add Provider") : String(localized: "Edit Provider"))
-            .font(.headline)
-            .padding()
     }
 
     // MARK: - Form

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -87,7 +87,6 @@ struct SidebarView: View {
                 )
             }
         }
-        .frame(minWidth: 280)
         .onChange(of: sidebarState.searchText) { _, newValue in
             viewModel.searchText = newValue
         }

--- a/TablePro/Views/Sidebar/TableOperationDialog.swift
+++ b/TablePro/Views/Sidebar/TableOperationDialog.swift
@@ -172,9 +172,6 @@ struct TableOperationDialog: View {
             ignoreForeignKeys = false
             cascade = false
         }
-        .onExitCommand {
-            isPresented = false
-        }
     }
 
     private func confirmAndDismiss() {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -34,9 +34,7 @@ struct TerminalTabContentView: View {
         .task {
             await connectWhenReady()
             await withTaskCancellationHandler {
-                while !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(86_400))
-                }
+                try? await Task.sleep(for: .seconds(86_400))
             } onCancel: { [sessionState] in
                 Task { @MainActor in
                     sessionState?.disconnect()
@@ -264,15 +262,8 @@ private final class TerminalFocusHelperView: NSView {
     }
 
     @objc private func copySelection() {
-        guard let terminal = terminalView, let window = terminal.window else { return }
-        guard let event = NSEvent.keyEvent(
-            with: .keyDown, location: .zero, modifierFlags: .command,
-            timestamp: ProcessInfo.processInfo.systemUptime,
-            windowNumber: window.windowNumber, context: nil,
-            characters: "c", charactersIgnoringModifiers: "c",
-            isARepeat: false, keyCode: 8
-        ) else { return }
-        terminal.keyDown(with: event)
+        guard let terminal = terminalView else { return }
+        NSApp.sendAction(#selector(NSText.copy(_:)), to: terminal, from: nil)
     }
 
     @objc private func pasteFromClipboard() {

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -34,7 +34,9 @@ struct TerminalTabContentView: View {
         .task {
             await connectWhenReady()
             await withTaskCancellationHandler {
-                try? await Task.sleep(for: .seconds(86_400))
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(86_400))
+                }
             } onCancel: { [sessionState] in
                 Task { @MainActor in
                     sessionState?.disconnect()


### PR DESCRIPTION
## Summary
### UI pattern fixes (issue #846)
- Sync sidebar minimum width: raise `NSSplitViewItem.minimumThickness` to 280, remove conflicting SwiftUI `.frame(minWidth: 280)`
- Move Delete button to far left in connection form footer, separated from Cancel/Save
- Replace manual sheet headers with `.navigationTitle` in AI provider editor and URL import sheet
- Use `.buttonStyle(.borderless)` for welcome screen toolbar buttons, remove custom `RoundedRectangle` backgrounds
- Use `AlertHelper` with sheet attachment in ERDiagramView and AppDelegate instead of bare `runModal()`
- Add chevron.down disclosure indicator to SetPickerView
- Add `.message` to NSOpenPanel in SSH/SSL browse methods
- Remove duplicate `.onExitCommand` in TableOperationDialog

### Editor and terminal cleanup
- Deduplicate SQLEditorView onAppear logic into `initializeEditor()` method
- Localize metadata strings in HistoryPanelView (`"Database: ..."`, `"Error: ..."`)
- Extract UserDefaults magic string to `static let dateFilterKey` in HistoryPanelView
- Replace synthetic NSEvent in terminal copy with `NSApp.sendAction` responder chain

Closes #846

## Test plan
- [ ] Drag sidebar divider to minimum — stops at 280pt, no clipping
- [ ] Connection form (edit mode): Delete button at far left
- [ ] AI Settings → Add Provider: native `.navigationTitle` header
- [ ] Connection form → Import from URL: native sheet title
- [ ] Welcome screen: + and folder+ buttons have native hover/pressed states
- [ ] Right sidebar SET field: button shows chevron indicator
- [ ] SSH/SSL browse: open panel shows descriptive message
- [ ] Table operation dialog: Escape dismisses correctly
- [ ] Terminal: right-click → Copy works
- [ ] Query history panel: metadata shows localized "Database:" and "Error:" labels
- [ ] SQL editor: switching tabs doesn't break editor initialization