### PR TITLE
test(ai): cover AISettings.activeProvider, migrateAI, Factory.resolve

### DIFF
--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -214,7 +214,8 @@ final class AppSettingsManager {
     /// Auto-pick the first configured provider as active when nothing is selected.
     /// Avoids a "AI suddenly stopped working" upgrade UX when older settings JSON
     /// (with multiple providers and no activeProviderID concept) is loaded.
-    private static func migrateAI(_ settings: AISettings) -> AISettings {
+    /// Internal so `@testable` tests can exercise it directly.
+    internal static func migrateAI(_ settings: AISettings) -> AISettings {
         guard settings.activeProviderID == nil, let first = settings.providers.first else {
             return settings
         }

--- a/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
+++ b/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
@@ -1,0 +1,136 @@
+//
+//  AIProviderFactoryResolveTests.swift
+//  TableProTests
+//
+//  Verifies AIProviderFactory.resolve(settings:) returns the active
+//  provider's config or nil according to enabled / activeProvider rules.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AIProviderFactory.resolve")
+@MainActor
+struct AIProviderFactoryResolveTests {
+    /// Each test uses a unique provider id so the factory cache (keyed by id)
+    /// doesn't leak state between tests.
+    private func makeProvider(
+        id: UUID = UUID(),
+        name: String = "Test",
+        type: AIProviderType = .claude,
+        model: String = "test-model"
+    ) -> AIProviderConfig {
+        AIProviderConfig(id: id, name: name, type: type, model: model)
+    }
+
+    @Test("Returns nil when AI is disabled")
+    func nilWhenDisabled() {
+        let provider = makeProvider()
+        let settings = AISettings(
+            enabled: false,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        #expect(AIProviderFactory.resolve(settings: settings) == nil)
+    }
+
+    @Test("Returns nil when no active provider is set")
+    func nilWhenNoActive() {
+        let provider = makeProvider()
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: nil
+        )
+        #expect(AIProviderFactory.resolve(settings: settings) == nil)
+    }
+
+    @Test("Returns nil when activeProviderID points to a missing provider")
+    func nilWhenIDDoesNotMatch() {
+        let provider = makeProvider()
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: UUID()
+        )
+        #expect(AIProviderFactory.resolve(settings: settings) == nil)
+    }
+
+    @Test("Returns ResolvedProvider for an active apiKey provider")
+    func resolvesApiKeyProvider() {
+        let provider = makeProvider(type: .claude, model: "claude-3-5-sonnet")
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved != nil)
+        #expect(resolved?.config.id == provider.id)
+        #expect(resolved?.config.type == .claude)
+        #expect(resolved?.model == "claude-3-5-sonnet")
+        AIProviderFactory.invalidateCache(for: provider.id)
+    }
+
+    @Test("Returns ResolvedProvider for an oauth provider (Copilot, no key lookup)")
+    func resolvesOauthProvider() {
+        let provider = makeProvider(type: .copilot, model: "gpt-4o")
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved != nil)
+        #expect(resolved?.config.type == .copilot)
+        #expect(resolved?.model == "gpt-4o")
+        AIProviderFactory.invalidateCache(for: provider.id)
+    }
+
+    @Test("Returns ResolvedProvider for an Ollama provider (no auth)")
+    func resolvesOllamaProvider() {
+        let provider = makeProvider(type: .ollama, model: "llama3")
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved != nil)
+        #expect(resolved?.config.type == .ollama)
+        #expect(resolved?.model == "llama3")
+        AIProviderFactory.invalidateCache(for: provider.id)
+    }
+
+    @Test("Resolves the active provider when multiple are configured")
+    func picksActiveAmongMany() {
+        let claude = makeProvider(name: "Claude", type: .claude, model: "claude-x")
+        let openAI = makeProvider(name: "OpenAI", type: .openAI, model: "gpt-x")
+        let target = makeProvider(name: "Gemini", type: .gemini, model: "gemini-x")
+        let settings = AISettings(
+            enabled: true,
+            providers: [claude, openAI, target],
+            activeProviderID: target.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved?.config.id == target.id)
+        #expect(resolved?.config.type == .gemini)
+        AIProviderFactory.invalidateCache(for: claude.id)
+        AIProviderFactory.invalidateCache(for: openAI.id)
+        AIProviderFactory.invalidateCache(for: target.id)
+    }
+
+    @Test("Empty model string passes through to ResolvedProvider")
+    func emptyModelPassesThrough() {
+        let provider = makeProvider(type: .claude, model: "")
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved?.model == "")
+        AIProviderFactory.invalidateCache(for: provider.id)
+    }
+}

