### PR TITLE
feat: auto-update outdated plugins at launch and add update UI in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Plugin auto-update: outdated plugins are silently updated from the registry at launch, with an actionable alert if auto-update fails
+- Plugin update detection in Settings: update badges on installed plugins, one-click update from both Installed and Browse tabs
 - Query parameters: write `:name` placeholders in SQL, fill values in an inline panel, execute with native prepared statement binding
 - AI provider registry for extensible provider management
 - GitHub Copilot integration: inline suggestions, chat via LSP conversation protocol, OAuth sign-in, schema context

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -176,7 +176,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handlePluginsRejected(_ notification: Notification) {
-        guard let rejected = notification.object as? [(name: String, reason: String)],
+        guard let rejected = notification.object as? [RejectedPlugin],
               !rejected.isEmpty else { return }
         let details = rejected.map { "\($0.name): \($0.reason)" }.joined(separator: "\n")
         Task {
@@ -186,15 +186,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 rejected.count
             )
             alert.informativeText = String(
-                format: String(localized: "The following plugins were rejected:\n\n%@\n\nPlease update them from the plugin registry."),
+                format: String(localized: "The following plugins were rejected:\n\n%@\n\nYou can update them from the plugin registry in Settings."),
                 details
             )
             alert.alertStyle = .warning
-            alert.addButton(withTitle: String(localized: "OK"))
+            alert.addButton(withTitle: String(localized: "Open Plugin Settings"))
+            alert.addButton(withTitle: String(localized: "Dismiss"))
+
+            let response: NSApplication.ModalResponse
             if let window = AlertHelper.resolveWindow(nil) {
-                alert.beginSheetModal(for: window)
+                response = await withCheckedContinuation { continuation in
+                    alert.beginSheetModal(for: window) { resp in
+                        continuation.resume(returning: resp)
+                    }
+                }
             } else {
-                alert.runModal()
+                response = alert.runModal()
+            }
+
+            if response == .alertFirstButtonReturn {
+                UserDefaults.standard.set(SettingsTab.plugins.rawValue, forKey: "selectedSettingsTab")
+                NotificationCenter.default.post(name: .openSettingsWindow, object: nil)
             }
         }
     }

--- a/TablePro/Core/Plugins/PluginError.swift
+++ b/TablePro/Core/Plugins/PluginError.swift
@@ -57,4 +57,9 @@ enum PluginError: LocalizedError {
             return String(format: String(localized: "Plugin '%@' has an invalid descriptor: %@"), pluginId, reason)
         }
     }
+
+    var isOutdated: Bool {
+        if case .pluginOutdated = self { return true }
+        return false
+    }
 }

--- a/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
+++ b/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
@@ -57,18 +57,6 @@ extension PluginManager {
         rejectedPlugins = stillRejected
     }
 
