### PR TITLE
fix: dead code, color correctness, key constants, icon consistency

### DIFF
--- a/TablePro/Assets.xcassets/dynamodb-icon.imageset/Contents.json
+++ b/TablePro/Assets.xcassets/dynamodb-icon.imageset/Contents.json
@@ -11,6 +11,6 @@
   },
   "properties": {
     "preserves-vector-representation": true,
-    "template-rendering-intent": "original"
+    "template-rendering-intent": "template"
   }
 }

--- a/TablePro/Assets.xcassets/mongodb-icon.imageset/Contents.json
+++ b/TablePro/Assets.xcassets/mongodb-icon.imageset/Contents.json
@@ -11,6 +11,6 @@
   },
   "properties": {
     "preserves-vector-representation": true,
-    "template-rendering-intent": "original"
+    "template-rendering-intent": "template"
   }
 }

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -386,8 +386,6 @@ final class ConnectionStorage {
 // MARK: - Stored Connection (Codable wrapper)
 
 private struct StoredConnection: Codable {
-    static let sharedEncoder = JSONEncoder()
-    static let sharedDecoder = JSONDecoder()
 
     let id: UUID
     let name: String
@@ -527,7 +525,7 @@ private struct StoredConnection: Codable {
         self.localOnly = connection.localOnly
 
         // SSH tunnel mode (v2 format preserving jump hosts, profiles, etc.)
-        self.sshTunnelModeJson = try? Self.sharedEncoder.encode(connection.sshTunnelMode)
+        self.sshTunnelModeJson = try? JSONEncoder().encode(connection.sshTunnelMode)
 
         // Plugin-driven additional fields
         self.additionalFields = connection.additionalFields.isEmpty ? nil : connection.additionalFields
@@ -673,7 +671,7 @@ private struct StoredConnection: Codable {
         // Prefer sshTunnelModeJson (v2 format) over legacy flat fields
         let resolvedTunnelMode: SSHTunnelMode
         if let json = sshTunnelModeJson,
-           let decoded = try? Self.sharedDecoder.decode(SSHTunnelMode.self, from: json) {
+           let decoded = try? JSONDecoder().decode(SSHTunnelMode.self, from: json) {
             resolvedTunnelMode = decoded
             switch decoded {
             case .disabled:

--- a/TablePro/Extensions/Color+Hex.swift
+++ b/TablePro/Extensions/Color+Hex.swift
@@ -12,7 +12,7 @@ extension Color {
             .trimmingCharacters(in: CharacterSet(charactersIn: "#"))
 
         guard cleaned.count == 6, let rgbValue = UInt64(cleaned, radix: 16) else {
-            self = .gray
+            self = Color(nsColor: .labelColor)
             return
         }
 
@@ -20,6 +20,6 @@ extension Color {
         let green = Double((rgbValue >> 8) & 0xFF) / 255.0
         let blue = Double(rgbValue & 0xFF) / 255.0
 
-        self.init(red: red, green: green, blue: blue)
+        self.init(.sRGB, red: red, green: green, blue: blue)
     }
 }

--- a/TablePro/Extensions/NSViewController+SwiftUI.swift
+++ b/TablePro/Extensions/NSViewController+SwiftUI.swift
@@ -2,14 +2,12 @@
 //  NSViewController+SwiftUI.swift
 //  TablePro
 //
-//  Helper extension to present SwiftUI views from AppKit
-//
 
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 
 extension NSViewController {
-    /// Present a SwiftUI view as a sheet with proper keyboard handling
     func presentAsSheet<Content: View>(_ swiftUIView: Content, onSave: (() -> Void)? = nil, onCancel: (() -> Void)? = nil) {
         let hostingController = KeyboardHandlingHostingController(rootView: swiftUIView)
         hostingController.onSave = onSave
@@ -20,38 +18,31 @@ extension NSViewController {
     }
 }
 
-/// Custom NSHostingController that properly handles keyboard events
 private class KeyboardHandlingHostingController<Content: View>: NSHostingController<Content> {
     var onSave: (() -> Void)?
     var onCancel: (() -> Void)?
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        // Check for Command modifier
         let commandPressed = event.modifierFlags.contains(.command)
 
-        // Handle Cmd+Return (Save)
-        if commandPressed && (event.keyCode == 36 || event.keyCode == 76) {
+        if commandPressed && (event.keyCode == UInt16(kVK_Return) || event.keyCode == UInt16(kVK_ANSI_KeypadEnter)) {
             onSave?()
             return true
         }
 
-        // Let super handle other events
         return super.performKeyEquivalent(with: event)
     }
 
     override func cancelOperation(_ sender: Any?) {
-        // Handle Escape key
         onCancel?()
     }
 
     override func keyDown(with event: NSEvent) {
-        // Check for Escape key without modifiers
-        if event.keyCode == 53 && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
+        if event.keyCode == UInt16(kVK_Escape) && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
             onCancel?()
             return
         }
 
-        // Pass other keys to super
         super.keyDown(with: event)
     }
 }

--- a/TablePro/Theme/HexColor.swift
+++ b/TablePro/Theme/HexColor.swift
@@ -2,19 +2,18 @@ import AppKit
 import SwiftUI
 
 extension String {
-    /// Parse this hex color string to NSColor (sRGB). Returns gray for invalid input.
     var nsColor: NSColor {
         let hex = trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: "#"))
 
         let hexLength = (hex as NSString).length
         guard hexLength == 6 || hexLength == 8 else {
-            return .gray
+            return .labelColor
         }
 
         var value: UInt64 = 0
         guard Scanner(string: hex).scanHexInt64(&value) else {
-            return .gray
+            return .labelColor
         }
 
         let r, g, b, a: CGFloat
@@ -34,19 +33,16 @@ extension String {
         return NSColor(srgbRed: r, green: g, blue: b, alpha: a)
     }
 
-    /// Parse this hex color string to SwiftUI Color.
     var swiftUIColor: Color {
         Color(nsColor: nsColor)
     }
 
-    /// Parse this hex color string to CGColor (sRGB).
     var cgColor: CGColor {
         nsColor.cgColor
     }
 }
 
 extension NSColor {
-    /// Convert this NSColor to a hex string "#RRGGBB" or "#RRGGBBAA" (if alpha < 1).
     var hexString: String {
         guard let converted = usingColorSpace(.sRGB) else {
             return "#808080"

--- a/TablePro/Theme/ResolvedThemeColors.swift
+++ b/TablePro/Theme/ResolvedThemeColors.swift
@@ -16,8 +16,6 @@ struct ResolvedEditorColors {
     let lineNumberSwiftUI: Color
     let invisibles: NSColor
     let invisiblesSwiftUI: Color
-    let currentStatementHighlight: NSColor
-    let currentStatementHighlightSwiftUI: Color
 
     let keyword: NSColor
     let keywordSwiftUI: Color
@@ -51,8 +49,6 @@ struct ResolvedEditorColors {
         lineNumberSwiftUI = colors.lineNumber.swiftUIColor
         invisibles = colors.invisibles.nsColor
         invisiblesSwiftUI = colors.invisibles.swiftUIColor
-        currentStatementHighlight = colors.currentStatementHighlight.nsColor
-        currentStatementHighlightSwiftUI = colors.currentStatementHighlight.swiftUIColor
 
         keyword = colors.syntax.keyword.nsColor
         keywordSwiftUI = colors.syntax.keyword.swiftUIColor

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -419,9 +419,4 @@ extension View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
-    func toolbarButtonStyle() -> some View {
-        self
-            .buttonStyle(.borderless)
-            .foregroundStyle(.secondary)
-    }
 }

--- a/TablePro/Views/Settings/Sections/LicenseSection.swift
+++ b/TablePro/Views/Settings/Sections/LicenseSection.swift
@@ -43,7 +43,7 @@ struct LicenseSection: View {
                         .controlSize(.small)
                 }
                 .padding(6)
-                .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+                .background(Color(nsColor: .systemOrange).opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
             }
 
             LabeledContent("Email:", value: license.email)

--- a/TablePro/Views/Settings/Sections/MCPTokenRevealSheet.swift
+++ b/TablePro/Views/Settings/Sections/MCPTokenRevealSheet.swift
@@ -49,10 +49,10 @@ struct MCPTokenRevealSheet: View {
         } icon: {
             Image(systemName: "exclamationmark.triangle.fill")
         }
-        .foregroundStyle(.orange)
+        .foregroundStyle(Color(nsColor: .systemOrange))
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.orange.opacity(0.1))
+        .background(Color(nsColor: .systemOrange).opacity(0.1))
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 


### PR DESCRIPTION
## Summary

Batch cleanup of cosmetic issues from the macOS HIG audit. Net -24 lines.

- **Dead code removed**: `toolbarButtonStyle()` (zero usages), `currentStatementHighlight` resolved properties (never read outside Theme/)
- **Color correctness**: `Color+Hex` fallback `.gray` → `.labelColor` (dark-mode adaptive), specify `.sRGB` colorspace explicitly; `HexColor.swift` fallback `.gray` → `.labelColor`; `.orange.opacity()` → `Color(nsColor: .systemOrange).opacity()` in LicenseSection and MCPTokenRevealSheet
- **Key constants**: raw key codes (36, 76, 53) replaced with `kVK_Return`, `kVK_ANSI_KeypadEnter`, `kVK_Escape` from Carbon.HIToolbox
- **Icon consistency**: DynamoDB and MongoDB icons changed from "original" to "template" rendering to match all 16 other database icons
- **Storage cleanup**: removed static `sharedEncoder`/`sharedDecoder` from `StoredConnection` that shadowed outer scope — replaced with local `JSONEncoder()`/`JSONDecoder()`
- **Doc comments removed** from HexColor.swift per no-comments policy

## Test plan

- [ ] Theme loads correctly in light and dark mode
- [ ] Invalid hex color in custom theme shows as label color (not gray)
- [ ] DynamoDB and MongoDB icons tint correctly with foreground color
- [ ] Cmd+Return in sheet dialogs still works
- [ ] Escape in sheet dialogs still works
- [ ] License expiry warning banner has correct orange tint
- [ ] MCP token reveal sheet has correct orange warning tint