### PR TITLE
fix: plugin query sanitization and typed parameter conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Query parameter conversion handles Bool, Date, Data, and non-finite numbers correctly
+- Plugin default query methods handle trailing semicolons and whitespace correctly
 - ER diagram no longer uses a polling loop to wait for database connection
 - MCP server now shuts down reliably on app quit
 - Result tab bar and history panel follow macOS HIG patterns

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -515,7 +515,8 @@ public extension PluginDatabaseDriver {
                 nextOffset: result.rows.count
             )
         }
-        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET 0"
+        let sanitized = Self.sanitizeQueryForWrapping(query)
+        let wrappedQuery = "SELECT * FROM (\(sanitized)) _t LIMIT \(limit + 1) OFFSET 0"
         let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
         let hasMore = result.rows.count > limit
         let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
@@ -530,7 +531,8 @@ public extension PluginDatabaseDriver {
     }
 
     func fetchNextPageParameterized(query: String, parameters: [String?], offset: Int, limit: Int) async throws -> PluginPagedResult {
-        let wrappedQuery = "SELECT * FROM (\(query)) _t LIMIT \(limit + 1) OFFSET \(offset)"
+        let sanitized = Self.sanitizeQueryForWrapping(query)
+        let wrappedQuery = "SELECT * FROM (\(sanitized)) _t LIMIT \(limit + 1) OFFSET \(offset)"
         let result = try await executeParameterized(query: wrappedQuery, parameters: parameters)
         let hasMore = result.rows.count > limit
         let rows = hasMore ? Array(result.rows.prefix(limit)) : result.rows
@@ -545,7 +547,8 @@ public extension PluginDatabaseDriver {
     }
 
     func fetchRowCount(query: String) async throws -> Int {
-        let result = try await execute(query: "SELECT COUNT(*) FROM (\(query)) _t")
+        let sanitized = Self.sanitizeQueryForWrapping(query)
+        let result = try await execute(query: "SELECT COUNT(*) FROM (\(sanitized)) _t")
         guard let firstRow = result.rows.first, let value = firstRow.first, let countStr = value else {
             return 0
         }
@@ -553,7 +556,16 @@ public extension PluginDatabaseDriver {
     }
 
     func fetchRows(query: String, offset: Int, limit: Int) async throws -> PluginQueryResult {
-        try await execute(query: "\(query) LIMIT \(limit) OFFSET \(offset)")
+        let sanitized = Self.sanitizeQueryForWrapping(query)
+        return try await execute(query: "\(sanitized) LIMIT \(limit) OFFSET \(offset)")
+    }
+
+    private static func sanitizeQueryForWrapping(_ query: String) -> String {
+        var result = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        while result.hasSuffix(";") {
+            result = String(result.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return result
     }
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -59,6 +59,35 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "PluginDriverAdapter")
 
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static func stringValue(for parameter: Any) -> String {
+        switch parameter {
+        case let s as String:
+            return s
+        case let b as Bool:
+            return b ? "1" : "0"
+        case let i as any BinaryInteger:
+            return String(i)
+        case let f as any BinaryFloatingPoint:
+            let d = Double(f)
+            guard d.isFinite else { return "NULL" }
+            return String(d)
+        case let d as Date:
+            return Self.iso8601Formatter.string(from: d)
+        case let data as Data:
+            return data.map { String(format: "%02x", $0) }.joined()
+        case let uuid as UUID:
+            return uuid.uuidString
+        default:
+            return String(describing: parameter)
+        }
+    }
+
     init(connection: DatabaseConnection, pluginDriver: any PluginDatabaseDriver) {
         self.connection = connection
         self.pluginDriver = pluginDriver
@@ -96,7 +125,7 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     func executeParameterized(query: String, parameters: [Any?]) async throws -> QueryResult {
         let stringParams = parameters.map { param -> String? in
             guard let p = param else { return nil }
-            return String(describing: p)
+            return Self.stringValue(for: p)
         }
         let pluginResult = try await pluginDriver.executeParameterized(query: query, parameters: stringParams)
         return mapQueryResult(pluginResult)
@@ -126,7 +155,7 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     func fetchFirstPageParameterized(query: String, parameters: [Any?], limit: Int) async throws -> PagedQueryResult {
         let stringParams = parameters.map { param -> String? in
             guard let p = param else { return nil }
-            return String(describing: p)
+            return Self.stringValue(for: p)
         }
         let pluginResult = try await pluginDriver.fetchFirstPageParameterized(query: query, parameters: stringParams, limit: limit)
         return mapPagedResult(pluginResult)
@@ -135,7 +164,7 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     func fetchNextPageParameterized(query: String, parameters: [Any?], offset: Int, limit: Int) async throws -> PagedQueryResult {
         let stringParams = parameters.map { param -> String? in
             guard let p = param else { return nil }
-            return String(describing: p)
+            return Self.stringValue(for: p)
         }
         let pluginResult = try await pluginDriver.fetchNextPageParameterized(query: query, parameters: stringParams, offset: offset, limit: limit)
         return mapPagedResult(pluginResult)


### PR DESCRIPTION
## Summary

Fixes two plugin-layer issues found during the macOS HIG audit (round 3).

**Plugin protocol default query sanitization**
- Added `sanitizeQueryForWrapping()` to strip trailing semicolons and whitespace before wrapping queries in subqueries or appending LIMIT/OFFSET
- Applied to all 5 default methods: `fetchRowCount`, `fetchRows`, `fetchFirstPageParameterized`, `fetchNextPageParameterized`, and the non-parameterized `fetchFirstPage`/`fetchNextPage`
- Prevents `SELECT COUNT(*) FROM (SELECT * FROM users;) _t` syntax errors

**Typed parameter conversion in PluginDriverAdapter**
- Replaced `String(describing:)` with typed dispatch via `stringValue(for:)`
- `Bool` → `"1"`/`"0"` (not `"true"`/`"false"`)
- `Date` → ISO 8601 with fractional seconds (not locale-dependent `description`)
- `Data` → lowercase hex string (not `"N bytes"`)
- `UUID` → standard UUID string
- Non-finite floats (`NaN`, `Infinity`) → `"NULL"` (not `"nan"`/`"inf"`)
- Falls back to `String(describing:)` for unknown types

## Test plan

- [ ] Execute parameterized query with Bool parameter — verify `1`/`0` sent
- [ ] Execute parameterized query with Date parameter — verify ISO 8601 format
- [ ] Run `SELECT * FROM table;` (with semicolon) — verify pagination works (no syntax error)
- [ ] Run `SELECT COUNT(*) FROM (complex query with trailing whitespace)` — verify row count works
- [ ] Plugin drivers that override these methods — verify no behavior change (defaults only affect plugins that don't override)