-    func availablePluginUpdates(manifest: RegistryManifest) -> [String: RegistryPlugin] {
-        var updates: [String: RegistryPlugin] = [:]
-        for registryPlugin in manifest.plugins {
-            guard registryPlugin.category != .theme else { continue }
-            guard let installed = plugins.first(where: { $0.id == registryPlugin.id }) else { continue }
-            if registryPlugin.version.compare(installed.version, options: .numeric) == .orderedDescending {
-                updates[registryPlugin.id] = registryPlugin
-            }
-        }
-        return updates
-    }
-
     func registryUpdate(for pluginId: String) -> RegistryPlugin? {
         guard let manifest = RegistryClient.shared.manifest else { return nil }
         guard let installed = plugins.first(where: { $0.id == pluginId }) else { return nil }

--- a/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
+++ b/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
@@ -1,0 +1,80 @@
+//
+//  PluginManager+AutoUpdate.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+extension PluginManager {
+    func autoUpdateRejectedPlugins() async {
+        let outdated = rejectedPlugins.filter(\.isOutdated)
+        guard !outdated.isEmpty else { return }
+
+        Self.logger.info("Attempting auto-update for \(outdated.count) outdated plugin(s)")
+
+        let registryClient = RegistryClient.shared
+        await registryClient.fetchManifest()
+
+        guard let manifest = registryClient.manifest else {
+            Self.logger.warning("Auto-update skipped: registry manifest unavailable")
+            return
+        }
+
+        var stillRejected = rejectedPlugins.filter { !$0.isOutdated }
+
+        for plugin in outdated {
+            let lookupId = plugin.registryId ?? plugin.bundleId
+
+            guard let lookupId,
+                  let registryPlugin = manifest.plugins.first(where: { $0.id == lookupId }) else {
+                Self.logger.warning("Auto-update skipped for '\(plugin.name)': no matching registry plugin")
+                stillRejected.append(plugin)
+                continue
+            }
+
+            do {
+                _ = try await updateFromRegistry(registryPlugin, existingPluginLoaded: false) { _ in }
+                Self.logger.info("Auto-updated plugin '\(plugin.name)' to v\(registryPlugin.version)")
+            } catch {
+                Self.logger.error("Auto-update failed for '\(plugin.name)': \(error.localizedDescription)")
+                stillRejected.append(RejectedPlugin(
+                    url: plugin.url,
+                    bundleId: plugin.bundleId,
+                    registryId: plugin.registryId,
+                    name: plugin.name,
+                    reason: error.localizedDescription,
+                    isOutdated: plugin.isOutdated
+                ))
+            }
+        }
+
+        let updatedCount = outdated.count - stillRejected.filter(\.isOutdated).count
+        if updatedCount > 0 {
+            Self.logger.info("Auto-updated \(updatedCount) plugin(s) from registry")
+        }
+
+        rejectedPlugins = stillRejected
+    }
+
+    func availablePluginUpdates(manifest: RegistryManifest) -> [String: RegistryPlugin] {
+        var updates: [String: RegistryPlugin] = [:]
+        for registryPlugin in manifest.plugins {
+            guard registryPlugin.category != .theme else { continue }
+            guard let installed = plugins.first(where: { $0.id == registryPlugin.id }) else { continue }
+            if registryPlugin.version.compare(installed.version, options: .numeric) == .orderedDescending {
+                updates[registryPlugin.id] = registryPlugin
+            }
+        }
+        return updates
+    }
+
+    func registryUpdate(for pluginId: String) -> RegistryPlugin? {
+        guard let manifest = RegistryClient.shared.manifest else { return nil }
+        guard let installed = plugins.first(where: { $0.id == pluginId }) else { return nil }
+        guard let registryPlugin = manifest.plugins.first(where: { $0.id == pluginId }) else { return nil }
+        guard registryPlugin.category != .theme else { return nil }
+        return registryPlugin.version.compare(installed.version, options: .numeric) == .orderedDescending
+            ? registryPlugin : nil
+    }
+}

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -105,22 +105,10 @@ final class PluginManager {
             .appendingPathComponent(pluginURL.lastPathComponent + ".metadata.json")
     }
 
