### PR TITLE
refactor: resolve codebase audit issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Raw SQL filter accepting destructive statements and comment injection
 - Export "Don't show again" preference lost when clicking "Open Folder"
 - Connection failure error not shown on welcome screen
 - Window position not restored between launches

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -38,9 +38,6 @@ final class DatabaseManager {
     /// counter to avoid cross-connection re-renders.
     internal(set) var connectionStatusVersions: [UUID: Int] = [:]
 
-    /// Backward-compatible alias for views not yet migrated to fine-grained counters.
-    var sessionVersion: Int { connectionStatusVersion }
-
     /// Currently selected session ID (displayed in UI)
     internal var currentSessionId: UUID?
 

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -281,7 +281,7 @@ struct FilterSQLGenerator {
     }()
 
     private static let commentInjectionPattern: NSRegularExpression? = {
-        try? NSRegularExpression(pattern: "--|\\/\\*", options: [])
+        try? NSRegularExpression(pattern: "(?:^|\\s)--|\\/\\*", options: [])
     }()
 
     private func isRawSQLSafe(_ sql: String) -> Bool {

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -38,12 +38,11 @@ struct FilterSQLGenerator {
         return conditions.joined(separator: separator)
     }
 
-    /// Generate a single filter condition
     func generateCondition(from filter: TableFilter) -> String? {
         guard filter.isValid else { return nil }
 
-        // Raw SQL mode - return as-is
         if filter.isRawSQL, let rawSQL = filter.rawSQL {
+            guard isRawSQLSafe(rawSQL) else { return nil }
             return "(\(rawSQL))"
         }
 
@@ -273,9 +272,36 @@ struct FilterSQLGenerator {
             .replacingOccurrences(of: "_", with: "\\_")
     }
 
+    // MARK: - Raw SQL Validation
+
+    private static let destructiveStatementPattern: NSRegularExpression? = {
+        let keywords = "DROP|DELETE|INSERT|UPDATE|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|EXEC|EXECUTE"
+        let pattern = ";\\s*(\(keywords))\\b"
+        return try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+    }()
+
+    private static let commentInjectionPattern: NSRegularExpression? = {
+        try? NSRegularExpression(pattern: "--|\\/\\*", options: [])
+    }()
+
+    private func isRawSQLSafe(_ sql: String) -> Bool {
+        let range = NSRange(sql.startIndex..., in: sql)
+
+        if let pattern = Self.destructiveStatementPattern,
+           pattern.firstMatch(in: sql, range: range) != nil {
+            return false
+        }
+
+        if let pattern = Self.commentInjectionPattern,
+           pattern.firstMatch(in: sql, range: range) != nil {
+            return false
+        }
+
+        return true
+    }
+
     // MARK: - List Parsing
 
-    /// Parse comma-separated list values
     private func parseListValues(_ input: String) -> [String] {
         input.split(separator: ",", omittingEmptySubsequences: true)
             .compactMap {

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -20,7 +20,6 @@ final class PluginManager {
 
     internal(set) var isInstalling = false
 
-    /// True once the initial plugin discovery + loading pass has completed.
     internal(set) var hasFinishedInitialLoad = false {
         didSet {
             if hasFinishedInitialLoad {
@@ -32,11 +31,8 @@ final class PluginManager {
         }
     }
 
-    /// Continuations waiting for the initial load to complete.
     private var initialLoadWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Await completion of the initial plugin load (non-blocking alternative to loadPendingPlugins).
-    /// Times out after 10 seconds to prevent indefinite suspension.
     func waitForInitialLoad() async {
         if hasFinishedInitialLoad { return }
         await withTaskGroup(of: Void.self) { group in
@@ -52,13 +48,11 @@ final class PluginManager {
             group.addTask {
                 try? await Task.sleep(for: .seconds(10))
             }
-            // Return when either completes (load finishes or timeout)
             await group.next()
             group.cancelAll()
         }
     }
 
-    /// Plugins that were rejected during discovery (version mismatch, signature, etc.).
     internal(set) var rejectedPlugins: [(name: String, reason: String)] = []
 
     private static let needsRestartKey = "com.TablePro.needsRestart"
@@ -154,18 +148,15 @@ final class PluginManager {
 
     // MARK: - Loading
 
-    /// Discover and load all plugins. Discovery is synchronous (reads Info.plist),
-    /// then bundle loading runs on a background thread to avoid blocking the UI.
-    /// Only the final registration into dictionaries happens on MainActor.
     func loadPlugins() {
         migrateDisabledPluginsKey()
         discoverAllPlugins()
         let pending = pendingPluginURLs
         Task {
-            let loaded = await Self.loadBundlesOffMain(pending)
+            let validated = await Self.validateAndLoadBundles(pending)
             self.pendingPluginURLs.removeAll()
             self.needsRestartStorage = false
-            self.registerLoadedPlugins(loaded)
+            self.registerValidatedBundles(validated)
             self.validateDependencies()
             self.hasFinishedInitialLoad = true
             Self.logger.info("Loaded \(self.plugins.count) plugin(s): \(self.driverPlugins.count) driver(s), \(self.exportPlugins.count) export format(s), \(self.importPlugins.count) import format(s)")
@@ -175,105 +166,126 @@ final class PluginManager {
         }
     }
 
-    /// Holds the result of loading a single plugin bundle off the main thread.
-    /// Only stores the loaded Bundle and its origin. Protocol property reads
-    /// (principalClass, static vars) happen later on @MainActor in registerLoadedPlugins
-    /// to avoid ObjC runtime thread-safety issues during initial class resolution.
-    private struct LoadedBundle: @unchecked Sendable {
+    private struct ValidatedBundle: @unchecked Sendable {
         let url: URL
         let source: PluginSource
         let bundle: Bundle
     }
 
-    /// Perform the expensive bundle.load() off MainActor (dynamic linker I/O).
-    /// Does NOT access bundle.principalClass — that triggers ObjC runtime dispatch
-    /// that is not thread-safe during initial resolution. Version checks use Info.plist
-    /// which is safe after load().
-    nonisolated private static func loadBundlesOffMain(
+    nonisolated private static func validateBundleVersions(
+        _ bundle: Bundle,
+        source: PluginSource
+    ) throws {
+        let infoPlist = bundle.infoDictionary ?? [:]
+        let pluginKitVersion = infoPlist["TableProPluginKitVersion"] as? Int ?? 0
+
+        if pluginKitVersion > currentPluginKitVersion {
+            throw PluginError.incompatibleVersion(
+                required: pluginKitVersion,
+                current: currentPluginKitVersion
+            )
+        }
+
+        if let minAppVersion = infoPlist["TableProMinAppVersion"] as? String {
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+            if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
+                throw PluginError.appVersionTooOld(minimumRequired: minAppVersion, currentApp: appVersion)
+            }
+        }
+
+        if source == .userInstalled {
+            if pluginKitVersion < currentPluginKitVersion {
+                throw PluginError.pluginOutdated(
+                    pluginVersion: pluginKitVersion,
+                    requiredVersion: currentPluginKitVersion
+                )
+            }
+        }
+    }
+
+    nonisolated private static func validateAndLoadBundle(
+        at url: URL,
+        source: PluginSource
+    ) throws -> Bundle {
+        guard let bundle = Bundle(url: url) else {
+            throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
+        }
+
+        try validateBundleVersions(bundle, source: source)
+
+        guard bundle.load() else {
+            throw PluginError.invalidBundle("Bundle failed to load executable")
+        }
+
+        return bundle
+    }
+
+    nonisolated private static func validateAndLoadBundles(
         _ pending: [(url: URL, source: PluginSource)]
-    ) async -> [LoadedBundle] {
-        var results: [LoadedBundle] = []
+    ) async -> [ValidatedBundle] {
+        var results: [ValidatedBundle] = []
         for entry in pending {
-            guard let bundle = Bundle(url: entry.url) else {
-                logger.error("Cannot create bundle from \(entry.url.lastPathComponent)")
-                continue
+            do {
+                let bundle = try validateAndLoadBundle(at: entry.url, source: entry.source)
+                results.append(ValidatedBundle(url: entry.url, source: entry.source, bundle: bundle))
+            } catch {
+                logger.error("Failed to load plugin at \(entry.url.lastPathComponent): \(error.localizedDescription)")
             }
-
-            let infoPlist = bundle.infoDictionary ?? [:]
-            let pluginKitVersion = infoPlist["TableProPluginKitVersion"] as? Int ?? 0
-            if pluginKitVersion > currentPluginKitVersion {
-                logger.error("Plugin \(entry.url.lastPathComponent) requires PluginKit v\(pluginKitVersion), current is v\(currentPluginKitVersion)")
-                continue
-            }
-
-            if let minAppVersion = infoPlist["TableProMinAppVersion"] as? String {
-                let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-                if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
-                    logger.error("Plugin \(entry.url.lastPathComponent) requires app v\(minAppVersion)")
-                    continue
-                }
-            }
-
-            if entry.source == .userInstalled {
-                if pluginKitVersion < currentPluginKitVersion {
-                    logger.error("User plugin \(entry.url.lastPathComponent) was built with PluginKit v\(pluginKitVersion), but v\(currentPluginKitVersion) is required")
-                    continue
-                }
-            }
-
-            // Heavy I/O: dynamic linker resolution, C bridge library initialization
-            guard bundle.load() else {
-                logger.error("Bundle failed to load executable: \(entry.url.lastPathComponent)")
-                continue
-            }
-
-            results.append(LoadedBundle(url: entry.url, source: entry.source, bundle: bundle))
         }
         return results
     }
 
-    /// Register pre-loaded bundles into the plugin dictionaries. Must be called on MainActor.
-    /// Resolves principalClass and reads all static protocol properties here (safe on main thread)
-    /// rather than in loadBundlesOffMain where ObjC runtime dispatch is not thread-safe.
-    private func registerLoadedPlugins(_ loaded: [LoadedBundle]) {
-        let disabled = disabledPluginIds
-
-        for item in loaded {
-            guard let principalClass = item.bundle.principalClass as? any TableProPlugin.Type else {
-                Self.logger.error("Principal class does not conform to TableProPlugin: \(item.url.lastPathComponent)")
-                continue
-            }
-
-            let bundleId = item.bundle.bundleIdentifier ?? item.url.lastPathComponent
-            let driverType = principalClass as? any DriverPlugin.Type
-            let version = Self.readRegistryVersion(for: item.url) ?? principalClass.pluginVersion
-            let entry = PluginEntry(
-                id: bundleId,
-                bundle: item.bundle,
-                url: item.url,
-                source: item.source,
-                name: principalClass.pluginName,
-                version: version,
-                pluginDescription: principalClass.pluginDescription,
-                capabilities: principalClass.capabilities,
-                isEnabled: !disabled.contains(bundleId),
-                databaseTypeId: driverType?.databaseTypeId,
-                additionalTypeIds: driverType?.additionalDatabaseTypeIds ?? [],
-                pluginIconName: driverType?.iconName ?? "puzzlepiece",
-                defaultPort: driverType?.defaultPort
-            )
-
-            plugins.append(entry)
-            validateCapabilityDeclarations(principalClass, pluginId: bundleId)
-
-            if entry.isEnabled {
-                let instance = principalClass.init()
-                registerCapabilities(instance, pluginId: bundleId)
-            }
-
-            Self.logger.info("Loaded plugin '\(entry.name)' v\(entry.version) [\(item.source == .builtIn ? "built-in" : "user")]")
+    private func registerBundle(_ bundle: Bundle, url: URL, source: PluginSource) -> PluginEntry? {
+        guard let principalClass = bundle.principalClass as? any TableProPlugin.Type else {
+            Self.logger.error("Principal class does not conform to TableProPlugin: \(url.lastPathComponent)")
+            return nil
         }
 
+        let bundleId = bundle.bundleIdentifier ?? url.lastPathComponent
+
+        if source == .userInstalled,
+           let existing = plugins.first(where: { $0.id == bundleId }),
+           existing.source == .builtIn
+        {
+            Self.logger.info("Skipping user-installed '\(bundleId)' — built-in version already loaded")
+            return existing
+        }
+
+        let disabled = disabledPluginIds
+        let driverType = principalClass as? any DriverPlugin.Type
+        let version = Self.readRegistryVersion(for: url) ?? principalClass.pluginVersion
+        let entry = PluginEntry(
+            id: bundleId,
+            bundle: bundle,
+            url: url,
+            source: source,
+            name: principalClass.pluginName,
+            version: version,
+            pluginDescription: principalClass.pluginDescription,
+            capabilities: principalClass.capabilities,
+            isEnabled: !disabled.contains(bundleId),
+            databaseTypeId: driverType?.databaseTypeId,
+            additionalTypeIds: driverType?.additionalDatabaseTypeIds ?? [],
+            pluginIconName: driverType?.iconName ?? "puzzlepiece",
+            defaultPort: driverType?.defaultPort
+        )
+
+        plugins.append(entry)
+        validateCapabilityDeclarations(principalClass, pluginId: bundleId)
+
+        if entry.isEnabled {
+            let instance = principalClass.init()
+            registerCapabilities(instance, pluginId: bundleId)
+        }
+
+        Self.logger.info("Loaded plugin '\(entry.name)' v\(entry.version) [\(source == .builtIn ? "built-in" : "user")]")
+        return entry
+    }
+
+    private func registerValidatedBundles(_ validated: [ValidatedBundle]) {
+        for item in validated {
+            _ = registerBundle(item.bundle, url: item.url, source: item.source)
+        }
         queryBuildingDriverCache.removeAll()
     }
 
@@ -305,8 +317,8 @@ final class PluginManager {
         let pending = pendingPluginURLs
         pendingPluginURLs.removeAll()
 
-        let loaded = await Self.loadBundlesOffMain(pending)
-        registerLoadedPlugins(loaded)
+        let validated = await Self.validateAndLoadBundles(pending)
+        registerValidatedBundles(validated)
         hasFinishedInitialLoad = true
         validateDependencies()
         Self.logger.info("Loaded \(self.plugins.count) plugin(s): \(self.driverPlugins.count) driver(s), \(self.exportPlugins.count) export format(s), \(self.importPlugins.count) import format(s)")
@@ -359,7 +371,6 @@ final class PluginManager {
         }
     }
 
-    /// Remove user-installed plugins that now ship as built-in to avoid dead weight.
     private func removeUserInstalledDuplicates(builtInDir: URL) {
         let fm = FileManager.default
         guard let builtInBundles = try? fm.contentsOfDirectory(
@@ -399,33 +410,9 @@ final class PluginManager {
             throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
         }
 
-        let infoPlist = bundle.infoDictionary ?? [:]
-
-        let pluginKitVersion = infoPlist["TableProPluginKitVersion"] as? Int ?? 0
-        if pluginKitVersion > Self.currentPluginKitVersion {
-            throw PluginError.incompatibleVersion(
-                required: pluginKitVersion,
-                current: Self.currentPluginKitVersion
-            )
-        }
-
-        if let minAppVersion = infoPlist["TableProMinAppVersion"] as? String {
-            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-            if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
-                throw PluginError.appVersionTooOld(minimumRequired: minAppVersion, currentApp: appVersion)
-            }
-        }
+        try Self.validateBundleVersions(bundle, source: source)
 
         if source == .userInstalled {
-            // User-installed plugins compiled against an older DriverPlugin protocol
-            // have stale witness tables — accessing protocol properties crashes with
-            // EXC_BAD_ACCESS. Reject them before loading the bundle.
-            if pluginKitVersion < Self.currentPluginKitVersion {
-                throw PluginError.pluginOutdated(
-                    pluginVersion: pluginKitVersion,
-                    requiredVersion: Self.currentPluginKitVersion
-                )
-            }
             try verifyCodeSignature(bundle: bundle)
         }
 
@@ -434,92 +421,24 @@ final class PluginManager {
 
     @discardableResult
     func loadPlugin(at url: URL, source: PluginSource) throws -> PluginEntry {
-        guard let bundle = Bundle(url: url) else {
-            throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
-        }
-
-        let infoPlist = bundle.infoDictionary ?? [:]
-
-        let pluginKitVersion = infoPlist["TableProPluginKitVersion"] as? Int ?? 0
-        if pluginKitVersion > Self.currentPluginKitVersion {
-            throw PluginError.incompatibleVersion(
-                required: pluginKitVersion,
-                current: Self.currentPluginKitVersion
-            )
-        }
-
-        if let minAppVersion = infoPlist["TableProMinAppVersion"] as? String {
-            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-            if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
-                throw PluginError.appVersionTooOld(minimumRequired: minAppVersion, currentApp: appVersion)
-            }
-        }
-
         if source == .userInstalled {
-            if pluginKitVersion < Self.currentPluginKitVersion {
-                throw PluginError.pluginOutdated(
-                    pluginVersion: pluginKitVersion,
-                    requiredVersion: Self.currentPluginKitVersion
-                )
+            guard let signatureBundle = Bundle(url: url) else {
+                throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
             }
-            try verifyCodeSignature(bundle: bundle)
+            try verifyCodeSignature(bundle: signatureBundle)
         }
 
-        guard bundle.load() else {
-            throw PluginError.invalidBundle("Bundle failed to load executable")
-        }
+        let bundle = try Self.validateAndLoadBundle(at: url, source: source)
 
-        guard let principalClass = bundle.principalClass as? any TableProPlugin.Type else {
+        guard let entry = registerBundle(bundle, url: url, source: source) else {
             throw PluginError.invalidBundle("Principal class does not conform to TableProPlugin")
         }
-
-        let bundleId = bundle.bundleIdentifier ?? url.lastPathComponent
-
-        // Skip user-installed plugin if a built-in version already exists
-        if source == .userInstalled,
-           let existing = plugins.first(where: { $0.id == bundleId }),
-           existing.source == .builtIn
-        {
-            Self.logger.info("Skipping user-installed '\(bundleId)' — built-in version already loaded")
-            return existing
-        }
-
-        let disabled = disabledPluginIds
-
-        let driverType = principalClass as? any DriverPlugin.Type
-        let version = Self.readRegistryVersion(for: url) ?? principalClass.pluginVersion
-        let entry = PluginEntry(
-            id: bundleId,
-            bundle: bundle,
-            url: url,
-            source: source,
-            name: principalClass.pluginName,
-            version: version,
-            pluginDescription: principalClass.pluginDescription,
-            capabilities: principalClass.capabilities,
-            isEnabled: !disabled.contains(bundleId),
-            databaseTypeId: driverType?.databaseTypeId,
-            additionalTypeIds: driverType?.additionalDatabaseTypeIds ?? [],
-            pluginIconName: driverType?.iconName ?? "puzzlepiece",
-            defaultPort: driverType?.defaultPort
-        )
-
-        plugins.append(entry)
-        validateCapabilityDeclarations(principalClass, pluginId: bundleId)
-
-        if entry.isEnabled {
-            let instance = principalClass.init()
-            registerCapabilities(instance, pluginId: bundleId)
-        }
-
-        Self.logger.info("Loaded plugin '\(entry.name)' v\(entry.version) [\(source == .builtIn ? "built-in" : "user")]")
 
         return entry
     }
 
     func replaceExistingPlugin(bundleId: String) {
         guard let existingIndex = plugins.firstIndex(where: { $0.id == bundleId }) else { return }
-        // Order matters: unregisterCapabilities reads from `plugins` to find the principal class
         unregisterCapabilities(pluginId: bundleId)
         plugins[existingIndex].bundle.unload()
         plugins.remove(at: existingIndex)

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -421,14 +421,19 @@ final class PluginManager {
 
     @discardableResult
     func loadPlugin(at url: URL, source: PluginSource) throws -> PluginEntry {
-        if source == .userInstalled {
-            guard let signatureBundle = Bundle(url: url) else {
-                throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
-            }
-            try verifyCodeSignature(bundle: signatureBundle)
+        guard let bundle = Bundle(url: url) else {
+            throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
         }
 
-        let bundle = try Self.validateAndLoadBundle(at: url, source: source)
+        try Self.validateBundleVersions(bundle, source: source)
+
+        if source == .userInstalled {
+            try verifyCodeSignature(bundle: bundle)
+        }
+
+        guard bundle.load() else {
+            throw PluginError.invalidBundle("Bundle failed to load executable")
+        }
 
         guard let entry = registerBundle(bundle, url: url, source: source) else {
             throw PluginError.invalidBundle("Principal class does not conform to TableProPlugin")

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -19,7 +19,7 @@ final class SchemaProviderRegistry {
     private var refCounts: [UUID: Int] = [:]
     private var removalTasks: [UUID: Task<Void, Never>] = [:]
 
-    init() {}
+    private init() {}
 
     func provider(for connectionId: UUID) -> SQLSchemaProvider? {
         providers[connectionId]

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -244,7 +244,7 @@ final class AppSettingsManager {
     }
 
     private func applyHistorySettingsImmediately() async {
-        QueryHistoryManager.shared.applySettingsChange()
+        await QueryHistoryManager.shared.applySettingsChange()
     }
 
     // MARK: - Actions

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -1,20 +1,10 @@
-//
-//  QueryHistoryManager.swift
-//  TablePro
-//
-//  Thread-safe coordinator for query history
-//
-
 import Foundation
 
-/// Thread-safe manager for query history
-/// NOT an ObservableObject - uses NotificationCenter for UI communication
 final class QueryHistoryManager {
     static let shared = QueryHistoryManager()
 
     private let storage: QueryHistoryStorage
 
-    /// Creates an isolated manager with its own storage. For testing only.
     init(isolatedStorage: QueryHistoryStorage) {
         self.storage = isolatedStorage
     }
@@ -23,32 +13,26 @@ final class QueryHistoryManager {
         self.storage = QueryHistoryStorage.shared
     }
 
-    /// Perform cleanup if auto-cleanup is enabled in settings
-    /// Should be called from app startup (MainActor context)
     @MainActor
-    func performStartupCleanup() {
-        // Check if auto cleanup is enabled
+    func performStartupCleanup() async {
         guard AppSettingsManager.shared.history.autoCleanup else { return }
 
-        // Update the settings cache before cleanup
-        storage.updateSettingsCache()
-
-        // Perform cleanup
-        storage.cleanup()
+        let settings = AppSettingsManager.shared.history
+        await storage.updateSettingsCache(maxEntries: settings.maxEntries, maxDays: settings.maxDays)
+        await storage.cleanup()
     }
 
-    /// Apply settings changes directly (called by AppSettingsManager)
     @MainActor
-    func applySettingsChange() {
-        storage.updateSettingsCache()
+    func applySettingsChange() async {
+        let settings = AppSettingsManager.shared.history
+        await storage.updateSettingsCache(maxEntries: settings.maxEntries, maxDays: settings.maxDays)
         if AppSettingsManager.shared.history.autoCleanup {
-            storage.cleanup()
+            await storage.cleanup()
         }
     }
 
     // MARK: - History Capture
 
-    /// Record a query execution (fire-and-forget background write)
     func recordQuery(
         query: String,
         connectionId: UUID,
@@ -83,7 +67,6 @@ final class QueryHistoryManager {
 
     // MARK: - History Retrieval
 
-    /// Fetch history entries asynchronously
     func fetchHistory(
         limit: Int = 100,
         offset: Int = 0,
@@ -100,7 +83,6 @@ final class QueryHistoryManager {
         )
     }
 
-    /// Search queries using FTS5 full-text search
     func searchQueries(_ text: String) async -> [QueryHistoryEntry] {
         if text.trimmingCharacters(in: .whitespaces).isEmpty {
             return await fetchHistory()
@@ -108,7 +90,6 @@ final class QueryHistoryManager {
         return await storage.fetchHistory(searchText: text)
     }
 
-    /// Delete a history entry asynchronously
     func deleteHistory(id: UUID) async -> Bool {
         let success = await storage.deleteHistory(id: id)
         if success {
@@ -119,12 +100,10 @@ final class QueryHistoryManager {
         return success
     }
 
-    /// Get total history count asynchronously
     func getHistoryCount() async -> Int {
         await storage.getHistoryCount()
     }
 
-    /// Clear all history entries asynchronously
     func clearAllHistory() async -> Bool {
         let success = await storage.clearAllHistory()
         if success {
@@ -137,12 +116,10 @@ final class QueryHistoryManager {
 
     // MARK: - Cleanup
 
-    /// Manually trigger cleanup (normally runs automatically)
-    /// Must be called from MainActor context
     @MainActor
-    func cleanup() {
-        // Update settings cache before cleanup
-        storage.updateSettingsCache()
-        storage.cleanup()
+    func cleanup() async {
+        let settings = AppSettingsManager.shared.history
+        await storage.updateSettingsCache(maxEntries: settings.maxEntries, maxDays: settings.maxDays)
+        await storage.cleanup()
     }
 }

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -1,15 +1,7 @@
-//
-//  QueryHistoryStorage.swift
-//  TablePro
-//
-//  SQLite storage for query history with FTS5 full-text search
-//
-
 import Foundation
 import os
 import SQLite3
 
-/// Date filter options for history queries
 enum DateFilter {
     case today
     case thisWeek
@@ -33,22 +25,13 @@ enum DateFilter {
     }
 }
 
-/// Thread-safe SQLite storage for query history
-final class QueryHistoryStorage {
+actor QueryHistoryStorage {
     static let shared = QueryHistoryStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "QueryHistoryStorage")
 
-    // Thread-safe queue for all database operations
-    private let queue = DispatchQueue(label: "com.TablePro.queryhistory", qos: .utility)
     private var db: OpaquePointer?
-
-    // Configuration - cached from settings (to avoid MainActor issues on background queue)
-    // These are updated via updateSettingsCache() before cleanup runs
-    private let settingsLock = NSLock()
     private var cachedMaxHistoryEntries: Int = 10_000
     private var cachedMaxHistoryDays: Int = 90
-
-    // Throttle cleanup: only run every 100 inserts
     private var insertsSinceCleanup: Int = 0
 
     private static var isRunningTests: Bool {
@@ -56,21 +39,13 @@ final class QueryHistoryStorage {
     }
 
     private init() {
-        queue.async { [weak self] in
-            self?.setupDatabase()
-        }
+        setupDatabase()
     }
 
     #if DEBUG
-    /// Creates an isolated instance with a unique database file. For testing only.
     init(isolatedForTesting: Bool) {
         testDatabaseSuffix = isolatedForTesting ? "_\(UUID().uuidString)" : nil
-        let semaphore = DispatchSemaphore(value: 0)
-        queue.async { [self] in
-            setupDatabase()
-            semaphore.signal()
-        }
-        semaphore.wait()
+        setupDatabase()
     }
     #endif
 
@@ -90,32 +65,6 @@ final class QueryHistoryStorage {
         }
     }
 
-    // MARK: - Database Work Helpers
-
-    /// Run database work on the serial queue, returning a result via async/await
-    private func performDatabaseWork<T>(_ work: @escaping () throws -> T) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            queue.async {
-                do {
-                    let result = try work()
-                    continuation.resume(returning: result)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-
-    /// Run non-throwing database work on the serial queue
-    private func performDatabaseWork<T>(_ work: @escaping () -> T) async -> T {
-        await withCheckedContinuation { continuation in
-            queue.async {
-                let result = work()
-                continuation.resume(returning: result)
-            }
-        }
-    }
-
     // MARK: - Database Setup
 
     private func setupDatabase() {
@@ -130,7 +79,6 @@ final class QueryHistoryStorage {
         }
         let TableProDir = appSupport.appendingPathComponent("TablePro")
 
-        // Create directory if needed
         try? fileManager.createDirectory(at: TableProDir, withIntermediateDirectories: true)
 
         let suffix = testDatabaseSuffix ?? ""
@@ -141,13 +89,11 @@ final class QueryHistoryStorage {
 
         self.dbPath = dbPath
 
-        // Open database
         if sqlite3_open(dbPath, &db) != SQLITE_OK {
             Self.logger.error("Error opening database")
             return
         }
 
-        // Enable WAL mode for concurrent reads and batched writes
         execute("PRAGMA journal_mode=WAL;")
         execute("PRAGMA synchronous=NORMAL;")
 
@@ -159,11 +105,6 @@ final class QueryHistoryStorage {
 
     private func migrateIfNeeded() {
         let currentVersion = getUserVersion()
-
-        // Future migrations go here:
-        // if currentVersion < 2 {
-        //     execute("ALTER TABLE history ADD COLUMN new_col TEXT;")
-        // }
 
         let targetVersion: Int32 = 1
         if currentVersion < targetVersion {
@@ -189,7 +130,6 @@ final class QueryHistoryStorage {
     // MARK: - Table Creation
 
     private func createTables() {
-        // History table
         let historyTable = """
             CREATE TABLE IF NOT EXISTS history (
                 id TEXT PRIMARY KEY,
@@ -204,7 +144,6 @@ final class QueryHistoryStorage {
             );
             """
 
-        // FTS5 virtual table for full-text search
         let ftsTable = """
             CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
                 query,
@@ -213,7 +152,6 @@ final class QueryHistoryStorage {
             );
             """
 
-        // Triggers to keep FTS5 in sync
         let ftsInsertTrigger = """
             CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
                 INSERT INTO history_fts(rowid, query) VALUES (new.rowid, new.query);
@@ -233,13 +171,11 @@ final class QueryHistoryStorage {
             END;
             """
 
-        // Indexes
         let historyIndexes = [
             "CREATE INDEX IF NOT EXISTS idx_history_connection ON history(connection_id);",
             "CREATE INDEX IF NOT EXISTS idx_history_executed_at ON history(executed_at DESC);",
         ]
 
-        // Execute all table creation statements
         execute(historyTable)
         execute(ftsTable)
         execute(ftsInsertTrigger)
@@ -262,10 +198,27 @@ final class QueryHistoryStorage {
 
     // MARK: - History Operations
 
-    /// Add a history entry asynchronously
-    func addHistory(_ entry: QueryHistoryEntry) async -> Bool {
-        // Capture values as Swift strings BEFORE entering async block
-        // to ensure they remain valid throughout the operation
+    func addHistory(_ entry: QueryHistoryEntry) -> Bool {
+        insertsSinceCleanup += 1
+        if insertsSinceCleanup >= 100 {
+            performCleanup()
+            insertsSinceCleanup = 0
+        }
+
+        let sql = """
+            INSERT INTO history (id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            return false
+        }
+
+        defer { sqlite3_finalize(statement) }
+
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
         let idString = entry.id.uuidString
         let queryString = entry.query
         let connectionIdString = entry.connectionId.uuidString
@@ -274,86 +227,40 @@ final class QueryHistoryStorage {
         let executionTime = entry.executionTime
         let rowCount = Int32(entry.rowCount)
         let wasSuccessful: Int32 = entry.wasSuccessful ? 1 : 0
-        let errorMessageString = entry.errorMessage
 
-        return await performDatabaseWork { [weak self] in
-            guard let self = self else { return false }
+        sqlite3_bind_text(statement, 1, idString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 2, queryString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 3, connectionIdString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 4, databaseNameString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_double(statement, 5, executedAt)
+        sqlite3_bind_double(statement, 6, executionTime)
+        sqlite3_bind_int(statement, 7, rowCount)
+        sqlite3_bind_int(statement, 8, wasSuccessful)
 
-            // Throttled cleanup: only run every 100 inserts
-            self.insertsSinceCleanup += 1
-            if self.insertsSinceCleanup >= 100 {
-                self.performCleanup()
-                self.insertsSinceCleanup = 0
-            }
-
-            let sql = """
-                INSERT INTO history (id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
-                """
-
-            var statement: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &statement, nil) == SQLITE_OK else {
-                return false
-            }
-
-            defer { sqlite3_finalize(statement) }
-
-            // SQLITE_TRANSIENT tells SQLite to make its own copy of the string
-            let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-
-            sqlite3_bind_text(statement, 1, idString, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_text(statement, 2, queryString, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_text(statement, 3, connectionIdString, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_text(statement, 4, databaseNameString, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_double(statement, 5, executedAt)
-            sqlite3_bind_double(statement, 6, executionTime)
-            sqlite3_bind_int(statement, 7, rowCount)
-            sqlite3_bind_int(statement, 8, wasSuccessful)
-
-            if let errorMessage = errorMessageString {
-                sqlite3_bind_text(statement, 9, errorMessage, -1, SQLITE_TRANSIENT)
-            } else {
-                sqlite3_bind_null(statement, 9)
-            }
-
-            let result = sqlite3_step(statement)
-            return result == SQLITE_DONE
+        if let errorMessage = entry.errorMessage {
+            sqlite3_bind_text(statement, 9, errorMessage, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(statement, 9)
         }
+
+        let result = sqlite3_step(statement)
+        return result == SQLITE_DONE
     }
 
-    /// Fetch history with optional filters asynchronously
     func fetchHistory(
         limit: Int = 100,
         offset: Int = 0,
         connectionId: UUID? = nil,
         searchText: String? = nil,
         dateFilter: DateFilter = .all
-    ) async -> [QueryHistoryEntry] {
-        await performDatabaseWork { [weak self] in
-            guard let self = self else { return [] }
-            return self.fetchHistorySync(
-                limit: limit, offset: offset, connectionId: connectionId, searchText: searchText,
-                dateFilter: dateFilter)
-        }
-    }
-
-    /// Internal synchronous fetch (must be called on queue)
-    private func fetchHistorySync(
-        limit: Int,
-        offset: Int,
-        connectionId: UUID?,
-        searchText: String?,
-        dateFilter: DateFilter
     ) -> [QueryHistoryEntry] {
         var entries: [QueryHistoryEntry] = []
 
-        // Build query with placeholders
         var sql: String
         var bindIndex: Int32 = 1
         var hasConnectionFilter = false
         var hasDateFilter = false
 
-        // Use FTS5 for full-text search if search text provided
         if let searchText = searchText, !searchText.isEmpty {
             sql = """
                 SELECT h.id, h.query, h.connection_id, h.database_name, h.executed_at, h.execution_time, h.row_count, h.was_successful, h.error_message
@@ -362,7 +269,6 @@ final class QueryHistoryStorage {
                 WHERE history_fts MATCH ?
                 """
 
-            // Add additional filters
             if connectionId != nil {
                 sql += " AND h.connection_id = ?"
                 hasConnectionFilter = true
@@ -404,11 +310,7 @@ final class QueryHistoryStorage {
 
         let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
-        // Bind parameters in order
         if let searchText = searchText, !searchText.isEmpty {
-            // Sanitize for FTS5: wrap in double quotes for exact phrase matching,
-            // escaping any internal double quotes to prevent parse errors from
-            // special characters like *, OR, AND, etc.
             let sanitized = "\"\(searchText.replacingOccurrences(of: "\"", with: "\"\""))\""
             sqlite3_bind_text(statement, bindIndex, sanitized, -1, SQLITE_TRANSIENT)
             bindIndex += 1
@@ -437,94 +339,70 @@ final class QueryHistoryStorage {
         return entries
     }
 
-    /// Delete a specific history entry asynchronously
-    func deleteHistory(id: UUID) async -> Bool {
+    func deleteHistory(id: UUID) -> Bool {
         let idString = id.uuidString
-        return await performDatabaseWork { [weak self] in
-            guard let self = self else { return false }
-
-            let sql = "DELETE FROM history WHERE id = ?;"
-            var statement: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &statement, nil) == SQLITE_OK else {
-                return false
-            }
-
-            defer { sqlite3_finalize(statement) }
-
-            let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-            sqlite3_bind_text(statement, 1, idString, -1, SQLITE_TRANSIENT)
-            return sqlite3_step(statement) == SQLITE_DONE
+        let sql = "DELETE FROM history WHERE id = ?;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            return false
         }
+
+        defer { sqlite3_finalize(statement) }
+
+        let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, idString, -1, SQLITE_TRANSIENT)
+        return sqlite3_step(statement) == SQLITE_DONE
     }
 
-    /// Get total history count asynchronously
-    func getHistoryCount() async -> Int {
-        await performDatabaseWork { [weak self] in
-            guard let self = self else { return 0 }
-
-            let sql = "SELECT COUNT(*) FROM history;"
-            var statement: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &statement, nil) == SQLITE_OK else {
-                return 0
-            }
-
-            defer { sqlite3_finalize(statement) }
-
-            if sqlite3_step(statement) == SQLITE_ROW {
-                return Int(sqlite3_column_int(statement, 0))
-            }
+    func getHistoryCount() -> Int {
+        let sql = "SELECT COUNT(*) FROM history;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             return 0
         }
+
+        defer { sqlite3_finalize(statement) }
+
+        if sqlite3_step(statement) == SQLITE_ROW {
+            return Int(sqlite3_column_int(statement, 0))
+        }
+        return 0
     }
 
-    /// Clear all history entries asynchronously
-    func clearAllHistory() async -> Bool {
-        await performDatabaseWork { [weak self] in
-            guard let self = self else { return false }
-
-            let sql = "DELETE FROM history;"
-            var statement: OpaquePointer?
-            guard sqlite3_prepare_v2(self.db, sql, -1, &statement, nil) == SQLITE_OK else {
-                return false
-            }
-
-            defer { sqlite3_finalize(statement) }
-            return sqlite3_step(statement) == SQLITE_DONE
+    func clearAllHistory() -> Bool {
+        let sql = "DELETE FROM history;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            return false
         }
+
+        defer { sqlite3_finalize(statement) }
+        return sqlite3_step(statement) == SQLITE_DONE
+    }
+
+    // MARK: - Settings Cache
+
+    func updateSettingsCache(maxEntries: Int, maxDays: Int) {
+        cachedMaxHistoryEntries = maxEntries == 0 ? Int.max : maxEntries
+        cachedMaxHistoryDays = maxDays == 0 ? Int.max : maxDays
     }
 
     // MARK: - Cleanup
 
-    /// Update cached settings from AppSettingsManager (must be called from MainActor)
-    @MainActor
-    func updateSettingsCache() {
-        let settings = AppSettingsManager.shared.history
-        // Use Int.max for "unlimited" (0) values
-        settingsLock.lock()
-        cachedMaxHistoryEntries = settings.maxEntries == 0 ? Int.max : settings.maxEntries
-        cachedMaxHistoryDays = settings.maxDays == 0 ? Int.max : settings.maxDays
-        settingsLock.unlock()
+    func cleanup() {
+        performCleanup()
     }
 
-    /// Perform cleanup: delete old entries and limit total count
     private func performCleanup() {
-        // Snapshot settings under lock for thread-safe access
-        settingsLock.lock()
         let maxDays = cachedMaxHistoryDays
         let maxEntries = cachedMaxHistoryEntries
-        settingsLock.unlock()
 
-        // Try to wrap all cleanup operations in a single transaction to reduce journal flushes.
-        // If BEGIN IMMEDIATE fails (e.g., WAL write contention), fall back to auto-commit mode
-        // so cleanup still runs — just without the single-transaction optimization.
         let inTransaction = sqlite3_exec(db, "BEGIN IMMEDIATE;", nil, nil, nil) == SQLITE_OK
         if !inTransaction {
             Self.logger.warning("Failed to begin transaction for cleanup, falling back to auto-commit")
         }
 
-        // Skip cleanup if days is unlimited
         if maxDays < Int.max {
-            // Delete entries older than maxHistoryDays
             let cutoffDate = Date().addingTimeInterval(-Double(maxDays * 24 * 60 * 60))
             let deleteOldSQL = "DELETE FROM history WHERE executed_at < ?;"
 
@@ -536,9 +414,7 @@ final class QueryHistoryStorage {
             sqlite3_finalize(statement)
         }
 
-        // Skip entry limit cleanup if unlimited
         if maxEntries < Int.max {
-            // Delete oldest entries if count exceeds limit
             let countSQL = "SELECT COUNT(*) FROM history;"
             var countStatement: OpaquePointer?
             if sqlite3_prepare_v2(db, countSQL, -1, &countStatement, nil) == SQLITE_OK {
@@ -574,13 +450,6 @@ final class QueryHistoryStorage {
                 Self.logger.warning("Failed to commit cleanup transaction, attempting rollback")
                 sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
             }
-        }
-    }
-
-    /// Manually trigger cleanup (call on app launch if autoCleanup is enabled)
-    func cleanup() {
-        queue.async { [weak self] in
-            self?.performCleanup()
         }
     }
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -619,7 +619,7 @@ struct TableProApp: App {
     init() {
         // Perform startup cleanup of query history if auto-cleanup is enabled
         Task {
-            QueryHistoryManager.shared.performStartupCleanup()
+            await QueryHistoryManager.shared.performStartupCleanup()
         }
     }
 

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -80,7 +80,6 @@ final class WelcomeViewModel {
     @ObservationIgnored private var importObserver: NSObjectProtocol?
     @ObservationIgnored private var linkedFoldersObserver: NSObjectProtocol?
     @ObservationIgnored private var importFromAppObserver: NSObjectProtocol?
-    @ObservationIgnored private var newConnectionObserver: NSObjectProtocol?
 
     // MARK: - Computed Properties
 
@@ -217,7 +216,7 @@ final class WelcomeViewModel {
 
     deinit {
         [connectionUpdatedObserver, shareFileObserver, exportObserver,
-         importObserver, importFromAppObserver, linkedFoldersObserver, newConnectionObserver].forEach {
+         importObserver, importFromAppObserver, linkedFoldersObserver].forEach {
             if let observer = $0 {
                 NotificationCenter.default.removeObserver(observer)
             }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -54,7 +54,7 @@ enum ActiveSheet: Identifiable {
         case .importDialog: "importDialog"
         case .quickSwitcher: "quickSwitcher"
         case .exportQueryResults: "exportQueryResults"
-        case .maintenance: "maintenance"
+        case .maintenance(let operation, let tableName): "maintenance-\(operation)-\(tableName)"
         }
     }
 }

--- a/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
@@ -648,7 +648,8 @@ struct FilterSQLGeneratorTests {
         ("age > 18 AND status = 'active'", "(age > 18 AND status = 'active')"),
         ("id IN (SELECT id FROM other)", "(id IN (SELECT id FROM other))"),
         ("YEAR(created_at) = 2024", "(YEAR(created_at) = 2024)"),
-        ("status = 'semi;colon'", "(status = 'semi;colon')")
+        ("status = 'semi;colon'", "(status = 'semi;colon')"),
+        ("data->>'key' = 'value'", "(data->>'key' = 'value')")
     ])
     func testRawSQLAllowsLegitimateConditions(input: String, expected: String) {
         let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)

--- a/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
@@ -614,6 +614,48 @@ struct FilterSQLGeneratorTests {
         #expect(result == "(age > 18)")
     }
 
+    @Test("Raw SQL rejects destructive statement injection", arguments: [
+        "1=1; DROP TABLE users",
+        "1=1; DELETE FROM users",
+        "1=1; INSERT INTO users VALUES (1)",
+        "1=1; UPDATE users SET admin=1",
+        "1=1; ALTER TABLE users ADD COLUMN pwned TEXT",
+        "1=1; CREATE TABLE evil (id INT)",
+        "1=1; TRUNCATE TABLE users",
+        "1=1; GRANT ALL ON *.* TO attacker",
+        "1=1; REVOKE ALL ON *.* FROM user",
+        "1=1; EXEC xp_cmdshell 'whoami'",
+        "1=1; EXECUTE sp_executesql 'SELECT 1'",
+        "1=1; drop table users"
+    ])
+    func testRawSQLRejectsDestructiveStatements(input: String) {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(columnName: "__RAW__", rawSQL: input)
+        #expect(generator.generateCondition(from: filter) == nil)
+    }
+
+    @Test("Raw SQL rejects comment injection", arguments: [
+        "1=1 -- always true",
+        "1=1 /* comment */"
+    ])
+    func testRawSQLRejectsCommentInjection(input: String) {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(columnName: "__RAW__", rawSQL: input)
+        #expect(generator.generateCondition(from: filter) == nil)
+    }
+
+    @Test("Raw SQL allows legitimate WHERE conditions", arguments: [
+        ("age > 18 AND status = 'active'", "(age > 18 AND status = 'active')"),
+        ("id IN (SELECT id FROM other)", "(id IN (SELECT id FROM other))"),
+        ("YEAR(created_at) = 2024", "(YEAR(created_at) = 2024)"),
+        ("status = 'semi;colon'", "(status = 'semi;colon')")
+    ])
+    func testRawSQLAllowsLegitimateConditions(input: String, expected: String) {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let filter = TableFilter(columnName: "__RAW__", rawSQL: input)
+        #expect(generator.generateCondition(from: filter) == expected)
+    }
+
     // MARK: - Identifier Quoting Per DB Type
 
     @Test("MySQL uses backtick quoting")


### PR DESCRIPTION
## Summary
- Fix raw SQL filter injection by adding validation that rejects destructive statements and comment injection
- Fix non-unique SwiftUI sheet identity for `.maintenance` ActiveSheet (was silently dropping sequential presentations)
- Enforce singleton pattern on `SchemaProviderRegistry` with private init
- Remove dead `newConnectionObserver` from `WelcomeViewModel`
- Extract shared plugin validation in `PluginManager` to eliminate three copies of version-check logic (-81 lines)
- Remove unused `sessionVersion` backward-compatibility shim from `DatabaseManager`
- Migrate `QueryHistoryStorage` from `DispatchQueue` + `NSLock` to Swift `actor` (-154 lines)

## Changes
- 12 files changed, 272 insertions, 442 deletions (-170 net)
- 18 new test cases for `FilterSQLGenerator` raw SQL validation

## Test plan
- [ ] Verify raw SQL filters work for legitimate WHERE conditions (e.g., `age > 18 AND status = 'active'`)
- [ ] Verify raw SQL filters reject injection attempts (e.g., `1=1; DROP TABLE users`)
- [ ] Open two different maintenance operations in sequence, verify both sheets present correctly
- [ ] Run `FilterSQLGeneratorTests` — all 18 new parameterized tests pass
- [ ] Verify query history still records and retrieves entries after actor migration
- [ ] Verify plugin loading works for both built-in and user-installed plugins
- [ ] Full build succeeds with no new warnings