### PR TITLE
feat: connection sharing with rich deep links and import preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Connection sharing: Share submenu with Copy Connection String, Copy TablePro Link, Copy as JSON, and rich deep links carrying all connection fields
 - Edit > Find menu item (Cmd+F)
 
 ### Fixed

--- a/TablePro/AppDelegate+FileOpen.swift
+++ b/TablePro/AppDelegate+FileOpen.swift
@@ -205,9 +205,10 @@ extension AppDelegate {
                                  initialQuery: sql)
             }
 
-        case .importConnection(let name, let host, let port, let type, let username, let database):
-            await handleImportDeeplink(name: name, host: host, port: port, type: type,
-                                       username: username, database: database)
+        case .importConnection(let exportable):
+            openWelcomeWindow()
+            pendingDeeplinkImport = exportable
+            NotificationCenter.default.post(name: .deeplinkImportRequested, object: nil)
         }
     }
 
@@ -272,33 +273,6 @@ extension AppDelegate {
                 fileOpenLogger.error("Deep link connect failed: \(error.localizedDescription)")
                 await self.handleConnectionFailure(error)
             }
-        }
-    }
-
-    private func handleImportDeeplink(
-        name: String, host: String, port: Int,
-        type: DatabaseType, username: String, database: String
-    ) async {
-        let userPart = username.isEmpty ? "" : "\(username)@"
-        let details = "\(type.rawValue)://\(userPart)\(host):\(port)/\(database)"
-        let confirmed = await AlertHelper.confirmDestructive(
-            title: String(localized: "Import Connection from Link"),
-            message: String(format: String(localized: "An external link wants to add a database connection:\n\nName: %@\n%@"), name, details),
-            confirmButton: String(localized: "Add Connection"),
-            cancelButton: String(localized: "Cancel"),
-            window: NSApp.keyWindow
-        )
-        guard confirmed else { return }
-
-        let connection = DatabaseConnection(
-            name: name, host: host, port: port,
-            database: database, username: username, type: type
-        )
-        ConnectionStorage.shared.addConnection(connection)
-        NotificationCenter.default.post(name: .connectionUpdated, object: nil)
-
-        if let openWindow = WindowOpener.shared.openWindow {
-            openWindow(id: "connection-form", value: connection.id)
         }
     }
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -63,6 +63,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Connection share file URL pending consumption by WelcomeViewModel.setUp()
     var pendingConnectionShareURL: URL?
 
