### PR TITLE
fix(ios): TabView navigation fixes and code review cleanup

### DIFF
--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -33,7 +33,7 @@ final class ConnectionCoordinator {
         }
     }
     var pendingQuery: String?
-    var tablesPath = NavigationPath()
+    var navigationPath = NavigationPath()
 
     private(set) var queryHistory: [QueryHistoryItem] = []
     private let historyStorage = QueryHistoryStorage()
@@ -277,7 +277,7 @@ final class ConnectionCoordinator {
         appState.pendingTableName = nil
         selectedTab = .tables
         Task { @MainActor in
-            tablesPath.append(table)
+            navigationPath.append(table)
         }
     }
 

--- a/TableProMobile/TableProMobile/Models/ConnectedTab.swift
+++ b/TableProMobile/TableProMobile/Models/ConnectedTab.swift
@@ -3,7 +3,7 @@
 //  TableProMobile
 //
 
-enum ConnectedTab: String, CaseIterable {
+enum ConnectedTab: String, CaseIterable, Sendable {
     case tables
     case query
     case history

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -39,7 +39,7 @@ struct ConnectedView: View {
         .navigationTitle(connection.name.isEmpty ? connection.host : connection.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            if let cached = cachedCoordinator, cached.session != nil {
+            if let cached = cachedCoordinator {
                 coordinator = cached
                 if case .connected = cached.phase { return }
                 await cached.connect()
@@ -104,6 +104,7 @@ struct ConnectedView: View {
                 }
                 Tab("Settings", systemImage: "gear", value: .settings) {
                     SettingsView()
+                        .environment(coordinator)
                 }
             }
             .navigationTitle(tabTitle(coordinator))
@@ -117,15 +118,19 @@ struct ConnectedView: View {
         .background {
             Button("") { coordinator.selectedTab = .tables }
                 .keyboardShortcut("1", modifiers: .command)
+                .accessibilityLabel(Text("Tables"))
                 .hidden()
             Button("") { coordinator.selectedTab = .query }
                 .keyboardShortcut("2", modifiers: .command)
+                .accessibilityLabel(Text("Query"))
                 .hidden()
             Button("") { coordinator.selectedTab = .history }
                 .keyboardShortcut("3", modifiers: .command)
+                .accessibilityLabel(Text("History"))
                 .hidden()
             Button("") { coordinator.selectedTab = .settings }
                 .keyboardShortcut("4", modifiers: .command)
+                .accessibilityLabel(Text("Settings"))
                 .hidden()
         }
         .overlay(alignment: .top) {

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -36,6 +36,8 @@ struct ConnectedView: View {
                 connectingView
             }
         }
+        .navigationTitle(connection.name.isEmpty ? connection.host : connection.name)
+        .navigationBarTitleDisplayMode(.inline)
         .task {
             if let cached = cachedCoordinator, cached.session != nil {
                 coordinator = cached
@@ -86,7 +88,7 @@ struct ConnectedView: View {
 
     private func connectedContent(_ coordinator: ConnectionCoordinator) -> some View {
         @Bindable var coordinator = coordinator
-        return NavigationStack(path: $coordinator.tablesPath) {
+        return NavigationStack(path: $coordinator.navigationPath) {
             TabView(selection: $coordinator.selectedTab) {
                 Tab("Tables", systemImage: "tablecells", value: .tables) {
                     TableListView()
@@ -104,7 +106,7 @@ struct ConnectedView: View {
                     SettingsView()
                 }
             }
-            .navigationTitle(coordinator.displayName)
+            .navigationTitle(tabTitle(coordinator))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { connectionToolbar(coordinator) }
             .navigationDestination(for: TableInfo.self) { table in
@@ -165,6 +167,14 @@ struct ConnectedView: View {
             activity.title = connection.name.isEmpty ? connection.host : connection.name
             activity.isEligibleForHandoff = true
             activity.userInfo = ["connectionId": connection.id.uuidString]
+        }
+    }
+
+    private func tabTitle(_ coordinator: ConnectionCoordinator) -> String {
+        switch coordinator.selectedTab {
+        case .tables, .query: coordinator.displayName
+        case .history: String(localized: "History")
+        case .settings: String(localized: "Settings")
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -354,16 +354,14 @@ struct ConnectionListView: View {
         var items = sectionItems
         items.move(fromOffsets: source, toOffset: destination)
         var all = appState.connections
-        for (i, item) in items.enumerated() {
+        let baseOrder = items.compactMap { item in
+            all.firstIndex { $0.id == item.id }.map { all[$0].sortOrder }
+        }.sorted()
+        for (i, item) in items.enumerated() where i < baseOrder.count {
             if let idx = all.firstIndex(where: { $0.id == item.id }) {
-                all[idx].sortOrder = i
+                all[idx].sortOrder = baseOrder[i]
             }
         }
-        all.sort {
-            if $0.sortOrder != $1.sortOrder { return $0.sortOrder < $1.sortOrder }
-            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-        }
-        for index in all.indices { all[index].sortOrder = index }
         appState.reorderConnections(all)
     }
 

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -529,10 +529,10 @@ struct DataBrowserView: View {
             if rows.count < pagination.pageSize, pagination.totalRows == nil {
                 pagination.totalRows = pagination.currentOffset + rows.count
             }
-            if columnDetails.isEmpty {
+            if columnDetails.isEmpty || isInitial {
                 columnDetails = try await session.driver.fetchColumns(table: table.name, schema: nil)
             }
-            if foreignKeys.isEmpty {
+            if foreignKeys.isEmpty || isInitial {
                 do {
                     foreignKeys = try await session.driver.fetchForeignKeys(table: table.name, schema: nil)
                 } catch {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -42,9 +42,6 @@ struct QueryEditorView: View {
             Divider()
             resultSection
         }
-        .navigationTitle(coordinator.displayName)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar { toolbarContent }
         .onAppear {
             if let pending = coordinator.pendingQuery {
                 query = pending
@@ -107,31 +104,57 @@ struct QueryEditorView: View {
             SQLHighlightTextView(text: $query)
                 .frame(minHeight: 80, maxHeight: result != nil || appError != nil ? 120 : 250)
 
-            if isExecuting || executionTime != nil || result != nil {
-                HStack {
-                    if isExecuting, let startTime = executionStartTime {
-                        TimelineView(.periodic(from: startTime, by: 0.1)) { context in
-                            let elapsed = context.date.timeIntervalSince(startTime)
-                            Label(String(format: "%.1fs", elapsed), systemImage: "clock")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    } else if let time = executionTime {
-                        Label(String(format: "%.1fms", time * 1000), systemImage: "clock")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if let result, !result.rows.isEmpty {
-                        Text(verbatim: "\(result.rows.count) rows")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 4)
-            }
+            actionBar
         }
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 12) {
+            Button {
+                if isExecuting {
+                    executeTask?.cancel()
+                    Task { try? await session?.driver.cancelCurrentQuery() }
+                } else {
+                    executeTask = Task { await executeQuery() }
+                }
+            } label: {
+                Label(
+                    isExecuting ? String(localized: "Stop") : String(localized: "Run"),
+                    systemImage: isExecuting ? "stop.fill" : "play.fill"
+                )
+                .font(.subheadline.weight(.medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(isExecuting ? .red : .accentColor)
+            .disabled(!isExecuting && query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .keyboardShortcut(.return, modifiers: .command)
+
+            Spacer()
+
+            if isExecuting, let startTime = executionStartTime {
+                TimelineView(.periodic(from: startTime, by: 0.1)) { context in
+                    let elapsed = context.date.timeIntervalSince(startTime)
+                    Text(String(format: "%.1fs", elapsed))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            } else if let time = executionTime {
+                Text(String(format: "%.1fms", time * 1000))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let result, !result.rows.isEmpty {
+                Text(verbatim: "\(result.rows.count) rows")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            queryMenu
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     // MARK: - Results
@@ -259,93 +282,69 @@ struct QueryEditorView: View {
         }
     }
 
-    // MARK: - Toolbar
+    // MARK: - Query Menu
 
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        if safeModeLevel != .off {
-            ToolbarItem(placement: .topBarLeading) {
-                Image(systemName: safeModeLevel == .readOnly ? "lock.fill" : "shield.fill")
-                    .foregroundStyle(safeModeLevel == .readOnly ? .red : .orange)
-                    .font(.caption)
-            }
-        }
-
-        ToolbarItem(placement: .primaryAction) {
+    private var queryMenu: some View {
+        Menu {
             Button {
-                if isExecuting {
-                    executeTask?.cancel()
-                    Task { try? await session?.driver.cancelCurrentQuery() }
-                } else {
-                    executeTask = Task { await executeQuery() }
-                }
+                coordinator.selectedTab = .history
             } label: {
-                Image(systemName: isExecuting ? "stop.fill" : "play.fill")
+                Label("History", systemImage: "clock")
             }
-            .disabled(!isExecuting && query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            .keyboardShortcut(.return, modifiers: .command)
-        }
 
-        ToolbarItem(placement: .topBarTrailing) {
-            Menu {
-                Button {
-                    coordinator.selectedTab = .history
+            if !tables.isEmpty {
+                Menu {
+                    ForEach(tables) { table in
+                        Button(table.name) {
+                            let quoted = SQLBuilder.quoteIdentifier(table.name, for: databaseType)
+                            query = "SELECT * FROM \(quoted) LIMIT 100"
+                        }
+                    }
                 } label: {
-                    Label("History", systemImage: "clock")
+                    Label("SELECT * FROM ...", systemImage: "text.badge.star")
                 }
+            }
 
-                if !tables.isEmpty {
-                    Menu {
-                        ForEach(tables) { table in
-                            Button(table.name) {
-                                let quoted = SQLBuilder.quoteIdentifier(table.name, for: databaseType)
-                                query = "SELECT * FROM \(quoted) LIMIT 100"
-                            }
-                        }
-                    } label: {
-                        Label("SELECT * FROM ...", systemImage: "text.badge.star")
-                    }
-                }
-
-                if let result, !result.rows.isEmpty {
-                    Section("Share Results") {
-                        ForEach(ExportFormat.allCases) { format in
-                            Button {
-                                shareText = ClipboardExporter.exportRows(
-                                    columns: result.columns, rows: result.rows,
-                                    format: format
-                                )
-                                showShareSheet = true
-                            } label: {
-                                Label(format.rawValue, systemImage: "square.and.arrow.up")
-                            }
-                        }
-                    }
-                    Section("Copy Results") {
-                        ForEach(ExportFormat.allCases) { format in
-                            Button {
-                                let text = ClipboardExporter.exportRows(
-                                    columns: result.columns, rows: result.rows,
-                                    format: format
-                                )
-                                ClipboardExporter.copyToClipboard(text)
-                            } label: {
-                                Label(format.rawValue, systemImage: "doc.on.clipboard")
-                            }
+            if let result, !result.rows.isEmpty {
+                Section("Share Results") {
+                    ForEach(ExportFormat.allCases) { format in
+                        Button {
+                            shareText = ClipboardExporter.exportRows(
+                                columns: result.columns, rows: result.rows,
+                                format: format
+                            )
+                            showShareSheet = true
+                        } label: {
+                            Label(format.rawValue, systemImage: "square.and.arrow.up")
                         }
                     }
                 }
-
-                Divider()
-
-                Button(role: .destructive) {
-                    showClearConfirmation = true
-                } label: {
-                    Label("Clear", systemImage: "trash")
+                Section("Copy Results") {
+                    ForEach(ExportFormat.allCases) { format in
+                        Button {
+                            let text = ClipboardExporter.exportRows(
+                                columns: result.columns, rows: result.rows,
+                                format: format
+                            )
+                            ClipboardExporter.copyToClipboard(text)
+                        } label: {
+                            Label(format.rawValue, systemImage: "doc.on.clipboard")
+                        }
+                    }
                 }
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                showClearConfirmation = true
             } label: {
-                Image(systemName: "ellipsis.circle")
+                Label("Clear", systemImage: "trash")
             }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.body)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -58,19 +58,22 @@ struct QueryEditorView: View {
                 UserDefaults.standard.set(newValue, forKey: "lastQuery.\(connectionId.uuidString)")
             }
         }
+        .onDisappear {
+            saveQueryTask?.cancel()
+        }
         .onChange(of: coordinator.pendingQuery) { _, newQuery in
             if let newQuery {
                 query = newQuery
                 coordinator.pendingQuery = nil
             }
         }
-        .alert("Write Query Blocked", isPresented: $showWriteBlockedAlert) {
+        .alert(String(localized: "Write Query Blocked"), isPresented: $showWriteBlockedAlert) {
             Button("OK", role: .cancel) {}
         } message: {
             Text("This connection is in read-only mode. Write queries are not allowed.")
         }
-        .confirmationDialog("Execute Write Query?", isPresented: $showWriteConfirmation, titleVisibility: .visible) {
-            Button("Execute", role: .destructive) {
+        .confirmationDialog(String(localized: "Execute Write Query?"), isPresented: $showWriteConfirmation, titleVisibility: .visible) {
+            Button(String(localized: "Execute"), role: .destructive) {
                 executeTask = Task { await executeQueryDirect(pendingWriteQuery) }
             }
         } message: {
@@ -195,7 +198,7 @@ struct QueryEditorView: View {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.largeTitle)
                             .foregroundStyle(.green)
-                        Text(verbatim: "\(result.rowsAffected) row(s) affected")
+                        Text(String(format: String(localized: "%d row(s) affected"), result.rowsAffected))
                             .font(.body)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
@@ -44,15 +44,15 @@ struct QueryHistoryView: View {
 
             if !coordinator.queryHistory.isEmpty {
                 Section {
-                    Button("Clear All History", role: .destructive) {
+                    Button(String(localized: "Clear All History"), role: .destructive) {
                         showClearConfirmation = true
                     }
                 }
             }
         }
         .listStyle(.insetGrouped)
-        .confirmationDialog("Clear History", isPresented: $showClearConfirmation) {
-            Button("Clear All", role: .destructive) {
+        .confirmationDialog(String(localized: "Clear History"), isPresented: $showClearConfirmation) {
+            Button(String(localized: "Clear All"), role: .destructive) {
                 coordinator.clearHistory()
             }
         }

--- a/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
@@ -51,8 +51,6 @@ struct QueryHistoryView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle("History")
-        .navigationBarTitleDisplayMode(.inline)
         .confirmationDialog("Clear History", isPresented: $showClearConfirmation) {
             Button("Clear All", role: .destructive) {
                 coordinator.clearHistory()

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -88,6 +88,10 @@ struct RowDetailView: View {
                 .tabViewStyle(.page(indexDisplayMode: .never))
             }
         }
+        .background(Color(.systemGroupedBackground))
+        .onDisappear {
+            dismissSuccessTask?.cancel()
+        }
         .onChange(of: currentIndex) {
             hapticSelection += 1
         }

--- a/TableProMobile/TableProMobile/Views/SettingsView.swift
+++ b/TableProMobile/TableProMobile/Views/SettingsView.swift
@@ -27,6 +27,5 @@ struct SettingsView: View {
                 }
             }
         }
-        .navigationTitle(String(localized: "Settings"))
     }
 }

--- a/TableProMobile/TableProMobile/Views/SettingsView.swift
+++ b/TableProMobile/TableProMobile/Views/SettingsView.swift
@@ -27,5 +27,6 @@ struct SettingsView: View {
                 }
             }
         }
+        .navigationTitle(String(localized: "Settings"))
     }
 }


### PR DESCRIPTION
## Summary

- Fix NavigationStack/TabView architecture: single NavigationStack wrapping TabView instead of per-tab stacks. Resolves toolbar and title not displaying on iPhone.
- Move QueryEditorView run button and menu inline (TabView blocks toolbar propagation)
- Dynamic navigationTitle per tab (Tables/Query show connection name, History/Settings show tab name)
- Cache coordinators in ConnectionListView to preserve state across back/forward navigation
- Load databases/schemas before setting phase to prevent toolbar flicker
- Fix coordinator race condition on mid-connect navigation
- Fix reorderSection sort corruption in grouped connection list
- Localize alert/dialog strings in QueryEditorView and QueryHistoryView
- Cancel pending tasks on view disappear (saveQueryTask, dismissSuccessTask)
- Refresh columnDetails on initial DataBrowserView load
- Add accessibility labels to keyboard shortcut buttons
- Add Sendable conformance to ConnectedTab
- Add systemGroupedBackground to RowDetailView

## Test plan

- [ ] Connect to a database, verify toolbar (database switcher, schema icon) appears
- [ ] Switch between tabs, verify title updates (connection name / History / Settings)
- [ ] Query tab: inline Run button visible, tap to execute, ellipsis menu works
- [ ] Tables tab: tap a table, DataBrowserView pushes with native animation
- [ ] Back to connection list, tap same connection again, connects without issues
- [ ] RowDetailView: no white background bleeding behind nav/bottom bars
- [ ] Grouped connections: reorder within a group, verify other groups unchanged
- [ ] iPad: verify all tabs work with sidebar layout