### PR TITLE
fix: SQL escaping and ABI crash guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened SQL parameter escaping in plugin fallback to handle control characters and edge-case numeric formats
 - Query parameter conversion handles Bool, Date, Data, and non-finite numbers correctly
 - Plugin default query methods handle trailing semicolons and whitespace correctly
 - ER diagram no longer uses a polling loop to wait for database connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added runtime guard against DriverPlugin ABI mismatch for user-installed plugins
 - Hardened SQL parameter escaping in plugin fallback to handle control characters and edge-case numeric formats
 - Query parameter conversion handles Bool, Date, Data, and non-finite numbers correctly
 - Plugin default query methods handle trailing semicolons and whitespace correctly

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -449,7 +449,7 @@ public extension PluginDatabaseDriver {
         return sql
     }
 
-    private static func escapedParameterValue(_ value: String) -> String {
+    static func escapedParameterValue(_ value: String) -> String {
         if isNumericLiteral(value) {
             return value
         }
@@ -480,7 +480,7 @@ public extension PluginDatabaseDriver {
         return escaped
     }
 
-    private static func isNumericLiteral(_ value: String) -> Bool {
+    static func isNumericLiteral(_ value: String) -> Bool {
         guard !value.isEmpty else { return false }
         var scanner = value.makeIterator()
         var hasDigit = false

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -449,19 +449,72 @@ public extension PluginDatabaseDriver {
         return sql
     }
 
-    /// Escape a parameter value for safe interpolation into SQL.
-    /// Numeric values are unquoted; strings are single-quoted with proper escaping.
     private static func escapedParameterValue(_ value: String) -> String {
-        // Numeric: don't quote
-        if Int64(value) != nil || (Double(value) != nil && value.contains(".")) {
+        if isNumericLiteral(value) {
             return value
         }
-        // String: escape and quote
-        let escaped = value
-            .replacingOccurrences(of: "\0", with: "")
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
-        return "'\(escaped)'"
+        var escaped = ""
+        escaped.reserveCapacity(value.count + 2)
+        escaped.append("'")
+        for char in value {
+            switch char {
+            case "'":
+                escaped.append("''")
+            case "\0":
+                continue
+            case "\\":
+                escaped.append("\\\\")
+            case "\n":
+                escaped.append("\\n")
+            case "\r":
+                escaped.append("\\r")
+            case "\t":
+                escaped.append("\\t")
+            case "\u{1A}":
+                escaped.append("\\Z")
+            default:
+                escaped.append(char)
+            }
+        }
+        escaped.append("'")
+        return escaped
+    }
+
+    private static func isNumericLiteral(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        var scanner = value.makeIterator()
+        var hasDigit = false
+        var hasDot = false
+        var hasE = false
+
+        var first = true
+        while let c = scanner.next() {
+            if first {
+                first = false
+                if c == "-" || c == "+" { continue }
+            }
+            if c.isNumber {
+                hasDigit = true
+                continue
+            }
+            if c == "." && !hasDot && !hasE {
+                hasDot = true
+                continue
+            }
+            if (c == "e" || c == "E") && hasDigit && !hasE {
+                hasE = true
+                hasDigit = false
+                if let next = scanner.next() {
+                    if next == "+" || next == "-" || next.isNumber {
+                        if next.isNumber { hasDigit = true }
+                        continue
+                    }
+                }
+                return false
+            }
+            return false
+        }
+        return hasDigit
     }
 
     func fetchFirstPage(query: String, limit: Int) async throws -> PluginPagedResult {

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -251,8 +251,26 @@ final class PluginManager {
             return existing
         }
 
+        let rawDriverType = principalClass as? any DriverPlugin.Type
+        let pluginKitVersion = bundle.infoDictionary?["TableProPluginKitVersion"] as? Int ?? 0
+        if rawDriverType != nil, source == .userInstalled, pluginKitVersion != Self.currentPluginKitVersion {
+            assertionFailure(
+                "DriverPlugin '\(bundleId)' has TableProPluginKitVersion \(pluginKitVersion) but current is \(Self.currentPluginKitVersion); ABI mismatch would crash on static property access"
+            )
+            Self.logger.error("Plugin '\(bundleId)' DriverPlugin ABI mismatch: plist=\(pluginKitVersion) current=\(Self.currentPluginKitVersion). Rejecting to prevent crash.")
+            rejectedPlugins.append(RejectedPlugin(
+                url: url,
+                bundleId: bundleId,
+                registryId: Self.readRegistryMetadata(for: url)?.pluginId,
+                name: principalClass.pluginName,
+                reason: String(localized: "Incompatible plugin version"),
+                isOutdated: pluginKitVersion < Self.currentPluginKitVersion
+            ))
+            return nil
+        }
+
         let disabled = disabledPluginIds
-        let driverType = principalClass as? any DriverPlugin.Type
+        let driverType = rawDriverType
         let version = Self.readRegistryMetadata(for: url)?.version ?? principalClass.pluginVersion
         let entry = PluginEntry(
             id: bundleId,

--- a/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
+++ b/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
@@ -1,0 +1,138 @@
+//
+//  PluginParameterEscapingTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+private final class StubDriver: PluginDatabaseDriver {
+    var supportsSchemas: Bool { false }
+    var supportsTransactions: Bool { false }
+    var currentSchema: String? { nil }
+    var serverVersion: String? { nil }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func ping() async throws {}
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+    }
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+// MARK: - isNumericLiteral
+
+@Suite("isNumericLiteral")
+struct IsNumericLiteralTests {
+
+    @Test("Integers")
+    func integers() {
+        #expect(StubDriver.isNumericLiteral("0"))
+        #expect(StubDriver.isNumericLiteral("123"))
+        #expect(StubDriver.isNumericLiteral("-42"))
+        #expect(StubDriver.isNumericLiteral("+7"))
+    }
+
+    @Test("Decimals")
+    func decimals() {
+        #expect(StubDriver.isNumericLiteral("3.14"))
+        #expect(StubDriver.isNumericLiteral("-0.5"))
+        #expect(StubDriver.isNumericLiteral(".5"))
+        #expect(StubDriver.isNumericLiteral("+.5"))
+    }
+
+    @Test("Scientific notation")
+    func scientificNotation() {
+        #expect(StubDriver.isNumericLiteral("1e5"))
+        #expect(StubDriver.isNumericLiteral("1E5"))
+        #expect(StubDriver.isNumericLiteral("1.5e-3"))
+        #expect(StubDriver.isNumericLiteral("+1e+2"))
+        #expect(StubDriver.isNumericLiteral("2.5E10"))
+    }
+
+    @Test("Not numeric")
+    func notNumeric() {
+        #expect(!StubDriver.isNumericLiteral(""))
+        #expect(!StubDriver.isNumericLiteral("NaN"))
+        #expect(!StubDriver.isNumericLiteral("inf"))
+        #expect(!StubDriver.isNumericLiteral("-"))
+        #expect(!StubDriver.isNumericLiteral("+"))
+        #expect(!StubDriver.isNumericLiteral("."))
+        #expect(!StubDriver.isNumericLiteral("1e"))
+        #expect(!StubDriver.isNumericLiteral("abc"))
+        #expect(!StubDriver.isNumericLiteral("1 OR 1=1"))
+        #expect(!StubDriver.isNumericLiteral("12abc"))
+        #expect(!StubDriver.isNumericLiteral("1.2.3"))
+    }
+}
+
+// MARK: - escapedParameterValue
+
+@Suite("escapedParameterValue")
+struct EscapedParameterValueTests {
+
+    @Test("Numeric values returned unquoted")
+    func numericUnquoted() {
+        #expect(StubDriver.escapedParameterValue("123") == "123")
+        #expect(StubDriver.escapedParameterValue("-42") == "-42")
+        #expect(StubDriver.escapedParameterValue("3.14") == "3.14")
+        #expect(StubDriver.escapedParameterValue("1e5") == "1e5")
+    }
+
+    @Test("Plain strings quoted")
+    func plainStringsQuoted() {
+        #expect(StubDriver.escapedParameterValue("hello") == "'hello'")
+        #expect(StubDriver.escapedParameterValue("") == "''")
+    }
+
+    @Test("Single quotes escaped")
+    func singleQuotesEscaped() {
+        #expect(StubDriver.escapedParameterValue("O'Brien") == "'O''Brien'")
+        #expect(StubDriver.escapedParameterValue("it''s") == "'it''''s'")
+    }
+
+    @Test("Control characters escaped")
+    func controlCharactersEscaped() {
+        #expect(StubDriver.escapedParameterValue("a\nb") == "'a\\nb'")
+        #expect(StubDriver.escapedParameterValue("a\rb") == "'a\\rb'")
+        #expect(StubDriver.escapedParameterValue("a\tb") == "'a\\tb'")
+        #expect(StubDriver.escapedParameterValue("a\\b") == "'a\\\\b'")
+    }
+
+    @Test("NUL bytes stripped")
+    func nulBytesStripped() {
+        #expect(StubDriver.escapedParameterValue("a\0b") == "'ab'")
+    }
+
+    @Test("SUB character escaped")
+    func subCharacterEscaped() {
+        #expect(StubDriver.escapedParameterValue("a\u{1A}b") == "'a\\Zb'")
+    }
+
+    @Test("SQL injection attempt quoted")
+    func sqlInjectionQuoted() {
+        #expect(StubDriver.escapedParameterValue("1 OR 1=1") == "'1 OR 1=1'")
+        #expect(StubDriver.escapedParameterValue("'; DROP TABLE users; --") == "'''; DROP TABLE users; --'")
+    }
+
+    @Test("NaN and inf are quoted as strings")
+    func nanInfQuoted() {
+        #expect(StubDriver.escapedParameterValue("NaN") == "'NaN'")
+        #expect(StubDriver.escapedParameterValue("inf") == "'inf'")
+        #expect(StubDriver.escapedParameterValue("-Infinity") == "'-Infinity'")
+    }
+}


### PR DESCRIPTION
## Summary

Hardens two security-related items from the macOS HIG audit (the final HIGH-severity items).

**SQL parameter escaping hardening** (`PluginDatabaseDriver.swift`)
- `escapedParameterValue` now escapes control characters: `\n` → `\\n`, `\r` → `\\r`, `\t` → `\\t`, `\u{1A}` → `\\Z` (MySQL SUB)
- NUL bytes still stripped, backslashes and single quotes still escaped
- New `isNumericLiteral` replaces fragile `Int64(value) != nil` check — handles scientific notation (`1e5`, `1.5E-3`), signed numbers, rejects `NaN`/`inf`/empty strings
- Removed doc comment blocks per no-comments policy

**DriverPlugin ABI crash guard** (`PluginManager.swift`)
- Added runtime check in `registerBundle`: if a user-installed plugin has a `TableProPluginKitVersion` that doesn't match `currentPluginKitVersion`, it's rejected before any `DriverPlugin` static property access
- Prevents `EXC_BAD_INSTRUCTION` crash from protocol witness table mismatch
- Plugin is added to `rejectedPlugins` with "Incompatible plugin version" reason (triggers the existing user-facing alert)
- Debug builds also hit `assertionFailure` to catch version-bump mistakes during development

## Test plan

- [ ] Execute parameterized query with a value containing `\n` newline — verify it's escaped, not a raw newline in SQL
- [ ] Execute parameterized query with value `"1e5"` — verify it's treated as numeric (unquoted)
- [ ] Execute parameterized query with value `"NaN"` — verify it's quoted as a string
- [ ] Execute parameterized query with value `"1 OR 1=1"` — verify it's quoted as a string
- [ ] Load all built-in plugins — verify no regression (all load successfully)
- [ ] Manually set a user plugin's `TableProPluginKitVersion` to a wrong value — verify it's rejected with alert, not crashed