### PR TITLE
fix: clipboard, deprecated APIs, window tabbing, comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Miscellaneous HIG view cleanup: use ClipboardService, remove deprecated cornerRadius, fix window tabbing state, consistent double-click detection
 - Added runtime guard against DriverPlugin ABI mismatch for user-installed plugins
 - Hardened SQL parameter escaping in plugin fallback to handle control characters and edge-case numeric formats
 - Query parameter conversion handles Bool, Date, Data, and non-finite numbers correctly

--- a/TablePro/AppDelegate+ConnectionHandler.swift
+++ b/TablePro/AppDelegate+ConnectionHandler.swift
@@ -2,16 +2,12 @@
 //  AppDelegate+ConnectionHandler.swift
 //  TablePro
 //
-//  Database URL and SQLite file open handlers with cold-start queuing
-//
 
 import AppKit
 import os
 
 private let connectionLogger = Logger(subsystem: "com.TablePro", category: "ConnectionHandler")
 
-/// Typed queue entry for URLs waiting on the SwiftUI window system.
-/// Replaces the separate `queuedDatabaseURLs` and `queuedSQLiteFileURLs` arrays.
 enum QueuedURLEntry {
     case databaseURL(URL)
     case sqliteFile(URL)
@@ -321,11 +317,13 @@ extension AppDelegate {
 
     private func openNewConnectionWindow(for connection: DatabaseConnection) {
         let hadExistingMain = NSApp.windows.contains { isMainWindow($0) && $0.isVisible }
+        let savedTabbing = NSWindow.allowsAutomaticWindowTabbing
         if hadExistingMain && !AppSettingsManager.shared.tabs.groupAllConnectionTabs {
             NSWindow.allowsAutomaticWindowTabbing = false
         }
         let payload = EditorTabPayload(connectionId: connection.id)
         WindowManager.shared.openTab(payload: payload)
+        NSWindow.allowsAutomaticWindowTabbing = savedTabbing
     }
 
     // MARK: - Post-Connect Actions

--- a/TablePro/AppDelegate+FileOpen.swift
+++ b/TablePro/AppDelegate+FileOpen.swift
@@ -2,8 +2,6 @@
 //  AppDelegate+FileOpen.swift
 //  TablePro
 //
-//  URL and file open handling dispatched from application(_:open:)
-//
 
 import AppKit
 import os
@@ -239,12 +237,14 @@ extension AppDelegate {
         }
 
         let hadExistingMain = NSApp.windows.contains { isMainWindow($0) && $0.isVisible }
+        let savedTabbing = NSWindow.allowsAutomaticWindowTabbing
         if hadExistingMain && !AppSettingsManager.shared.tabs.groupAllConnectionTabs {
             NSWindow.allowsAutomaticWindowTabbing = false
         }
 
         let deeplinkPayload = EditorTabPayload(connectionId: connection.id)
         WindowManager.shared.openTab(payload: deeplinkPayload)
+        NSWindow.allowsAutomaticWindowTabbing = savedTabbing
 
         Task {
             do {

--- a/TablePro/AppDelegate+WindowConfig.swift
+++ b/TablePro/AppDelegate+WindowConfig.swift
@@ -2,8 +2,6 @@
 //  AppDelegate+WindowConfig.swift
 //  TablePro
 //
-//  Window lifecycle, styling, dock menu, and auto-reconnect
-//
 
 import AppKit
 import os
@@ -399,7 +397,7 @@ extension AppDelegate {
     }
 
     func closeRestoredMainWindows() {
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             for window in NSApp.windows where self?.isMainWindow(window) == true {
                 window.close()
             }

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -2,8 +2,6 @@
 //  AppDelegate.swift
 //  TablePro
 //
-//  Window configuration using AppKit-native approach
-//
 
 import AppKit
 import os
@@ -21,43 +19,20 @@ internal extension URL {
     }
 }
 
-/// AppDelegate handles window lifecycle events using proper AppKit patterns.
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     private static let logger = Logger(subsystem: "com.TablePro", category: "AppDelegate")
     static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
-    /// Track windows that have been configured to avoid re-applying styles
     var configuredWindows = Set<ObjectIdentifier>()
-
-    /// SQL files queued until a database connection is active (drained on .databaseDidConnect)
     var queuedFileURLs: [URL] = []
-
-    /// Database URL and SQLite file entries queued until the SwiftUI window system is ready
     var queuedURLEntries: [QueuedURLEntry] = []
-
-    /// True while handling a file-open event — suppresses welcome window
     var isHandlingFileOpen = false
-
-    /// Counter for outstanding suppressions; welcome window is suppressed while > 0
     var fileOpenSuppressionCount = 0
-
-    /// True while a queued URL polling task is active — prevents duplicate pollers
     var isProcessingQueuedURLs = false
-
-    /// True while auto-reconnect is in progress at startup
     var isAutoReconnecting = false
-
-    /// ConnectionIds currently being connected from URL handlers.
-    /// Prevents duplicate connections when the same URL is opened twice rapidly.
     var connectingURLConnectionIds = Set<UUID>()
-
-    /// Normalized param keys for URLs currently being connected.
-    /// Catches duplicates even before connectToSession creates the session.
     var connectingURLParamKeys = Set<String>()
-
-    /// File paths currently being connected from file-open handlers.
-    /// Prevents duplicate connections when the same file is opened twice rapidly.
     var connectingFilePaths = Set<String>()
 
     // MARK: - NSApplicationDelegate

--- a/TablePro/Views/Components/SectionHeaderView.swift
+++ b/TablePro/Views/Components/SectionHeaderView.swift
@@ -81,7 +81,7 @@ struct SectionHeaderView<Actions: View>: View {
                 ThemeEngine.shared.colors.ui.controlBackgroundSwiftUI.opacity(0.5) :
                 Color.clear
         )
-        .cornerRadius(6)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
     }
 }

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -388,9 +388,7 @@ struct WelcomeWindowView: View {
         .padding(.vertical, 4)
         .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
         .contentShape(Rectangle())
-        .simultaneousGesture(TapGesture(count: 2).onEnded {
-            vm.connectToLinkedConnection(linked)
-        })
+        .background { DoubleClickDetector { vm.connectToLinkedConnection(linked) } }
         .listRowSeparator(.hidden)
         .contextMenu {
             Button {

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -28,7 +28,6 @@ struct FilterPanelView: View {
             filterHeader
 
             Divider()
-                .foregroundStyle(Color(nsColor: .separatorColor))
 
             if !filterState.filters.isEmpty {
                 filterList

--- a/TablePro/Views/Filter/SQLPreviewSheet.swift
+++ b/TablePro/Views/Filter/SQLPreviewSheet.swift
@@ -12,20 +12,9 @@ struct SQLPreviewSheet: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            HStack {
-                Text("Generated WHERE Clause")
-                    .font(.body.weight(.semibold))
-                Spacer()
-                Button(action: { dismiss() }) {
-                    Image(systemName: "xmark.circle.fill")
-                        .imageScale(.large)
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(.tertiary)
-                }
-                .buttonStyle(.borderless)
-                .accessibilityLabel(String(localized: "Close"))
-                .help(String(localized: "Close preview"))
-            }
+            Text("Generated WHERE Clause")
+                .font(.body.weight(.semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             ScrollView {
                 Text(sql.isEmpty ? "(no conditions)" : sql)

--- a/TablePro/Views/Results/InlineErrorBanner.swift
+++ b/TablePro/Views/Results/InlineErrorBanner.swift
@@ -22,8 +22,7 @@ struct InlineErrorBanner: View {
                 .textSelection(.enabled)
             Spacer()
             Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(message, forType: .string)
+                ClipboardService.shared.writeText(message)
             } label: {
                 Image(systemName: "doc.on.doc")
                     .frame(width: 24, height: 24)


### PR DESCRIPTION
## Summary

Batch cleanup of remaining LOW-severity HIG/view issues from the macOS audit.

- `InlineErrorBanner`: use `ClipboardService.shared.writeText` instead of direct `NSPasteboard.general`
- `SectionHeaderView`: replace deprecated `.cornerRadius(6)` with `.clipShape(RoundedRectangle(...))`
- `FilterPanelView`: remove redundant `.foregroundStyle` on Divider (already uses system separator)
- `SQLPreviewSheet`: remove duplicate close button (header xmark) — keep footer Close per macOS HIG
- `WelcomeWindowView`: replace `simultaneousGesture(TapGesture(count:2))` with `DoubleClickDetector` for consistency
- `AppDelegate+ConnectionHandler/FileOpen`: save and restore `allowsAutomaticWindowTabbing` instead of leaving it dirty
- `AppDelegate+WindowConfig`: replace `DispatchQueue.main.async` with `Task { @MainActor in }` on `@MainActor` class
- `AppDelegate*.swift`: remove doc comment blocks per no-comments policy

## Test plan

- [ ] Copy error from inline error banner — verify clipboard works
- [ ] Open SQL preview sheet — verify single Close button at bottom
- [ ] Double-click linked connection in welcome window — verify it connects
- [ ] Open connection via URL when another connection window exists — verify window tabbing still works correctly
- [ ] Filter panel divider — verify appearance unchanged