### PR TITLE
fix: correct SSL and SSH parsing in foreign app importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TablePlus import: correctly map all SSL/TLS modes instead of treating Prefer as disabled
+- DBeaver import: parse SSL configuration from handler properties
+- Sequel Ace import: read SSH port as number, not string
+- TablePlus import: import SSH key passphrases from keychain
 - Filter value field now works correctly with Chinese, Japanese, and Korean input methods (#878)
 - Saving a filter preset with a duplicate name no longer silently overwrites the existing preset
 - Raw SQL filter accepting destructive statements and comment injection

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -160,6 +160,7 @@ struct DBeaverImporter: ForeignAppImporter {
         }
 
         let sshConfig = parseSSHConfig(config)
+        let sslConfig = parseSSLConfig(config)
         let color = parseColor(config)
 
         return ExportableConnection(
@@ -170,7 +171,7 @@ struct DBeaverImporter: ForeignAppImporter {
             username: username,
             type: dbType,
             sshConfig: sshConfig,
-            sslConfig: nil,
+            sslConfig: sslConfig,
             color: color,
             tagName: nil,
             groupName: groupName,
@@ -229,6 +230,35 @@ struct DBeaverImporter: ForeignAppImporter {
             totpAlgorithm: nil,
             totpDigits: nil,
             totpPeriod: nil
+        )
+    }
+
+    private func parseSSLConfig(_ config: [String: Any]) -> ExportableSSLConfig? {
+        guard let handlers = config["handlers"] as? [String: Any],
+              let sslHandler = handlers["ssl"] as? [String: Any] else { return nil }
+
+        let enabled = sslHandler["enabled"] as? Bool ?? false
+        guard enabled else { return nil }
+
+        let properties = sslHandler["properties"] as? [String: Any] ?? [:]
+
+        let mode: String
+        switch properties["sslMode"] as? String ?? "" {
+        case "require": mode = SSLMode.required.rawValue
+        case "verify-ca": mode = SSLMode.verifyCa.rawValue
+        case "verify-full": mode = SSLMode.verifyIdentity.rawValue
+        default: mode = SSLMode.preferred.rawValue
+        }
+
+        let caCertPath = properties["caCertPath"] as? String
+        let clientCertPath = properties["clientCertPath"] as? String
+        let clientKeyPath = properties["clientKeyPath"] as? String
+
+        return ExportableSSLConfig(
+            mode: mode,
+            caCertificatePath: caCertPath,
+            clientCertificatePath: clientCertPath,
+            clientKeyPath: clientKeyPath
         )
     }
 

--- a/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
@@ -195,8 +195,14 @@ struct SequelAceImporter: ForeignAppImporter {
         guard connectionType == 2 else { return nil }
         let host = entry["sshHost"] as? String ?? ""
         let user = entry["sshUser"] as? String ?? ""
-        let portString = entry["sshPort"] as? String ?? "22"
-        let port = Int(portString) ?? 22
+        let port: Int
+        if let intPort = entry["sshPort"] as? Int {
+            port = intPort
+        } else if let strPort = entry["sshPort"] as? String, let parsed = Int(strPort) {
+            port = parsed
+        } else {
+            port = 22
+        }
         let keyEnabled = (entry["sshKeyLocationEnabled"] as? Int ?? 0) != 0
         let rawKeyPath = entry["sshKeyLocation"] as? String ?? ""
         let keyPath = ForeignAppPathHelper.resolveKeyPath(rawKeyPath)

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -65,7 +65,7 @@ struct TablePlusImporter: ForeignAppImporter {
 
                 if includePasswords, let connId = entry["ID"] as? String {
                     let creds = readCredentials(for: connId)
-                    if creds.password != nil || creds.sshPassword != nil {
+                    if creds.password != nil || creds.sshPassword != nil || creds.keyPassphrase != nil {
                         credentials[String(index)] = creds
                     }
                 }
@@ -201,12 +201,21 @@ struct TablePlusImporter: ForeignAppImporter {
     }
 
     private func parseSSLConfig(_ entry: [String: Any]) -> ExportableSSLConfig? {
+        guard entry.keys.contains("tLSMode") else { return nil }
         let tlsMode = entry["tLSMode"] as? Int ?? 0
-        guard tlsMode != 0 else { return nil }
+
+        let mode: String
+        switch tlsMode {
+        case 0: mode = SSLMode.preferred.rawValue
+        case 1: mode = SSLMode.required.rawValue
+        case 2: mode = SSLMode.verifyCa.rawValue
+        case 3: mode = SSLMode.verifyIdentity.rawValue
+        default: return nil
+        }
 
         let paths = entry["TlsKeyPaths"] as? [String] ?? []
         return ExportableSSLConfig(
-            mode: "Required",
+            mode: mode,
             caCertificatePath: !paths.isEmpty ? paths[0] : nil,
             clientCertificatePath: paths.count > 1 ? paths[1] : nil,
             clientKeyPath: paths.count > 2 ? paths[2] : nil
@@ -222,10 +231,14 @@ struct TablePlusImporter: ForeignAppImporter {
             service: "com.tableplus.TablePlus",
             account: "\(connectionId)_server"
         )
+        let keyPassphrase = ForeignKeychainReader.readPassword(
+            service: "com.tableplus.TablePlus",
+            account: "\(connectionId)_server_key"
+        )
         return ExportableCredentials(
             password: dbPassword,
             sshPassword: sshPassword,
-            keyPassphrase: nil,
+            keyPassphrase: keyPassphrase,
             totpSecret: nil,
             pluginSecureFields: nil
         )

--- a/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
@@ -85,6 +85,11 @@ struct DBeaverImporterTests {
         sshUsername: String = "",
         sshAuthType: String = "PASSWORD",
         sshKeyPath: String = "",
+        sslEnabled: Bool = false,
+        sslMode: String = "",
+        sslCaCertPath: String = "",
+        sslClientCertPath: String = "",
+        sslClientKeyPath: String = "",
         color: String? = nil
     ) -> [String: Any] {
         var config: [String: Any] = [
@@ -98,19 +103,41 @@ struct DBeaverImporterTests {
         if let color = color {
             config["color"] = color
         }
+
+        var handlers: [String: Any] = [:]
         if sshEnabled {
-            config["handlers"] = [
-                "ssh_tunnel": [
-                    "enabled": true,
-                    "properties": [
-                        "host": sshHost,
-                        "port": sshPort as Any,
-                        "username": sshUsername,
-                        "authType": sshAuthType,
-                        "keyPath": sshKeyPath
-                    ] as [String: Any]
+            handlers["ssh_tunnel"] = [
+                "enabled": true,
+                "properties": [
+                    "host": sshHost,
+                    "port": sshPort as Any,
+                    "username": sshUsername,
+                    "authType": sshAuthType,
+                    "keyPath": sshKeyPath
                 ] as [String: Any]
-            ]
+            ] as [String: Any]
+        }
+        if sslEnabled {
+            var sslProperties: [String: Any] = [:]
+            if !sslMode.isEmpty {
+                sslProperties["sslMode"] = sslMode
+            }
+            if !sslCaCertPath.isEmpty {
+                sslProperties["caCertPath"] = sslCaCertPath
+            }
+            if !sslClientCertPath.isEmpty {
+                sslProperties["clientCertPath"] = sslClientCertPath
+            }
+            if !sslClientKeyPath.isEmpty {
+                sslProperties["clientKeyPath"] = sslClientKeyPath
+            }
+            handlers["ssl"] = [
+                "enabled": true,
+                "properties": sslProperties
+            ] as [String: Any]
+        }
+        if !handlers.isEmpty {
+            config["handlers"] = handlers
         }
 
         var dict: [String: Any] = [
@@ -516,5 +543,118 @@ struct DBeaverImporterTests {
 
         let result = try importer.importConnections(includePasswords: false)
         #expect(result.envelope.connections[0].type == "exoticdb")
+    }
+
+    // MARK: - SSL Parsing
+
+    @Test("importConnections parses SSL with require mode")
+    func testImportConnections_parsesSSLRequireMode() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(name: "SSL Require", sslEnabled: true, sslMode: "require")
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Required")
+    }
+
+    @Test("importConnections parses SSL with verify-ca mode")
+    func testImportConnections_parsesSSLVerifyCaMode() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(name: "SSL Verify CA", sslEnabled: true, sslMode: "verify-ca")
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Verify CA")
+    }
+
+    @Test("importConnections parses SSL with verify-full mode")
+    func testImportConnections_parsesSSLVerifyFullMode() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(name: "SSL Verify Full", sslEnabled: true, sslMode: "verify-full")
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Verify Identity")
+    }
+
+    @Test("importConnections SSL enabled with empty mode defaults to Preferred")
+    func testImportConnections_sslEnabledEmptyModeDefaultsToPreferred() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(name: "SSL Default", sslEnabled: true, sslMode: "")
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Preferred")
+    }
+
+    @Test("importConnections parses SSL certificate paths")
+    func testImportConnections_parsesSSLCertPaths() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(
+                name: "SSL Certs",
+                sslEnabled: true,
+                sslMode: "verify-full",
+                sslCaCertPath: "/path/to/ca.pem",
+                sslClientCertPath: "/path/to/cert.pem",
+                sslClientKeyPath: "/path/to/key.pem"
+            )
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+
+        #expect(ssl != nil)
+        #expect(ssl?.caCertificatePath == "/path/to/ca.pem")
+        #expect(ssl?.clientCertificatePath == "/path/to/cert.pem")
+        #expect(ssl?.clientKeyPath == "/path/to/key.pem")
+    }
+
+    @Test("importConnections no SSL when handler missing")
+    func testImportConnections_noSSLWhenHandlerMissing() throws {
+        let connections: [String: [String: Any]] = [
+            "pg-1": makeConnection(name: "No SSL", sslEnabled: false)
+        ]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        #expect(result.envelope.connections[0].sslConfig == nil)
+    }
+
+    @Test("importConnections no SSL when handler disabled")
+    func testImportConnections_noSSLWhenHandlerDisabled() throws {
+        var connDict = makeConnection(name: "SSL Disabled")
+        var config = connDict["configuration"] as! [String: Any]
+        config["handlers"] = [
+            "ssl": [
+                "enabled": false,
+                "properties": [
+                    "sslMode": "require"
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+        connDict["configuration"] = config
+
+        let connections: [String: [String: Any]] = ["pg-1": connDict]
+        try writeDataSources(makeDataSourcesJSON(connections: connections))
+
+        let result = try importer.importConnections(includePasswords: false)
+        #expect(result.envelope.connections[0].sslConfig == nil)
     }
 }

--- a/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
@@ -640,7 +640,10 @@ struct DBeaverImporterTests {
     @Test("importConnections no SSL when handler disabled")
     func testImportConnections_noSSLWhenHandlerDisabled() throws {
         var connDict = makeConnection(name: "SSL Disabled")
-        var config = connDict["configuration"] as! [String: Any]
+        guard var config = connDict["configuration"] as? [String: Any] else {
+            Issue.record("Expected configuration dict")
+            return
+        }
         config["handlers"] = [
             "ssl": [
                 "enabled": false,

--- a/TableProTests/Core/Services/ForeignApp/SequelAceImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/SequelAceImporterTests.swift
@@ -53,7 +53,7 @@ struct SequelAceImporterTests {
         colorIndex: Int = -1,
         sshHost: String = "",
         sshUser: String = "",
-        sshPort: String = "22",
+        sshPort: Any = 22 as Int,
         sshKeyEnabled: Int = 0,
         sshKeyLocation: String = "",
         useSSL: Int = 0,
@@ -166,7 +166,7 @@ struct SequelAceImporterTests {
                 id: 1,
                 sshHost: "bastion.example.com",
                 sshUser: "deploy",
-                sshPort: "2222",
+                sshPort: 2222,
                 sshKeyEnabled: 1,
                 sshKeyLocation: "~/.ssh/id_ed25519"
             )
@@ -365,7 +365,7 @@ struct SequelAceImporterTests {
                 id: 1,
                 sshHost: "bastion.com",
                 sshUser: "admin",
-                sshPort: "22",
+                sshPort: 22,
                 sshKeyEnabled: 0
             )
         ]
@@ -416,5 +416,45 @@ struct SequelAceImporterTests {
         let result = try importer.importConnections(includePasswords: false)
         // The inner group name should be used for the nested connection
         #expect(result.envelope.connections[0].groupName == "Inner")
+    }
+
+    @Test("importConnections SSH port parsed as Int")
+    func testImportConnections_sshPortParsedAsInt() throws {
+        let children: [[String: Any]] = [
+            makeConnection(
+                name: "SSH Int Port",
+                type: 2,
+                id: 1,
+                sshHost: "bastion.com",
+                sshUser: "deploy",
+                sshPort: 2222
+            )
+        ]
+        try writeFavorites(makeFavoritesRoot(children: children))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssh = result.envelope.connections[0].sshConfig
+
+        #expect(ssh?.port == 2222)
+    }
+
+    @Test("importConnections SSH port parsed as String fallback")
+    func testImportConnections_sshPortParsedAsString() throws {
+        let children: [[String: Any]] = [
+            makeConnection(
+                name: "SSH String Port",
+                type: 2,
+                id: 1,
+                sshHost: "bastion.com",
+                sshUser: "deploy",
+                sshPort: "3333"
+            )
+        ]
+        try writeFavorites(makeFavoritesRoot(children: children))
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssh = result.envelope.connections[0].sshConfig
+
+        #expect(ssh?.port == 3333)
     }
 }

--- a/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
@@ -58,7 +58,7 @@ struct TablePlusImporterTests {
         sshUser: String = "",
         usePrivateKey: Bool = false,
         privateKeyPath: String = "",
-        tlsMode: Int = 0,
+        tlsMode: Int? = nil,
         tlsKeyPaths: [String] = [],
         environment: String = ""
     ) -> [String: Any] {
@@ -72,9 +72,11 @@ struct TablePlusImporterTests {
             "ID": id,
             "GroupID": groupId,
             "isOverSSH": isOverSSH,
-            "tLSMode": tlsMode,
             "Enviroment": environment
         ]
+        if let tlsMode {
+            entry["tLSMode"] = tlsMode
+        }
         if isOverSSH {
             entry["ServerAddress"] = sshHost
             entry["ServerPort"] = sshPort
@@ -237,14 +239,50 @@ struct TablePlusImporterTests {
         #expect(ssl?.clientKeyPath == "/path/to/client-key.pem")
     }
 
-    @Test("importConnections no SSL when tLSMode is 0")
-    func testImportConnections_noSSLWhenTLSModeZero() throws {
+    @Test("importConnections no SSL when tLSMode key is absent")
+    func testImportConnections_noSSLWhenTLSModeAbsent() throws {
         try writeConnections([
-            makeConnection(name: "No SSL", id: "nossl-1", tlsMode: 0)
+            makeConnection(name: "No SSL", id: "nossl-1")
         ])
 
         let result = try importer.importConnections(includePasswords: false)
         #expect(result.envelope.connections[0].sslConfig == nil)
+    }
+
+    @Test("importConnections SSL mode Preferred when tLSMode is 0")
+    func testImportConnections_sslModePreferredWhenTLSModeZero() throws {
+        try writeConnections([
+            makeConnection(name: "Prefer SSL", id: "ssl-prefer", tlsMode: 0)
+        ])
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Preferred")
+    }
+
+    @Test("importConnections SSL mode Verify CA when tLSMode is 2")
+    func testImportConnections_sslModeVerifyCA() throws {
+        try writeConnections([
+            makeConnection(name: "Verify CA", id: "ssl-ca", tlsMode: 2)
+        ])
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Verify CA")
+    }
+
+    @Test("importConnections SSL mode Verify Identity when tLSMode is 3")
+    func testImportConnections_sslModeVerifyIdentity() throws {
+        try writeConnections([
+            makeConnection(name: "Verify Identity", id: "ssl-identity", tlsMode: 3)
+        ])
+
+        let result = try importer.importConnections(includePasswords: false)
+        let ssl = result.envelope.connections[0].sslConfig
+        #expect(ssl != nil)
+        #expect(ssl?.mode == "Verify Identity")
     }
 
     @Test("importConnections preserves groups")

--- a/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
@@ -285,6 +285,16 @@ struct TablePlusImporterTests {
         #expect(ssl?.mode == "Verify Identity")
     }
 
+    @Test("importConnections no SSL for unknown tLSMode value")
+    func testImportConnections_noSSLForUnknownTLSMode() throws {
+        try writeConnections([
+            makeConnection(name: "Unknown TLS", id: "ssl-unknown", tlsMode: 99)
+        ])
+
+        let result = try importer.importConnections(includePasswords: false)
+        #expect(result.envelope.connections[0].sslConfig == nil)
+    }
+
     @Test("importConnections preserves groups")
     func testImportConnections_preservesGroups() throws {
         try writeGroups([


### PR DESCRIPTION
## Summary

Fixes #887. PostgreSQL connections imported from TablePlus fail with `FATAL: no pg_hba.conf entry for host..., no encryption` because the SSL mode is lost during import.

Full analysis revealed bugs across all three importers:

- **TablePlus**: `tLSMode=0` (Prefer) was treated as "SSL disabled", and all non-zero modes were hardcoded to "Required". Now correctly maps all 4 TablePlus TLS modes (Prefer, Required, Verify CA, Verify Identity)
- **DBeaver**: SSL configuration from `handlers.ssl` was not parsed at all. Now reads SSL mode and certificate paths following the same handler pattern as the existing SSH tunnel parsing
- **Sequel Ace**: SSH port was read as `String` but Sequel Ace stores it as `Int`, causing custom SSH ports to silently default to 22. Now uses the Int-then-String pattern
- **TablePlus**: SSH key passphrases were not imported from the TablePlus keychain

## Test plan

- [x] All 24 TablePlus importer tests pass (3 new SSL mode tests + 1 renamed)
- [x] All 31 DBeaver importer tests pass (7 new SSL tests)
- [x] All 22 Sequel Ace importer tests pass (2 new SSH port type tests)