### PR TITLE
feat: query parameter support in SQL editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Query parameters: write `:name` placeholders in SQL, fill values in an inline panel, execute with native prepared statement binding
 - AI provider registry for extensible provider management
 - GitHub Copilot integration: inline suggestions, chat via LSP conversation protocol, OAuth sign-in, schema context
 - Connection sharing: Share submenu with Copy Connection String, Copy TablePro Link, Copy as JSON, and rich deep links carrying all connection fields

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 </dict>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>TableProPluginKitVersion</key>
-    <integer>6</integer>
+    <integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>TableProPluginKitVersion</key>
-    <integer>6</integer>
+    <integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 </dict>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -142,6 +142,8 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     // Progressive loading
     func fetchFirstPage(query: String, limit: Int) async throws -> PluginPagedResult
     func fetchNextPage(query: String, offset: Int, limit: Int) async throws -> PluginPagedResult
+    func fetchFirstPageParameterized(query: String, parameters: [String?], limit: Int) async throws -> PluginPagedResult
+    func fetchNextPageParameterized(query: String, parameters: [String?], offset: Int, limit: Int) async throws -> PluginPagedResult
 }
 
 public extension PluginDatabaseDriver {
@@ -489,6 +491,47 @@ public extension PluginDatabaseDriver {
 
     func fetchNextPage(query: String, offset: Int, limit: Int) async throws -> PluginPagedResult {
         let result = try await fetchRows(query: query, offset: offset, limit: limit + 1)
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+        return PluginPagedResult(
+            columns: result.columns,
+            columnTypeNames: result.columnTypeNames,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: offset + rows.count
+        )
+    }
+
+    func fetchFirstPageParameterized(query: String, parameters: [String?], limit: Int) async throws -> PluginPagedResult {
+        guard limit > 0 else {
+            let result = try await executeParameterized(query: query, parameters: parameters)
+            return PluginPagedResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET 0"
+        let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+        return PluginPagedResult(
+            columns: result.columns,
+            columnTypeNames: result.columnTypeNames,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: rows.count
+        )
+    }
+
+    func fetchNextPageParameterized(query: String, parameters: [String?], offset: Int, limit: Int) async throws -> PluginPagedResult {
+        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET \(offset)"
+        let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
         let hasMore = result.rows.count > limit
         let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
         return PluginPagedResult(

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -63,6 +63,9 @@ protocol DatabaseDriver: AnyObject {
     /// Fetch subsequent pages of results
     func fetchNextPage(query: String, offset: Int, limit: Int) async throws -> PagedQueryResult
 
+    func fetchFirstPageParameterized(query: String, parameters: [Any?], limit: Int) async throws -> PagedQueryResult
+    func fetchNextPageParameterized(query: String, parameters: [Any?], offset: Int, limit: Int) async throws -> PagedQueryResult
+
     // MARK: - Schema Operations
 
     /// Fetch all tables in the database
@@ -386,7 +389,47 @@ extension DatabaseDriver {
         )
     }
 
-    /// Default no-op implementation for drivers that don't support query cancellation
+    func fetchFirstPageParameterized(query: String, parameters: [Any?], limit: Int) async throws -> PagedQueryResult {
+        guard limit > 0 else {
+            let result = try await executeParameterized(query: query, parameters: parameters)
+            return PagedQueryResult(
+                columns: result.columns,
+                columnTypes: result.columnTypes,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                hasMore: false,
+                nextOffset: result.rows.count
+            )
+        }
+        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET 0"
+        let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+        return PagedQueryResult(
+            columns: result.columns,
+            columnTypes: result.columnTypes,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: rows.count
+        )
+    }
+
+    func fetchNextPageParameterized(query: String, parameters: [Any?], offset: Int, limit: Int) async throws -> PagedQueryResult {
+        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET \(offset)"
+        let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
+        let hasMore = result.rows.count > limit
+        let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
+        return PagedQueryResult(
+            columns: result.columns,
+            columnTypes: result.columnTypes,
+            rows: rows,
+            executionTime: result.executionTime,
+            hasMore: hasMore,
+            nextOffset: offset + rows.count
+        )
+    }
+
     func cancelQuery() throws {
         // No-op by default
     }

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -123,6 +123,24 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         return mapPagedResult(pluginResult)
     }
 
+    func fetchFirstPageParameterized(query: String, parameters: [Any?], limit: Int) async throws -> PagedQueryResult {
+        let stringParams = parameters.map { param -> String? in
+            guard let p = param else { return nil }
+            return String(describing: p)
+        }
+        let pluginResult = try await pluginDriver.fetchFirstPageParameterized(query: query, parameters: stringParams, limit: limit)
+        return mapPagedResult(pluginResult)
+    }
+
+    func fetchNextPageParameterized(query: String, parameters: [Any?], offset: Int, limit: Int) async throws -> PagedQueryResult {
+        let stringParams = parameters.map { param -> String? in
+            guard let p = param else { return nil }
+            return String(describing: p)
+        }
+        let pluginResult = try await pluginDriver.fetchNextPageParameterized(query: query, parameters: stringParams, offset: offset, limit: limit)
+        return mapPagedResult(pluginResult)
+    }
+
     // MARK: - Schema Operations
 
     func fetchTables() async throws -> [TableInfo] {

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -12,7 +12,7 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager()
-    static let currentPluginKitVersion = 6
+    static let currentPluginKitVersion = 7
     private static let disabledPluginsKey = "com.TablePro.disabledPlugins"
     private static let legacyDisabledPluginsKey = "disabledPlugins"
 

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -40,8 +40,14 @@ final class QueryHistoryManager {
         executionTime: TimeInterval,
         rowCount: Int,
         wasSuccessful: Bool,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        parameterValues: [QueryParameter]? = nil
     ) {
+        var encodedParams: String?
+        if let parameterValues, !parameterValues.isEmpty {
+            encodedParams = try? String(data: JSONEncoder().encode(parameterValues), encoding: .utf8)
+        }
+
         let entry = QueryHistoryEntry(
             query: query,
             connectionId: connectionId,
@@ -49,7 +55,8 @@ final class QueryHistoryManager {
             executionTime: executionTime,
             rowCount: rowCount,
             wasSuccessful: wasSuccessful,
-            errorMessage: errorMessage
+            errorMessage: errorMessage,
+            parameterValues: encodedParams
         )
 
         Task {

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -111,9 +111,27 @@ actor QueryHistoryStorage {
         }
 
         if currentVersion < 2 {
-            execute("ALTER TABLE history ADD COLUMN parameter_values TEXT;")
+            if !hasColumn("parameter_values", inTable: "history") {
+                execute("ALTER TABLE history ADD COLUMN parameter_values TEXT;")
+            }
             setUserVersion(2)
         }
+    }
+
+    private func hasColumn(_ column: String, inTable table: String) -> Bool {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, "PRAGMA table_info(\(table))", -1, &statement, nil) == SQLITE_OK else {
+            return false
+        }
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let name = sqlite3_column_text(statement, 1) {
+                if String(cString: name) == column {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private func getUserVersion() -> Int32 {
@@ -144,7 +162,8 @@ actor QueryHistoryStorage {
                 execution_time REAL NOT NULL,
                 row_count INTEGER NOT NULL,
                 was_successful INTEGER NOT NULL,
-                error_message TEXT
+                error_message TEXT,
+                parameter_values TEXT
             );
             """
 

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -106,9 +106,13 @@ actor QueryHistoryStorage {
     private func migrateIfNeeded() {
         let currentVersion = getUserVersion()
 
-        let targetVersion: Int32 = 1
-        if currentVersion < targetVersion {
-            setUserVersion(targetVersion)
+        if currentVersion < 1 {
+            setUserVersion(1)
+        }
+
+        if currentVersion < 2 {
+            execute("ALTER TABLE history ADD COLUMN parameter_values TEXT;")
+            setUserVersion(2)
         }
     }
 
@@ -206,8 +210,8 @@ actor QueryHistoryStorage {
         }
 
         let sql = """
-            INSERT INTO history (id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            INSERT INTO history (id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message, parameter_values)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """
 
         var statement: OpaquePointer?
@@ -243,6 +247,12 @@ actor QueryHistoryStorage {
             sqlite3_bind_null(statement, 9)
         }
 
+        if let parameterValues = entry.parameterValues {
+            sqlite3_bind_text(statement, 10, parameterValues, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(statement, 10)
+        }
+
         let result = sqlite3_step(statement)
         return result == SQLITE_DONE
     }
@@ -263,7 +273,7 @@ actor QueryHistoryStorage {
 
         if let searchText = searchText, !searchText.isEmpty {
             sql = """
-                SELECT h.id, h.query, h.connection_id, h.database_name, h.executed_at, h.execution_time, h.row_count, h.was_successful, h.error_message
+                SELECT h.id, h.query, h.connection_id, h.database_name, h.executed_at, h.execution_time, h.row_count, h.was_successful, h.error_message, h.parameter_values
                 FROM history h
                 INNER JOIN history_fts ON h.rowid = history_fts.rowid
                 WHERE history_fts MATCH ?
@@ -280,7 +290,7 @@ actor QueryHistoryStorage {
             }
         } else {
             sql =
-                "SELECT id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message FROM history"
+                "SELECT id, query, connection_id, database_name, executed_at, execution_time, row_count, was_successful, error_message, parameter_values FROM history"
 
             var whereClauses: [String] = []
 
@@ -473,6 +483,7 @@ actor QueryHistoryStorage {
         let rowCount = Int(sqlite3_column_int(statement, 6))
         let wasSuccessful = sqlite3_column_int(statement, 7) == 1
         let errorMessage = sqlite3_column_text(statement, 8).map { String(cString: $0) }
+        let parameterValues = sqlite3_column_text(statement, 9).map { String(cString: $0) }
 
         return QueryHistoryEntry(
             id: id,
@@ -483,7 +494,8 @@ actor QueryHistoryStorage {
             executionTime: executionTime,
             rowCount: rowCount,
             wasSuccessful: wasSuccessful,
-            errorMessage: errorMessage
+            errorMessage: errorMessage,
+            parameterValues: parameterValues
         )
     }
 }

--- a/TablePro/Core/Utilities/SQL/SQLParameterExtractor.swift
+++ b/TablePro/Core/Utilities/SQL/SQLParameterExtractor.swift
@@ -1,0 +1,178 @@
+//
+//  SQLParameterExtractor.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+enum SQLParameterExtractor {
+    static func extractParameters(from sql: String) -> [String] {
+        var result: [String] = []
+        var seen = Set<String>()
+        scan(sql: sql) { name, _ in
+            if !seen.contains(name) {
+                seen.insert(name)
+                result.append(name)
+            }
+        }
+        return result
+    }
+
+    static func convertToNativeStyle(
+        sql: String,
+        parameters: [QueryParameter],
+        style: ParameterStyle
+    ) -> (sql: String, values: [Any?]) {
+        let nsSQL = sql as NSString
+        let length = nsSQL.length
+        guard length > 0 else { return (sql: sql, values: []) }
+
+        let paramLookup = Dictionary(parameters.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        var resultSQL = ""
+        var values: [Any?] = []
+        var dollarIndex = 1
+        var lastCopied = 0
+
+        scan(sql: sql) { name, range in
+            if lastCopied < range.location {
+                resultSQL += nsSQL.substring(with: NSRange(location: lastCopied, length: range.location - lastCopied))
+            }
+
+            if let param = paramLookup[name] {
+                values.append(param.isNull ? nil : param.value)
+            } else {
+                values.append(nil)
+            }
+
+            switch style {
+            case .questionMark:
+                resultSQL += "?"
+            case .dollar:
+                resultSQL += "$\(dollarIndex)"
+                dollarIndex += 1
+            }
+
+            lastCopied = range.location + range.length
+        }
+
+        if lastCopied < length {
+            resultSQL += nsSQL.substring(with: NSRange(location: lastCopied, length: length - lastCopied))
+        }
+
+        return (sql: resultSQL, values: values)
+    }
+
+    // MARK: - Private
+
+    private static let singleQuote = UInt16(UnicodeScalar("'").value)
+    private static let doubleQuote = UInt16(UnicodeScalar("\"").value)
+    private static let backtick = UInt16(UnicodeScalar("`").value)
+    private static let colonChar = UInt16(UnicodeScalar(":").value)
+    private static let dash = UInt16(UnicodeScalar("-").value)
+    private static let slash = UInt16(UnicodeScalar("/").value)
+    private static let star = UInt16(UnicodeScalar("*").value)
+    private static let newline = UInt16(UnicodeScalar("\n").value)
+    private static let backslash = UInt16(UnicodeScalar("\\").value)
+    private static let underscore = UInt16(UnicodeScalar("_").value)
+
+    private static func isIdentifierStart(_ ch: UInt16) -> Bool {
+        (ch >= 0x41 && ch <= 0x5A) || (ch >= 0x61 && ch <= 0x7A) || ch == underscore
+    }
+
+    private static func isIdentifierChar(_ ch: UInt16) -> Bool {
+        isIdentifierStart(ch) || (ch >= 0x30 && ch <= 0x39)
+    }
+
+    private static func scan(
+        sql: String,
+        onParameter: (_ name: String, _ range: NSRange) -> Void
+    ) {
+        let nsSQL = sql as NSString
+        let length = nsSQL.length
+        guard length > 0 else { return }
+
+        var inString = false
+        var stringCharVal: UInt16 = 0
+        var inLineComment = false
+        var inBlockComment = false
+        var i = 0
+
+        while i < length {
+            let ch = nsSQL.character(at: i)
+
+            if inLineComment {
+                if ch == newline { inLineComment = false }
+                i += 1
+                continue
+            }
+
+            if inBlockComment {
+                if ch == star && i + 1 < length && nsSQL.character(at: i + 1) == slash {
+                    inBlockComment = false
+                    i += 2
+                    continue
+                }
+                i += 1
+                continue
+            }
+
+            if !inString && ch == dash && i + 1 < length && nsSQL.character(at: i + 1) == dash {
+                inLineComment = true
+                i += 2
+                continue
+            }
+
+            if !inString && ch == slash && i + 1 < length && nsSQL.character(at: i + 1) == star {
+                inBlockComment = true
+                i += 2
+                continue
+            }
+
+            if inString && ch == backslash && i + 1 < length {
+                i += 2
+                continue
+            }
+
+            if ch == singleQuote || ch == doubleQuote || ch == backtick {
+                if !inString {
+                    inString = true
+                    stringCharVal = ch
+                } else if ch == stringCharVal {
+                    if i + 1 < length && nsSQL.character(at: i + 1) == stringCharVal {
+                        i += 1
+                    } else {
+                        inString = false
+                    }
+                }
+                i += 1
+                continue
+            }
+
+            if !inString && ch == colonChar {
+                if i + 1 < length && nsSQL.character(at: i + 1) == colonChar {
+                    i += 2
+                    while i < length && isIdentifierChar(nsSQL.character(at: i)) {
+                        i += 1
+                    }
+                    continue
+                }
+
+                if i + 1 < length && isIdentifierStart(nsSQL.character(at: i + 1)) {
+                    let nameStart = i + 1
+                    var nameEnd = nameStart
+                    while nameEnd < length && isIdentifierChar(nsSQL.character(at: nameEnd)) {
+                        nameEnd += 1
+                    }
+                    let paramRange = NSRange(location: i, length: nameEnd - i)
+                    let name = nsSQL.substring(with: NSRange(location: nameStart, length: nameEnd - nameStart))
+                    onParameter(name, paramRange)
+                    i = nameEnd
+                    continue
+                }
+            }
+
+            i += 1
+        }
+    }
+}

--- a/TablePro/Core/Utilities/SQL/SQLParameterExtractor.swift
+++ b/TablePro/Core/Utilities/SQL/SQLParameterExtractor.swift
@@ -75,6 +75,7 @@ enum SQLParameterExtractor {
     private static let newline = UInt16(UnicodeScalar("\n").value)
     private static let backslash = UInt16(UnicodeScalar("\\").value)
     private static let underscore = UInt16(UnicodeScalar("_").value)
+    private static let dollarChar = UInt16(UnicodeScalar("$").value)
 
     private static func isIdentifierStart(_ ch: UInt16) -> Bool {
         (ch >= 0x41 && ch <= 0x5A) || (ch >= 0x61 && ch <= 0x7A) || ch == underscore
@@ -147,6 +148,45 @@ enum SQLParameterExtractor {
                 }
                 i += 1
                 continue
+            }
+
+            if !inString && ch == dollarChar {
+                let tagStart = i + 1
+                if tagStart < length && nsSQL.character(at: tagStart) == dollarChar {
+                    var j = tagStart + 1
+                    while j < length - 1 {
+                        if nsSQL.character(at: j) == dollarChar && nsSQL.character(at: j + 1) == dollarChar {
+                            i = j + 2
+                            break
+                        }
+                        j += 1
+                    }
+                    if i < tagStart + 1 { i = length }
+                    continue
+                }
+                var tagEnd = tagStart
+                while tagEnd < length && isIdentifierChar(nsSQL.character(at: tagEnd)) {
+                    tagEnd += 1
+                }
+                if tagEnd > tagStart && tagEnd < length && nsSQL.character(at: tagEnd) == dollarChar {
+                    let tagLen = tagEnd - i + 1
+                    let openTag = nsSQL.substring(with: NSRange(location: i, length: tagLen))
+                    var j = tagEnd + 1
+                    var found = false
+                    while j <= length - tagLen {
+                        if nsSQL.character(at: j) == dollarChar {
+                            let candidate = nsSQL.substring(with: NSRange(location: j, length: tagLen))
+                            if candidate == openTag {
+                                i = j + tagLen
+                                found = true
+                                break
+                            }
+                        }
+                        j += 1
+                    }
+                    if !found { i = length }
+                    continue
+                }
             }
 
             if !inString && ch == colonChar {

--- a/TablePro/Models/Query/QueryHistoryEntry.swift
+++ b/TablePro/Models/Query/QueryHistoryEntry.swift
@@ -18,6 +18,7 @@ struct QueryHistoryEntry: Identifiable, Codable, Hashable {
     let rowCount: Int  // -1 if unknown
     let wasSuccessful: Bool
     let errorMessage: String?
+    let parameterValues: String?
 
     init(
         id: UUID = UUID(),
@@ -28,7 +29,8 @@ struct QueryHistoryEntry: Identifiable, Codable, Hashable {
         executionTime: TimeInterval,
         rowCount: Int,
         wasSuccessful: Bool,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        parameterValues: String? = nil
     ) {
         self.id = id
         self.query = query
@@ -39,6 +41,7 @@ struct QueryHistoryEntry: Identifiable, Codable, Hashable {
         self.rowCount = rowCount
         self.wasSuccessful = wasSuccessful
         self.errorMessage = errorMessage
+        self.parameterValues = parameterValues
     }
 
     /// Formatted execution time for display

--- a/TablePro/Models/Query/QueryParameter.swift
+++ b/TablePro/Models/Query/QueryParameter.swift
@@ -1,0 +1,30 @@
+//
+//  QueryParameter.swift
+//  TablePro
+//
+
+import Foundation
+
+enum QueryParameterType: String, Codable, CaseIterable, Sendable {
+    case string
+    case integer
+    case decimal
+    case date
+    case boolean
+}
+
+struct QueryParameter: Identifiable, Codable, Equatable, Hashable, Sendable {
+    let id: UUID
+    let name: String
+    var value: String
+    var type: QueryParameterType
+    var isNull: Bool
+
+    init(name: String, value: String = "", type: QueryParameterType = .string, isNull: Bool = false) {
+        self.id = UUID()
+        self.name = name
+        self.value = value
+        self.type = type
+        self.isNull = isNull
+    }
+}

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -123,9 +123,6 @@ struct QueryTab: Identifiable, Equatable {
         return resultSets.first { $0.id == id }
     }
 
-    var queryParameters: [QueryParameter] = []
-    var isParameterPanelVisible: Bool = false
-
     var sourceFileURL: URL?
 
     // Snapshot of file content at last save/load (nil for non-file tabs).

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -123,7 +123,9 @@ struct QueryTab: Identifiable, Equatable {
         return resultSets.first { $0.id == id }
     }
 
-    // Source file URL for .sql files opened from disk (used for deduplication)
+    var queryParameters: [QueryParameter] = []
+    var isParameterPanelVisible: Bool = false
+
     var sourceFileURL: URL?
 
     // Snapshot of file content at last save/load (nil for non-file tabs).

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -110,6 +110,9 @@ struct QueryTab: Identifiable, Equatable {
     // Whether this tab is a preview (temporary) tab that gets replaced on next navigation
     var isPreview: Bool
 
+    var queryParameters: [QueryParameter] = []
+    var isParameterPanelVisible: Bool = false
+
     // Multi-result-set support (Phase 0: added alongside existing single-result properties)
     var resultSets: [ResultSet] = []
     var activeResultSetId: UUID?
@@ -217,6 +220,8 @@ struct QueryTab: Identifiable, Equatable {
         self.filterState = TabFilterState()
         self.columnLayout = ColumnLayoutState()
         self.isPreview = false
+        self.queryParameters = persisted.queryParameters ?? []
+        self.isParameterPanelVisible = false
         self.sourceFileURL = persisted.sourceFileURL
         self.resultVersion = 0
         self.metadataVersion = 0
@@ -289,7 +294,8 @@ struct QueryTab: Identifiable, Equatable {
             databaseName: databaseName,
             schemaName: schemaName,
             sourceFileURL: sourceFileURL,
-            erDiagramSchemaKey: erDiagramSchemaKey
+            erDiagramSchemaKey: erDiagramSchemaKey,
+            queryParameters: queryParameters.isEmpty ? nil : queryParameters
         )
     }
 

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -27,6 +27,7 @@ struct PersistedTab: Codable {
     var schemaName: String?
     var sourceFileURL: URL?
     var erDiagramSchemaKey: String?
+    var queryParameters: [QueryParameter]?
 }
 
 /// Stores pending changes for a tab (used to preserve state when switching tabs)
@@ -104,6 +105,7 @@ struct PaginationState: Equatable {
     var loadMoreOffset: Int = 0
     var isLoadingMore: Bool = false
     var baseQueryForMore: String?
+    var baseQueryParameterValues: [String?]?
 
     /// Default page size constant (used when no explicit value is provided)
     /// Note: For new tabs, callers should pass AppSettingsManager.shared.dataGrid.defaultPageSize
@@ -202,6 +204,7 @@ struct PaginationState: Equatable {
         loadMoreOffset = 0
         isLoadingMore = false
         baseQueryForMore = nil
+        baseQueryParameterValues = nil
     }
 
     /// Update page size (limit)

--- a/TablePro/Models/Settings/EditorSettings.swift
+++ b/TablePro/Models/Settings/EditorSettings.swift
@@ -74,6 +74,7 @@ struct EditorSettings: Codable, Equatable {
     var wordWrap: Bool
     var vimModeEnabled: Bool
     var uppercaseKeywords: Bool
+    var queryParametersEnabled: Bool
     var jsonViewerPreferredMode: JSONViewMode
 
     static let `default` = EditorSettings(
@@ -83,6 +84,7 @@ struct EditorSettings: Codable, Equatable {
         wordWrap: false,
         vimModeEnabled: false,
         uppercaseKeywords: false,
+        queryParametersEnabled: true,
         jsonViewerPreferredMode: .text
     )
 
@@ -93,6 +95,7 @@ struct EditorSettings: Codable, Equatable {
         wordWrap: Bool = false,
         vimModeEnabled: Bool = false,
         uppercaseKeywords: Bool = false,
+        queryParametersEnabled: Bool = true,
         jsonViewerPreferredMode: JSONViewMode = .text
     ) {
         self.showLineNumbers = showLineNumbers
@@ -101,6 +104,7 @@ struct EditorSettings: Codable, Equatable {
         self.wordWrap = wordWrap
         self.vimModeEnabled = vimModeEnabled
         self.uppercaseKeywords = uppercaseKeywords
+        self.queryParametersEnabled = queryParametersEnabled
         self.jsonViewerPreferredMode = jsonViewerPreferredMode
     }
 
@@ -112,6 +116,7 @@ struct EditorSettings: Codable, Equatable {
         wordWrap = try container.decodeIfPresent(Bool.self, forKey: .wordWrap) ?? false
         vimModeEnabled = try container.decodeIfPresent(Bool.self, forKey: .vimModeEnabled) ?? false
         uppercaseKeywords = try container.decodeIfPresent(Bool.self, forKey: .uppercaseKeywords) ?? false
+        queryParametersEnabled = try container.decodeIfPresent(Bool.self, forKey: .queryParametersEnabled) ?? true
         jsonViewerPreferredMode = try container.decodeIfPresent(JSONViewMode.self, forKey: .jsonViewerPreferredMode) ?? .text
     }
 

--- a/TablePro/Models/Settings/EditorSettings.swift
+++ b/TablePro/Models/Settings/EditorSettings.swift
@@ -76,6 +76,7 @@ struct EditorSettings: Codable, Equatable {
     var uppercaseKeywords: Bool
     var queryParametersEnabled: Bool
     var jsonViewerPreferredMode: JSONViewMode
+    var queryParametersEnabled: Bool
 
     static let `default` = EditorSettings(
         showLineNumbers: true,
@@ -106,6 +107,7 @@ struct EditorSettings: Codable, Equatable {
         self.uppercaseKeywords = uppercaseKeywords
         self.queryParametersEnabled = queryParametersEnabled
         self.jsonViewerPreferredMode = jsonViewerPreferredMode
+        self.queryParametersEnabled = queryParametersEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -118,6 +120,7 @@ struct EditorSettings: Codable, Equatable {
         uppercaseKeywords = try container.decodeIfPresent(Bool.self, forKey: .uppercaseKeywords) ?? false
         queryParametersEnabled = try container.decodeIfPresent(Bool.self, forKey: .queryParametersEnabled) ?? true
         jsonViewerPreferredMode = try container.decodeIfPresent(JSONViewMode.self, forKey: .jsonViewerPreferredMode) ?? .text
+        queryParametersEnabled = try container.decodeIfPresent(Bool.self, forKey: .queryParametersEnabled) ?? true
     }
 
     /// Clamped tab width (1-16)

--- a/TablePro/Models/Settings/EditorSettings.swift
+++ b/TablePro/Models/Settings/EditorSettings.swift
@@ -76,7 +76,6 @@ struct EditorSettings: Codable, Equatable {
     var uppercaseKeywords: Bool
     var queryParametersEnabled: Bool
     var jsonViewerPreferredMode: JSONViewMode
-    var queryParametersEnabled: Bool
 
     static let `default` = EditorSettings(
         showLineNumbers: true,
@@ -107,7 +106,6 @@ struct EditorSettings: Codable, Equatable {
         self.uppercaseKeywords = uppercaseKeywords
         self.queryParametersEnabled = queryParametersEnabled
         self.jsonViewerPreferredMode = jsonViewerPreferredMode
-        self.queryParametersEnabled = queryParametersEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -120,7 +118,6 @@ struct EditorSettings: Codable, Equatable {
         uppercaseKeywords = try container.decodeIfPresent(Bool.self, forKey: .uppercaseKeywords) ?? false
         queryParametersEnabled = try container.decodeIfPresent(Bool.self, forKey: .queryParametersEnabled) ?? true
         jsonViewerPreferredMode = try container.decodeIfPresent(JSONViewMode.self, forKey: .jsonViewerPreferredMode) ?? .text
-        queryParametersEnabled = try container.decodeIfPresent(Bool.self, forKey: .queryParametersEnabled) ?? true
     }
 
     /// Clamped tab width (1-16)

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -24829,7 +24829,7 @@
         }
       }
     },
-    "Missing value for parameter: :%@" : {
+    "Missing value for parameter: %@" : {
 
     },
     "Mode" : {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -136,6 +136,9 @@
         }
       }
     },
+    ":%@" : {
+
+    },
     ".%@" : {
       "localizations" : {
         "tr" : {
@@ -8469,6 +8472,9 @@
           }
         }
       }
+    },
+    "Close parameter panel" : {
+
     },
     "Close preview" : {
       "localizations" : {
@@ -24823,6 +24829,9 @@
         }
       }
     },
+    "Missing value for parameter: :%@" : {
+
+    },
     "Mode" : {
 
     },
@@ -29185,6 +29194,9 @@
         }
       }
     },
+    "Parameters" : {
+
+    },
     "Parent Group" : {
       "localizations" : {
         "tr" : {
@@ -31716,6 +31728,9 @@
           }
         }
       }
+    },
+    "Query parameters (:name syntax)" : {
+
     },
     "Query Result Limit" : {
       "localizations" : {

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -17,6 +17,8 @@ struct QueryEditorView: View {
 
     @Binding var queryText: String
     @Binding var cursorPositions: [CursorPosition]
+    @Binding var parameters: [QueryParameter]
+    @Binding var isParameterPanelVisible: Bool
     var onExecute: () -> Void
     var schemaProvider: SQLSchemaProvider?
     var databaseType: DatabaseType?
@@ -43,7 +45,14 @@ struct QueryEditorView: View {
 
             Divider()
 
-            // SQL Editor (CodeEditSourceEditor-based with tree-sitter highlighting)
+            if isParameterPanelVisible && !parameters.isEmpty {
+                QueryParameterPanelView(
+                    parameters: $parameters,
+                    onDismiss: { isParameterPanelVisible = false }
+                )
+                Divider()
+            }
+
             SQLEditorView(
                 text: $queryText,
                 cursorPositions: $cursorPositions,
@@ -203,6 +212,8 @@ struct QueryEditorView: View {
     QueryEditorView(
         queryText: .constant("SELECT * FROM users\nWHERE active = true\nORDER BY created_at DESC;"),
         cursorPositions: .constant([]),
+        parameters: .constant([]),
+        isParameterPanelVisible: .constant(false),
         onExecute: {},
         databaseType: .mysql
     )

--- a/TablePro/Views/Editor/QueryParameterPanelView.swift
+++ b/TablePro/Views/Editor/QueryParameterPanelView.swift
@@ -1,0 +1,145 @@
+//
+//  QueryParameterPanelView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+extension QueryParameterType {
+    var displayName: String {
+        switch self {
+        case .string: return "String"
+        case .integer: return "Integer"
+        case .decimal: return "Decimal"
+        case .date: return "Date"
+        case .boolean: return "Boolean"
+        }
+    }
+}
+
+struct QueryParameterPanelView: View {
+    @Binding var parameters: [QueryParameter]
+    var onDismiss: () -> Void
+
+    private let maxParameterListHeight: CGFloat = 200
+
+    var body: some View {
+        VStack(spacing: 0) {
+            panelHeader
+
+            Divider()
+                .foregroundStyle(Color(nsColor: .separatorColor))
+
+            if !parameters.isEmpty {
+                parameterList
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var panelHeader: some View {
+        HStack(spacing: 8) {
+            Text("Parameters")
+                .font(.callout.weight(.medium))
+
+            Spacer()
+
+            Button("Clear All") {
+                for index in parameters.indices {
+                    parameters[index].value = ""
+                    parameters[index].isNull = false
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Close parameter panel"))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var parameterRows: some View {
+        VStack(spacing: 0) {
+            ForEach(parameters) { parameter in
+                if let index = parameters.firstIndex(where: { $0.id == parameter.id }) {
+                    QueryParameterRowView(
+                        parameter: Binding(
+                            get: { parameters[index] },
+                            set: { parameters[index] = $0 }
+                        )
+                    )
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var parameterList: some View {
+        let estimatedHeight = CGFloat(parameters.count) * 32 + 8
+        if estimatedHeight > maxParameterListHeight {
+            ScrollView {
+                parameterRows
+            }
+            .frame(maxHeight: maxParameterListHeight)
+        } else {
+            parameterRows
+        }
+    }
+}
+
+struct QueryParameterRowView: View {
+    @Binding var parameter: QueryParameter
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(":\(parameter.name)")
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 120, alignment: .leading)
+                .lineLimit(1)
+
+            TextField(parameter.type.displayName, text: $parameter.value)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .disabled(parameter.isNull)
+
+            Picker("", selection: $parameter.type) {
+                ForEach(QueryParameterType.allCases, id: \.self) { paramType in
+                    Text(paramType.displayName).tag(paramType)
+                }
+            }
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .fixedSize()
+            .labelsHidden()
+            .frame(width: 90)
+
+            Toggle("NULL", isOn: $parameter.isNull)
+                .controlSize(.small)
+                .toggleStyle(.checkbox)
+                .frame(width: 60)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview("Parameter Panel") {
+    QueryParameterPanelView(
+        parameters: .constant([
+            QueryParameter(name: "user_id", value: "42", type: .integer),
+            QueryParameter(name: "name", value: "John", type: .string),
+            QueryParameter(name: "created_at", type: .date, isNull: true)
+        ]),
+        onDismiss: {}
+    )
+    .frame(width: 600)
+}

--- a/TablePro/Views/Editor/QueryParameterPanelView.swift
+++ b/TablePro/Views/Editor/QueryParameterPanelView.swift
@@ -47,7 +47,6 @@ struct QueryParameterPanelView: View {
             Button("Clear All") {
                 for index in parameters.indices {
                     parameters[index].value = ""
-                    parameters[index].isNull = false
                 }
             }
             .buttonStyle(.bordered)
@@ -68,14 +67,18 @@ struct QueryParameterPanelView: View {
     private var parameterRows: some View {
         VStack(spacing: 0) {
             ForEach(parameters) { parameter in
-                if let index = parameters.firstIndex(where: { $0.id == parameter.id }) {
-                    QueryParameterRowView(
-                        parameter: Binding(
-                            get: { parameters[index] },
-                            set: { parameters[index] = $0 }
-                        )
+                QueryParameterRowView(
+                    parameter: Binding(
+                        get: {
+                            parameters.first(where: { $0.id == parameter.id }) ?? parameter
+                        },
+                        set: { newValue in
+                            if let idx = parameters.firstIndex(where: { $0.id == parameter.id }) {
+                                parameters[idx] = newValue
+                            }
+                        }
                     )
-                }
+                )
             }
         }
         .padding(.vertical, 4)

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -269,6 +269,8 @@ struct MainEditorContentView: View {
                     QueryEditorView(
                         queryText: queryTextBinding(for: tab),
                         cursorPositions: $bindableCoordinator.cursorPositions,
+                        parameters: parameterBinding(for: tab),
+                        isParameterPanelVisible: parameterVisibilityBinding(for: tab),
                         onExecute: { coordinator.runQuery() },
                         schemaProvider: coordinator.schemaProvider,
                         databaseType: coordinator.connection.type,
@@ -352,6 +354,28 @@ struct MainEditorContentView: View {
                 guard queryLength < QueryTab.maxPersistableQuerySize else { return }
 
                 coordinator.persistence.saveLastQuery(newValue)
+            }
+        )
+    }
+
+    private func parameterBinding(for tab: QueryTab) -> Binding<[QueryParameter]> {
+        let tabId = tab.id
+        return Binding(
+            get: { tab.queryParameters },
+            set: { newValue in
+                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+                tabManager.tabs[index].queryParameters = newValue
+            }
+        )
+    }
+
+    private func parameterVisibilityBinding(for tab: QueryTab) -> Binding<Bool> {
+        let tabId = tab.id
+        return Binding(
+            get: { tab.isParameterPanelVisible },
+            set: { newValue in
+                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+                tabManager.tabs[index].isParameterPanelVisible = newValue
             }
         )
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -125,12 +125,18 @@ extension MainContentCoordinator {
             }
         }
 
+        let tabId = tabManager.tabs[index].id
+
         if level == .silent {
             Task {
                 let window = NSApp.keyWindow
-                let dangerousStatements = statements.filter { isDangerousQuery($0) }
-                if !dangerousStatements.isEmpty {
-                    guard await confirmDangerousQueries(dangerousStatements, window: window) else { return }
+                if statements.count == 1 {
+                    guard await confirmDangerousQueryIfNeeded(statements[0], window: window) else { return }
+                } else {
+                    let dangerousStatements = statements.filter { isDangerousQuery($0) }
+                    if !dangerousStatements.isEmpty {
+                        guard await confirmDangerousQueries(dangerousStatements, window: window) else { return }
+                    }
                 }
                 executeParameterizedAfterSafeMode(statements, parameters: parameters)
             }
@@ -154,8 +160,8 @@ extension MainContentCoordinator {
                 case .allowed:
                     executeParameterizedAfterSafeMode(statements, parameters: parameters)
                 case .blocked(let reason):
-                    if index < tabManager.tabs.count {
-                        tabManager.tabs[index].errorMessage = reason
+                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                        tabManager.tabs[idx].errorMessage = reason
                     }
                 }
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -2,9 +2,6 @@
 //  MainContentCoordinator+ExecuteAll.swift
 //  TablePro
 //
-//  Execute All Statements and safe mode dispatch logic shared
-//  between runQuery() and runAllStatements().
-//
 
 import AppKit
 import Foundation
@@ -20,6 +17,27 @@ extension MainContentCoordinator {
 
         let statements = SQLStatementScanner.allStatements(in: fullQuery)
         guard !statements.isEmpty else { return }
+
+        if AppSettingsManager.shared.editor.queryParametersEnabled {
+            let combinedSQL = statements.joined(separator: "; ")
+            let detectedNames = SQLParameterExtractor.extractParameters(from: combinedSQL)
+
+            if !detectedNames.isEmpty {
+                let reconciled = detectAndReconcileParameters(
+                    sql: combinedSQL,
+                    existing: tabManager.tabs[index].queryParameters
+                )
+                tabManager.tabs[index].queryParameters = reconciled
+
+                if !tabManager.tabs[index].isParameterPanelVisible {
+                    tabManager.tabs[index].isParameterPanelVisible = true
+                    return
+                }
+
+                dispatchParameterizedStatements(statements, parameters: reconciled, tabIndex: index)
+                return
+            }
+        }
 
         dispatchStatements(statements, tabIndex: index)
     }
@@ -88,6 +106,72 @@ extension MainContentCoordinator {
             } else {
                 executeMultipleStatements(statements)
             }
+        }
+    }
+
+    internal func dispatchParameterizedStatements(
+        _ statements: [String],
+        parameters: [QueryParameter],
+        tabIndex index: Int
+    ) {
+        let level = safeModeLevel
+
+        if level == .readOnly {
+            let writeStatements = statements.filter { isWriteQuery($0) }
+            if !writeStatements.isEmpty {
+                tabManager.tabs[index].errorMessage =
+                    String(localized: "Cannot execute write queries: connection is read-only")
+                return
+            }
+        }
+
+        if level == .silent {
+            Task {
+                let window = NSApp.keyWindow
+                let dangerousStatements = statements.filter { isDangerousQuery($0) }
+                if !dangerousStatements.isEmpty {
+                    guard await confirmDangerousQueries(dangerousStatements, window: window) else { return }
+                }
+                executeParameterizedAfterSafeMode(statements, parameters: parameters)
+            }
+        } else if level.requiresConfirmation {
+            guard !isShowingSafeModePrompt else { return }
+            isShowingSafeModePrompt = true
+            Task {
+                defer { isShowingSafeModePrompt = false }
+                let window = NSApp.keyWindow
+                let combinedSQL = statements.joined(separator: "\n")
+                let hasWrite = statements.contains { isWriteQuery($0) }
+                let permission = await SafeModeGuard.checkPermission(
+                    level: level,
+                    isWriteOperation: hasWrite,
+                    sql: combinedSQL,
+                    operationDescription: String(localized: "Execute Query"),
+                    window: window,
+                    databaseType: connection.type
+                )
+                switch permission {
+                case .allowed:
+                    executeParameterizedAfterSafeMode(statements, parameters: parameters)
+                case .blocked(let reason):
+                    if index < tabManager.tabs.count {
+                        tabManager.tabs[index].errorMessage = reason
+                    }
+                }
+            }
+        } else {
+            executeParameterizedAfterSafeMode(statements, parameters: parameters)
+        }
+    }
+
+    private func executeParameterizedAfterSafeMode(
+        _ statements: [String],
+        parameters: [QueryParameter]
+    ) {
+        if statements.count == 1 {
+            executeQueryWithParameters(statements[0], parameters: parameters)
+        } else {
+            executeMultipleStatementsWithParameters(statements, parameters: parameters)
         }
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
@@ -46,6 +46,7 @@ extension MainContentCoordinator {
         let offset = tab.pagination.loadMoreOffset
         let limit = AppSettingsManager.shared.dataGrid.validatedQueryResultLimit
         let capturedGeneration = queryGeneration
+        let storedParamValues = tab.pagination.baseQueryParameterValues
 
         tabManager.tabs[idx].pagination.isLoadingMore = true
         toolbarState.setExecuting(true)
@@ -59,11 +60,22 @@ extension MainContentCoordinator {
                 }
                 let fetchStart = CFAbsoluteTimeGetCurrent()
                 progressLog.info("[loadMore] offset=\(offset) limit=\(limit)")
-                let pagedResult = try await driver.fetchNextPage(
-                    query: baseQuery,
-                    offset: offset,
-                    limit: limit
-                )
+                let pagedResult: PagedQueryResult
+                if let paramValues = storedParamValues {
+                    let anyParams: [Any?] = paramValues.map { $0 as Any? }
+                    pagedResult = try await driver.fetchNextPageParameterized(
+                        query: baseQuery,
+                        parameters: anyParams,
+                        offset: offset,
+                        limit: limit
+                    )
+                } else {
+                    pagedResult = try await driver.fetchNextPage(
+                        query: baseQuery,
+                        offset: offset,
+                        limit: limit
+                    )
+                }
                 let fetchElapsed = CFAbsoluteTimeGetCurrent() - fetchStart
                 progressLog.info("[loadMore] rows=\(pagedResult.rows.count) hasMore=\(pagedResult.hasMore) fetchTime=\(String(format: "%.3f", fetchElapsed))s")
 
@@ -165,6 +177,7 @@ extension MainContentCoordinator {
         guard !tabManager.tabs[idx].pagination.isLoadingMore else { return }
 
         let capturedGeneration = queryGeneration
+        let storedParamValues = tabManager.tabs[idx].pagination.baseQueryParameterValues
 
         tabManager.tabs[idx].pagination.isLoadingMore = true
         toolbarState.setExecuting(true)
@@ -179,7 +192,13 @@ extension MainContentCoordinator {
 
                 let start = CFAbsoluteTimeGetCurrent()
                 progressLog.info("[fetchAll] executing full query: \(baseQuery.prefix(100), privacy: .public)")
-                let result = try await driver.execute(query: baseQuery)
+                let result: QueryResult
+                if let paramValues = storedParamValues {
+                    let anyParams: [Any?] = paramValues.map { $0 as Any? }
+                    result = try await driver.executeParameterized(query: baseQuery, parameters: anyParams)
+                } else {
+                    result = try await driver.execute(query: baseQuery)
+                }
                 let fetchTime = CFAbsoluteTimeGetCurrent() - start
                 progressLog.info("[fetchAll] rows=\(result.rows.count) fetchTime=\(String(format: "%.3f", fetchTime))s")
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
@@ -217,7 +217,7 @@ extension MainContentCoordinator {
 
     // MARK: - Multi-Statement Result Application
 
-    private func applyMultiStatementResults(
+    internal func applyMultiStatementResults(
         tabId: UUID,
         capturedGeneration: Int,
         cumulativeTime: TimeInterval,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -77,6 +77,53 @@ extension MainContentCoordinator {
         }
     }
 
+    nonisolated static func fetchQueryDataParameterized(
+        driver: DatabaseDriver,
+        sql: String,
+        parameters: [Any?],
+        useProgressiveLoading: Bool,
+        progressiveLimit: Int
+    ) async throws -> QueryFetchResult {
+        if useProgressiveLoading && progressiveLimit > 0 {
+            let start = CFAbsoluteTimeGetCurrent()
+            progressLog.info("[fetchFirstPageParameterized] sql=\(sql.prefix(100), privacy: .public) limit=\(progressiveLimit) params=\(parameters.count)")
+            let pagedResult = try await driver.fetchFirstPageParameterized(
+                query: sql,
+                parameters: parameters,
+                limit: progressiveLimit
+            )
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            progressLog.info("[fetchFirstPageParameterized] rows=\(pagedResult.rows.count) hasMore=\(pagedResult.hasMore) driverTime=\(String(format: "%.3f", pagedResult.executionTime))s totalTime=\(String(format: "%.3f", elapsed))s")
+            let pageContext: QueryPageContext? = pagedResult.hasMore
+                ? QueryPageContext(hasMore: true, nextOffset: pagedResult.nextOffset, baseQuery: sql)
+                : nil
+            return QueryFetchResult(
+                columns: pagedResult.columns,
+                columnTypes: pagedResult.columnTypes,
+                rows: pagedResult.rows,
+                executionTime: pagedResult.executionTime,
+                rowsAffected: 0,
+                statusMessage: nil,
+                pageContext: pageContext
+            )
+        } else {
+            let start = CFAbsoluteTimeGetCurrent()
+            progressLog.info("[executeParameterized] sql=\(sql.prefix(100), privacy: .public) params=\(parameters.count)")
+            let result = try await driver.executeParameterized(query: sql, parameters: parameters)
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            progressLog.info("[executeParameterized] rows=\(result.rows.count) driverTime=\(String(format: "%.3f", result.executionTime))s totalTime=\(String(format: "%.3f", elapsed))s")
+            return QueryFetchResult(
+                columns: result.columns,
+                columnTypes: result.columnTypes,
+                rows: result.rows,
+                executionTime: result.executionTime,
+                rowsAffected: result.rowsAffected,
+                statusMessage: result.statusMessage,
+                pageContext: nil
+            )
+        }
+    }
+
     /// Determine whether progressive loading should be used for this query
     func resolveProgressiveLoading(sql: String, tabType: TabType) -> (useProgressive: Bool, limit: Int) {
         let dataGridSettings = AppSettingsManager.shared.dataGrid
@@ -195,7 +242,8 @@ extension MainContentCoordinator {
         hasSchema: Bool,
         sql: String,
         connection conn: DatabaseConnection,
-        queryPageContext: QueryPageContext? = nil
+        queryPageContext: QueryPageContext? = nil,
+        queryParameterValues: [QueryParameter]? = nil
     ) {
         guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
 
@@ -312,7 +360,8 @@ extension MainContentCoordinator {
             executionTime: executionTime,
             rowCount: rows.count,
             wasSuccessful: true,
-            errorMessage: nil
+            errorMessage: nil,
+            parameterValues: queryParameterValues
         )
 
         // Clear stale edit state immediately so the save banner

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
@@ -1,0 +1,476 @@
+import Foundation
+import os
+import TableProPluginKit
+
+private let paramLog = Logger(subsystem: "com.TablePro", category: "QueryParameters")
+
+extension MainContentCoordinator {
+    func detectAndReconcileParameters(sql: String, existing: [QueryParameter]) -> [QueryParameter] {
+        let detectedNames = SQLParameterExtractor.extractParameters(from: sql)
+        guard !detectedNames.isEmpty else { return [] }
+
+        let existingByName = Dictionary(
+            existing.map { ($0.name, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return detectedNames.map { name in
+            if let existing = existingByName[name] {
+                return existing
+            }
+            return QueryParameter(name: name)
+        }
+    }
+
+    func executeQueryWithParameters(_ sql: String, parameters: [QueryParameter]) {
+        guard let index = tabManager.selectedTabIndex else { return }
+
+        let missing = parameters.filter {
+            !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if let firstMissing = missing.first {
+            tabManager.tabs[index].errorMessage = String(
+                format: String(localized: "Missing value for parameter: :%@"),
+                firstMissing.name
+            )
+            return
+        }
+
+        let style = PluginMetadataRegistry.shared.snapshot(
+            forTypeId: connection.type.pluginTypeId
+        )?.parameterStyle ?? .questionMark
+        let conversion = SQLParameterExtractor.convertToNativeStyle(
+            sql: sql,
+            parameters: parameters,
+            style: style
+        )
+
+        paramLog.info("Executing parameterized query: \(conversion.sql.prefix(100), privacy: .public) with \(conversion.values.count) parameters")
+
+        executeQueryInternalParameterized(
+            conversion.sql,
+            parameters: conversion.values,
+            originalParameters: parameters
+        )
+    }
+
+    internal func executeQueryInternalParameterized(
+        _ sql: String,
+        parameters: [Any?],
+        originalParameters: [QueryParameter]
+    ) {
+        guard let index = tabManager.selectedTabIndex else { return }
+        guard !tabManager.tabs[index].isExecuting else { return }
+
+        if currentQueryTask != nil {
+            currentQueryTask?.cancel()
+            do {
+                try DatabaseManager.shared.driver(for: connectionId)?.cancelQuery()
+            } catch {
+                Self.logger.warning("cancelQuery failed: \(error.localizedDescription, privacy: .public)")
+            }
+            currentQueryTask = nil
+        }
+        queryGeneration += 1
+        let capturedGeneration = queryGeneration
+
+        var tab = tabManager.tabs[index]
+        tab.isExecuting = true
+        tab.executionTime = nil
+        tab.errorMessage = nil
+        tab.explainText = nil
+        tab.explainPlan = nil
+        tabManager.tabs[index] = tab
+        toolbarState.setExecuting(true)
+
+        if PluginManager.shared.supportsQueryProgress(for: connection.type) {
+            installClickHouseProgressHandler()
+        }
+
+        let conn = connection
+        let tabId = tabManager.tabs[index].id
+
+        let (useProgressiveLoading, progressiveLimit) = resolveProgressiveLoading(
+            sql: sql,
+            tabType: tab.tabType
+        )
+        let effectiveSQL = sql
+
+        let (tableName, isEditable) = resolveTableEditability(tab: tab, sql: effectiveSQL)
+
+        currentQueryTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                var parallelSchemaTask: Task<SchemaResult, Error>?
+                var needsMetadataFetch = false
+
+                if isEditable, let tableName = tableName {
+                    let cached = isMetadataCached(tabId: tabId, tableName: tableName)
+                    needsMetadataFetch = !cached
+
+                    if needsMetadataFetch {
+                        let connId = connectionId
+                        parallelSchemaTask = Task {
+                            guard let driver = DatabaseManager.shared.driver(for: connId) else {
+                                throw DatabaseError.notConnected
+                            }
+                            async let cols = driver.fetchColumns(table: tableName)
+                            async let fks = driver.fetchForeignKeys(table: tableName)
+                            let result = try await (columnInfo: cols, fkInfo: fks)
+                            let approxCount = try? await driver.fetchApproximateRowCount(
+                                table: tableName
+                            )
+                            return (
+                                columnInfo: result.columnInfo,
+                                fkInfo: result.fkInfo,
+                                approximateRowCount: approxCount
+                            )
+                        }
+                    }
+                }
+
+                guard let queryDriver = DatabaseManager.shared.driver(for: connectionId) else {
+                    throw DatabaseError.notConnected
+                }
+                let fetchResult: QueryFetchResult
+                do {
+                    fetchResult = try await Self.fetchQueryDataParameterized(
+                        driver: queryDriver,
+                        sql: effectiveSQL,
+                        parameters: parameters,
+                        useProgressiveLoading: useProgressiveLoading,
+                        progressiveLimit: progressiveLimit
+                    )
+                }
+                let safeColumns = fetchResult.columns
+                let safeColumnTypes = fetchResult.columnTypes
+                let safeRows = fetchResult.rows
+                let safeExecutionTime = fetchResult.executionTime
+                let safeRowsAffected = fetchResult.rowsAffected
+                let safeStatusMessage = fetchResult.statusMessage
+                let pageContext = fetchResult.pageContext
+
+                guard !Task.isCancelled else {
+                    parallelSchemaTask?.cancel()
+                    await resetExecutionState(tabId: tabId, executionTime: safeExecutionTime)
+                    return
+                }
+
+                var schemaResult: SchemaResult?
+                if needsMetadataFetch {
+                    schemaResult = await awaitSchemaResult(
+                        parallelTask: parallelSchemaTask,
+                        tableName: tableName ?? ""
+                    )
+                }
+
+                let metadata = schemaResult.map { self.parseSchemaMetadata($0) }
+
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    currentQueryTask = nil
+                    if PluginManager.shared.supportsQueryProgress(for: self.connection.type) {
+                        self.clearClickHouseProgress()
+                    }
+                    toolbarState.setExecuting(false)
+                    toolbarState.lastQueryDuration = safeExecutionTime
+
+                    if capturedGeneration != queryGeneration || Task.isCancelled {
+                        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                            tabManager.tabs[idx].isExecuting = false
+                        }
+                        return
+                    }
+
+                    applyPhase1Result(
+                        tabId: tabId,
+                        columns: safeColumns,
+                        columnTypes: safeColumnTypes,
+                        rows: safeRows,
+                        executionTime: safeExecutionTime,
+                        rowsAffected: safeRowsAffected,
+                        statusMessage: safeStatusMessage,
+                        tableName: tableName,
+                        isEditable: isEditable,
+                        metadata: metadata,
+                        hasSchema: schemaResult != nil,
+                        sql: sql,
+                        connection: conn,
+                        queryPageContext: pageContext,
+                        queryParameterValues: originalParameters
+                    )
+
+                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                        tabManager.tabs[idx].pagination.baseQueryParameterValues =
+                            parameters.map { value in
+                                if let stringValue = value as? String {
+                                    return stringValue
+                                }
+                                return nil
+                            }
+                    }
+                }
+
+                if isEditable, let tableName = tableName {
+                    if needsMetadataFetch {
+                        launchPhase2Work(
+                            tableName: tableName,
+                            tabId: tabId,
+                            capturedGeneration: capturedGeneration,
+                            connectionType: conn.type,
+                            schemaResult: schemaResult
+                        )
+                    } else {
+                        launchPhase2Count(
+                            tableName: tableName,
+                            tabId: tabId,
+                            capturedGeneration: capturedGeneration,
+                            connectionType: conn.type
+                        )
+                    }
+                } else if !isEditable || tableName == nil {
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        guard capturedGeneration == queryGeneration else { return }
+                        guard !Task.isCancelled else { return }
+                        changeManager.clearChangesAndUndoHistory()
+                    }
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                        var tab = tabManager.tabs[idx]
+                        tab.isExecuting = false
+                        tab.pagination.isLoadingMore = false
+                        tabManager.tabs[idx] = tab
+                    }
+                    currentQueryTask = nil
+                    toolbarState.setExecuting(false)
+                    guard capturedGeneration == queryGeneration else { return }
+                    handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
+                }
+            }
+        }
+    }
+
+    func executeMultipleStatementsWithParameters(_ statements: [String], parameters: [QueryParameter]) {
+        guard let index = tabManager.selectedTabIndex else { return }
+        guard !tabManager.tabs[index].isExecuting else { return }
+
+        let missing = parameters.filter {
+            !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if let firstMissing = missing.first {
+            tabManager.tabs[index].errorMessage = String(
+                format: String(localized: "Missing value for parameter: :%@"),
+                firstMissing.name
+            )
+            return
+        }
+
+        let style = PluginMetadataRegistry.shared.snapshot(
+            forTypeId: connection.type.pluginTypeId
+        )?.parameterStyle ?? .questionMark
+
+        currentQueryTask?.cancel()
+        queryGeneration += 1
+        let capturedGeneration = queryGeneration
+
+        var tab = tabManager.tabs[index]
+        tab.isExecuting = true
+        tab.executionTime = nil
+        tab.errorMessage = nil
+        tabManager.tabs[index] = tab
+        toolbarState.setExecuting(true)
+
+        let conn = connection
+        let tabId = tabManager.tabs[index].id
+        let totalCount = statements.count
+
+        currentQueryTask = Task {
+            var cumulativeTime: TimeInterval = 0
+            var lastSelectResult: QueryResult?
+            var lastSelectSQL: String?
+            var totalRowsAffected = 0
+            var executedCount = 0
+            var failedSQL: String?
+            var newResultSets: [ResultSet] = []
+
+            do {
+                guard let driver = DatabaseManager.shared.driver(for: conn.id) else {
+                    throw DatabaseError.notConnected
+                }
+
+                let useTransaction = driver.supportsTransactions
+
+                if useTransaction {
+                    try await driver.beginTransaction()
+                }
+
+                @MainActor func rollbackAndResetState() async {
+                    if useTransaction {
+                        do {
+                            try await driver.rollbackTransaction()
+                        } catch {
+                            paramLog.error("Rollback failed: \(error.localizedDescription, privacy: .public)")
+                        }
+                    }
+                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                        tabManager.tabs[idx].isExecuting = false
+                    }
+                    currentQueryTask = nil
+                    toolbarState.setExecuting(false)
+                }
+
+                for (stmtIndex, stmtSQL) in statements.enumerated() {
+                    guard !Task.isCancelled else {
+                        await rollbackAndResetState()
+                        return
+                    }
+                    guard capturedGeneration == queryGeneration else {
+                        await rollbackAndResetState()
+                        return
+                    }
+
+                    failedSQL = stmtSQL
+                    let stmtParamNames = SQLParameterExtractor.extractParameters(from: stmtSQL)
+
+                    let result: QueryResult
+                    if stmtParamNames.isEmpty {
+                        result = try await driver.execute(query: stmtSQL)
+                    } else {
+                        let conversion = SQLParameterExtractor.convertToNativeStyle(
+                            sql: stmtSQL,
+                            parameters: parameters,
+                            style: style
+                        )
+                        result = try await driver.executeParameterized(
+                            query: conversion.sql,
+                            parameters: conversion.values
+                        )
+                    }
+
+                    failedSQL = nil
+                    executedCount = stmtIndex + 1
+                    cumulativeTime += result.executionTime
+                    totalRowsAffected += result.rowsAffected
+
+                    if !result.columns.isEmpty {
+                        lastSelectResult = result
+                        lastSelectSQL = stmtSQL
+                    }
+
+                    let stmtTableName = await MainActor.run { extractTableName(from: stmtSQL) }
+                    let rs = ResultSet(label: stmtTableName ?? "Result \(stmtIndex + 1)")
+                    rs.rowBuffer = RowBuffer(
+                        rows: result.rows.map { row in row.map { $0.map { String($0) } } },
+                        columns: result.columns.map { String($0) },
+                        columnTypes: result.columnTypes
+                    )
+                    rs.executionTime = result.executionTime
+                    rs.rowsAffected = result.rowsAffected
+                    rs.statusMessage = result.statusMessage
+                    rs.tableName = stmtTableName
+                    rs.resultVersion = 1
+                    newResultSets.append(rs)
+
+                    let historySQL = stmtSQL.hasSuffix(";") ? stmtSQL : stmtSQL + ";"
+                    await MainActor.run {
+                        QueryHistoryManager.shared.recordQuery(
+                            query: historySQL,
+                            connectionId: conn.id,
+                            databaseName: conn.database,
+                            executionTime: result.executionTime,
+                            rowCount: result.rows.count,
+                            wasSuccessful: true,
+                            errorMessage: nil,
+                            parameterValues: stmtParamNames.isEmpty ? nil : parameters
+                        )
+                    }
+                }
+
+                if useTransaction {
+                    try await driver.commitTransaction()
+                }
+
+                await MainActor.run {
+                    applyMultiStatementResults(
+                        tabId: tabId,
+                        capturedGeneration: capturedGeneration,
+                        cumulativeTime: cumulativeTime,
+                        totalRowsAffected: totalRowsAffected,
+                        lastSelectResult: lastSelectResult,
+                        lastSelectSQL: lastSelectSQL,
+                        newResultSets: newResultSets
+                    )
+                }
+            } catch {
+                if let driver = DatabaseManager.shared.driver(for: conn.id), driver.supportsTransactions {
+                    do {
+                        try await driver.rollbackTransaction()
+                    } catch {
+                        paramLog.error("Rollback failed: \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+
+                if capturedGeneration != queryGeneration {
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                            tabManager.tabs[idx].isExecuting = false
+                        }
+                        currentQueryTask = nil
+                        toolbarState.setExecuting(false)
+                    }
+                    return
+                }
+
+                let failedStmtIndex = executedCount + 1
+                let contextMsg = "Statement \(failedStmtIndex)/\(totalCount) failed: "
+                    + error.localizedDescription
+
+                let errorRS = ResultSet(label: "Error \(failedStmtIndex)")
+                errorRS.errorMessage = error.localizedDescription
+                newResultSets.append(errorRS)
+
+                await MainActor.run {
+                    currentQueryTask = nil
+                    toolbarState.setExecuting(false)
+
+                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+                        var errTab = tabManager.tabs[idx]
+                        errTab.errorMessage = contextMsg
+                        errTab.isExecuting = false
+                        errTab.executionTime = cumulativeTime
+
+                        let pinnedResults = errTab.resultSets.filter(\.isPinned)
+                        errTab.resultSets = pinnedResults + newResultSets
+                        errTab.activeResultSetId = newResultSets.last?.id
+
+                        tabManager.tabs[idx] = errTab
+                    }
+
+                    let rawSQL = failedSQL ?? statements[min(executedCount, totalCount - 1)]
+                    let recordSQL = rawSQL.hasSuffix(";") ? rawSQL : rawSQL + ";"
+                    QueryHistoryManager.shared.recordQuery(
+                        query: recordSQL,
+                        connectionId: conn.id,
+                        databaseName: conn.database,
+                        executionTime: cumulativeTime,
+                        rowCount: 0,
+                        wasSuccessful: false,
+                        errorMessage: error.localizedDescription
+                    )
+
+                    AlertHelper.showErrorSheet(
+                        title: String(localized: "Query Execution Failed"),
+                        message: contextMsg,
+                        window: contentWindow
+                    )
+                }
+            }
+        }
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
@@ -30,8 +30,8 @@ extension MainContentCoordinator {
         }
         if let firstMissing = missing.first {
             tabManager.tabs[index].errorMessage = String(
-                format: String(localized: "Missing value for parameter: :%@"),
-                firstMissing.name
+                format: String(localized: "Missing value for parameter: %@"),
+                ":\(firstMissing.name)"
             )
             return
         }
@@ -264,8 +264,8 @@ extension MainContentCoordinator {
         }
         if let firstMissing = missing.first {
             tabManager.tabs[index].errorMessage = String(
-                format: String(localized: "Missing value for parameter: :%@"),
-                firstMissing.name
+                format: String(localized: "Missing value for parameter: %@"),
+                ":\(firstMissing.name)"
             )
             return
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -771,11 +771,11 @@ final class MainContentCoordinator {
                     return
                 }
 
-                if paramStatements.count == 1 {
-                    executeQueryWithParameters(paramStatements[0], parameters: reconciled)
-                } else {
-                    executeMultipleStatementsWithParameters(paramStatements, parameters: reconciled)
-                }
+                dispatchParameterizedStatements(
+                    paramStatements,
+                    parameters: reconciled,
+                    tabIndex: index
+                )
                 return
             }
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -753,7 +753,33 @@ final class MainContentCoordinator {
             return
         }
 
-        // Split into individual statements for multi-statement support
+        if AppSettingsManager.shared.editor.queryParametersEnabled {
+            let paramStatements = SQLStatementScanner.allStatements(in: sql)
+            guard !paramStatements.isEmpty else { return }
+            let combinedSQL = paramStatements.joined(separator: "; ")
+            let detectedNames = SQLParameterExtractor.extractParameters(from: combinedSQL)
+
+            if !detectedNames.isEmpty {
+                let reconciled = detectAndReconcileParameters(
+                    sql: combinedSQL,
+                    existing: tabManager.tabs[index].queryParameters
+                )
+                tabManager.tabs[index].queryParameters = reconciled
+
+                if !tabManager.tabs[index].isParameterPanelVisible {
+                    tabManager.tabs[index].isParameterPanelVisible = true
+                    return
+                }
+
+                if paramStatements.count == 1 {
+                    executeQueryWithParameters(paramStatements[0], parameters: reconciled)
+                } else {
+                    executeMultipleStatementsWithParameters(paramStatements, parameters: reconciled)
+                }
+                return
+            }
+        }
+
         let statements = SQLStatementScanner.allStatements(in: sql)
         guard !statements.isEmpty else { return }
 
@@ -1135,7 +1161,7 @@ final class MainContentCoordinator {
 
     /// Reset execution state when a query is cancelled
     @MainActor
-    private func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
+    internal func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
         if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
             tabManager.tabs[idx].isExecuting = false
         }
@@ -1144,7 +1170,7 @@ final class MainContentCoordinator {
         toolbarState.lastQueryDuration = executionTime
     }
 
-    private func resolveTableEditability(tab: QueryTab, sql: String) -> (tableName: String?, isEditable: Bool) {
+    internal func resolveTableEditability(tab: QueryTab, sql: String) -> (tableName: String?, isEditable: Bool) {
         let usesNoSQLBrowsing = PluginManager.shared.editorLanguage(for: connection.type) != .sql
             || (DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter)?
                 .queryBuildingPluginDriver != nil

--- a/TablePro/Views/Settings/EditorSettingsView.swift
+++ b/TablePro/Views/Settings/EditorSettingsView.swift
@@ -21,6 +21,7 @@ struct EditorSettingsView: View {
                     Text("8 spaces").tag(8)
                 }
                 Toggle("Auto-uppercase keywords", isOn: $settings.uppercaseKeywords)
+                Toggle("Query parameters (:name syntax)", isOn: $settings.queryParametersEnabled)
                 Toggle("Vim mode", isOn: $settings.vimModeEnabled)
             }
 

--- a/TableProTests/Core/Utilities/SQLParameterExtractorTests.swift
+++ b/TableProTests/Core/Utilities/SQLParameterExtractorTests.swift
@@ -1,0 +1,232 @@
+//
+//  SQLParameterExtractorTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import TableProPluginKit
+import XCTest
+
+final class SQLParameterExtractorTests: XCTestCase {
+    // MARK: - extractParameters
+
+    func testNoParameters() {
+        XCTAssertEqual(SQLParameterExtractor.extractParameters(from: "SELECT 1"), [])
+    }
+
+    func testSingleParameter() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT * FROM t WHERE id = :id"),
+            ["id"]
+        )
+    }
+
+    func testMultipleParameters() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "WHERE id = :id AND name = :name"),
+            ["id", "name"]
+        )
+    }
+
+    func testDuplicateParameters() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "WHERE :id = :id OR :name = :id"),
+            ["id", "name"]
+        )
+    }
+
+    func testUnderscoreInName() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "WHERE user_id = :user_id"),
+            ["user_id"]
+        )
+    }
+
+    func testParameterAtEnd() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "WHERE id = :id"),
+            ["id"]
+        )
+    }
+
+    func testDoubleColonCast() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT col::integer FROM t"),
+            []
+        )
+    }
+
+    func testCastFollowedByParameter() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT col::int WHERE id = :id"),
+            ["id"]
+        )
+    }
+
+    func testCastVarcharWithLength() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT col::varchar(255) WHERE id = :id"),
+            ["id"]
+        )
+    }
+
+    func testParameterInSingleQuotes() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT ':name' FROM t"),
+            []
+        )
+    }
+
+    func testParameterInDoubleQuotes() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT \":name\" FROM t"),
+            []
+        )
+    }
+
+    func testParameterInBackticks() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT `:name` FROM t"),
+            []
+        )
+    }
+
+    func testEscapedQuoteInString() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT ':name''s value' FROM t"),
+            []
+        )
+    }
+
+    func testParameterInLineComment() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT 1 -- :name"),
+            []
+        )
+    }
+
+    func testParameterInBlockComment() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT /* :name */ 1"),
+            []
+        )
+    }
+
+    func testParameterAfterComment() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "-- comment\nSELECT :name"),
+            ["name"]
+        )
+    }
+
+    func testBareColon() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT : FROM t"),
+            []
+        )
+    }
+
+    func testColonFollowedByNumber() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT :123 FROM t"),
+            []
+        )
+    }
+
+    func testEmptyString() {
+        XCTAssertEqual(SQLParameterExtractor.extractParameters(from: ""), [])
+    }
+
+    func testMultipleStatementsParameters() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT :a; SELECT :b"),
+            ["a", "b"]
+        )
+    }
+
+    func testBackslashEscapeInString() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "SELECT '\\:name' FROM t"),
+            []
+        )
+    }
+
+    // MARK: - convertToNativeStyle
+
+    func testConvertToQuestionMark() {
+        let params = [
+            QueryParameter(name: "id", value: "42", type: .integer),
+            QueryParameter(name: "name", value: "Alice", type: .string)
+        ]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "WHERE id = :id AND name = :name",
+            parameters: params,
+            style: .questionMark
+        )
+        XCTAssertEqual(result.sql, "WHERE id = ? AND name = ?")
+        XCTAssertEqual(result.values.count, 2)
+        XCTAssertEqual(result.values[0] as? String, "42")
+        XCTAssertEqual(result.values[1] as? String, "Alice")
+    }
+
+    func testConvertToDollar() {
+        let params = [
+            QueryParameter(name: "id", value: "42"),
+            QueryParameter(name: "name", value: "Alice")
+        ]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "WHERE id = :id AND name = :name",
+            parameters: params,
+            style: .dollar
+        )
+        XCTAssertEqual(result.sql, "WHERE id = $1 AND name = $2")
+        XCTAssertEqual(result.values.count, 2)
+    }
+
+    func testConvertDuplicateParameter() {
+        let params = [QueryParameter(name: "id", value: "42")]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "WHERE :id = :id",
+            parameters: params,
+            style: .questionMark
+        )
+        XCTAssertEqual(result.sql, "WHERE ? = ?")
+        XCTAssertEqual(result.values.count, 2)
+        XCTAssertEqual(result.values[0] as? String, "42")
+        XCTAssertEqual(result.values[1] as? String, "42")
+    }
+
+    func testConvertNullParameter() {
+        let params = [QueryParameter(name: "id", value: "42", isNull: true)]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "WHERE id = :id",
+            parameters: params,
+            style: .questionMark
+        )
+        XCTAssertEqual(result.sql, "WHERE id = ?")
+        XCTAssertEqual(result.values.count, 1)
+        XCTAssertNil(result.values[0])
+    }
+
+    func testConvertSkipsParameterInString() {
+        let params = [QueryParameter(name: "id", value: "42")]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "WHERE ':id' = :id",
+            parameters: params,
+            style: .questionMark
+        )
+        XCTAssertEqual(result.sql, "WHERE ':id' = ?")
+        XCTAssertEqual(result.values.count, 1)
+    }
+
+    func testConvertSkipsDoubleColon() {
+        let params = [QueryParameter(name: "id", value: "42")]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "SELECT col::text WHERE id = :id",
+            parameters: params,
+            style: .dollar
+        )
+        XCTAssertEqual(result.sql, "SELECT col::text WHERE id = $1")
+        XCTAssertEqual(result.values.count, 1)
+    }
+}