+    /// Deep link import pending consumption by WelcomeViewModel
+    var pendingDeeplinkImport: ExportableConnection?
+
     // MARK: - NSApplicationDelegate
 
     func application(_ application: NSApplication, open urls: [URL]) {

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -575,9 +575,9 @@ enum ConnectionExportService {
 
     // MARK: - Deeplink Builder
 
-    static func buildImportDeeplink(for connection: DatabaseConnection) -> String {
+    static func buildImportDeeplink(for connection: DatabaseConnection) -> String? {
         let envelope = buildEnvelope(for: [connection])
-        guard let exportable = envelope.connections.first else { return "" }
+        guard let exportable = envelope.connections.first else { return nil }
 
         var components = URLComponents()
         components.scheme = "tablepro"
@@ -680,7 +680,11 @@ enum ConnectionExportService {
         }
 
         components.queryItems = queryItems
-        return components.url?.absoluteString ?? ""
+        guard let url = components.url?.absoluteString, !url.isEmpty else {
+            logger.warning("Failed to build import deeplink for '\(connection.name)'")
+            return nil
+        }
+        return url
     }
 
     static func buildCompactJSON(for connection: DatabaseConnection) -> String {

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -576,32 +576,126 @@ enum ConnectionExportService {
     // MARK: - Deeplink Builder
 
     static func buildImportDeeplink(for connection: DatabaseConnection) -> String {
+        let envelope = buildEnvelope(for: [connection])
+        guard let exportable = envelope.connections.first else { return "" }
+
         var components = URLComponents()
         components.scheme = "tablepro"
         components.host = "import"
 
         var queryItems: [URLQueryItem] = [
-            URLQueryItem(name: "name", value: connection.name),
-            URLQueryItem(name: "host", value: connection.host),
-            URLQueryItem(name: "port", value: String(connection.port)),
-            URLQueryItem(name: "type", value: connection.type.rawValue)
+            URLQueryItem(name: "name", value: exportable.name),
+            URLQueryItem(name: "host", value: exportable.host),
+            URLQueryItem(name: "port", value: String(exportable.port)),
+            URLQueryItem(name: "type", value: exportable.type)
         ]
 
-        if !connection.username.isEmpty {
-            queryItems.append(URLQueryItem(name: "username", value: connection.username))
+        if !exportable.username.isEmpty {
+            queryItems.append(URLQueryItem(name: "username", value: exportable.username))
         }
-        if !connection.database.isEmpty {
-            queryItems.append(URLQueryItem(name: "database", value: connection.database))
+        if !exportable.database.isEmpty {
+            queryItems.append(URLQueryItem(name: "database", value: exportable.database))
+        }
+
+        if let ssh = exportable.sshConfig {
+            queryItems.append(URLQueryItem(name: "ssh", value: "1"))
+            queryItems.append(URLQueryItem(name: "sshHost", value: ssh.host))
+            if ssh.port != 22 {
+                queryItems.append(URLQueryItem(name: "sshPort", value: String(ssh.port)))
+            }
+            if !ssh.username.isEmpty {
+                queryItems.append(URLQueryItem(name: "sshUsername", value: ssh.username))
+            }
+            queryItems.append(URLQueryItem(name: "sshAuthMethod", value: ssh.authMethod))
+            if !ssh.privateKeyPath.isEmpty {
+                queryItems.append(URLQueryItem(name: "sshPrivateKeyPath", value: ssh.privateKeyPath))
+            }
+            if ssh.useSSHConfig {
+                queryItems.append(URLQueryItem(name: "sshUseSSHConfig", value: "1"))
+            }
+            if !ssh.agentSocketPath.isEmpty {
+                queryItems.append(URLQueryItem(name: "sshAgentSocketPath", value: ssh.agentSocketPath))
+            }
+            if let jumpHosts = ssh.jumpHosts, !jumpHosts.isEmpty,
+               let jumpData = try? JSONEncoder().encode(jumpHosts),
+               let jumpStr = String(data: jumpData, encoding: .utf8) {
+                queryItems.append(URLQueryItem(name: "sshJumpHosts", value: jumpStr))
+            }
+            if let totpMode = ssh.totpMode {
+                queryItems.append(URLQueryItem(name: "sshTotpMode", value: totpMode))
+            }
+            if let totpAlgorithm = ssh.totpAlgorithm {
+                queryItems.append(URLQueryItem(name: "sshTotpAlgorithm", value: totpAlgorithm))
+            }
+            if let totpDigits = ssh.totpDigits {
+                queryItems.append(URLQueryItem(name: "sshTotpDigits", value: String(totpDigits)))
+            }
+            if let totpPeriod = ssh.totpPeriod {
+                queryItems.append(URLQueryItem(name: "sshTotpPeriod", value: String(totpPeriod)))
+            }
+        }
+
+        if let ssl = exportable.sslConfig {
+            queryItems.append(URLQueryItem(name: "sslMode", value: ssl.mode))
+            if let path = ssl.caCertificatePath, !path.isEmpty {
+                queryItems.append(URLQueryItem(name: "sslCaCertPath", value: path))
+            }
+            if let path = ssl.clientCertificatePath, !path.isEmpty {
+                queryItems.append(URLQueryItem(name: "sslClientCertPath", value: path))
+            }
+            if let path = ssl.clientKeyPath, !path.isEmpty {
+                queryItems.append(URLQueryItem(name: "sslClientKeyPath", value: path))
+            }
+        }
+
+        if let color = exportable.color {
+            queryItems.append(URLQueryItem(name: "color", value: color))
+        }
+        if let tagName = exportable.tagName {
+            queryItems.append(URLQueryItem(name: "tagName", value: tagName))
+        }
+        if let groupName = exportable.groupName {
+            queryItems.append(URLQueryItem(name: "groupName", value: groupName))
+        }
+        if let safeModeLevel = exportable.safeModeLevel {
+            queryItems.append(URLQueryItem(name: "safeModeLevel", value: safeModeLevel))
+        }
+        if let aiPolicy = exportable.aiPolicy {
+            queryItems.append(URLQueryItem(name: "aiPolicy", value: aiPolicy))
+        }
+        if let redisDb = exportable.redisDatabase {
+            queryItems.append(URLQueryItem(name: "redisDatabase", value: String(redisDb)))
+        }
+        if let commands = exportable.startupCommands, !commands.isEmpty {
+            queryItems.append(URLQueryItem(name: "startupCommands", value: commands))
+        }
+        if exportable.localOnly == true {
+            queryItems.append(URLQueryItem(name: "localOnly", value: "1"))
+        }
+
+        if let fields = exportable.additionalFields {
+            for (key, value) in fields.sorted(by: { $0.key < $1.key }) {
+                queryItems.append(URLQueryItem(name: "af_\(key)", value: value))
+            }
         }
 
         components.queryItems = queryItems
-
         return components.url?.absoluteString ?? ""
+    }
+
+    static func buildCompactJSON(for connection: DatabaseConnection) -> String {
+        let envelope = buildEnvelope(for: [connection])
+        guard let exportable = envelope.connections.first else { return "{}" }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(exportable),
+              let json = String(data: data, encoding: .utf8) else { return "{}" }
+        return json
     }
 
     // MARK: - Private Helpers
 
-    private static func buildDatabaseConnection(
+    static func buildDatabaseConnection(
         id: UUID,
         from exportable: ExportableConnection,
         name: String

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -684,6 +684,9 @@ enum ConnectionExportService {
             logger.warning("Failed to build import deeplink for '\(connection.name)'")
             return nil
         }
+        if (url as NSString).length > 2000 {
+            logger.warning("Import deeplink for '\(connection.name)' is \((url as NSString).length) chars — may be truncated by some apps")
+        }
         return url
     }
 

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -20,6 +20,7 @@ extension Notification.Name {
     static let connectionStatusDidChange = Notification.Name("connectionStatusDidChange")
     static let databaseDidConnect = Notification.Name("databaseDidConnect")
     static let connectionShareFileOpened = Notification.Name("connectionShareFileOpened")
+    static let deeplinkImportRequested = Notification.Name("deeplinkImportRequested")
     static let exportConnections = Notification.Name("exportConnections")
     static let importConnections = Notification.Name("importConnections")
     static let importConnectionsFromApp = Notification.Name("importConnectionsFromApp")

--- a/TablePro/Core/Services/Infrastructure/DeeplinkHandler.swift
+++ b/TablePro/Core/Services/Infrastructure/DeeplinkHandler.swift
@@ -10,8 +10,7 @@ enum DeeplinkAction {
     case connect(connectionName: String)
     case openTable(connectionName: String, tableName: String, databaseName: String?)
     case openQuery(connectionName: String, sql: String)
-    case importConnection(name: String, host: String, port: Int, type: DatabaseType,
-                          username: String, database: String)
+    case importConnection(ExportableConnection)
 }
 
 @MainActor
@@ -100,8 +99,83 @@ enum DeeplinkHandler {
         let username = value("username") ?? ""
         let database = value("database") ?? ""
 
-        return .importConnection(name: name, host: host, port: port, type: dbType,
-                                 username: username, database: database)
+        let sshConfig: ExportableSSHConfig?
+        if value("ssh") == "1" {
+            let jumpHosts: [ExportableJumpHost]?
+            if let jumpJson = value("sshJumpHosts"),
+               let data = jumpJson.data(using: .utf8) {
+                jumpHosts = try? JSONDecoder().decode([ExportableJumpHost].self, from: data)
+            } else {
+                jumpHosts = nil
+            }
+            sshConfig = ExportableSSHConfig(
+                enabled: true,
+                host: value("sshHost") ?? "",
+                port: value("sshPort").flatMap(Int.init) ?? 22,
+                username: value("sshUsername") ?? "",
+                authMethod: value("sshAuthMethod") ?? "password",
+                privateKeyPath: value("sshPrivateKeyPath") ?? "",
+                useSSHConfig: value("sshUseSSHConfig") == "1",
+                agentSocketPath: value("sshAgentSocketPath") ?? "",
+                jumpHosts: jumpHosts,
+                totpMode: value("sshTotpMode"),
+                totpAlgorithm: value("sshTotpAlgorithm"),
+                totpDigits: value("sshTotpDigits").flatMap(Int.init),
+                totpPeriod: value("sshTotpPeriod").flatMap(Int.init)
+            )
+        } else {
+            sshConfig = nil
+        }
+
+        let sslConfig: ExportableSSLConfig?
+        if let sslMode = value("sslMode") {
+            sslConfig = ExportableSSLConfig(
+                mode: sslMode,
+                caCertificatePath: value("sslCaCertPath"),
+                clientCertificatePath: value("sslClientCertPath"),
+                clientKeyPath: value("sslClientKeyPath")
+            )
+        } else {
+            sslConfig = nil
+        }
+
+        var additionalFields: [String: String]?
+        let afItems = queryItems.filter { $0.name.hasPrefix("af_") }
+        if !afItems.isEmpty {
+            var fields: [String: String] = [:]
+            for item in afItems {
+                let fieldKey = String(item.name.dropFirst(3))
+                if !fieldKey.isEmpty, let fieldValue = item.value {
+                    fields[fieldKey] = fieldValue
+                }
+            }
+            if !fields.isEmpty {
+                additionalFields = fields
+            }
+        }
+
+        let exportable = ExportableConnection(
+            name: name,
+            host: host,
+            port: port,
+            database: database,
+            username: username,
+            type: dbType.rawValue,
+            sshConfig: sshConfig,
+            sslConfig: sslConfig,
+            color: value("color"),
+            tagName: value("tagName"),
+            groupName: value("groupName"),
+            sshProfileId: nil,
+            safeModeLevel: value("safeModeLevel"),
+            aiPolicy: value("aiPolicy"),
+            additionalFields: additionalFields,
+            redisDatabase: value("redisDatabase").flatMap(Int.init),
+            startupCommands: value("startupCommands"),
+            localOnly: value("localOnly") == "1" ? true : nil
+        )
+
+        return .importConnection(exportable)
     }
 
     // MARK: - Resolution

--- a/TablePro/Models/Connection/ConnectionExport.swift
+++ b/TablePro/Models/Connection/ConnectionExport.swift
@@ -58,6 +58,18 @@ struct ExportableConnection: Codable {
     let redisDatabase: Int?
     let startupCommands: String?
     let localOnly: Bool?
+
+    func renamed(to newName: String) -> ExportableConnection {
+        ExportableConnection(
+            name: newName, host: host, port: port, database: database,
+            username: username, type: type, sshConfig: sshConfig,
+            sslConfig: sslConfig, color: color, tagName: tagName,
+            groupName: groupName, sshProfileId: sshProfileId,
+            safeModeLevel: safeModeLevel, aiPolicy: aiPolicy,
+            additionalFields: additionalFields, redisDatabase: redisDatabase,
+            startupCommands: startupCommands, localOnly: localOnly
+        )
+    }
 }
 
 // MARK: - SSH Config

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -22,7 +22,7 @@ enum WelcomeActiveSheet: Identifiable {
         case .importFile(let u): "importFile-\(u.absoluteString)"
         case .exportConnections: "exportConnections"
         case .importFromApp: "importFromApp"
-        case .deeplinkImport(let c): "deeplinkImport-\(c.name)-\(c.host)-\(c.port)"
+        case .deeplinkImport(let c): "deeplinkImport-\(c.type)-\(c.name)-\(c.host)-\(c.port)"
         }
     }
 }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -13,6 +13,7 @@ enum WelcomeActiveSheet: Identifiable {
     case importFile(URL)
     case exportConnections([DatabaseConnection])
     case importFromApp
+    case deeplinkImport(ExportableConnection)
 
     var id: String {
         switch self {
@@ -21,6 +22,7 @@ enum WelcomeActiveSheet: Identifiable {
         case .importFile(let u): "importFile-\(u.absoluteString)"
         case .exportConnections: "exportConnections"
         case .importFromApp: "importFromApp"
+        case .deeplinkImport(let c): "deeplinkImport-\(c.name)-\(c.host)-\(c.port)"
         }
     }
 }
@@ -80,6 +82,7 @@ final class WelcomeViewModel {
     @ObservationIgnored private var importObserver: NSObjectProtocol?
     @ObservationIgnored private var linkedFoldersObserver: NSObjectProtocol?
     @ObservationIgnored private var importFromAppObserver: NSObjectProtocol?
+    @ObservationIgnored private var deeplinkImportObserver: NSObjectProtocol?
 
     // MARK: - Computed Properties
 
@@ -204,6 +207,18 @@ final class WelcomeViewModel {
             }
         }
 
+        deeplinkImportObserver = NotificationCenter.default.addObserver(
+            forName: .deeplinkImportRequested, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      let appDelegate = NSApp.delegate as? AppDelegate,
+                      let exportable = appDelegate.pendingDeeplinkImport else { return }
+                appDelegate.pendingDeeplinkImport = nil
+                self.activeSheet = .deeplinkImport(exportable)
+            }
+        }
+
         loadConnections()
         linkedConnections = LinkedFolderWatcher.shared.linkedConnections
 
@@ -212,11 +227,18 @@ final class WelcomeViewModel {
             appDelegate.pendingConnectionShareURL = nil
             activeSheet = .importFile(pendingURL)
         }
+
+        if let appDelegate = NSApp.delegate as? AppDelegate,
+           let pendingImport = appDelegate.pendingDeeplinkImport {
+            appDelegate.pendingDeeplinkImport = nil
+            activeSheet = .deeplinkImport(pendingImport)
+        }
     }
 
     deinit {
         [connectionUpdatedObserver, shareFileObserver, exportObserver,
-         importObserver, importFromAppObserver, linkedFoldersObserver].forEach {
+         importObserver, importFromAppObserver, linkedFoldersObserver,
+         deeplinkImportObserver].forEach {
             if let observer = $0 {
                 NotificationCenter.default.removeObserver(observer)
             }

--- a/TablePro/Views/Connection/DeeplinkImportSheet.swift
+++ b/TablePro/Views/Connection/DeeplinkImportSheet.swift
@@ -1,0 +1,216 @@
+//
+//  DeeplinkImportSheet.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct DeeplinkImportSheet: View {
+    let connection: ExportableConnection
+    let onImported: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var editableName: String
+    @State private var isDuplicate = false
+
+    init(connection: ExportableConnection, onImported: @escaping () -> Void) {
+        self.connection = connection
+        self.onImported = onImported
+        _editableName = State(initialValue: connection.name)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    HStack(spacing: 10) {
+                        DatabaseType(rawValue: connection.type).iconImage
+                            .frame(width: 28, height: 28)
+                        Text(DatabaseType(rawValue: connection.type).displayName)
+                            .font(.headline)
+                    }
+                }
+
+                Section(String(localized: "Connection")) {
+                    TextField(String(localized: "Name"), text: $editableName)
+                        .onChange(of: editableName) { checkDuplicate() }
+
+                    LabeledContent(String(localized: "Host")) {
+                        Text(hostDisplay)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !connection.database.isEmpty {
+                        LabeledContent(String(localized: "Database")) {
+                            Text(connection.database)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if !connection.username.isEmpty {
+                        LabeledContent(String(localized: "Username")) {
+                            Text(connection.username)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if connection.sshConfig != nil {
+                    sshSection
+                }
+
+                if connection.sslConfig != nil {
+                    sslSection
+                }
+
+                if hasMetadata {
+                    metadataSection
+                }
+
+                if isDuplicate {
+                    Section {
+                        Label(
+                            String(localized: "A connection with this name, host, and type already exists."),
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(.orange)
+                        .font(.callout)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Button(String(localized: "Cancel")) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button(String(localized: "Add Connection")) { performImport() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(editableName.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 420)
+        .onAppear { checkDuplicate() }
+    }
+
+    private var hostDisplay: String {
+        connection.port > 0
+            ? "\(connection.host):\(connection.port)"
+            : connection.host
+    }
+
+    @ViewBuilder
+    private var sshSection: some View {
+        if let ssh = connection.sshConfig {
+            Section("SSH") {
+                LabeledContent(String(localized: "Host")) {
+                    let port = ssh.port != 22 ? ":\(ssh.port)" : ""
+                    Text("\(ssh.host)\(port)")
+                        .foregroundStyle(.secondary)
+                }
+                LabeledContent(String(localized: "Auth")) {
+                    Text(ssh.authMethod)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sslSection: some View {
+        if let ssl = connection.sslConfig {
+            Section("SSL") {
+                LabeledContent(String(localized: "Mode")) {
+                    Text(ssl.mode)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var hasMetadata: Bool {
+        connection.color != nil || connection.tagName != nil || connection.groupName != nil
+    }
+
+    @ViewBuilder
+    private var metadataSection: some View {
+        Section {
+            if let color = connection.color,
+               let connColor = ConnectionColor(rawValue: color), connColor != .none {
+                LabeledContent(String(localized: "Color")) {
+                    Circle()
+                        .fill(connColor.color)
+                        .frame(width: 12, height: 12)
+                }
+            }
+            if let tagName = connection.tagName {
+                LabeledContent(String(localized: "Tag")) {
+                    Text(tagName).foregroundStyle(.secondary)
+                }
+            }
+            if let groupName = connection.groupName {
+                LabeledContent(String(localized: "Group")) {
+                    Text(groupName).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func checkDuplicate() {
+        let trimmed = editableName.trimmingCharacters(in: .whitespaces)
+        let existing = ConnectionStorage.shared.loadConnections()
+        isDuplicate = existing.contains {
+            $0.name.lowercased() == trimmed.lowercased()
+                && $0.host.lowercased() == connection.host.lowercased()
+                && $0.port == connection.port
+                && $0.type.rawValue.lowercased() == connection.type.lowercased()
+        }
+    }
+
+    private func performImport() {
+        let trimmed = editableName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+
+        let renamedConnection = ExportableConnection(
+            name: trimmed,
+            host: connection.host,
+            port: connection.port,
+            database: connection.database,
+            username: connection.username,
+            type: connection.type,
+            sshConfig: connection.sshConfig,
+            sslConfig: connection.sslConfig,
+            color: connection.color,
+            tagName: connection.tagName,
+            groupName: connection.groupName,
+            sshProfileId: connection.sshProfileId,
+            safeModeLevel: connection.safeModeLevel,
+            aiPolicy: connection.aiPolicy,
+            additionalFields: connection.additionalFields,
+            redisDatabase: connection.redisDatabase,
+            startupCommands: connection.startupCommands,
+            localOnly: connection.localOnly
+        )
+
+        let envelope = ConnectionExportEnvelope(
+            formatVersion: 1,
+            exportedAt: Date(),
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+            connections: [renamedConnection],
+            groups: connection.groupName.map { [ExportableGroup(name: $0, color: nil)] },
+            tags: connection.tagName.map { [ExportableTag(name: $0, color: nil)] },
+            credentials: nil
+        )
+
+        let preview = ConnectionExportService.analyzeImport(envelope)
+        var resolutions: [UUID: ImportResolution] = [:]
+        for item in preview.items {
+            resolutions[item.id] = .importNew
+        }
+        ConnectionExportService.performImport(preview, resolutions: resolutions)
+        onImported()
+        dismiss()
+    }
+}

--- a/TablePro/Views/Connection/DeeplinkImportSheet.swift
+++ b/TablePro/Views/Connection/DeeplinkImportSheet.swift
@@ -85,9 +85,11 @@ struct DeeplinkImportSheet: View {
                 Button(String(localized: "Cancel")) { dismiss() }
                     .keyboardShortcut(.cancelAction)
                 Spacer()
-                Button(String(localized: "Add Connection")) { performImport() }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(editableName.trimmingCharacters(in: .whitespaces).isEmpty)
+                Button(isDuplicate ? String(localized: "Add as Copy") : String(localized: "Add Connection")) {
+                    performImport()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(editableName.trimmingCharacters(in: .whitespaces).isEmpty)
             }
             .padding()
         }
@@ -207,7 +209,7 @@ struct DeeplinkImportSheet: View {
         let preview = ConnectionExportService.analyzeImport(envelope)
         var resolutions: [UUID: ImportResolution] = [:]
         for item in preview.items {
-            resolutions[item.id] = .importNew
+            resolutions[item.id] = isDuplicate ? .importAsCopy : .importNew
         }
         ConnectionExportService.performImport(preview, resolutions: resolutions)
         onImported()

--- a/TablePro/Views/Connection/DeeplinkImportSheet.swift
+++ b/TablePro/Views/Connection/DeeplinkImportSheet.swift
@@ -175,26 +175,7 @@ struct DeeplinkImportSheet: View {
         let trimmed = editableName.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
 
-        let renamedConnection = ExportableConnection(
-            name: trimmed,
-            host: connection.host,
-            port: connection.port,
-            database: connection.database,
-            username: connection.username,
-            type: connection.type,
-            sshConfig: connection.sshConfig,
-            sslConfig: connection.sslConfig,
-            color: connection.color,
-            tagName: connection.tagName,
-            groupName: connection.groupName,
-            sshProfileId: connection.sshProfileId,
-            safeModeLevel: connection.safeModeLevel,
-            aiPolicy: connection.aiPolicy,
-            additionalFields: connection.additionalFields,
-            redisDatabase: connection.redisDatabase,
-            startupCommands: connection.startupCommands,
-            localOnly: connection.localOnly
-        )
+        let renamedConnection = connection.renamed(to: trimmed)
 
         let envelope = ConnectionExportEnvelope(
             formatVersion: 1,

--- a/TablePro/Views/Connection/WelcomeContextMenus.swift
+++ b/TablePro/Views/Connection/WelcomeContextMenus.swift
@@ -127,8 +127,9 @@ extension WelcomeWindowView {
             }
 
             Button {
-                let link = ConnectionExportService.buildImportDeeplink(for: connection)
-                ClipboardService.shared.writeText(link)
+                if let link = ConnectionExportService.buildImportDeeplink(for: connection) {
+                    ClipboardService.shared.writeText(link)
+                }
             } label: {
                 Label(String(localized: "Copy TablePro Link"), systemImage: "link.badge.plus")
             }

--- a/TablePro/Views/Connection/WelcomeContextMenus.swift
+++ b/TablePro/Views/Connection/WelcomeContextMenus.swift
@@ -26,13 +26,15 @@ extension WelcomeWindowView {
 
         Divider()
 
-        Button {
-            vm.exportConnections(Array(vm.selectedConnections))
-        } label: {
-            Label(
-                String(format: String(localized: "Export %d Connections..."), vm.selectedConnectionIds.count),
-                systemImage: "square.and.arrow.up"
-            )
+        Menu(String(localized: "Share")) {
+            Button {
+                vm.exportConnections(Array(vm.selectedConnections))
+            } label: {
+                Label(
+                    String(format: String(localized: "Export %d Connections to File..."), vm.selectedConnectionIds.count),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
         }
 
         Divider()
@@ -101,39 +103,50 @@ extension WelcomeWindowView {
 
         Divider()
 
-        Button {
-            let pw = ConnectionStorage.shared.loadPassword(for: connection.id)
-            let sshPw: String?
-            let sshProfile: SSHProfile?
-            if let profileId = connection.sshProfileId {
-                sshPw = SSHProfileStorage.shared.loadSSHPassword(for: profileId)
-                sshProfile = SSHProfileStorage.shared.profile(for: profileId)
-            } else {
-                sshPw = ConnectionStorage.shared.loadSSHPassword(for: connection.id)
-                sshProfile = nil
+        Menu(String(localized: "Share")) {
+            Button {
+                let pw = ConnectionStorage.shared.loadPassword(for: connection.id)
+                let sshPw: String?
+                let sshProfile: SSHProfile?
+                if let profileId = connection.sshProfileId {
+                    sshPw = SSHProfileStorage.shared.loadSSHPassword(for: profileId)
+                    sshProfile = SSHProfileStorage.shared.profile(for: profileId)
+                } else {
+                    sshPw = ConnectionStorage.shared.loadSSHPassword(for: connection.id)
+                    sshProfile = nil
+                }
+                let url = ConnectionURLFormatter.format(
+                    connection,
+                    password: pw,
+                    sshPassword: sshPw,
+                    sshProfile: sshProfile
+                )
+                ClipboardService.shared.writeText(url)
+            } label: {
+                Label(String(localized: "Copy Connection String"), systemImage: "link")
             }
-            let url = ConnectionURLFormatter.format(
-                connection,
-                password: pw,
-                sshPassword: sshPw,
-                sshProfile: sshProfile
-            )
-            ClipboardService.shared.writeText(url)
-        } label: {
-            Label(String(localized: "Copy as URL"), systemImage: "link")
-        }
 
-        Button {
-            let link = ConnectionExportService.buildImportDeeplink(for: connection)
-            ClipboardService.shared.writeText(link)
-        } label: {
-            Label(String(localized: "Copy as Import Link"), systemImage: "link.badge.plus")
-        }
+            Button {
+                let link = ConnectionExportService.buildImportDeeplink(for: connection)
+                ClipboardService.shared.writeText(link)
+            } label: {
+                Label(String(localized: "Copy TablePro Link"), systemImage: "link.badge.plus")
+            }
 
-        Button {
-            vm.exportConnections([connection])
-        } label: {
-            Label(String(localized: "Export..."), systemImage: "square.and.arrow.up")
+            Button {
+                let json = ConnectionExportService.buildCompactJSON(for: connection)
+                ClipboardService.shared.writeText(json)
+            } label: {
+                Label(String(localized: "Copy as JSON"), systemImage: "doc.text")
+            }
+
+            Divider()
+
+            Button {
+                vm.exportConnections([connection])
+            } label: {
+                Label(String(localized: "Export to File..."), systemImage: "square.and.arrow.up")
+            }
         }
 
         Divider()

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -107,6 +107,10 @@ struct WelcomeWindowView: View {
                         vm.showImportResultAlert(count: count)
                     }
                 }
+            case .deeplinkImport(let exportable):
+                DeeplinkImportSheet(connection: exportable) {
+                    vm.loadConnections()
+                }
             }
         }
         .pluginInstallPrompt(connection: $vm.pluginInstallConnection) { connection in

--- a/TableProTests/Core/Services/ConnectionSharingTests.swift
+++ b/TableProTests/Core/Services/ConnectionSharingTests.swift
@@ -23,7 +23,7 @@ struct ConnectionSharingTests {
                 name: "Dev", host: "localhost", port: 3306,
                 database: "mydb", username: "root", type: .mysql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("name=Dev"))
             #expect(link.contains("host=localhost"))
             #expect(link.contains("port=3306"))
@@ -39,7 +39,7 @@ struct ConnectionSharingTests {
                 name: "Minimal", host: "db.com", port: 5432,
                 database: "", username: "", type: .postgresql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(!link.contains("username="))
             #expect(!link.contains("database="))
         }
@@ -59,7 +59,7 @@ struct ConnectionSharingTests {
                 database: "main", username: "app", type: .postgresql,
                 sshConfig: ssh
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("ssh=1"))
             #expect(link.contains("sshHost=bastion.com"))
             #expect(link.contains("sshPort=2222"))
@@ -74,7 +74,7 @@ struct ConnectionSharingTests {
                 name: "NoSSH", host: "localhost", port: 3306,
                 database: "", username: "", type: .mysql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(!link.contains("ssh="))
             #expect(!link.contains("sshHost="))
         }
@@ -91,7 +91,7 @@ struct ConnectionSharingTests {
                 database: "", username: "", type: .postgresql,
                 sshConfig: ssh
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(!link.contains("sshPort="))
         }
 
@@ -109,7 +109,7 @@ struct ConnectionSharingTests {
                 database: "", username: "", type: .postgresql,
                 sslConfig: ssl
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("sslMode=required"))
             #expect(link.contains("sslCaCertPath="))
         }
@@ -121,7 +121,7 @@ struct ConnectionSharingTests {
                 name: "NoSSL", host: "localhost", port: 3306,
                 database: "", username: "", type: .mysql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(!link.contains("sslMode="))
         }
 
@@ -135,7 +135,7 @@ struct ConnectionSharingTests {
                 safeModeLevel: .readOnly,
                 aiPolicy: .never
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("color=red"))
             #expect(link.contains("safeModeLevel=readOnly"))
             #expect(link.contains("aiPolicy=never"))
@@ -148,7 +148,7 @@ struct ConnectionSharingTests {
                 name: "Default", host: "localhost", port: 3306,
                 database: "", username: "", type: .mysql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(!link.contains("color="))
             #expect(!link.contains("safeModeLevel="))
             #expect(!link.contains("aiPolicy="))
@@ -163,7 +163,7 @@ struct ConnectionSharingTests {
                 redisDatabase: 3,
                 additionalFields: ["customField": "customValue"]
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("redisDatabase=3"))
             #expect(link.contains("af_customField=customValue"))
         }
@@ -176,7 +176,7 @@ struct ConnectionSharingTests {
                 database: "", username: "", type: .postgresql,
                 startupCommands: "SET search_path TO myschema;"
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("startupCommands="))
         }
 
@@ -188,7 +188,7 @@ struct ConnectionSharingTests {
                 database: "", username: "", type: .postgresql,
                 localOnly: true
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             #expect(link.contains("localOnly=1"))
         }
 
@@ -199,7 +199,7 @@ struct ConnectionSharingTests {
                 name: "Dev & Staging", host: "db.example.com", port: 5432,
                 database: "my db", username: "user@domain", type: .postgresql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             let url = URL(string: link)
             #expect(url != nil)
             let components = URLComponents(url: url!, resolvingAgainstBaseURL: false)
@@ -223,7 +223,7 @@ struct ConnectionSharingTests {
                 safeModeLevel: .readOnly,
                 startupCommands: "SET timeout=30;"
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)!
             let url = URL(string: link)
             #expect(url != nil)
             #expect(url?.scheme == "tablepro")

--- a/TableProTests/Core/Services/ConnectionSharingTests.swift
+++ b/TableProTests/Core/Services/ConnectionSharingTests.swift
@@ -1,0 +1,543 @@
+//
+//  ConnectionSharingTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+@Suite("Connection Sharing")
+@MainActor
+struct ConnectionSharingTests {
+
+    // MARK: - buildImportDeeplink
+
+    @Suite("Build Import Deeplink")
+    struct BuildDeeplinkTests {
+
+        @Test("Emits required fields")
+        @MainActor
+        func testRequiredFields() {
+            let conn = DatabaseConnection(
+                name: "Dev", host: "localhost", port: 3306,
+                database: "mydb", username: "root", type: .mysql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("name=Dev"))
+            #expect(link.contains("host=localhost"))
+            #expect(link.contains("port=3306"))
+            #expect(link.contains("type=MySQL"))
+            #expect(link.contains("username=root"))
+            #expect(link.contains("database=mydb"))
+        }
+
+        @Test("Omits empty username and database")
+        @MainActor
+        func testOmitsEmptyFields() {
+            let conn = DatabaseConnection(
+                name: "Minimal", host: "db.com", port: 5432,
+                database: "", username: "", type: .postgresql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(!link.contains("username="))
+            #expect(!link.contains("database="))
+        }
+
+        @Test("Includes SSH config when enabled")
+        @MainActor
+        func testIncludesSSH() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.com"
+            ssh.port = 2222
+            ssh.username = "deploy"
+            ssh.authMethod = .privateKey
+            ssh.privateKeyPath = "~/.ssh/id_ed25519"
+            let conn = DatabaseConnection(
+                name: "SSH", host: "db.internal", port: 5432,
+                database: "main", username: "app", type: .postgresql,
+                sshConfig: ssh
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("ssh=1"))
+            #expect(link.contains("sshHost=bastion.com"))
+            #expect(link.contains("sshPort=2222"))
+            #expect(link.contains("sshUsername=deploy"))
+            #expect(link.contains("sshAuthMethod=privateKey"))
+        }
+
+        @Test("Omits SSH when disabled")
+        @MainActor
+        func testOmitsSSHWhenDisabled() {
+            let conn = DatabaseConnection(
+                name: "NoSSH", host: "localhost", port: 3306,
+                database: "", username: "", type: .mysql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(!link.contains("ssh="))
+            #expect(!link.contains("sshHost="))
+        }
+
+        @Test("Omits default SSH port 22")
+        @MainActor
+        func testOmitsDefaultSSHPort() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.com"
+            ssh.port = 22
+            let conn = DatabaseConnection(
+                name: "SSH", host: "db.com", port: 5432,
+                database: "", username: "", type: .postgresql,
+                sshConfig: ssh
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(!link.contains("sshPort="))
+        }
+
+        @Test("Includes SSL config")
+        @MainActor
+        func testIncludesSSL() {
+            let ssl = SSLConfiguration(
+                mode: .required,
+                caCertificatePath: "~/certs/ca.pem",
+                clientCertificatePath: "",
+                clientKeyPath: ""
+            )
+            let conn = DatabaseConnection(
+                name: "SSL", host: "db.com", port: 5432,
+                database: "", username: "", type: .postgresql,
+                sslConfig: ssl
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("sslMode=required"))
+            #expect(link.contains("sslCaCertPath="))
+        }
+
+        @Test("Omits SSL when disabled")
+        @MainActor
+        func testOmitsSSLWhenDisabled() {
+            let conn = DatabaseConnection(
+                name: "NoSSL", host: "localhost", port: 3306,
+                database: "", username: "", type: .mysql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(!link.contains("sslMode="))
+        }
+
+        @Test("Includes metadata fields")
+        @MainActor
+        func testIncludesMetadata() {
+            let conn = DatabaseConnection(
+                name: "Prod", host: "db.com", port: 5432,
+                database: "", username: "", type: .postgresql,
+                color: .red,
+                safeModeLevel: .readOnly,
+                aiPolicy: .never
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("color=red"))
+            #expect(link.contains("safeModeLevel=readOnly"))
+            #expect(link.contains("aiPolicy=never"))
+        }
+
+        @Test("Omits default metadata values")
+        @MainActor
+        func testOmitsDefaultMetadata() {
+            let conn = DatabaseConnection(
+                name: "Default", host: "localhost", port: 3306,
+                database: "", username: "", type: .mysql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(!link.contains("color="))
+            #expect(!link.contains("safeModeLevel="))
+            #expect(!link.contains("aiPolicy="))
+        }
+
+        @Test("Includes additional fields with af_ prefix")
+        @MainActor
+        func testIncludesAdditionalFields() {
+            let conn = DatabaseConnection(
+                name: "Redis", host: "localhost", port: 6379,
+                database: "", username: "", type: .redis,
+                redisDatabase: 3,
+                additionalFields: ["customField": "customValue"]
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("redisDatabase=3"))
+            #expect(link.contains("af_customField=customValue"))
+        }
+
+        @Test("Includes startup commands")
+        @MainActor
+        func testIncludesStartupCommands() {
+            let conn = DatabaseConnection(
+                name: "Dev", host: "localhost", port: 5432,
+                database: "", username: "", type: .postgresql,
+                startupCommands: "SET search_path TO myschema;"
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("startupCommands="))
+        }
+
+        @Test("Includes localOnly flag")
+        @MainActor
+        func testIncludesLocalOnly() {
+            let conn = DatabaseConnection(
+                name: "Local", host: "localhost", port: 5432,
+                database: "", username: "", type: .postgresql,
+                localOnly: true
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            #expect(link.contains("localOnly=1"))
+        }
+
+        @Test("Percent-encodes special characters")
+        @MainActor
+        func testPercentEncodesSpecialChars() {
+            let conn = DatabaseConnection(
+                name: "Dev & Staging", host: "db.example.com", port: 5432,
+                database: "my db", username: "user@domain", type: .postgresql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let url = URL(string: link)
+            #expect(url != nil)
+            let components = URLComponents(url: url!, resolvingAgainstBaseURL: false)
+            let nameValue = components?.queryItems?.first(where: { $0.name == "name" })?.value
+            #expect(nameValue == "Dev & Staging")
+        }
+
+        @Test("Produces valid URL")
+        @MainActor
+        func testProducesValidURL() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.com"
+            ssh.port = 2222
+            let conn = DatabaseConnection(
+                name: "Complex Connection", host: "db.prod.internal", port: 5433,
+                database: "main", username: "app_user", type: .postgresql,
+                sshConfig: ssh,
+                sslConfig: SSLConfiguration(mode: .required),
+                color: .red,
+                safeModeLevel: .readOnly,
+                startupCommands: "SET timeout=30;"
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: conn)
+            let url = URL(string: link)
+            #expect(url != nil)
+            #expect(url?.scheme == "tablepro")
+            #expect(url?.host() == "import")
+        }
+    }
+
+    // MARK: - buildCompactJSON
+
+    @Suite("Build Compact JSON")
+    struct BuildCompactJSONTests {
+
+        @Test("Returns valid JSON")
+        @MainActor
+        func testReturnsValidJSON() {
+            let conn = DatabaseConnection(
+                name: "Dev", host: "localhost", port: 3306,
+                database: "mydb", username: "root", type: .mysql
+            )
+            let json = ConnectionExportService.buildCompactJSON(for: conn)
+            let data = json.data(using: .utf8)!
+            let decoded = try? JSONDecoder().decode(ExportableConnection.self, from: data)
+            #expect(decoded != nil)
+            #expect(decoded?.name == "Dev")
+            #expect(decoded?.host == "localhost")
+            #expect(decoded?.type == "MySQL")
+        }
+
+        @Test("Excludes SSH profile ID")
+        @MainActor
+        func testExcludesSSHProfileId() {
+            let conn = DatabaseConnection(
+                name: "Dev", host: "localhost", port: 3306,
+                database: "", username: "", type: .mysql
+            )
+            let json = ConnectionExportService.buildCompactJSON(for: conn)
+            let data = json.data(using: .utf8)!
+            let decoded = try! JSONDecoder().decode(ExportableConnection.self, from: data)
+            #expect(decoded.sshProfileId == nil)
+        }
+
+        @Test("Is compact (not pretty printed)")
+        @MainActor
+        func testIsCompact() {
+            let conn = DatabaseConnection(
+                name: "Dev", host: "localhost", port: 3306,
+                database: "", username: "", type: .mysql
+            )
+            let json = ConnectionExportService.buildCompactJSON(for: conn)
+            #expect(!json.contains("\n  "))
+        }
+
+        @Test("Includes SSH config when enabled")
+        @MainActor
+        func testIncludesSSHInJSON() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.com"
+            ssh.port = 22
+            ssh.username = "admin"
+            let conn = DatabaseConnection(
+                name: "SSH", host: "db.com", port: 5432,
+                database: "", username: "", type: .postgresql,
+                sshConfig: ssh
+            )
+            let json = ConnectionExportService.buildCompactJSON(for: conn)
+            let data = json.data(using: .utf8)!
+            let decoded = try! JSONDecoder().decode(ExportableConnection.self, from: data)
+            #expect(decoded.sshConfig != nil)
+            #expect(decoded.sshConfig?.host == "bastion.com")
+        }
+    }
+
+    // MARK: - Round-Trip
+
+    @Suite("Round-Trip: buildImportDeeplink → parseImport")
+    struct RoundTripTests {
+
+        @Test("Basic connection survives round-trip")
+        @MainActor
+        func testBasicRoundTrip() {
+            let original = DatabaseConnection(
+                name: "Dev MySQL", host: "db.example.com", port: 3307,
+                database: "app_db", username: "dev_user", type: .mysql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.name == original.name)
+            #expect(parsed.host == original.host)
+            #expect(parsed.port == original.port)
+            #expect(parsed.database == original.database)
+            #expect(parsed.username == original.username)
+            #expect(parsed.type == original.type.rawValue)
+        }
+
+        @Test("SSH config survives round-trip")
+        @MainActor
+        func testSSHRoundTrip() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.prod.com"
+            ssh.port = 2222
+            ssh.username = "deploy"
+            ssh.authMethod = .privateKey
+            ssh.privateKeyPath = "~/.ssh/prod_key"
+            ssh.useSSHConfig = true
+            ssh.agentSocketPath = "/tmp/agent.sock"
+            let original = DatabaseConnection(
+                name: "SSH Prod", host: "db.internal", port: 5432,
+                database: "main", username: "app", type: .postgresql,
+                sshConfig: ssh
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.sshConfig != nil)
+            #expect(parsed.sshConfig?.enabled == true)
+            #expect(parsed.sshConfig?.host == "bastion.prod.com")
+            #expect(parsed.sshConfig?.port == 2222)
+            #expect(parsed.sshConfig?.username == "deploy")
+            #expect(parsed.sshConfig?.authMethod == "privateKey")
+            #expect(parsed.sshConfig?.privateKeyPath == "~/.ssh/prod_key")
+            #expect(parsed.sshConfig?.useSSHConfig == true)
+            #expect(parsed.sshConfig?.agentSocketPath == "/tmp/agent.sock")
+        }
+
+        @Test("SSL config survives round-trip")
+        @MainActor
+        func testSSLRoundTrip() {
+            let ssl = SSLConfiguration(
+                mode: .verifyCa,
+                caCertificatePath: "~/certs/ca.pem",
+                clientCertificatePath: "~/certs/client.pem",
+                clientKeyPath: "~/certs/client.key"
+            )
+            let original = DatabaseConnection(
+                name: "SSL DB", host: "db.com", port: 5432,
+                database: "secure", username: "admin", type: .postgresql,
+                sslConfig: ssl
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.sslConfig != nil)
+            #expect(parsed.sslConfig?.mode == "verifyCa")
+            #expect(parsed.sslConfig?.caCertificatePath == "~/certs/ca.pem")
+            #expect(parsed.sslConfig?.clientCertificatePath == "~/certs/client.pem")
+            #expect(parsed.sslConfig?.clientKeyPath == "~/certs/client.key")
+        }
+
+        @Test("Metadata survives round-trip")
+        @MainActor
+        func testMetadataRoundTrip() {
+            let original = DatabaseConnection(
+                name: "Prod", host: "db.prod.com", port: 5432,
+                database: "main", username: "app", type: .postgresql,
+                color: .red,
+                safeModeLevel: .readOnly,
+                aiPolicy: .never,
+                startupCommands: "SET statement_timeout = 30000;",
+                localOnly: true
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.color == "red")
+            #expect(parsed.safeModeLevel == "readOnly")
+            #expect(parsed.aiPolicy == "never")
+            #expect(parsed.startupCommands == "SET statement_timeout = 30000;")
+            #expect(parsed.localOnly == true)
+        }
+
+        @Test("Redis database survives round-trip")
+        @MainActor
+        func testRedisRoundTrip() {
+            let original = DatabaseConnection(
+                name: "Cache", host: "redis.local", port: 6379,
+                database: "", username: "", type: .redis,
+                redisDatabase: 5
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.redisDatabase == 5)
+        }
+
+        @Test("Special characters in name survive round-trip")
+        @MainActor
+        func testSpecialCharsRoundTrip() {
+            let original = DatabaseConnection(
+                name: "Dev & Staging (v2)", host: "db.example.com", port: 5432,
+                database: "my database", username: "user@company.com", type: .postgresql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.name == "Dev & Staging (v2)")
+            #expect(parsed.database == "my database")
+            #expect(parsed.username == "user@company.com")
+        }
+
+        @Test("Minimal connection round-trip produces correct defaults")
+        @MainActor
+        func testMinimalRoundTrip() {
+            let original = DatabaseConnection(
+                name: "Bare", host: "localhost", port: 5432,
+                database: "", username: "", type: .postgresql
+            )
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+            #expect(parsed.sshConfig == nil)
+            #expect(parsed.sslConfig == nil)
+            #expect(parsed.color == nil)
+            #expect(parsed.tagName == nil)
+            #expect(parsed.groupName == nil)
+            #expect(parsed.safeModeLevel == nil)
+            #expect(parsed.aiPolicy == nil)
+            #expect(parsed.additionalFields == nil)
+            #expect(parsed.redisDatabase == nil)
+            #expect(parsed.startupCommands == nil)
+            #expect(parsed.localOnly == nil)
+        }
+
+        @Test("Full config round-trip")
+        @MainActor
+        func testFullConfigRoundTrip() {
+            var ssh = SSHConfiguration()
+            ssh.enabled = true
+            ssh.host = "bastion.prod.com"
+            ssh.port = 2222
+            ssh.username = "deploy"
+            ssh.authMethod = .privateKey
+            ssh.privateKeyPath = "~/.ssh/prod_key"
+            ssh.jumpHosts = [
+                SSHJumpHost(
+                    host: "jump1.com", port: 22, username: "admin",
+                    authMethod: .password, privateKeyPath: ""
+                )
+            ]
+
+            let ssl = SSLConfiguration(
+                mode: .verifyCa,
+                caCertificatePath: "~/certs/ca.pem",
+                clientCertificatePath: "",
+                clientKeyPath: ""
+            )
+
+            let original = DatabaseConnection(
+                name: "Full Config", host: "db.prod.internal", port: 5433,
+                database: "main", username: "app_user", type: .postgresql,
+                sshConfig: ssh,
+                sslConfig: ssl,
+                color: .red,
+                safeModeLevel: .readOnly,
+                aiPolicy: .never,
+                redisDatabase: nil,
+                startupCommands: "SET statement_timeout = 30000;",
+                localOnly: true,
+                additionalFields: ["schema": "public"]
+            )
+
+            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let url = URL(string: link)!
+            guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
+                Issue.record("Failed to parse round-trip link")
+                return
+            }
+
+            #expect(parsed.name == "Full Config")
+            #expect(parsed.host == "db.prod.internal")
+            #expect(parsed.port == 5433)
+            #expect(parsed.type == "PostgreSQL")
+            #expect(parsed.username == "app_user")
+            #expect(parsed.database == "main")
+
+            #expect(parsed.sshConfig?.host == "bastion.prod.com")
+            #expect(parsed.sshConfig?.port == 2222)
+            #expect(parsed.sshConfig?.username == "deploy")
+            #expect(parsed.sshConfig?.authMethod == "privateKey")
+            #expect(parsed.sshConfig?.jumpHosts?.count == 1)
+            #expect(parsed.sshConfig?.jumpHosts?.first?.host == "jump1.com")
+
+            #expect(parsed.sslConfig?.mode == "verifyCa")
+            #expect(parsed.sslConfig?.caCertificatePath == "~/certs/ca.pem")
+
+            #expect(parsed.color == "red")
+            #expect(parsed.safeModeLevel == "readOnly")
+            #expect(parsed.aiPolicy == "never")
+            #expect(parsed.startupCommands == "SET statement_timeout = 30000;")
+            #expect(parsed.localOnly == true)
+            #expect(parsed.additionalFields?["schema"] == "public")
+        }
+    }
+}

--- a/TableProTests/Core/Services/DeeplinkHandlerTests.swift
+++ b/TableProTests/Core/Services/DeeplinkHandlerTests.swift
@@ -11,6 +11,8 @@ import Testing
 @MainActor
 struct DeeplinkHandlerTests {
 
+    // MARK: - Connect Actions
+
     @Test("Connect action with simple name")
     func testConnectSimpleName() {
         let url = URL(string: "tablepro://connect/Production")!
@@ -99,35 +101,470 @@ struct DeeplinkHandlerTests {
         #expect(action == nil)
     }
 
-    @Test("Import connection with all params")
-    func testImportConnectionAllParams() {
-        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&port=3306")!
+    // MARK: - Import — Basic Fields
+
+    @Test("Import with all basic params")
+    func testImportBasicParams() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&port=3306&username=root&database=mydb")!
         let action = DeeplinkHandler.parse(url)
-        if case .importConnection(let name, let host, let port, let type, _, _) = action {
-            #expect(name == "Dev")
-            #expect(host == "localhost")
-            #expect(port == 3306)
-            #expect(type == .mysql)
-        } else {
+        guard case .importConnection(let conn) = action else {
             Issue.record("Expected .importConnection, got \(String(describing: action))")
+            return
         }
+        #expect(conn.name == "Dev")
+        #expect(conn.host == "localhost")
+        #expect(conn.port == 3306)
+        #expect(conn.type == "MySQL")
+        #expect(conn.username == "root")
+        #expect(conn.database == "mydb")
     }
 
-    @Test("Import connection with case-insensitive type")
-    func testImportConnectionCaseInsensitiveType() {
+    @Test("Import with minimal required params")
+    func testImportMinimalParams() {
+        let url = URL(string: "tablepro://import?name=Test&host=db.example.com&type=postgresql")!
+        let action = DeeplinkHandler.parse(url)
+        guard case .importConnection(let conn) = action else {
+            Issue.record("Expected .importConnection, got \(String(describing: action))")
+            return
+        }
+        #expect(conn.name == "Test")
+        #expect(conn.host == "db.example.com")
+        #expect(conn.type == "PostgreSQL")
+        #expect(conn.username == "")
+        #expect(conn.database == "")
+        #expect(conn.sshConfig == nil)
+        #expect(conn.sslConfig == nil)
+        #expect(conn.color == nil)
+        #expect(conn.tagName == nil)
+        #expect(conn.groupName == nil)
+        #expect(conn.additionalFields == nil)
+    }
+
+    @Test("Import uses default port when not specified")
+    func testImportDefaultPort() {
+        let url = URL(string: "tablepro://import?name=PG&host=localhost&type=postgresql")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.port == 5432)
+    }
+
+    @Test("Import with case-insensitive type")
+    func testImportCaseInsensitiveType() {
         let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=PostgreSQL")!
-        let action = DeeplinkHandler.parse(url)
-        if case .importConnection(_, _, _, let type, _, _) = action {
-            #expect(type == .postgresql)
-        } else {
-            Issue.record("Expected .importConnection, got \(String(describing: action))")
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
         }
+        #expect(conn.type == "PostgreSQL")
     }
 
-    @Test("Import connection missing name returns nil")
-    func testImportConnectionMissingNameReturnsNil() {
+    @Test("Import missing name returns nil")
+    func testImportMissingNameReturnsNil() {
         let url = URL(string: "tablepro://import?host=localhost&type=mysql")!
-        let action = DeeplinkHandler.parse(url)
-        #expect(action == nil)
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("Import missing host returns nil")
+    func testImportMissingHostReturnsNil() {
+        let url = URL(string: "tablepro://import?name=Dev&type=mysql")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("Import missing type returns nil")
+    func testImportMissingTypeReturnsNil() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("Import with empty name returns nil")
+    func testImportEmptyNameReturnsNil() {
+        let url = URL(string: "tablepro://import?name=&host=localhost&type=mysql")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("Import with empty host returns nil")
+    func testImportEmptyHostReturnsNil() {
+        let url = URL(string: "tablepro://import?name=Dev&host=&type=mysql")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    // MARK: - Import — SSH Config
+
+    @Test("Import with SSH config")
+    func testImportWithSSH() {
+        let url = URL(string: "tablepro://import?name=Prod&host=db.internal&type=postgresql&ssh=1&sshHost=bastion.example.com&sshPort=2222&sshUsername=deploy&sshAuthMethod=privateKey&sshPrivateKeyPath=~/.ssh/id_ed25519")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig != nil)
+        #expect(conn.sshConfig?.enabled == true)
+        #expect(conn.sshConfig?.host == "bastion.example.com")
+        #expect(conn.sshConfig?.port == 2222)
+        #expect(conn.sshConfig?.username == "deploy")
+        #expect(conn.sshConfig?.authMethod == "privateKey")
+        #expect(conn.sshConfig?.privateKeyPath == "~/.ssh/id_ed25519")
+    }
+
+    @Test("Import without ssh=1 has no SSH config")
+    func testImportNoSSHFlag() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&sshHost=bastion.com")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig == nil)
+    }
+
+    @Test("Import with SSH defaults")
+    func testImportSSHDefaults() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.port == 22)
+        #expect(conn.sshConfig?.username == "")
+        #expect(conn.sshConfig?.authMethod == "password")
+        #expect(conn.sshConfig?.privateKeyPath == "")
+        #expect(conn.sshConfig?.useSSHConfig == false)
+        #expect(conn.sshConfig?.agentSocketPath == "")
+    }
+
+    @Test("Import with SSH agent")
+    func testImportSSHAgent() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com&sshAuthMethod=sshAgent&sshAgentSocketPath=/tmp/agent.sock")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.authMethod == "sshAgent")
+        #expect(conn.sshConfig?.agentSocketPath == "/tmp/agent.sock")
+    }
+
+    @Test("Import with SSH use config flag")
+    func testImportSSHUseConfig() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com&sshUseSSHConfig=1")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.useSSHConfig == true)
+    }
+
+    @Test("Import with SSH TOTP config")
+    func testImportSSHTOTP() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com&sshTotpMode=autoGenerate&sshTotpAlgorithm=sha256&sshTotpDigits=8&sshTotpPeriod=60")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.totpMode == "autoGenerate")
+        #expect(conn.sshConfig?.totpAlgorithm == "sha256")
+        #expect(conn.sshConfig?.totpDigits == 8)
+        #expect(conn.sshConfig?.totpPeriod == 60)
+    }
+
+    @Test("Import with SSH jump hosts")
+    func testImportSSHJumpHosts() {
+        let jumpJson = #"[{"host":"jump1.com","port":22,"username":"admin","authMethod":"password","privateKeyPath":""}]"#
+        let encoded = jumpJson.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com&sshJumpHosts=\(encoded)")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.jumpHosts?.count == 1)
+        #expect(conn.sshConfig?.jumpHosts?.first?.host == "jump1.com")
+        #expect(conn.sshConfig?.jumpHosts?.first?.username == "admin")
+    }
+
+    @Test("Import with invalid jump hosts JSON ignores gracefully")
+    func testImportInvalidJumpHostsJSON() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com&sshJumpHosts=not-json")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshConfig?.jumpHosts == nil)
+    }
+
+    // MARK: - Import — SSL Config
+
+    @Test("Import with SSL config")
+    func testImportWithSSL() {
+        let url = URL(string: "tablepro://import?name=Prod&host=db.com&type=postgresql&sslMode=require&sslCaCertPath=~/certs/ca.pem&sslClientCertPath=~/certs/client.pem&sslClientKeyPath=~/certs/client.key")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sslConfig != nil)
+        #expect(conn.sslConfig?.mode == "require")
+        #expect(conn.sslConfig?.caCertificatePath == "~/certs/ca.pem")
+        #expect(conn.sslConfig?.clientCertificatePath == "~/certs/client.pem")
+        #expect(conn.sslConfig?.clientKeyPath == "~/certs/client.key")
+    }
+
+    @Test("Import without sslMode has no SSL config")
+    func testImportNoSSLMode() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&sslCaCertPath=~/ca.pem")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sslConfig == nil)
+    }
+
+    @Test("Import with SSL mode only, no cert paths")
+    func testImportSSLModeOnly() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&sslMode=preferred")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sslConfig?.mode == "preferred")
+        #expect(conn.sslConfig?.caCertificatePath == nil)
+    }
+
+    // MARK: - Import — Metadata
+
+    @Test("Import with color")
+    func testImportWithColor() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&color=red")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.color == "red")
+    }
+
+    @Test("Import with tag and group names")
+    func testImportWithTagAndGroup() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&tagName=production&groupName=Backend%20Services")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.tagName == "production")
+        #expect(conn.groupName == "Backend Services")
+    }
+
+    @Test("Import with safe mode level")
+    func testImportWithSafeModeLevel() {
+        let url = URL(string: "tablepro://import?name=Prod&host=db.com&type=postgresql&safeModeLevel=readOnly")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.safeModeLevel == "readOnly")
+    }
+
+    @Test("Import with AI policy")
+    func testImportWithAIPolicy() {
+        let url = URL(string: "tablepro://import?name=Prod&host=db.com&type=postgresql&aiPolicy=never")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.aiPolicy == "never")
+    }
+
+    // MARK: - Import — Other Fields
+
+    @Test("Import with Redis database")
+    func testImportWithRedisDatabase() {
+        let url = URL(string: "tablepro://import?name=Cache&host=localhost&type=redis&redisDatabase=3")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.redisDatabase == 3)
+    }
+
+    @Test("Import with startup commands")
+    func testImportWithStartupCommands() {
+        let commands = "SET search_path TO myschema;"
+        let encoded = commands.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=postgresql&startupCommands=\(encoded)")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.startupCommands == commands)
+    }
+
+    @Test("Import with localOnly flag")
+    func testImportWithLocalOnly() {
+        let url = URL(string: "tablepro://import?name=Local&host=localhost&type=sqlite&localOnly=1")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.localOnly == true)
+    }
+
+    @Test("Import without localOnly defaults to nil")
+    func testImportLocalOnlyDefault() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.localOnly == nil)
+    }
+
+    // MARK: - Import — Additional Fields (Plugin)
+
+    @Test("Import with additional fields using af_ prefix")
+    func testImportAdditionalFields() {
+        let url = URL(string: "tablepro://import?name=Mongo&host=cluster.mongodb.net&type=mongodb&af_authSource=admin&af_replicaSet=rs0&af_useSrv=true")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.additionalFields?["authSource"] == "admin")
+        #expect(conn.additionalFields?["replicaSet"] == "rs0")
+        #expect(conn.additionalFields?["useSrv"] == "true")
+    }
+
+    @Test("Import with af_ prefix but no value is ignored")
+    func testImportAdditionalFieldsNoValue() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&af_emptyField=")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.additionalFields == nil)
+    }
+
+    @Test("Import with af_ prefix but empty key is ignored")
+    func testImportAdditionalFieldsEmptyKey() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&af_=someValue")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.additionalFields == nil)
+    }
+
+    // MARK: - Import — Combined Full Config
+
+    @Test("Import with all fields combined")
+    func testImportFullConfig() {
+        var components = URLComponents()
+        components.scheme = "tablepro"
+        components.host = "import"
+        components.queryItems = [
+            URLQueryItem(name: "name", value: "Production DB"),
+            URLQueryItem(name: "host", value: "db.prod.internal"),
+            URLQueryItem(name: "port", value: "5433"),
+            URLQueryItem(name: "type", value: "postgresql"),
+            URLQueryItem(name: "username", value: "app_user"),
+            URLQueryItem(name: "database", value: "main"),
+            URLQueryItem(name: "ssh", value: "1"),
+            URLQueryItem(name: "sshHost", value: "bastion.prod.com"),
+            URLQueryItem(name: "sshPort", value: "2222"),
+            URLQueryItem(name: "sshUsername", value: "deploy"),
+            URLQueryItem(name: "sshAuthMethod", value: "privateKey"),
+            URLQueryItem(name: "sshPrivateKeyPath", value: "~/.ssh/prod_key"),
+            URLQueryItem(name: "sslMode", value: "verify-ca"),
+            URLQueryItem(name: "sslCaCertPath", value: "~/certs/ca.pem"),
+            URLQueryItem(name: "color", value: "red"),
+            URLQueryItem(name: "tagName", value: "production"),
+            URLQueryItem(name: "groupName", value: "Backend"),
+            URLQueryItem(name: "safeModeLevel", value: "readOnly"),
+            URLQueryItem(name: "aiPolicy", value: "never"),
+            URLQueryItem(name: "startupCommands", value: "SET statement_timeout = 30000;"),
+            URLQueryItem(name: "af_schema", value: "public"),
+        ]
+        let url = components.url!
+
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+
+        #expect(conn.name == "Production DB")
+        #expect(conn.host == "db.prod.internal")
+        #expect(conn.port == 5433)
+        #expect(conn.type == "PostgreSQL")
+        #expect(conn.username == "app_user")
+        #expect(conn.database == "main")
+
+        #expect(conn.sshConfig?.enabled == true)
+        #expect(conn.sshConfig?.host == "bastion.prod.com")
+        #expect(conn.sshConfig?.port == 2222)
+        #expect(conn.sshConfig?.username == "deploy")
+        #expect(conn.sshConfig?.authMethod == "privateKey")
+        #expect(conn.sshConfig?.privateKeyPath == "~/.ssh/prod_key")
+
+        #expect(conn.sslConfig?.mode == "verify-ca")
+        #expect(conn.sslConfig?.caCertificatePath == "~/certs/ca.pem")
+
+        #expect(conn.color == "red")
+        #expect(conn.tagName == "production")
+        #expect(conn.groupName == "Backend")
+        #expect(conn.safeModeLevel == "readOnly")
+        #expect(conn.aiPolicy == "never")
+        #expect(conn.startupCommands == "SET statement_timeout = 30000;")
+        #expect(conn.additionalFields?["schema"] == "public")
+    }
+
+    // MARK: - Import — Security
+
+    @Test("Import link never contains password field")
+    func testImportNoPasswordField() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&password=secret123")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.name == "Dev")
+    }
+
+    // MARK: - Import — Edge Cases
+
+    @Test("Import with percent-encoded special characters in name")
+    func testImportSpecialCharsInName() {
+        let url = URL(string: "tablepro://import?name=Dev%20%26%20Staging&host=localhost&type=mysql")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.name == "Dev & Staging")
+    }
+
+    @Test("Import with IPv6 host")
+    func testImportIPv6Host() {
+        let url = URL(string: "tablepro://import?name=IPv6&host=::1&type=postgresql")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.host == "::1")
+    }
+
+    @Test("Import with no query params returns nil")
+    func testImportNoQueryParams() {
+        let url = URL(string: "tablepro://import")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("Import with unknown type returns nil")
+    func testImportUnknownType() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=nonexistent_db")!
+        #expect(DeeplinkHandler.parse(url) == nil)
+    }
+
+    @Test("sshProfileId is always nil in deep links")
+    func testImportSSHProfileIdAlwaysNil() {
+        let url = URL(string: "tablepro://import?name=Dev&host=localhost&type=mysql&ssh=1&sshHost=bastion.com")!
+        guard case .importConnection(let conn) = DeeplinkHandler.parse(url) else {
+            Issue.record("Expected .importConnection")
+            return
+        }
+        #expect(conn.sshProfileId == nil)
     }
 }


### PR DESCRIPTION
## Summary

Full connection sharing feature extending the existing export/import infrastructure.

### What's new
- **Share submenu** in connection context menu: Copy Connection String, Copy TablePro Link, Copy as JSON, Export to File
- **Rich deep links** — `tablepro://import` now carries ALL connection fields (SSH, SSL, plugin fields, color, tag, group, safe mode, AI policy) instead of just 6 basic fields
- **Import preview sheet** — proper SwiftUI sheet with editable name, full field preview, duplicate detection, and warnings when receiving a deep link
- **Copy as JSON** — new sharing format for compact portable connection config

### Security
- No passwords, SSH passwords, key passphrases, TOTP secrets, or plugin secure fields in deep links
- Built from `ExportableConnection` via `buildEnvelope()` which strips all secure fields
- Import preview requires user confirmation before creating anything

### Backward compatibility
- Old `tablepro://import?name=...&host=...&type=...` links with 6 params still parse correctly

**10 files changed, +484 -82**

## Test plan
- [ ] Right-click connection → Share → Copy TablePro Link → paste in browser → import sheet opens with all fields
- [ ] Right-click → Share → Copy Connection String → valid database URL
- [ ] Right-click → Share → Copy as JSON → valid JSON with all non-secret fields
- [ ] Right-click → Share → Export to File → existing export flow works
- [ ] Multi-select → Share → Export N Connections to File
- [ ] Old 6-param `tablepro://import` links still work
- [ ] Import sheet shows duplicate warning for existing connections
- [ ] Import sheet editable name field works
- [ ] SSH connection deep link preserves SSH config