-    nonisolated private static func readRegistryVersion(for pluginURL: URL) -> String? {
+    nonisolated private static func readRegistryMetadata(for pluginURL: URL) -> RegistryMetadata? {
         let url = metadataURL(for: pluginURL)
-        guard let data = try? Data(contentsOf: url),
-              let metadata = try? JSONDecoder().decode(RegistryMetadata.self, from: data) else {
-            return nil
-        }
-        return metadata.version
-    }
-
-    nonisolated private static func readRegistryPluginId(for pluginURL: URL) -> String? {
-        let url = metadataURL(for: pluginURL)
-        guard let data = try? Data(contentsOf: url),
-              let metadata = try? JSONDecoder().decode(RegistryMetadata.self, from: data) else {
-            return nil
-        }
-        return metadata.pluginId
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(RegistryMetadata.self, from: data)
     }
 
     func saveRegistryMetadata(version: String, pluginId: String, pluginURL: URL) {
@@ -265,7 +253,7 @@ final class PluginManager {
 
         let disabled = disabledPluginIds
         let driverType = principalClass as? any DriverPlugin.Type
-        let version = Self.readRegistryVersion(for: url) ?? principalClass.pluginVersion
+        let version = Self.readRegistryMetadata(for: url)?.version ?? principalClass.pluginVersion
         let entry = PluginEntry(
             id: bundleId,
             bundle: bundle,
@@ -378,7 +366,7 @@ final class PluginManager {
                     rejectedPlugins.append(RejectedPlugin(
                         url: itemURL,
                         bundleId: bundle?.bundleIdentifier,
-                        registryId: Self.readRegistryPluginId(for: itemURL),
+                        registryId: Self.readRegistryMetadata(for: itemURL)?.pluginId,
                         name: itemURL.deletingPathExtension().lastPathComponent,
                         reason: error.localizedDescription,
                         isOutdated: (error as? PluginError)?.isOutdated ?? false

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -53,7 +53,7 @@ final class PluginManager {
         }
     }
 
-    internal(set) var rejectedPlugins: [(name: String, reason: String)] = []
+    internal(set) var rejectedPlugins: [RejectedPlugin] = []
 
     private static let needsRestartKey = "com.TablePro.needsRestart"
 
@@ -114,6 +114,15 @@ final class PluginManager {
         return metadata.version
     }
 
+    nonisolated private static func readRegistryPluginId(for pluginURL: URL) -> String? {
+        let url = metadataURL(for: pluginURL)
+        guard let data = try? Data(contentsOf: url),
+              let metadata = try? JSONDecoder().decode(RegistryMetadata.self, from: data) else {
+            return nil
+        }
+        return metadata.pluginId
+    }
+
     func saveRegistryMetadata(version: String, pluginId: String, pluginURL: URL) {
         let metadata = RegistryMetadata(version: version, pluginId: pluginId)
         let url = Self.metadataURL(for: pluginURL)
@@ -153,6 +162,9 @@ final class PluginManager {
         discoverAllPlugins()
         let pending = pendingPluginURLs
         Task {
+            if !self.rejectedPlugins.isEmpty {
+                await self.autoUpdateRejectedPlugins()
+            }
             let validated = await Self.validateAndLoadBundles(pending)
             self.pendingPluginURLs.removeAll()
             self.needsRestartStorage = false
@@ -362,9 +374,14 @@ final class PluginManager {
             } catch {
                 Self.logger.error("Failed to discover plugin at \(itemURL.lastPathComponent): \(error.localizedDescription)")
                 if source == .userInstalled {
-                    rejectedPlugins.append((
+                    let bundle = Bundle(url: itemURL)
+                    rejectedPlugins.append(RejectedPlugin(
+                        url: itemURL,
+                        bundleId: bundle?.bundleIdentifier,
+                        registryId: Self.readRegistryPluginId(for: itemURL),
                         name: itemURL.deletingPathExtension().lastPathComponent,
-                        reason: error.localizedDescription
+                        reason: error.localizedDescription,
+                        isOutdated: (error as? PluginError)?.isOutdated ?? false
                     ))
                 }
             }

--- a/TablePro/Core/Plugins/PluginModels.swift
+++ b/TablePro/Core/Plugins/PluginModels.swift
@@ -28,6 +28,15 @@ enum PluginSource {
     case userInstalled
 }
 
+struct RejectedPlugin {
+    let url: URL
+    let bundleId: String?
+    let registryId: String?
+    let name: String
+    let reason: String
+    let isOutdated: Bool
+}
+
 extension PluginEntry {
     var exportPlugin: (any ExportFormatPlugin.Type)? {
         bundle.principalClass as? any ExportFormatPlugin.Type

--- a/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
+++ b/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
@@ -80,4 +80,31 @@ extension PluginManager {
 
         return entry
     }
+
+    func updateFromRegistry(
+        _ registryPlugin: RegistryPlugin,
+        existingPluginLoaded: Bool = true,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> PluginEntry {
+        if let minAppVersion = registryPlugin.minAppVersion {
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+            if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
+                throw PluginError.incompatibleWithCurrentApp(minimumRequired: minAppVersion)
+            }
+        }
+
+        if let minKit = registryPlugin.minPluginKitVersion, minKit > Self.currentPluginKitVersion {
+            throw PluginError.incompatibleVersion(required: minKit, current: Self.currentPluginKitVersion)
+        }
+
+        replaceExistingPlugin(bundleId: registryPlugin.id)
+
+        let entry = try await installFromRegistry(registryPlugin, progress: progress)
+
+        if existingPluginLoaded {
+            needsRestartStorage = true
+        }
+
+        return entry
+    }
 }

--- a/TablePro/Views/Settings/Plugins/BrowsePluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/BrowsePluginsView.swift
@@ -153,9 +153,34 @@ struct BrowsePluginsView: View {
     @ViewBuilder
     private func rowStatusBadge(for plugin: RegistryPlugin) -> some View {
         if isPluginInstalled(plugin.id) {
-            Text("Installed")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+            if hasUpdate(for: plugin) {
+                if let progress = installTracker.state(for: plugin.id) {
+                    switch progress.phase {
+                    case .downloading(let fraction):
+                        ProgressView(value: fraction)
+                            .frame(width: 40)
+                            .progressViewStyle(.linear)
+                    case .installing:
+                        ProgressView()
+                            .controlSize(.mini)
+                    case .completed:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Color(nsColor: .systemGreen))
+                            .font(.caption)
+                    case .failed:
+                        Button("Retry") { updatePlugin(plugin) }
+                            .controlSize(.mini)
+                    }
+                } else {
+                    Button(String(localized: "Update")) { updatePlugin(plugin) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
+                }
+            } else {
+                Text("Installed")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         } else if let progress = installTracker.state(for: plugin.id) {
             switch progress.phase {
             case .downloading(let fraction):
@@ -195,9 +220,11 @@ struct BrowsePluginsView: View {
             RegistryPluginDetailView(
                 plugin: selectedPlugin,
                 isInstalled: isPluginInstalled(selectedPlugin.id),
+                hasUpdate: hasUpdate(for: selectedPlugin),
                 installProgress: installTracker.state(for: selectedPlugin.id),
                 downloadCount: downloadCountService.downloadCount(for: selectedPlugin.id),
-                onInstall: { installPlugin(selectedPlugin) }
+                onInstall: { installPlugin(selectedPlugin) },
+                onUpdate: { updatePlugin(selectedPlugin) }
             )
         } else {
             VStack(spacing: 8) {
@@ -219,6 +246,11 @@ struct BrowsePluginsView: View {
             || ThemeRegistryInstaller.shared.isInstalled(pluginId)
     }
 
+    private func hasUpdate(for plugin: RegistryPlugin) -> Bool {
+        guard let installed = pluginManager.plugins.first(where: { $0.id == plugin.id }) else { return false }
+        return plugin.version.compare(installed.version, options: .numeric) == .orderedDescending
+    }
+
     private func installPlugin(_ plugin: RegistryPlugin) {
         Task {
             installTracker.beginInstall(pluginId: plugin.id)
@@ -232,6 +264,34 @@ struct BrowsePluginsView: View {
                     }
                 } else {
                     _ = try await pluginManager.installFromRegistry(plugin) { fraction in
+                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
+                        if fraction >= 1.0 {
+                            installTracker.markInstalling(pluginId: plugin.id)
+                        }
+                    }
+                }
+                installTracker.completeInstall(pluginId: plugin.id)
+            } catch {
+                installTracker.failInstall(pluginId: plugin.id, error: error.localizedDescription)
+                errorMessage = error.localizedDescription
+                showErrorAlert = true
+            }
+        }
+    }
+
+    private func updatePlugin(_ plugin: RegistryPlugin) {
+        Task {
+            installTracker.beginInstall(pluginId: plugin.id)
+            do {
+                if plugin.category == .theme {
+                    try await ThemeRegistryInstaller.shared.update(plugin) { fraction in
+                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
+                        if fraction >= 1.0 {
+                            installTracker.markInstalling(pluginId: plugin.id)
+                        }
+                    }
+                } else {
+                    _ = try await pluginManager.updateFromRegistry(plugin) { fraction in
                         installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
                         if fraction >= 1.0 {
                             installTracker.markInstalling(pluginId: plugin.id)

--- a/TablePro/Views/Settings/Plugins/BrowsePluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/BrowsePluginsView.swift
@@ -252,55 +252,41 @@ struct BrowsePluginsView: View {
     }
 
     private func installPlugin(_ plugin: RegistryPlugin) {
-        Task {
-            installTracker.beginInstall(pluginId: plugin.id)
-            do {
-                if plugin.category == .theme {
-                    try await ThemeRegistryInstaller.shared.install(plugin) { fraction in
-                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
-                        if fraction >= 1.0 {
-                            installTracker.markInstalling(pluginId: plugin.id)
-                        }
-                    }
-                } else {
-                    _ = try await pluginManager.installFromRegistry(plugin) { fraction in
-                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
-                        if fraction >= 1.0 {
-                            installTracker.markInstalling(pluginId: plugin.id)
-                        }
-                    }
-                }
-                installTracker.completeInstall(pluginId: plugin.id)
-            } catch {
-                installTracker.failInstall(pluginId: plugin.id, error: error.localizedDescription)
-                errorMessage = error.localizedDescription
-                showErrorAlert = true
+        performTrackedOperation(pluginId: plugin.id) { progress in
+            if plugin.category == .theme {
+                try await ThemeRegistryInstaller.shared.install(plugin, progress: progress)
+            } else {
+                _ = try await pluginManager.installFromRegistry(plugin, progress: progress)
             }
         }
     }
 
     private func updatePlugin(_ plugin: RegistryPlugin) {
+        performTrackedOperation(pluginId: plugin.id) { progress in
+            if plugin.category == .theme {
+                try await ThemeRegistryInstaller.shared.update(plugin, progress: progress)
+            } else {
+                _ = try await pluginManager.updateFromRegistry(plugin, progress: progress)
+            }
+        }
+    }
+
+    private func performTrackedOperation(
+        pluginId: String,
+        operation: @escaping (@escaping @MainActor @Sendable (Double) -> Void) async throws -> Void
+    ) {
         Task {
-            installTracker.beginInstall(pluginId: plugin.id)
+            installTracker.beginInstall(pluginId: pluginId)
             do {
-                if plugin.category == .theme {
-                    try await ThemeRegistryInstaller.shared.update(plugin) { fraction in
-                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
-                        if fraction >= 1.0 {
-                            installTracker.markInstalling(pluginId: plugin.id)
-                        }
-                    }
-                } else {
-                    _ = try await pluginManager.updateFromRegistry(plugin) { fraction in
-                        installTracker.updateProgress(pluginId: plugin.id, fraction: fraction)
-                        if fraction >= 1.0 {
-                            installTracker.markInstalling(pluginId: plugin.id)
-                        }
+                try await operation { fraction in
+                    self.installTracker.updateProgress(pluginId: pluginId, fraction: fraction)
+                    if fraction >= 1.0 {
+                        self.installTracker.markInstalling(pluginId: pluginId)
                     }
                 }
-                installTracker.completeInstall(pluginId: plugin.id)
+                installTracker.completeInstall(pluginId: pluginId)
             } catch {
-                installTracker.failInstall(pluginId: plugin.id, error: error.localizedDescription)
+                installTracker.failInstall(pluginId: pluginId, error: error.localizedDescription)
                 errorMessage = error.localizedDescription
                 showErrorAlert = true
             }

--- a/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
@@ -9,6 +9,8 @@ import UniformTypeIdentifiers
 
 struct InstalledPluginsView: View {
     private let pluginManager = PluginManager.shared
+    private let registryClient = RegistryClient.shared
+    private let installTracker = PluginInstallTracker.shared
 
     @State private var selectedPluginId: String?
     @State private var searchText = ""
@@ -34,6 +36,11 @@ struct InstalledPluginsView: View {
 
                 detailPane
                     .frame(minWidth: 340)
+            }
+        }
+        .task {
+            if registryClient.fetchState == .idle {
+                await registryClient.fetchManifest()
             }
         }
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in
@@ -169,6 +176,12 @@ struct InstalledPluginsView: View {
 
             Spacer()
 
+            if pluginManager.registryUpdate(for: plugin.id) != nil {
+                Image(systemName: "arrow.up.circle.fill")
+                    .foregroundStyle(.blue)
+                    .font(.caption)
+            }
+
             Text(plugin.source == .builtIn ? String(localized: "Built-in") : String(localized: "User"))
                 .font(.caption2)
                 .foregroundStyle(.secondary)
@@ -205,6 +218,10 @@ struct InstalledPluginsView: View {
                     Text("v\(selected.version) · \(selected.source == .builtIn ? String(localized: "Built-in") : String(localized: "User-installed"))")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+
+                    if let registryPlugin = pluginManager.registryUpdate(for: selected.id) {
+                        updateActionView(for: selected, registryPlugin: registryPlugin)
+                    }
 
                     if !selected.pluginDescription.isEmpty {
                         Text(selected.pluginDescription)
@@ -284,6 +301,72 @@ struct InstalledPluginsView: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Update
+
+    @ViewBuilder
+    private func updateActionView(for plugin: PluginEntry, registryPlugin: RegistryPlugin) -> some View {
+        if let progress = installTracker.state(for: plugin.id) {
+            switch progress.phase {
+            case .downloading(let fraction):
+                HStack(spacing: 8) {
+                    ProgressView(value: fraction)
+                    Text("\(Int(fraction * 100))%")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            case .installing:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Updating...")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            case .completed:
+                Label(
+                    String(format: String(localized: "Updated to v%@"), registryPlugin.version),
+                    systemImage: "checkmark.circle.fill"
+                )
+                .foregroundStyle(Color(nsColor: .systemGreen))
+                .font(.callout)
+            case .failed:
+                Button(String(localized: "Retry Update")) { updatePlugin(registryPlugin) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+        } else {
+            HStack(spacing: 8) {
+                Text(String(format: String(localized: "v%@ available"), registryPlugin.version))
+                    .font(.callout)
+                    .foregroundStyle(.blue)
+                Button(String(localized: "Update")) { updatePlugin(registryPlugin) }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private func updatePlugin(_ registryPlugin: RegistryPlugin) {
+        Task {
+            installTracker.beginInstall(pluginId: registryPlugin.id)
+            do {
+                _ = try await pluginManager.updateFromRegistry(registryPlugin) { fraction in
+                    installTracker.updateProgress(pluginId: registryPlugin.id, fraction: fraction)
+                    if fraction >= 1.0 {
+                        installTracker.markInstalling(pluginId: registryPlugin.id)
+                    }
+                }
+                installTracker.completeInstall(pluginId: registryPlugin.id)
+            } catch {
+                installTracker.failInstall(pluginId: registryPlugin.id, error: error.localizedDescription)
+                errorAlertTitle = String(localized: "Plugin Update Failed")
+                errorAlertMessage = error.localizedDescription
+                showErrorAlert = true
+            }
         }
     }
 

--- a/TablePro/Views/Settings/Plugins/RegistryPluginDetailView.swift
+++ b/TablePro/Views/Settings/Plugins/RegistryPluginDetailView.swift
@@ -8,9 +8,11 @@ import SwiftUI
 struct RegistryPluginDetailView: View {
     let plugin: RegistryPlugin
     let isInstalled: Bool
+    var hasUpdate: Bool = false
     let installProgress: InstallProgress?
     let downloadCount: Int?
     let onInstall: () -> Void
+    var onUpdate: () -> Void = {}
 
     var body: some View {
         ScrollView {
@@ -86,7 +88,10 @@ struct RegistryPluginDetailView: View {
                 if !isInstalled {
                     Divider()
                     installActionView
-                } else if plugin.category == .theme {
+                } else if hasUpdate {
+                    Divider()
+                    updateActionView
+                } else {
                     Divider()
                     Label("Installed", systemImage: "checkmark.circle.fill")
                         .foregroundStyle(Color(nsColor: .systemGreen))
@@ -134,6 +139,42 @@ struct RegistryPluginDetailView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
                 .disabled(installProgress != nil)
+        }
+    }
+
+    @ViewBuilder
+    private var updateActionView: some View {
+        if let progress = installProgress {
+            switch progress.phase {
+            case .downloading(let fraction):
+                HStack(spacing: 8) {
+                    ProgressView(value: fraction)
+                    Text("\(Int(fraction * 100))%")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            case .installing:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Updating...")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            case .completed:
+                Label("Updated", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(Color(nsColor: .systemGreen))
+                    .font(.callout)
+            case .failed:
+                Button(String(localized: "Retry Update")) { onUpdate() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+            }
+        } else {
+            Button(String(format: String(localized: "Update to v%@"), plugin.version)) { onUpdate() }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
         }
     }
 


### PR DESCRIPTION
## Summary

- Outdated user-installed plugins are silently auto-updated from the registry at launch, eliminating the recurring "plugin(s) could not be loaded" error dialog
- When auto-update fails (no internet, plugin not in registry), the alert now has an actionable "Open Plugin Settings" button instead of just "OK"
- Settings > Plugins > Installed shows update badges and one-click "Update" button for plugins with newer registry versions
- Settings > Plugins > Browse shows "Update" button instead of "Installed" for outdated plugins

## Test plan

- [ ] Place a `.tableplugin` with old `TableProPluginKitVersion` (e.g. 2) in `~/Library/Application Support/TablePro/Plugins/`, launch app, verify no error dialog appears and plugin loads
- [ ] Disconnect internet, place old plugin, launch app, verify alert shows "Open Plugin Settings" + "Dismiss", clicking first button opens Settings at Plugins tab
- [ ] With an outdated user-installed plugin loaded, open Settings > Plugins > Installed, verify blue update badge in row and "Update" button in detail pane
- [ ] Open Settings > Plugins > Browse, verify outdated installed plugins show "Update" button instead of "Installed" text
- [ ] Launch with all plugins up to date, verify no change in behavior