--- a/TableProTests/Core/Utilities/SQLParameterExtractorTests.swift
+++ b/TableProTests/Core/Utilities/SQLParameterExtractorTests.swift
@@ -229,4 +229,38 @@ final class SQLParameterExtractorTests: XCTestCase {
         XCTAssertEqual(result.sql, "SELECT col::text WHERE id = $1")
         XCTAssertEqual(result.values.count, 1)
     }
+
+    // MARK: - Dollar-Quoted Strings
+
+    func testParameterInDollarQuotedString() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "CREATE FUNCTION foo() AS $$ SELECT :name $$ LANGUAGE sql"),
+            []
+        )
+    }
+
+    func testParameterInTaggedDollarQuotedString() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "DO $body$ SELECT :name $body$"),
+            []
+        )
+    }
+
+    func testParameterAfterDollarQuotedString() {
+        XCTAssertEqual(
+            SQLParameterExtractor.extractParameters(from: "$$ body $$ SELECT :id"),
+            ["id"]
+        )
+    }
+
+    func testConvertSkipsDollarQuotedString() {
+        let params = [QueryParameter(name: "id", value: "42")]
+        let result = SQLParameterExtractor.convertToNativeStyle(
+            sql: "$$ :id $$ WHERE id = :id",
+            parameters: params,
+            style: .questionMark
+        )
+        XCTAssertEqual(result.sql, "$$ :id $$ WHERE id = ?")
+        XCTAssertEqual(result.values.count, 1)
+    }
 }


