### PR TITLE
refactor: WelcomeViewModel, ERDiagram, ResultTabBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ER diagram no longer uses a polling loop to wait for database connection
 - MCP server now shuts down reliably on app quit
 - Result tab bar and history panel follow macOS HIG patterns
 - Improved keyboard and VoiceOver accessibility for interactive rows across the app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - MCP server now shuts down reliably on app quit
+- Result tab bar and history panel follow macOS HIG patterns
 - Improved keyboard and VoiceOver accessibility for interactive rows across the app
 - Compiled theme fallback colors now match the default theme JSON files
 - TablePlus import: correctly map all SSL/TLS modes instead of treating Prefer as disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP bridge now pins the server's TLS certificate fingerprint instead of accepting any certificate
 - Replaced custom search field with native NSSearchField in keyboard shortcuts, database switcher, and quick switcher
 - Column layout and filter state storage migrated from UserDefaults to file-based storage
+- Refactored welcome screen to properly separate view model and view layer responsibilities
 
 ### Added
 

--- a/TablePro/AppDelegate+FileOpen.swift
+++ b/TablePro/AppDelegate+FileOpen.swift
@@ -207,8 +207,8 @@ extension AppDelegate {
 
         case .importConnection(let exportable):
             openWelcomeWindow()
-            pendingDeeplinkImport = exportable
-            NotificationCenter.default.post(name: .deeplinkImportRequested, object: nil)
+            PendingActionStore.shared.deeplinkImport = exportable
+            NotificationCenter.default.post(name: .deeplinkImportRequested, object: exportable)
         }
     }
 
