### PR TITLE
fix(docs): customization overview 404 from YAML colon parse

### DIFF
--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Customization Overview
-description: Three settings tabs cover all customization in TablePro: Settings, Appearance, and Editor.
+description: Three settings tabs cover all TablePro customization. Settings, Appearance, and Editor.
 ---
 
 # Customization


### PR DESCRIPTION
## Bug

`https://docs.tablepro.app/customization/overview` returned 404 after PR #881. The other new overview pages (`features/overview`, `development/overview`) were fine.

## Cause

The frontmatter description contained an unquoted colon:

```yaml
description: Three settings tabs cover all customization in TablePro: Settings, Appearance, and Editor.
```

Mintlify's YAML parser saw `TablePro: Settings, ...` as a nested key and dropped the page from the deployed build.

## Fix

Rephrased to remove the inner colon:

```yaml
description: Three settings tabs cover all TablePro customization. Settings, Appearance, and Editor.
```

## Test plan

- [ ] Mintlify rebuild after merge
- [ ] `curl -I https://docs.tablepro.app/customization/overview` returns 200