### PR TITLE
perf(ai): cache provider key availability and stop idle Copilot LSP

### DIFF
--- a/TablePro/Core/AI/Copilot/CopilotIdleStopController.swift
+++ b/TablePro/Core/AI/Copilot/CopilotIdleStopController.swift
@@ -1,0 +1,57 @@
+//
+//  CopilotIdleStopController.swift
+//  TablePro
+//
+//  Schedules a deferred stop when an external condition (typically:
+//  Copilot LSP server is running but the user hasn't signed in) holds
+//  past a timeout. Pulled out of CopilotService so the timer logic
+//  can be unit-tested without launching the real LSP process.
+//
+
+import Foundation
+
+@MainActor
+final class CopilotIdleStopController {
+    private let timeout: Duration
+    private let isAuthenticated: () -> Bool
+    private let isRunning: () -> Bool
+    private let onStopRequest: () async -> Void
+    private var task: Task<Void, Never>?
+
+    init(
+        timeout: Duration,
+        isAuthenticated: @escaping () -> Bool,
+        isRunning: @escaping () -> Bool,
+        onStopRequest: @escaping () async -> Void
+    ) {
+        self.timeout = timeout
+        self.isAuthenticated = isAuthenticated
+        self.isRunning = isRunning
+        self.onStopRequest = onStopRequest
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    /// Cancel any prior schedule and start a new one. No-op when already authenticated.
+    func schedule() {
+        task?.cancel()
+        guard !isAuthenticated() else {
+            task = nil
+            return
+        }
+        task = Task {
+            try? await Task.sleep(for: self.timeout)
+            guard !Task.isCancelled else { return }
+            guard !self.isAuthenticated(), self.isRunning() else { return }
+            await self.onStopRequest()
+        }
+    }
+
+    /// Cancel any pending stop without triggering it.
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/TablePro/Core/AI/Copilot/CopilotService.swift
+++ b/TablePro/Core/AI/Copilot/CopilotService.swift
@@ -38,8 +38,16 @@ final class CopilotService {
     @ObservationIgnored private var serverGeneration: Int = 0
     @ObservationIgnored private var restartTask: Task<Void, Never>?
     @ObservationIgnored private var restartAttempt: Int = 0
-    @ObservationIgnored private var unauthenticatedStopTask: Task<Void, Never>?
     @ObservationIgnored private let authManager = CopilotAuthManager()
+    @ObservationIgnored private lazy var unauthenticatedStop = CopilotIdleStopController(
+        timeout: Self.unauthenticatedTimeout,
+        isAuthenticated: { self.isAuthenticated },
+        isRunning: { self.status == .running },
+        onStopRequest: {
+            Self.logger.info("Copilot LSP idle without sign-in, stopping")
+            await self.stop()
+        }
+    )
 
     /// Stops the LSP server if the user hasn't signed in within this window after start.
     /// Avoids leaving a Node process idle for users who add a Copilot config but never authorise.
@@ -114,8 +122,7 @@ final class CopilotService {
     func stop() async {
         restartTask?.cancel()
         restartTask = nil
-        unauthenticatedStopTask?.cancel()
-        unauthenticatedStopTask = nil
+        unauthenticatedStop.cancel()
         serverGeneration += 1
 
         if let client = lspClient {
@@ -149,8 +156,7 @@ final class CopilotService {
         }
         let username = try await authManager.completeSignIn(transport: transport)
         authState = .signedIn(username: username)
-        unauthenticatedStopTask?.cancel()
-        unauthenticatedStopTask = nil
+        unauthenticatedStop.cancel()
     }
 
     func signOut() async {
@@ -197,15 +203,7 @@ final class CopilotService {
     }
 
     private func scheduleUnauthenticatedStopIfNeeded() {
-        unauthenticatedStopTask?.cancel()
-        guard !isAuthenticated else { return }
-        unauthenticatedStopTask = Task {
-            try? await Task.sleep(for: Self.unauthenticatedTimeout)
-            guard !Task.isCancelled else { return }
-            guard !self.isAuthenticated, self.status == .running else { return }
-            Self.logger.info("Copilot LSP idle without sign-in, stopping")
-            await self.stop()
-        }
+        unauthenticatedStop.schedule()
     }
 
     private func handleStatusNotification(_ data: Data) {

--- a/TablePro/Core/AI/Copilot/CopilotService.swift
+++ b/TablePro/Core/AI/Copilot/CopilotService.swift
@@ -41,11 +41,11 @@ final class CopilotService {
     @ObservationIgnored private let authManager = CopilotAuthManager()
     @ObservationIgnored private lazy var unauthenticatedStop = CopilotIdleStopController(
         timeout: Self.unauthenticatedTimeout,
-        isAuthenticated: { self.isAuthenticated },
-        isRunning: { self.status == .running },
-        onStopRequest: {
+        isAuthenticated: { [weak self] in self?.isAuthenticated ?? true },
+        isRunning: { [weak self] in self?.status == .running },
+        onStopRequest: { [weak self] in
             Self.logger.info("Copilot LSP idle without sign-in, stopping")
-            await self.stop()
+            await self?.stop()
         }
     )
 

--- a/TablePro/Core/AI/Copilot/CopilotService.swift
+++ b/TablePro/Core/AI/Copilot/CopilotService.swift
@@ -38,7 +38,12 @@ final class CopilotService {
     @ObservationIgnored private var serverGeneration: Int = 0
     @ObservationIgnored private var restartTask: Task<Void, Never>?
     @ObservationIgnored private var restartAttempt: Int = 0
+    @ObservationIgnored private var unauthenticatedStopTask: Task<Void, Never>?
     @ObservationIgnored private let authManager = CopilotAuthManager()
+
+    /// Stops the LSP server if the user hasn't signed in within this window after start.
+    /// Avoids leaving a Node process idle for users who add a Copilot config but never authorise.
+    private static let unauthenticatedTimeout: Duration = .seconds(5 * 60)
 
     private init() {}
 
@@ -93,6 +98,7 @@ final class CopilotService {
             Self.logger.info("Copilot language server started successfully")
 
             await checkAuthStatus()
+            scheduleUnauthenticatedStopIfNeeded()
         } catch {
             guard generation == serverGeneration else { return }
             status = .error(error.localizedDescription)
@@ -108,6 +114,8 @@ final class CopilotService {
     func stop() async {
         restartTask?.cancel()
         restartTask = nil
+        unauthenticatedStopTask?.cancel()
+        unauthenticatedStopTask = nil
         serverGeneration += 1
 
         if let client = lspClient {
@@ -138,12 +146,15 @@ final class CopilotService {
         }
         let username = try await authManager.completeSignIn(transport: transport)
         authState = .signedIn(username: username)
+        unauthenticatedStopTask?.cancel()
+        unauthenticatedStopTask = nil
     }
 
     func signOut() async {
         guard let transport else { return }
         await authManager.signOut(transport: transport)
         authState = .signedOut
+        scheduleUnauthenticatedStopIfNeeded()
     }
 
     // MARK: - Private
@@ -182,6 +193,18 @@ final class CopilotService {
         }
     }
 
+    private func scheduleUnauthenticatedStopIfNeeded() {
+        unauthenticatedStopTask?.cancel()
+        guard !isAuthenticated else { return }
+        unauthenticatedStopTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.unauthenticatedTimeout)
+            guard !Task.isCancelled, let self else { return }
+            guard !self.isAuthenticated, self.status == .running else { return }
+            Self.logger.info("Copilot LSP idle without sign-in, stopping")
+            await self.stop()
+        }
+    }
+
     private func handleStatusNotification(_ data: Data) {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let params = json["params"] as? [String: Any] else { return }
@@ -194,6 +217,7 @@ final class CopilotService {
             statusMessage = message
             if let message, message.lowercased().contains("sign") || message.lowercased().contains("expired") {
                 authState = .signedOut
+                scheduleUnauthenticatedStopIfNeeded()
             }
         case "Warning":
             statusMessage = message

--- a/TablePro/Core/AI/Copilot/CopilotService.swift
+++ b/TablePro/Core/AI/Copilot/CopilotService.swift
@@ -133,6 +133,9 @@ final class CopilotService {
     // MARK: - Authentication
 
     func signIn() async throws {
+        if status == .stopped {
+            await start()
+        }
         guard let transport else {
             throw CopilotError.serverNotRunning
         }
@@ -196,9 +199,9 @@ final class CopilotService {
     private func scheduleUnauthenticatedStopIfNeeded() {
         unauthenticatedStopTask?.cancel()
         guard !isAuthenticated else { return }
-        unauthenticatedStopTask = Task { [weak self] in
+        unauthenticatedStopTask = Task {
             try? await Task.sleep(for: Self.unauthenticatedTimeout)
-            guard !Task.isCancelled, let self else { return }
+            guard !Task.isCancelled else { return }
             guard !self.isAuthenticated, self.status == .running else { return }
             Self.logger.info("Copilot LSP idle without sign-in, stopping")
             await self.stop()

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -19,8 +19,12 @@ final class SchemaProviderRegistry {
     private var refCounts: [UUID: Int] = [:]
     private var removalTasks: [UUID: Task<Void, Never>] = [:]
 
-    /// Internal so `@testable` tests can construct isolated instances; production code uses `.shared`.
+    #if DEBUG
+    /// Test-only init for `@testable` tests in DEBUG builds; release builds must use `.shared`.
     internal init() {}
+    #else
+    private init() {}
+    #endif
 
     func provider(for connectionId: UUID) -> SQLSchemaProvider? {
         providers[connectionId]

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -19,7 +19,8 @@ final class SchemaProviderRegistry {
     private var refCounts: [UUID: Int] = [:]
     private var removalTasks: [UUID: Task<Void, Never>] = [:]
 
-    private init() {}
+    /// Internal so `@testable` tests can construct isolated instances; production code uses `.shared`.
+    internal init() {}
 
     func provider(for connectionId: UUID) -> SQLSchemaProvider? {
         providers[connectionId]

--- a/TablePro/Views/Settings/AISettingsView.swift
+++ b/TablePro/Views/Settings/AISettingsView.swift
@@ -15,6 +15,7 @@ struct AISettingsView: View {
     @State private var addingProviderType: AIProviderType?
     @State private var pendingDeleteID: UUID?
     @State private var copilotService = CopilotService.shared
+    @State private var providersWithKey: Set<UUID> = []
 
     var body: some View {
         Form {
@@ -28,6 +29,10 @@ struct AISettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .task { refreshKeyAvailability() }
+        .onChange(of: settings.providers.map(\.id)) {
+            refreshKeyAvailability()
+        }
         .sheet(item: editingProviderBinding) { provider in
             AIProviderDetailSheet(
                 provider: provider,
@@ -301,10 +306,9 @@ struct AISettingsView: View {
             if provider.type == .custom {
                 return customStatusText(for: provider)
             }
-            let key = AIKeyStorage.shared.loadAPIKey(for: provider.id) ?? ""
-            return key.isEmpty
-                ? String(localized: "Not configured")
-                : String(localized: "API key set")
+            return providersWithKey.contains(provider.id)
+                ? String(localized: "API key set")
+                : String(localized: "Not configured")
         case .none:
             if provider.type == .ollama {
                 let endpoint = provider.endpoint.isEmpty ? provider.type.defaultEndpoint : provider.endpoint
@@ -331,14 +335,23 @@ struct AISettingsView: View {
     }
 
     private func customStatusText(for provider: AIProviderConfig) -> String {
-        let key = AIKeyStorage.shared.loadAPIKey(for: provider.id) ?? ""
-        if !key.isEmpty {
+        if providersWithKey.contains(provider.id) {
             return String(localized: "API key set")
         }
         if let host = URL(string: provider.endpoint)?.host, !host.isEmpty {
             return host
         }
         return String(localized: "Not configured")
+    }
+
+    private func refreshKeyAvailability() {
+        var ids: Set<UUID> = []
+        for provider in settings.providers where provider.type.authStyle == .apiKey {
+            if let key = AIKeyStorage.shared.loadAPIKey(for: provider.id), !key.isEmpty {
+                ids.insert(provider.id)
+            }
+        }
+        providersWithKey = ids
     }
 
     // MARK: - Mutations
@@ -367,6 +380,7 @@ struct AISettingsView: View {
         }
 
         AIProviderFactory.invalidateCache(for: provider.id)
+        refreshKeyAvailability()
 
         if isNew, settings.activeProviderID == nil {
             settings.activeProviderID = provider.id
@@ -380,6 +394,7 @@ struct AISettingsView: View {
         if settings.activeProviderID == id {
             settings.activeProviderID = nil
         }
+        refreshKeyAvailability()
     }
 }
 

--- a/TableProTests/Core/AI/CopilotIdleStopControllerTests.swift
+++ b/TableProTests/Core/AI/CopilotIdleStopControllerTests.swift
@@ -1,0 +1,111 @@
+//
+//  CopilotIdleStopControllerTests.swift
+//  TableProTests
+//
+//  Verifies the deferred-stop state machine extracted from CopilotService.
+//
+
+@testable import TablePro
+import Testing
+
+@MainActor
+private final class TestState {
+    var authenticated: Bool
+    var running: Bool
+    var stopCount: Int = 0
+
+    init(authenticated: Bool = false, running: Bool = true) {
+        self.authenticated = authenticated
+        self.running = running
+    }
+}
+
+@Suite("CopilotIdleStopController")
+@MainActor
+struct CopilotIdleStopControllerTests {
+    private static let timeout: Duration = .milliseconds(40)
+    private static let waitPastTimeout: Duration = .milliseconds(120)
+    private static let waitMidTimeout: Duration = .milliseconds(15)
+
+    private func makeController(state: TestState) -> CopilotIdleStopController {
+        CopilotIdleStopController(
+            timeout: Self.timeout,
+            isAuthenticated: { state.authenticated },
+            isRunning: { state.running },
+            onStopRequest: { state.stopCount += 1 }
+        )
+    }
+
+    @Test("Stops when timer fires while unauthenticated and running")
+    func stopsAfterTimeout() async throws {
+        let state = TestState()
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 1)
+    }
+
+    @Test("Skips when already authenticated at schedule time")
+    func skipsWhenAuthenticated() async throws {
+        let state = TestState(authenticated: true)
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 0)
+    }
+
+    @Test("Skips when authenticated by fire time")
+    func skipsWhenAuthenticatedByFireTime() async throws {
+        let state = TestState()
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        try await Task.sleep(for: Self.waitMidTimeout)
+        state.authenticated = true
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 0)
+    }
+
+    @Test("Skips when not running by fire time")
+    func skipsWhenNotRunningByFireTime() async throws {
+        let state = TestState()
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        state.running = false
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 0)
+    }
+
+    @Test("Cancel before fire prevents stop")
+    func cancelPreventsStop() async throws {
+        let state = TestState()
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        try await Task.sleep(for: Self.waitMidTimeout)
+        controller.cancel()
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 0)
+    }
+
+    @Test("Reschedule cancels prior timer; only fires once")
+    func rescheduleFiresOnce() async throws {
+        let state = TestState()
+        let controller = makeController(state: state)
+
+        controller.schedule()
+        try await Task.sleep(for: Self.waitMidTimeout)
+        controller.schedule()
+        try await Task.sleep(for: Self.waitPastTimeout)
+
+        #expect(state.stopCount == 1)
+    }
+}

--- a/TableProTests/Core/Database/DatabaseManagerVersionTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerVersionTests.swift
@@ -67,25 +67,6 @@ struct DatabaseManagerVersionTests {
         manager.removeSession(for: id)
     }
 
-    @Test("sessionVersion returns connectionStatusVersion for backward compatibility")
-    func sessionVersionBackwardCompat() {
-        let manager = DatabaseManager.shared
-        #expect(manager.sessionVersion == manager.connectionStatusVersion)
-
-        let (id, session) = makeSession()
-        manager.injectSession(session, for: id)
-
-        #expect(manager.sessionVersion == manager.connectionStatusVersion)
-
-        manager.updateSession(id) { session in
-            session.status = .connected
-        }
-
-        #expect(manager.sessionVersion == manager.connectionStatusVersion)
-
-        manager.removeSession(for: id)
-    }
-
     @Test("Multiple rapid mutations increment counters correctly")
     func rapidMutationsIncrementCorrectly() {
         let manager = DatabaseManager.shared

--- a/TableProTests/Core/Services/ConnectionSharingTests.swift
+++ b/TableProTests/Core/Services/ConnectionSharingTests.swift
@@ -309,7 +309,7 @@ struct ConnectionSharingTests {
                 name: "Dev MySQL", host: "db.example.com", port: 3307,
                 database: "app_db", username: "dev_user", type: .mysql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -340,7 +340,7 @@ struct ConnectionSharingTests {
                 database: "main", username: "app", type: .postgresql,
                 sshConfig: ssh
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -371,7 +371,7 @@ struct ConnectionSharingTests {
                 database: "secure", username: "admin", type: .postgresql,
                 sslConfig: ssl
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -396,7 +396,7 @@ struct ConnectionSharingTests {
                 startupCommands: "SET statement_timeout = 30000;",
                 localOnly: true
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -417,7 +417,7 @@ struct ConnectionSharingTests {
                 database: "", username: "", type: .redis,
                 redisDatabase: 5
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -433,7 +433,7 @@ struct ConnectionSharingTests {
                 name: "Dev & Staging (v2)", host: "db.example.com", port: 5432,
                 database: "my database", username: "user@company.com", type: .postgresql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -451,7 +451,7 @@ struct ConnectionSharingTests {
                 name: "Bare", host: "localhost", port: 5432,
                 database: "", username: "", type: .postgresql
             )
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")
@@ -483,7 +483,7 @@ struct ConnectionSharingTests {
             ssh.jumpHosts = [
                 SSHJumpHost(
                     host: "jump1.com", port: 22, username: "admin",
-                    authMethod: .password, privateKeyPath: ""
+                    authMethod: .privateKey, privateKeyPath: "~/.ssh/jump_key"
                 )
             ]
 
@@ -508,7 +508,7 @@ struct ConnectionSharingTests {
                 additionalFields: ["schema": "public"]
             )
 
-            let link = ConnectionExportService.buildImportDeeplink(for: original)
+            let link = ConnectionExportService.buildImportDeeplink(for: original)!
             let url = URL(string: link)!
             guard case .importConnection(let parsed) = DeeplinkHandler.parse(url) else {
                 Issue.record("Failed to parse round-trip link")

--- a/TableProTests/Models/EditorTabPayloadTests.swift
+++ b/TableProTests/Models/EditorTabPayloadTests.swift
@@ -138,6 +138,6 @@ struct EditorTabPayloadTests {
         #expect(payload.databaseName == tab.databaseName)
         #expect(payload.initialQuery == tab.query)
         #expect(payload.isView == tab.isView)
-        #expect(payload.showStructure == tab.showStructure)
+        #expect(payload.showStructure == (tab.resultsViewMode == .structure))
     }
 }

--- a/TableProTests/Views/Main/CommandActionsDispatchTests.swift
+++ b/TableProTests/Views/Main/CommandActionsDispatchTests.swift
@@ -98,7 +98,7 @@ struct CommandActionsDispatchTests {
 
         // Enable structure mode on the selected tab
         if let idx = coordinator.tabManager.selectedTabIndex {
-            coordinator.tabManager.tabs[idx].showStructure = true
+            coordinator.tabManager.tabs[idx].resultsViewMode = .structure
         }
 
         // Install a spy handler
@@ -121,7 +121,7 @@ struct CommandActionsDispatchTests {
 
         // Enable structure mode on the selected tab
         if let idx = coordinator.tabManager.selectedTabIndex {
-            coordinator.tabManager.tabs[idx].showStructure = true
+            coordinator.tabManager.tabs[idx].resultsViewMode = .structure
         }
 
         // Install a spy handler

--- a/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
+++ b/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
@@ -22,7 +22,7 @@ struct MainStatusBarLayoutTests {
             columnVisibilityManager: colVisManager,
             allColumns: [],
             selectedRowIndices: [],
-            showStructure: .constant(false),
+            viewMode: .constant(.data),
             onFirstPage: {},
             onPreviousPage: {},
             onNextPage: {},

--- a/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
+++ b/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
@@ -52,11 +52,11 @@ struct MultiConnectionNavigationTests {
             Issue.record("Expected selected tab index")
             return
         }
-        #expect(tabManager.tabs[idx].showStructure == false)
+        #expect(tabManager.tabs[idx].resultsViewMode != .structure)
 
         coordinator.openTableTab("users", showStructure: true)
 
-        #expect(tabManager.tabs[idx].showStructure == true)
+        #expect(tabManager.tabs[idx].resultsViewMode == .structure)
     }
 
     // MARK: - openTableTab: isView marks tab correctly

--- a/TableProTests/Views/Main/SessionStateFactoryTests.swift
+++ b/TableProTests/Views/Main/SessionStateFactoryTests.swift
@@ -88,7 +88,7 @@ struct SessionStateFactoryTests {
             Issue.record("Expected at least one tab")
             return
         }
-        #expect(tab.showStructure == true)
+        #expect(tab.resultsViewMode == .structure)
     }
 
     @Test("Payload with isView sets isView and clears isEditable")


### PR DESCRIPTION
## Summary

Two follow-ups deferred from the AI settings rewrite review (#879):

### 1. Keychain caching in AI settings

`AISettingsView.statusText(for:)` was hitting the Keychain on every row render to compute the status caption (\"API key set\" / \"Not configured\"). With multiple providers, that's N Keychain calls every time SwiftUI re-renders the form (which happens for every settings tweak).

Replaced with a cached \`Set<UUID>\` of providers that have a stored key. Refreshed on:
- View \`.task\` (initial load)
- \`onChange(of: settings.providers.map(\\.id))\` (add/remove)
- After save in detail sheet
- After provider removal

### 2. Idle stop for unauthenticated Copilot

Adding a Copilot provider auto-starts the LSP server (~50-100MB Node process). If the user never completes sign-in, the server runs forever.

Added a 5-minute timer that stops the LSP server when:
- Server is running AND
- User is not authenticated

Timer rules:
- Scheduled after \`start()\` succeeds
- Scheduled when auth flips to \`.signedOut\` (sign out or server-reported expiry)
- Cancelled when \`completeSignIn()\` succeeds
- Cancelled when \`stop()\` is called

Authenticated users are unaffected: their server stays running for chat and inline suggestions.

## Test plan

- [ ] Settings > AI: open with several providers configured, verify status captions are correct
- [ ] Add provider with API key > save > status updates to \"API key set\" without delay
- [ ] Remove provider > status disappears immediately
- [ ] Add Copilot provider but don't sign in > wait 5 minutes > LSP server stops (check console for \"Copilot LSP idle without sign-in, stopping\")
- [ ] Add Copilot, complete sign-in within 5 min > server stays running
- [ ] Sign out an authenticated Copilot > 5 min later, server stops