### PR TITLE
fix: treat query timeout as best-effort so Aurora DSQL can connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connection failure on PostgreSQL-compatible databases (e.g., Aurora DSQL) that don't support `SET statement_timeout`
 - Schema-qualified table names (e.g. `public.users`) now correctly resolve in autocomplete
 - Alert dialogs use sheet attachment instead of bare modal
 - Terminal copy uses responder chain instead of synthetic NSEvent

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -144,10 +144,16 @@ extension DatabaseManager {
             throw error
         }
 
-        // Apply timeout
+        // Apply timeout (best-effort)
         let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
         if timeoutSeconds > 0 {
-            try await driver.applyQueryTimeout(timeoutSeconds)
+            do {
+                try await driver.applyQueryTimeout(timeoutSeconds)
+            } catch {
+                Self.logger.warning(
+                    "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
+                )
+            }
         }
 
         await executeStartupCommands(
@@ -234,10 +240,16 @@ extension DatabaseManager {
             )
             try await driver.connect()
 
-            // Apply timeout
+            // Apply timeout (best-effort)
             let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
             if timeoutSeconds > 0 {
-                try await driver.applyQueryTimeout(timeoutSeconds)
+                do {
+                    try await driver.applyQueryTimeout(timeoutSeconds)
+                } catch {
+                    Self.logger.warning(
+                        "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
+                    )
+                }
             }
 
             await executeStartupCommands(

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -110,10 +110,17 @@ extension DatabaseManager {
         do {
             try await driver.connect()
 
-            // Apply query timeout from settings
+            // Apply query timeout from settings (best-effort — some PostgreSQL-compatible
+            // databases like Aurora DSQL don't support SET statement_timeout)
             let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
             if timeoutSeconds > 0 {
-                try await driver.applyQueryTimeout(timeoutSeconds)
+                do {
+                    try await driver.applyQueryTimeout(timeoutSeconds)
+                } catch {
+                    Self.logger.warning(
+                        "Query timeout not supported for \(connection.name): \(error.localizedDescription)"
+                    )
+                }
             }
 
             // Run startup commands before schema init


### PR DESCRIPTION
## Summary

- Aurora DSQL (and other PostgreSQL-compatible databases) don't support `SET statement_timeout`, which caused connection failure with: `ERROR: setting configuration parameter "statement_timeout" not supported`
- `applyQueryTimeout` is now best-effort at all 3 call sites in `DatabaseManager` — errors are logged as warnings instead of killing the connection
- Fix is at the caller level, not driver level: the `PluginDatabaseDriver` protocol's default `applyQueryTimeout` is already a no-op, so the caller should treat failures as non-fatal. This way all current and future drivers benefit without individual changes.

## Test plan

- [ ] Connect to Aurora DSQL — should succeed where it previously failed
- [ ] Connect to standard PostgreSQL with query timeout set in settings — timeout should still apply
- [ ] Disconnect network and let health monitor reconnect — reconnect should succeed
- [ ] Manual reconnect via toolbar button — should succeed