### PR TITLE
fix: overhaul Import URL dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Import URL auto-pastes from clipboard
-- Import URL shows parsed field preview before importing
-- Import URL applies statusColor and env tag from URL query parameters
-- Basic URL import for libSQL and Cloudflare D1
-- Registered URL schemes for Oracle, ClickHouse, etcd, D1, and libSQL
+- Import URL: dynamic placeholder, parsed preview, clipboard auto-paste, libSQL/D1 support, URL schemes for Oracle/ClickHouse/etcd/D1/libSQL
 - In-app feedback form for bug reports and feature requests via Help > Report an Issue
 - Per-connection "Local only" option to exclude individual connections from iCloud sync
 - Filter operator picker shows SQL symbols alongside names for quick visual recognition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Import URL auto-pastes from clipboard
+- Import URL shows parsed field preview before importing
+- Import URL applies statusColor and env tag from URL query parameters
+- Basic URL import for libSQL and Cloudflare D1
+- Registered URL schemes for Oracle, ClickHouse, etcd, D1, and libSQL
 - In-app feedback form for bug reports and feature requests via Help > Report an Issue
 - Per-connection "Local only" option to exclude individual connections from iCloud sync
 - Filter operator picker shows SQL symbols alongside names for quick visual recognition

--- a/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 struct ParsedConnectionURL {
     let type: DatabaseType
@@ -129,10 +130,12 @@ struct ConnectionURLParser {
 
         let isSrv = scheme == "mongodb+srv"
 
-        if dbType == .sqlite {
+        let isFileBased = dbType == .sqlite || dbType == .duckdb
+            || PluginMetadataRegistry.shared.snapshot(forTypeId: dbType.pluginTypeId)?.connectionMode == .fileBased
+        if isFileBased {
             let path = String(trimmed[schemeEnd.upperBound...])
             return .success(ParsedConnectionURL(
-                type: .sqlite,
+                type: dbType,
                 host: "",
                 port: nil,
                 database: path,
@@ -203,6 +206,10 @@ struct ConnectionURLParser {
             if scheme == "rediss" {
                 sslMode = sslMode ?? .required
             }
+        }
+
+        if scheme == "etcds" {
+            sslMode = sslMode ?? .required
         }
 
         // Oracle-specific: path component is the service name, not the database name

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -243,6 +243,13 @@
 				<string>cql</string>
 				<string>scylladb</string>
 				<string>scylla</string>
+				<string>oracle</string>
+				<string>clickhouse</string>
+				<string>ch</string>
+				<string>etcd</string>
+				<string>etcds</string>
+				<string>d1</string>
+				<string>libsql</string>
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -167,9 +167,10 @@ extension ConnectionFormView {
         .onAppear {
             if connectionURL.isEmpty,
                let clipString = NSPasteboard.general.string(forType: .string),
-               clipString.contains("://")
+               let firstLine = clipString.components(separatedBy: .newlines).first,
+               firstLine.contains("://")
             {
-                connectionURL = clipString.trimmingCharacters(in: .whitespacesAndNewlines)
+                connectionURL = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
             }
         }
     }
@@ -227,7 +228,7 @@ extension ConnectionFormView {
             Text(label)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
-                .frame(width: 50, alignment: .trailing)
+                .frame(width: 58, alignment: .trailing)
             Text(value)
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -86,16 +86,48 @@ extension ConnectionFormView {
 
     // MARK: - Import from URL Sheet
 
+    private var urlPlaceholder: String {
+        let snapshot = PluginMetadataRegistry.shared.snapshot(forTypeId: type.pluginTypeId)
+        let scheme = snapshot?.primaryUrlScheme ?? type.rawValue.lowercased()
+        let mode = snapshot?.connectionMode ?? .network
+
+        switch mode {
+        case .fileBased:
+            return "\(scheme):///path/to/database"
+        case .apiOnly:
+            if type.pluginTypeId == "libSQL" {
+                return "libsql://your-database.turso.io"
+            }
+            if type.pluginTypeId == "Cloudflare D1" {
+                return "d1://account-id/database-name"
+            }
+            return "\(scheme)://host/database"
+        case .network:
+            let port = snapshot?.defaultPort ?? 0
+            let portStr = port > 0 ? ":\(port)" : ""
+            return "\(scheme)://user:password@host\(portStr)/database"
+        }
+    }
+
+    private var parsedPreview: ParsedConnectionURL? {
+        let trimmed = connectionURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if case .success(let parsed) = ConnectionURLParser.parse(trimmed) {
+            return parsed
+        }
+        return nil
+    }
+
     var connectionURLImportSheet: some View {
         VStack(spacing: 16) {
-            Text(String(localized: "Paste a connection URL to auto-fill the form fields."))
+            Text("Paste a connection URL to auto-fill the form fields.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
             TextField(
                 String(localized: "Connection URL"),
                 text: $connectionURL,
-                prompt: Text("postgresql://user:password@host:5432/database")
+                prompt: Text(urlPlaceholder)
             )
             .textFieldStyle(.roundedBorder)
 
@@ -103,17 +135,21 @@ extension ConnectionFormView {
                 Text(urlParseError)
                     .font(.caption)
                     .foregroundStyle(Color(nsColor: .systemRed))
+            } else if let preview = parsedPreview {
+                urlPreviewView(preview)
             }
 
             HStack {
-                Button(String(localized: "Cancel")) {
+                Button("Cancel") {
+                    connectionURL = ""
+                    urlParseError = nil
                     showURLImport = false
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
-                Button(String(localized: "Import")) {
+                Button("Import") {
                     parseConnectionURL()
                     if urlParseError == nil && !connectionURL.isEmpty {
                         connectionURL = ""
@@ -128,5 +164,75 @@ extension ConnectionFormView {
         .navigationTitle(String(localized: "Import from URL"))
         .padding(20)
         .frame(width: 420)
+        .onAppear {
+            if connectionURL.isEmpty,
+               let clipString = NSPasteboard.general.string(forType: .string),
+               clipString.contains("://")
+            {
+                connectionURL = clipString.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+    }
+
+    private func urlPreviewView(_ parsed: ParsedConnectionURL) -> some View {
+        let snapshot = PluginMetadataRegistry.shared.snapshot(forTypeId: parsed.type.pluginTypeId)
+        let mode = snapshot?.connectionMode ?? .network
+
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(parsed.type.iconName)
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                Text(snapshot?.displayName ?? parsed.type.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+
+            switch mode {
+            case .fileBased:
+                if !parsed.database.isEmpty {
+                    previewRow(String(localized: "Path"), parsed.database)
+                }
+            case .apiOnly:
+                if !parsed.host.isEmpty {
+                    previewRow(String(localized: "Host"), parsed.host)
+                }
+            case .network:
+                if !parsed.host.isEmpty {
+                    let portStr = parsed.port.map { ":\($0)" } ?? ""
+                    previewRow(String(localized: "Host"), parsed.host + portStr)
+                }
+                if !parsed.username.isEmpty {
+                    previewRow(String(localized: "User"), parsed.username)
+                }
+                if !parsed.database.isEmpty {
+                    previewRow(String(localized: "Database"), parsed.database)
+                }
+                if let svc = parsed.oracleServiceName, !svc.isEmpty {
+                    previewRow(String(localized: "Service"), svc)
+                }
+                if let sshHost = parsed.sshHost {
+                    previewRow("SSH", sshHost)
+                }
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func previewRow(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .frame(width: 50, alignment: .trailing)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
     }
 }

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -570,8 +570,27 @@ extension ConnectionFormView {
                     additionalFieldValues["mongoParam_\(key)"] = value
                 }
             }
-            if parsed.type.pluginTypeId == "Redis", !parsed.database.isEmpty {
-                additionalFieldValues["redisDatabase"] = parsed.database
+            if parsed.type.pluginTypeId == "Redis", let redisDb = parsed.redisDatabase {
+                additionalFieldValues["redisDatabase"] = String(redisDb)
+            }
+            if let svcName = parsed.oracleServiceName, !svcName.isEmpty {
+                additionalFieldValues["oracleServiceName"] = svcName
+            }
+            if let hex = parsed.statusColor, !hex.isEmpty {
+                connectionColor = ConnectionURLParser.connectionColor(fromHex: hex)
+            }
+            if let env = parsed.envTag, !env.isEmpty {
+                selectedTagId = ConnectionURLParser.tagId(fromEnvName: env)
+            }
+            if parsed.type.pluginTypeId == "libSQL", !parsed.host.isEmpty {
+                var urlString = "https://\(parsed.host)"
+                if let port = parsed.port {
+                    urlString += ":\(port)"
+                }
+                additionalFieldValues["databaseUrl"] = urlString
+            }
+            if parsed.type.pluginTypeId == "Cloudflare D1", !parsed.host.isEmpty {
+                additionalFieldValues["cfAccountId"] = parsed.host
             }
             if let connectionName = parsed.connectionName, !connectionName.isEmpty {
                 name = connectionName

--- a/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
@@ -859,6 +859,62 @@ struct ConnectionURLParserTests {
         #expect(parsed.sshPort == 2222)
     }
 
+    // MARK: - DuckDB (file-based)
+
+    @Test("DuckDB absolute file path")
+    func testDuckDBAbsolutePath() {
+        let result = ConnectionURLParser.parse("duckdb:///Users/me/analytics.duckdb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .duckdb)
+        #expect(parsed.database == "/Users/me/analytics.duckdb")
+        #expect(parsed.host == "")
+    }
+
+    @Test("DuckDB relative file path")
+    func testDuckDBRelativePath() {
+        let result = ConnectionURLParser.parse("duckdb://data.duckdb")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .duckdb)
+        #expect(parsed.database == "data.duckdb")
+    }
+
+    // MARK: - etcds TLS
+
+    @Test("etcds scheme enables SSL")
+    func testEtcdsSchemeEnablesSSL() {
+        let result = ConnectionURLParser.parse("etcds://host:2379")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sslMode == .required)
+    }
+
+    @Test("etcd scheme does not enable SSL")
+    func testEtcdSchemeNoSSL() {
+        let result = ConnectionURLParser.parse("etcd://host:2379")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sslMode == nil)
+    }
+
+    // MARK: - Oracle service name
+
+    @Test("Oracle URL extracts service name")
+    func testOracleServiceName() {
+        let result = ConnectionURLParser.parse("oracle://user:pass@host:1521/ORCL")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .oracle)
+        #expect(parsed.oracleServiceName == "ORCL")
+        #expect(parsed.database == "")
+    }
+
     @Test("SSH URL with both usePrivateKey and useSSHAgent prefers last")
     func testSSHURLWithBothPrivateKeyAndAgent() {
         let result = ConnectionURLParser.parse(

--- a/docs/databases/cassandra.mdx
+++ b/docs/databases/cassandra.mdx
@@ -21,7 +21,13 @@ Click **New Connection**, select **Cassandra** or **ScyllaDB**, enter host/port/
 | **Username** | - | Disable auth for local dev |
 | **Password** | - | |
 
-See [Connection URL Reference](/databases/connection-urls#cassandra--scylladb) for URL format.
+## Connection URL
+
+```text
+cassandra://user:password@host:9042/keyspace
+```
+
+See [Connection URL Reference](/databases/connection-urls#cassandra--scylladb) for all parameters.
 
 ## Example configurations
 

--- a/docs/databases/clickhouse.mdx
+++ b/docs/databases/clickhouse.mdx
@@ -31,6 +31,14 @@ Uses HTTP API (HTTPS on port 8443 with SSL/TLS enabled). Cloud providers typical
 
 **SSL/TLS**: Enable in connection form for HTTPS (port 8443). Cloud requires HTTPS.
 
+## Connection URL
+
+```text
+clickhouse://user:password@host:8123/database
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Features
 
 ### Database Browsing

--- a/docs/databases/connection-urls.mdx
+++ b/docs/databases/connection-urls.mdx
@@ -26,7 +26,16 @@ TablePro parses standard database connection URLs for importing connections, ope
 | `oracle://` | Oracle Database |
 | `jdbc:oracle:thin:@//` | Oracle Database (JDBC thin) |
 | `cassandra://` | Cassandra |
+| `cql://` | Cassandra (alias) |
 | `scylladb://` | ScyllaDB |
+| `scylla://` | ScyllaDB (alias) |
+| `clickhouse://` | ClickHouse |
+| `ch://` | ClickHouse (alias) |
+| `duckdb://` | DuckDB |
+| `etcd://` | etcd |
+| `etcds://` | etcd with TLS |
+| `d1://` | Cloudflare D1 |
+| `libsql://` | libSQL / Turso |
 
 Append `+ssh` to any scheme (except SQLite) to use an SSH tunnel:
 
@@ -150,6 +159,8 @@ postgresql://user:pass@host/db?statusColor=FF3B30&env=production
 | Parameter | Description |
 |-----------|-------------|
 | `authSource` | Authentication database (defaults to `admin`) |
+| `authMechanism` | Authentication mechanism (e.g. `SCRAM-SHA-256`) |
+| `replicaSet` | Replica set name |
 
 **Example:**
 
@@ -176,11 +187,56 @@ scylladb://user:pass@host:9042/my_keyspace
 cassandra://host:9042                        # no auth, no default keyspace
 ```
 
+### DuckDB
+
+DuckDB uses file-based connections. The path after `://` is the file path, same as SQLite.
+
+```text
+duckdb:///Users/me/data/analytics.duckdb
+duckdb:///path/to/database.db
+```
+
+### ClickHouse
+
+ClickHouse uses HTTP on port 8123 by default. `ch://` is accepted as an alias.
+
+```text
+clickhouse://user:password@host:8123/mydb
+ch://default@localhost/analytics
+```
+
+### etcd
+
+The `etcds://` scheme automatically enables TLS. Default port is 2379.
+
+```text
+etcd://host:2379
+etcds://host:2379
+```
+
+### libSQL / Turso
+
+The URL host maps to the database URL. The auth token goes in the password field of the connection form.
+
+```text
+libsql://your-database.turso.io
+```
+
+### Cloudflare D1
+
+The host maps to the Cloudflare Account ID. The path sets the database name or UUID.
+
+```text
+d1://account-id/database-name
+```
+
 ### SSH Tunnel
 
 | Parameter | Description |
 |-----------|-------------|
 | `usePrivateKey` | `true` to use key-based SSH authentication instead of password |
+| `useSSHAgent` | `true` to use SSH agent for authentication |
+| `agentSocket` | Custom SSH agent socket path |
 
 **Example:**
 

--- a/docs/databases/duckdb.mdx
+++ b/docs/databases/duckdb.mdx
@@ -24,6 +24,14 @@ DuckDB is an embedded analytical database, optimized for OLAP workloads. TablePr
   </Step>
 </Steps>
 
+## Connection URL
+
+```text
+duckdb:///path/to/database.duckdb
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Opening DuckDB files from Finder
 
 Double-click any `.duckdb` file in Finder to open it directly in TablePro.

--- a/docs/databases/mongodb.mdx
+++ b/docs/databases/mongodb.mdx
@@ -56,6 +56,15 @@ TablePro supports MongoDB 5.0 and later. Collections appear as tables in the sid
 
 Configure in **SSL/TLS** section. MongoDB Atlas requires SSL/TLS - use **Required** or **Verify CA**. For unencrypted alternatives, use [SSH tunneling](/databases/ssh-tunneling).
 
+## Connection URL
+
+```text
+mongodb://user:password@host:27017/database?authSource=admin
+mongodb+srv://user:password@cluster.mongodb.net/database
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Features
 
 **Collection Browsing**: Sidebar shows all collections. Click to view documents in data grid.

--- a/docs/databases/mssql.mdx
+++ b/docs/databases/mssql.mdx
@@ -31,6 +31,15 @@ Run `scripts/build-freetds.sh` first. Click **New Connection**, select **SQL Ser
 **Remote**: Standard credentials
 **Azure SQL**: Host `server.database.windows.net`, user may need `user@servername` suffix
 
+## Connection URL
+
+```text
+mssql://user:password@host:1433/database
+sqlserver://user:password@host:1433/database
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Features
 
 **Schema Selection**: Default schema is `dbo`. Switch with **Cmd+K**. Shows accessible schemas and tables.

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -49,6 +49,14 @@ The Oracle driver is available as a downloadable plugin. When you select Oracle 
 
 **Oracle Cloud (ADB)**: Port 1522, service name format `mydb_tp`, requires TLS wallet download from Oracle Cloud Console
 
+## Connection URL
+
+```text
+oracle://user:password@host:1521/service_name
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Features
 
 **Schema Selection**: Each user is a schema. Switch with **⌘K**. Shows available schemas and objects.

--- a/docs/databases/redshift.mdx
+++ b/docs/databases/redshift.mdx
@@ -25,6 +25,14 @@ TablePro connects to Amazon Redshift, AWS's columnar data warehouse based on Pos
 
 Example: `my-cluster.abc123xyz.us-east-1.redshift.amazonaws.com:5439`
 
+## Connection URL
+
+```text
+redshift://user:password@cluster.region.redshift.amazonaws.com:5439/database
+```
+
+See [Connection URL Reference](/databases/connection-urls) for all parameters.
+
 ## Features
 
 **Schemas**: Like PostgreSQL. Switch with **Cmd+K**. Default schema is `public`. Tables show metadata from `svv_table_info`: distribution style, sort keys, table size.

--- a/docs/features/deep-links.mdx
+++ b/docs/features/deep-links.mdx
@@ -21,6 +21,15 @@ Open any database connection directly using its standard URL. Works from the ter
 | `redis://`, `rediss://` | Redis |
 | `mssql://`, `sqlserver://` | SQL Server |
 | `sqlite://` | SQLite (local file path) |
+| `redshift://` | Amazon Redshift |
+| `oracle://` | Oracle |
+| `clickhouse://` | ClickHouse |
+| `cassandra://` | Cassandra |
+| `scylladb://` | ScyllaDB |
+| `duckdb://` | DuckDB |
+| `etcd://` | etcd |
+| `d1://` | Cloudflare D1 |
+| `libsql://` | libSQL / Turso |
 
 ### URL Format
 
@@ -56,13 +65,13 @@ Pass additional options as query parameters:
 | Parameter | Description |
 |-----------|-------------|
 | `table` | Open a specific table after connecting |
-| `filter_column`, `filter_operation`, `filter_value` | Apply a filter on the opened table |
+| `column`, `operation`, `value` | Apply a filter on the opened table |
 | `condition` | Apply a raw SQL WHERE condition |
 | `schema` | Switch to a specific schema (PostgreSQL) or database (MySQL) after connecting |
 
 ```bash
 # Open a table with a filter
-open "mysql://root@localhost/mydb?table=users&filter_column=status&filter_operation=equal&filter_value=active" -a TablePro
+open "mysql://root@localhost/mydb?table=users&column=status&operation==&value=active" -a TablePro
 
 # Open with a raw SQL condition
 open "postgresql://admin@localhost/mydb?table=orders&condition=total%20%3E%20100" -a TablePro
@@ -132,6 +141,6 @@ open "tablepro://import?name=Staging&host=db.example.com&port=5432&type=postgres
 **Required parameters:** `name`, `host`, `type`
 **Optional parameters:** `port` (defaults to the database type's standard port), `username`, `database`
 
-Supported `type` values: `MySQL`, `MariaDB`, `PostgreSQL`, `SQLite`, `MongoDB` (case-insensitive).
+Supported `type` values: any registered database type name (case-insensitive). Examples: `MySQL`, `PostgreSQL`, `MongoDB`, `Redis`, `ClickHouse`, `Oracle`, `DuckDB`, `Cassandra`.
 
 


### PR DESCRIPTION
## Summary

Closes #853

- Dynamic URL placeholder that updates when switching database type (was hardcoded to PostgreSQL)
- Inline parsed preview showing detected type, host, port, user, database before importing
- Auto-paste from clipboard when opening the Import URL sheet
- Cancel now clears stale state
- Oracle service name, statusColor, envTag now applied from URL import
- DuckDB and other file-based URLs now parse correctly
- `etcds://` scheme enables TLS automatically
- Basic URL import support for libSQL/Turso and Cloudflare D1
- Registered URL schemes in Info.plist for Oracle, ClickHouse, etcd, D1, libSQL
- Fixed Redis database index not being applied from URL import
- Updated `deep-links.mdx` filter param names to match parser (`column`, not `filter_column`)
- Added missing schemes and database sections to `connection-urls.mdx`
- Added Connection URL sections to 7 per-database docs

## Test plan

- [ ] Open New Connection > Import from URL, switch database type, verify placeholder changes
- [ ] Paste `oracle://user:pass@host/ORCL`, verify service name field populated
- [ ] Paste `duckdb:///path/to/db.duckdb`, verify file path populated
- [ ] Paste `redis://:pass@host:6379/2`, verify database index is 2
- [ ] Paste `etcds://host:2379`, verify SSL mode set to required
- [ ] Paste URL with `?statusColor=FF3B30&env=production`, verify color and tag applied
- [ ] Paste `libsql://my-db.turso.io`, verify databaseUrl field populated
- [ ] Copy a URL to clipboard, open sheet, verify auto-paste
- [ ] Verify parsed preview appears below text field with type icon, host, port, user, database
- [ ] Cancel and reopen sheet, verify fields cleared
- [ ] Run `open "clickhouse://localhost:8123" -a TablePro` from Terminal