--- a/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
+++ b/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
@@ -60,6 +60,7 @@ struct AIProviderFactoryResolveTests {
     @Test("Returns ResolvedProvider for an active apiKey provider")
     func resolvesApiKeyProvider() {
         let provider = makeProvider(type: .claude, model: "claude-3-5-sonnet")
+        defer { AIProviderFactory.invalidateCache(for: provider.id) }
         let settings = AISettings(
             enabled: true,
             providers: [provider],
@@ -70,12 +71,12 @@ struct AIProviderFactoryResolveTests {
         #expect(resolved?.config.id == provider.id)
         #expect(resolved?.config.type == .claude)
         #expect(resolved?.model == "claude-3-5-sonnet")
-        AIProviderFactory.invalidateCache(for: provider.id)
     }
 
     @Test("Returns ResolvedProvider for an oauth provider (Copilot, no key lookup)")
     func resolvesOauthProvider() {
         let provider = makeProvider(type: .copilot, model: "gpt-4o")
+        defer { AIProviderFactory.invalidateCache(for: provider.id) }
         let settings = AISettings(
             enabled: true,
             providers: [provider],
@@ -85,12 +86,12 @@ struct AIProviderFactoryResolveTests {
         #expect(resolved != nil)
         #expect(resolved?.config.type == .copilot)
         #expect(resolved?.model == "gpt-4o")
-        AIProviderFactory.invalidateCache(for: provider.id)
     }
 
     @Test("Returns ResolvedProvider for an Ollama provider (no auth)")
     func resolvesOllamaProvider() {
         let provider = makeProvider(type: .ollama, model: "llama3")
+        defer { AIProviderFactory.invalidateCache(for: provider.id) }
         let settings = AISettings(
             enabled: true,
             providers: [provider],
@@ -100,7 +101,6 @@ struct AIProviderFactoryResolveTests {
         #expect(resolved != nil)
         #expect(resolved?.config.type == .ollama)
         #expect(resolved?.model == "llama3")
-        AIProviderFactory.invalidateCache(for: provider.id)
     }
 
     @Test("Resolves the active provider when multiple are configured")
@@ -108,6 +108,7 @@ struct AIProviderFactoryResolveTests {
         let claude = makeProvider(name: "Claude", type: .claude, model: "claude-x")
         let openAI = makeProvider(name: "OpenAI", type: .openAI, model: "gpt-x")
         let target = makeProvider(name: "Gemini", type: .gemini, model: "gemini-x")
+        defer { AIProviderFactory.invalidateCache(for: target.id) }
         let settings = AISettings(
             enabled: true,
             providers: [claude, openAI, target],
@@ -116,14 +117,12 @@ struct AIProviderFactoryResolveTests {
         let resolved = AIProviderFactory.resolve(settings: settings)
         #expect(resolved?.config.id == target.id)
         #expect(resolved?.config.type == .gemini)
-        AIProviderFactory.invalidateCache(for: claude.id)
-        AIProviderFactory.invalidateCache(for: openAI.id)
-        AIProviderFactory.invalidateCache(for: target.id)
     }
 
     @Test("Empty model string passes through to ResolvedProvider")
     func emptyModelPassesThrough() {
         let provider = makeProvider(type: .claude, model: "")
+        defer { AIProviderFactory.invalidateCache(for: provider.id) }
         let settings = AISettings(
             enabled: true,
             providers: [provider],
@@ -131,6 +130,5 @@ struct AIProviderFactoryResolveTests {
         )
         let resolved = AIProviderFactory.resolve(settings: settings)
         #expect(resolved?.model == "")
-        AIProviderFactory.invalidateCache(for: provider.id)
     }
 }

--- a/TableProTests/Core/Storage/AppSettingsManagerMigrationTests.swift
+++ b/TableProTests/Core/Storage/AppSettingsManagerMigrationTests.swift
@@ -1,0 +1,89 @@
+//
+//  AppSettingsManagerMigrationTests.swift
+//  TableProTests
+//
+//  Verifies the AISettings upgrade path that auto-picks an active
+//  provider when older settings JSON didn't have the concept.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AppSettingsManager.migrateAI")
+@MainActor
+struct AppSettingsManagerMigrationTests {
+    private func makeProvider(name: String, type: AIProviderType = .claude) -> AIProviderConfig {
+        AIProviderConfig(name: name, type: type)
+    }
+
+    @Test("No providers: leaves activeProviderID nil")
+    func emptyProvidersStaysNil() {
+        let input = AISettings(providers: [], activeProviderID: nil)
+        let migrated = AppSettingsManager.migrateAI(input)
+        #expect(migrated.activeProviderID == nil)
+        #expect(migrated.providers.isEmpty)
+    }
+
+    @Test("activeProviderID already set: returns settings unchanged")
+    func alreadySetReturnsUnchanged() {
+        let provider = makeProvider(name: "Claude")
+        let other = makeProvider(name: "Other")
+        let input = AISettings(providers: [other, provider], activeProviderID: provider.id)
+        let migrated = AppSettingsManager.migrateAI(input)
+        #expect(migrated.activeProviderID == provider.id)
+        #expect(migrated == input)
+    }
+
+    @Test("activeProviderID nil with one provider: picks that provider")
+    func picksOnlyProvider() {
+        let provider = makeProvider(name: "OpenAI", type: .openAI)
+        let input = AISettings(providers: [provider], activeProviderID: nil)
+        let migrated = AppSettingsManager.migrateAI(input)
+        #expect(migrated.activeProviderID == provider.id)
+    }
+
+    @Test("activeProviderID nil with multiple providers: picks the first")
+    func picksFirstWhenMultiple() {
+        let first = makeProvider(name: "First")
+        let second = makeProvider(name: "Second")
+        let third = makeProvider(name: "Third")
+        let input = AISettings(providers: [first, second, third], activeProviderID: nil)
+        let migrated = AppSettingsManager.migrateAI(input)
+        #expect(migrated.activeProviderID == first.id)
+    }
+
+    @Test("Migration is idempotent")
+    func idempotent() {
+        let provider = makeProvider(name: "Claude")
+        let input = AISettings(providers: [provider], activeProviderID: nil)
+        let once = AppSettingsManager.migrateAI(input)
+        let twice = AppSettingsManager.migrateAI(once)
+        #expect(once == twice)
+        #expect(twice.activeProviderID == provider.id)
+    }
+
+    @Test("Migration preserves other settings fields")
+    func preservesOtherFields() {
+        let provider = makeProvider(name: "Claude")
+        let input = AISettings(
+            enabled: false,
+            providers: [provider],
+            activeProviderID: nil,
+            inlineSuggestionsEnabled: true,
+            includeSchema: false,
+            includeCurrentQuery: false,
+            includeQueryResults: true,
+            maxSchemaTables: 50,
+            defaultConnectionPolicy: .never
+        )
+        let migrated = AppSettingsManager.migrateAI(input)
+        #expect(migrated.enabled == false)
+        #expect(migrated.inlineSuggestionsEnabled == true)
+        #expect(migrated.includeSchema == false)
+        #expect(migrated.includeCurrentQuery == false)
+        #expect(migrated.includeQueryResults == true)
+        #expect(migrated.maxSchemaTables == 50)
+        #expect(migrated.defaultConnectionPolicy == .never)
+    }
+}

--- a/TableProTests/Models/AISettingsTests.swift
+++ b/TableProTests/Models/AISettingsTests.swift
@@ -30,3 +30,67 @@ struct AISettingsTests {
         #expect(settings.enabled == false)
     }
 }
+
+// MARK: - Active Provider
+
+@Suite("AISettings.activeProvider")
+struct AISettingsActiveProviderTests {
+    private func makeProvider(name: String = "Test", type: AIProviderType = .claude) -> AIProviderConfig {
+        AIProviderConfig(name: name, type: type)
+    }
+
+    @Test("Returns nil when activeProviderID is nil")
+    func nilWhenIDNotSet() {
+        let settings = AISettings(providers: [makeProvider()], activeProviderID: nil)
+        #expect(settings.activeProvider == nil)
+        #expect(settings.hasActiveProvider == false)
+    }
+
+    @Test("Returns nil when activeProviderID does not match any provider")
+    func nilWhenIDMissing() {
+        let provider = makeProvider()
+        let settings = AISettings(providers: [provider], activeProviderID: UUID())
+        #expect(settings.activeProvider == nil)
+        #expect(settings.hasActiveProvider == false)
+    }
+
+    @Test("Returns the matching provider when activeProviderID matches")
+    func returnsMatchingProvider() {
+        let target = makeProvider(name: "Active")
+        let other = makeProvider(name: "Other")
+        let settings = AISettings(providers: [other, target], activeProviderID: target.id)
+        #expect(settings.activeProvider?.id == target.id)
+        #expect(settings.activeProvider?.name == "Active")
+        #expect(settings.hasActiveProvider == true)
+    }
+
+    @Test("hasCopilotConfigured detects a Copilot provider")
+    func hasCopilotConfigured() {
+        let claude = makeProvider(name: "Claude", type: .claude)
+        let copilot = makeProvider(name: "Copilot", type: .copilot)
+
+        let withoutCopilot = AISettings(providers: [claude], activeProviderID: claude.id)
+        #expect(withoutCopilot.hasCopilotConfigured == false)
+
+        let withCopilot = AISettings(providers: [claude, copilot], activeProviderID: claude.id)
+        #expect(withCopilot.hasCopilotConfigured == true)
+    }
+
+    @Test("Active provider survives decode round trip")
+    func decodeRoundTrip() throws {
+        let provider = makeProvider()
+        let settings = AISettings(providers: [provider], activeProviderID: provider.id)
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AISettings.self, from: data)
+        #expect(decoded.activeProvider?.id == provider.id)
+    }
+
+    @Test("Decoding without activeProviderID defaults to nil")
+    func decodingWithoutActiveProviderDefaultsToNil() throws {
+        let json = #"{"enabled": true, "providers": []}"#
+        let data = json.data(using: .utf8)!
+        let settings = try JSONDecoder().decode(AISettings.self, from: data)
+        #expect(settings.activeProviderID == nil)
+        #expect(settings.activeProvider == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds 20 unit tests for the AI settings layer that shipped in PR #879 but lacked coverage. Each suite is hermetic: no Keychain side effects, no network, fast (~1s total).

## Coverage

**AISettings.activeProvider** (6 tests)
- nil when activeProviderID is nil
- nil when activeProviderID does not match any provider
- returns the matching provider when ID matches
- hasCopilotConfigured detects a Copilot provider
- decode round-trip preserves activeProviderID
- decoding without activeProviderID defaults to nil

**AppSettingsManager.migrateAI** (6 tests)
- empty providers stays nil
- activeProviderID already set returns unchanged
- picks the only provider when one exists
- picks the first provider when many exist
- migration is idempotent
- preserves other settings fields

**AIProviderFactory.resolve** (8 tests)
- nil when AI is disabled
- nil when no active provider is set
- nil when activeProviderID points to a missing provider
- resolves apiKey provider (Claude)
- resolves oauth provider (Copilot, no key lookup)
- resolves ollama provider (no auth)
- picks active among many configured providers
- empty model string passes through

## Source change

Promoted `AppSettingsManager.migrateAI` from `private` to `internal` so `@testable` can call it directly. No public API change; release-build callers still go through the same `init()` entry point that uses it internally.

## Test plan

- [ ] `xcodebuild test -only-testing:TableProTests/AISettingsActiveProviderTests`
- [ ] `xcodebuild test -only-testing:TableProTests/AppSettingsManagerMigrationTests`
- [ ] `xcodebuild test -only-testing:TableProTests/AIProviderFactoryResolveTests`

All 20 tests pass locally.