@@ -280,7 +280,7 @@ extension AppDelegate {
 
     private func handleConnectionShareFile(_ url: URL) {
         openWelcomeWindow()
-        pendingConnectionShareURL = url
+        PendingActionStore.shared.connectionShareURL = url
         NotificationCenter.default.post(name: .connectionShareFileOpened, object: url)
     }
 

--- a/TablePro/AppDelegate+WindowConfig.swift
+++ b/TablePro/AppDelegate+WindowConfig.swift
@@ -140,6 +140,12 @@ extension AppDelegate {
         return rawValue == WindowId.connectionForm || rawValue.hasPrefix("\(WindowId.connectionForm)-")
     }
 
+    @objc func handleFocusConnectionForm() {
+        if let window = NSApp.windows.first(where: { isConnectionFormWindow($0) }) {
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+
     // MARK: - Welcome Window
 
     /// Hide the Welcome window immediately when we know we're going to

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -60,12 +60,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Prevents duplicate connections when the same file is opened twice rapidly.
     var connectingFilePaths = Set<String>()
 
-    /// Connection share file URL pending consumption by WelcomeViewModel.setUp()
-    var pendingConnectionShareURL: URL?
-
-    /// Deep link import pending consumption by WelcomeViewModel
-    var pendingDeeplinkImport: ExportableConnection?
-
     // MARK: - NSApplicationDelegate
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -172,6 +166,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.addObserver(
             self, selector: #selector(handlePluginsRejected(_:)),
             name: .pluginsRejected, object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleFocusConnectionForm),
+            name: .focusConnectionFormWindowRequested, object: nil
         )
     }
 

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -25,6 +25,7 @@ extension Notification.Name {
     static let importConnections = Notification.Name("importConnections")
     static let importConnectionsFromApp = Notification.Name("importConnectionsFromApp")
     static let linkedFoldersDidUpdate = Notification.Name("linkedFoldersDidUpdate")
+    static let focusConnectionFormWindowRequested = Notification.Name("focusConnectionFormWindowRequested")
 
     // MARK: - License
 

--- a/TablePro/Core/Services/Infrastructure/PendingActionStore.swift
+++ b/TablePro/Core/Services/Infrastructure/PendingActionStore.swift
@@ -1,0 +1,28 @@
+//
+//  PendingActionStore.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor @Observable
+final class PendingActionStore {
+    static let shared = PendingActionStore()
+
+    var connectionShareURL: URL?
+    var deeplinkImport: ExportableConnection?
+
+    private init() {}
+
+    func consumeConnectionShareURL() -> URL? {
+        let url = connectionShareURL
+        connectionShareURL = nil
+        return url
+    }
+
+    func consumeDeeplinkImport() -> ExportableConnection? {
+        let value = deeplinkImport
+        deeplinkImport = nil
+        return value
+    }
+}

--- a/TablePro/ViewModels/ERDiagramViewModel.swift
+++ b/TablePro/ViewModels/ERDiagramViewModel.swift
@@ -87,15 +87,11 @@ final class ERDiagramViewModel {
         guard loadState != .loaded else { return }
         loadState = .loading
 
-        // Wait for connection to be established (handles app restore race condition)
-        var driver: DatabaseDriver?
-        for _ in 0..<20 {
-            driver = DatabaseManager.shared.driver(for: connectionId)
-            if driver != nil { break }
-            try? await Task.sleep(for: .milliseconds(500))
+        if DatabaseManager.shared.driver(for: connectionId) == nil {
+            await waitForConnection()
         }
 
-        guard let driver else {
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
             loadState = .failed(String(localized: "No database connection"))
             return
         }
@@ -125,6 +121,43 @@ final class ERDiagramViewModel {
         } catch {
             Self.logger.error("Failed to load ER diagram: \(error.localizedDescription)")
             loadState = .failed(error.localizedDescription)
+        }
+    }
+
+    private func waitForConnection() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            let observerBox = OSAllocatedUnfairLock<NSObjectProtocol?>(initialState: nil)
+
+            @Sendable func resumeOnce() {
+                let alreadyResumed = resumed.withLock { value -> Bool in
+                    if value { return true }
+                    value = true
+                    return false
+                }
+                guard !alreadyResumed else { return }
+                let observer = observerBox.withLock { current -> NSObjectProtocol? in
+                    let value = current
+                    current = nil
+                    return value
+                }
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                continuation.resume()
+            }
+
+            let observer = NotificationCenter.default.addObserver(
+                forName: .databaseDidConnect, object: nil, queue: .main
+            ) { _ in
+                resumeOnce()
+            }
+            observerBox.withLock { $0 = observer }
+
+            Task {
+                try? await Task.sleep(for: .seconds(10))
+                resumeOnce()
+            }
         }
     }
 

--- a/TablePro/ViewModels/ERDiagramViewModel.swift
+++ b/TablePro/ViewModels/ERDiagramViewModel.swift
@@ -128,6 +128,7 @@ final class ERDiagramViewModel {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
             let observerBox = OSAllocatedUnfairLock<NSObjectProtocol?>(initialState: nil)
+            let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
             @Sendable func resumeOnce() {
                 let alreadyResumed = resumed.withLock { value -> Bool in
@@ -136,6 +137,7 @@ final class ERDiagramViewModel {
                     return false
                 }
                 guard !alreadyResumed else { return }
+                timeoutTaskBox.withLock { $0?.cancel(); $0 = nil }
                 let observer = observerBox.withLock { current -> NSObjectProtocol? in
                     let value = current
                     current = nil
@@ -154,10 +156,11 @@ final class ERDiagramViewModel {
             }
             observerBox.withLock { $0 = observer }
 
-            Task {
+            let timeoutTask = Task {
                 try? await Task.sleep(for: .seconds(10))
                 resumeOnce()
             }
+            timeoutTaskBox.withLock { $0 = timeoutTask }
         }
     }
 

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -58,6 +58,9 @@ final class WelcomeViewModel {
     var connectionError: String?
     var showConnectionError = false
 
+    var showImportFilePanel = false
+    var importResultCount: Int?
+
     var expandedGroupIds: Set<UUID> = {
         let strings = UserDefaults.standard.stringArray(forKey: "com.TablePro.expandedGroupIds") ?? []
         if strings.isEmpty {
@@ -170,6 +173,7 @@ final class WelcomeViewModel {
         ) { [weak self] notification in
             Task { @MainActor [weak self] in
                 guard let url = notification.object as? URL else { return }
+                _ = PendingActionStore.shared.consumeConnectionShareURL()
                 self?.activeSheet = .importFile(url)
             }
         }
@@ -209,12 +213,13 @@ final class WelcomeViewModel {
 
         deeplinkImportObserver = NotificationCenter.default.addObserver(
             forName: .deeplinkImportRequested, object: nil, queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
             Task { @MainActor [weak self] in
-                guard let self,
-                      let appDelegate = NSApp.delegate as? AppDelegate,
-                      let exportable = appDelegate.pendingDeeplinkImport else { return }
-                appDelegate.pendingDeeplinkImport = nil
+                guard let self else { return }
+                let exportable = (notification.object as? ExportableConnection)
+                    ?? PendingActionStore.shared.consumeDeeplinkImport()
+                guard let exportable else { return }
+                _ = PendingActionStore.shared.consumeDeeplinkImport()
                 self.activeSheet = .deeplinkImport(exportable)
             }
         }
@@ -222,15 +227,11 @@ final class WelcomeViewModel {
         loadConnections()
         linkedConnections = LinkedFolderWatcher.shared.linkedConnections
 
-        if let appDelegate = NSApp.delegate as? AppDelegate,
-           let pendingURL = appDelegate.pendingConnectionShareURL {
-            appDelegate.pendingConnectionShareURL = nil
+        if let pendingURL = PendingActionStore.shared.consumeConnectionShareURL() {
             activeSheet = .importFile(pendingURL)
         }
 
-        if let appDelegate = NSApp.delegate as? AppDelegate,
-           let pendingImport = appDelegate.pendingDeeplinkImport {
-            appDelegate.pendingDeeplinkImport = nil
+        if let pendingImport = PendingActionStore.shared.consumeDeeplinkImport() {
             activeSheet = .deeplinkImport(pendingImport)
         }
     }
@@ -446,39 +447,11 @@ final class WelcomeViewModel {
     }
 
     func importConnectionsFromFile() {
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.tableproConnectionShare]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        guard let window = AlertHelper.resolveWindow(nil)
-        else { return }
-        panel.beginSheetModal(for: window) { response in
-            guard response == .OK, let url = panel.url else { return }
-            self.activeSheet = .importFile(url)
-        }
+        showImportFilePanel = true
     }
 
-    func showImportResultAlert(count: Int) {
-        let alert = NSAlert()
-        if count > 0 {
-            alert.alertStyle = .informational
-            alert.messageText = String(localized: "Import Complete")
-            alert.informativeText = count == 1
-                ? String(localized: "1 connection was imported.")
-                : String(format: String(localized: "%d connections were imported."), count)
-            alert.icon = NSImage(systemSymbolName: "checkmark.circle.fill", accessibilityDescription: nil)?
-                .withSymbolConfiguration(.init(paletteColors: [.white, .systemGreen]))
-        } else {
-            alert.alertStyle = .informational
-            alert.messageText = String(localized: "No Connections Imported")
-            alert.informativeText = String(localized: "All selected connections were skipped.")
-        }
-        alert.addButton(withTitle: String(localized: "OK"))
-        if let window = AlertHelper.resolveWindow(nil) {
-            alert.beginSheetModal(for: window)
-        } else {
-            alert.runModal()
-        }
+    func showImportResult(count: Int) {
+        importResultCount = count
     }
 
     // MARK: - Keyboard Navigation
@@ -610,26 +583,7 @@ final class WelcomeViewModel {
     }
 
     func focusConnectionFormWindow() {
-        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "connection-form" }) {
-            window.makeKeyAndOrderFront(nil)
-            return
-        }
-
-        var observer: NSObjectProtocol?
-        observer = NotificationCenter.default.addObserver(
-            forName: NSWindow.didBecomeKeyNotification,
-            object: nil,
-            queue: .main
-        ) { notification in
-            guard let window = notification.object as? NSWindow,
-                  window.identifier?.rawValue == "connection-form" else { return }
-            if let observer { NotificationCenter.default.removeObserver(observer) }
-        }
-
-        Task {
-            try? await Task.sleep(for: .milliseconds(500))
-            if let observer { NotificationCenter.default.removeObserver(observer) }
-        }
+        NotificationCenter.default.post(name: .focusConnectionFormWindowRequested, object: nil)
     }
 
     // MARK: - Private Helpers

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -219,7 +219,7 @@ final class WelcomeViewModel {
                 let exportable = (notification.object as? ExportableConnection)
                     ?? PendingActionStore.shared.consumeDeeplinkImport()
                 guard let exportable else { return }
-                _ = PendingActionStore.shared.consumeDeeplinkImport()
+                PendingActionStore.shared.deeplinkImport = nil
                 self.activeSheet = .deeplinkImport(exportable)
             }
         }

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -95,7 +95,7 @@ struct WelcomeWindowView: View {
                 ConnectionImportSheet(fileURL: url) { count in
                     Task { @MainActor in
                         try? await Task.sleep(for: .milliseconds(300))
-                        vm.showImportResultAlert(count: count)
+                        vm.showImportResult(count: count)
                     }
                 }
             case .exportConnections(let conns):
@@ -104,7 +104,7 @@ struct WelcomeWindowView: View {
                 ImportFromAppSheet { count in
                     Task { @MainActor in
                         try? await Task.sleep(for: .milliseconds(300))
-                        vm.showImportResultAlert(count: count)
+                        vm.showImportResult(count: count)
                     }
                 }
             case .deeplinkImport(let exportable):
@@ -133,6 +133,34 @@ struct WelcomeWindowView: View {
         } message: {
             if let error = vm.connectionError {
                 Text(error)
+            }
+        }
+        .fileImporter(
+            isPresented: $vm.showImportFilePanel,
+            allowedContentTypes: [.tableproConnectionShare],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
+                vm.activeSheet = .importFile(url)
+            }
+        }
+        .alert(
+            (vm.importResultCount ?? 0) > 0
+                ? String(localized: "Import Complete")
+                : String(localized: "No Connections Imported"),
+            isPresented: Binding(
+                get: { vm.importResultCount != nil },
+                set: { if !$0 { vm.importResultCount = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { vm.importResultCount = nil }
+        } message: {
+            if let count = vm.importResultCount, count > 0 {
+                Text(count == 1
+                    ? String(localized: "1 connection was imported.")
+                    : String(format: String(localized: "%d connections were imported."), count))
+            } else {
+                Text(String(localized: "All selected connections were skipped."))
             }
         }
     }

--- a/TablePro/Views/Editor/HistoryPanelView.swift
+++ b/TablePro/Views/Editor/HistoryPanelView.swift
@@ -111,7 +111,7 @@ private extension HistoryPanelView {
                         .tag(entry.id)
                         .contextMenu { contextMenu(for: entry) }
                 }
-                .listStyle(.plain)
+                .listStyle(.sidebar)
                 .environment(\.defaultMinListRowHeight, 44)
                 .onDeleteCommand {
                     deleteSelectedEntry()

--- a/TablePro/Views/Results/ResultTabBar.swift
+++ b/TablePro/Views/Results/ResultTabBar.swift
@@ -28,34 +28,36 @@ struct ResultTabBar: View {
 
     private func resultTab(_ rs: ResultSet) -> some View {
         let isActive = rs.id == (activeResultSetId ?? resultSets.last?.id)
-        return HStack(spacing: 4) {
-            if rs.isPinned {
-                Image(systemName: "pin.fill")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.secondary)
-            }
-            Text(rs.label)
-                .font(.subheadline)
-                .lineLimit(1)
-            if !rs.isPinned {
-                Button { onClose?(rs.id) } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8))
+        return Button {
+            activeResultSetId = rs.id
+        } label: {
+            HStack(spacing: 4) {
+                if rs.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9))
                         .foregroundStyle(.secondary)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "Close result tab"))
+                Text(rs.label)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                if !rs.isPinned {
+                    Button { onClose?(rs.id) } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(localized: "Close result tab"))
+                }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isActive ? Color(nsColor: .selectedControlColor) : Color.clear)
+            )
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(isActive ? Color(nsColor: .selectedControlColor) : Color.clear)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { activeResultSetId = rs.id }
-        .accessibilityAddTraits(.isButton)
+        .buttonStyle(.plain)
         .contextMenu {
             Button(rs.isPinned ? String(localized: "Unpin") : String(localized: "Pin Result")) {
                 onPin?(rs.id)


### PR DESCRIPTION
## Summary

Second round of macOS HIG audit fixes, addressing MVVM layer violations, polling patterns, and remaining accessibility gaps.

**WelcomeViewModel MVVM cleanup**
- Extracted `pendingConnectionShareURL` and `pendingDeeplinkImport` from AppDelegate into `PendingActionStore` singleton — ViewModel no longer casts `NSApp.delegate`
- Replaced `NSOpenPanel` in ViewModel with `.fileImporter` modifier in View
- Replaced `NSAlert` in ViewModel with `.alert` modifier in View
- Moved window focus management to AppDelegate via `.focusConnectionFormWindowRequested` notification

**ERDiagramViewModel reactive connection wait**
- Replaced 500ms x 20 polling loop with notification-based wait using `.databaseDidConnect`
- Uses `OSAllocatedUnfairLock` for safe single-resume of `CheckedContinuation`
- 10-second timeout preserved as fallback

**Quick UI fixes**
- ResultTabBar: `.onTapGesture` replaced with `Button` for keyboard/VoiceOver accessibility
- HistoryPanelView: `.listStyle(.plain)` changed to `.listStyle(.sidebar)` per macOS HIG

## Test plan

- [ ] Welcome window: create new connection, import connections from file, import from app — all sheets present correctly
- [ ] Welcome window: open a `.tablepro` share file — import sheet appears
- [ ] Welcome window: receive deep link import — sheet appears
- [ ] Welcome window: click "New Connection" when form window exists — it focuses correctly
- [ ] ER diagram: open on a connection that's still connecting — diagram loads after connection completes (no polling)
- [ ] Result tab bar: Tab + Return selects result tabs; close/pin/context menu still work
- [ ] History panel: sidebar-style list with inset selection appearance