### PR DESCRIPTION
## Summary

- Add `:name` placeholder syntax for query parameters in the SQL editor
- Inline parameter panel (between toolbar and editor) for entering values with type picker and NULL toggle
- Native prepared statement binding through the existing `executeParameterized` driver stack
- Parameters persist across tab switches and app restarts
- Progressive loading, multi-statement execution, and query history all support parameters
- 27 unit tests for the parameter extractor (detection + conversion)

Closes #737

## How it works

1. Write `SELECT * FROM users WHERE id = :user_id AND status = :status`
2. Press Cmd+Return — parameter panel appears
3. Fill values, press Cmd+Return again — executes with native binding (`?` for MySQL/SQLite, `$N` for PostgreSQL)

## Changes

- **Model**: `QueryParameter` struct, `QueryParameterType` enum
- **Scanner**: `SQLParameterExtractor` — O(1)-per-char detection, handles `::` casts, strings, comments
- **UI**: `QueryParameterPanelView` — follows FilterPanelView pattern
- **Coordinator**: `MainContentCoordinator+QueryParameters.swift` — detection gate in `runQuery()`, parameterized execution
- **Driver protocols**: `fetchFirstPageParameterized` / `fetchNextPageParameterized` at all 3 layers
- **History**: schema migration v2, stores parameter values as JSON
- **Settings**: `queryParametersEnabled` toggle in Editor settings (default: on)

## Test plan

- [x] Build succeeds
- [x] 27 SQLParameterExtractorTests pass (detection, conversion, edge cases)
- [ ] Manual: MySQL connection with `:name` params — panel shows, executes with `?` binding
- [ ] Manual: PostgreSQL connection — converts to `$1`, `$2`
- [ ] Manual: `col::integer AND :name = 1` — only `:name` detected
- [ ] Manual: `:name` inside string literal — not detected
- [ ] Manual: tab switch + app restart — values persist
- [ ] Manual: multi-statement with parameters
- [ ] Manual: progressive loading with parameters (load more works)
- [ ] Manual: Settings > Editor > disable toggle — parameters not detected