### PR TITLE
build: shared OpenSSL dylibs to deduplicate across main app and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,5 @@ build/
 # Static libraries (downloaded from GitHub Releases via scripts/download-libs.sh)
 Libs/*.a
 Libs/.downloaded
+Libs/dylibs/
 Libs/ios/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- OpenSSL shared as dylib across app and plugins, saving ~15MB in bundle size
+
 ## [0.36.0] - 2026-04-27
 
 ### Added

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -2275,18 +2275,23 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs/dylibs";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.36.0;
 				OTHER_LDFLAGS = (
 					"-Wl,-w",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libssh2.a",
-					"-force_load",
-					"$(PROJECT_DIR)/Libs/libssl.a",
-					"-force_load",
-					"$(PROJECT_DIR)/Libs/libcrypto.a",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro;
@@ -2348,18 +2353,23 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs/dylibs";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.36.0;
 				OTHER_LDFLAGS = (
 					"-Wl,-w",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libssh2.a",
-					"-force_load",
-					"$(PROJECT_DIR)/Libs/libssl.a",
-					"-force_load",
-					"$(PROJECT_DIR)/Libs/libcrypto.a",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro;
@@ -2670,15 +2680,21 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/MSSQLDriverPlugin/CFreeTDS/include";
 				INFOPLIST_FILE = Plugins/MSSQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).MSSQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libsybdb.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-liconv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.MSSQLDriver;
@@ -2703,15 +2719,21 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/MSSQLDriverPlugin/CFreeTDS/include";
 				INFOPLIST_FILE = Plugins/MSSQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).MSSQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libsybdb.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-liconv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.MSSQLDriver;
@@ -2736,15 +2758,21 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/MySQLDriverPlugin/CMariaDB/include";
 				INFOPLIST_FILE = Plugins/MySQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).MySQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libmariadb.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-liconv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.MySQLDriver;
@@ -2769,15 +2797,21 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/MySQLDriverPlugin/CMariaDB/include";
 				INFOPLIST_FILE = Plugins/MySQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).MySQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libmariadb.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-liconv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.MySQLDriver;
@@ -2886,8 +2920,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/RedisDriverPlugin/CRedis/include";
 				INFOPLIST_FILE = Plugins/RedisDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).RedisPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -2895,8 +2935,8 @@
 					"$(PROJECT_DIR)/Libs/libhiredis.a",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libhiredis_ssl.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.RedisDriver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2920,8 +2960,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/RedisDriverPlugin/CRedis/include";
 				INFOPLIST_FILE = Plugins/RedisDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).RedisPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -2929,8 +2975,8 @@
 					"$(PROJECT_DIR)/Libs/libhiredis.a",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libhiredis_ssl.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.RedisDriver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2954,8 +3000,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/PostgreSQLDriverPlugin/CLibPQ/include";
 				INFOPLIST_FILE = Plugins/PostgreSQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).PostgreSQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -2963,8 +3015,8 @@
 					"$(PROJECT_DIR)/Libs/libpq.a",
 					"$(PROJECT_DIR)/Libs/libpgcommon.a",
 					"$(PROJECT_DIR)/Libs/libpgport.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.PostgreSQLDriver;
@@ -2989,8 +3041,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/PostgreSQLDriverPlugin/CLibPQ/include";
 				INFOPLIST_FILE = Plugins/PostgreSQLDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).PostgreSQLPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -2998,8 +3056,8 @@
 					"$(PROJECT_DIR)/Libs/libpq.a",
 					"$(PROJECT_DIR)/Libs/libpgcommon.a",
 					"$(PROJECT_DIR)/Libs/libpgport.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.PostgreSQLDriver;
@@ -3362,8 +3420,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/CassandraDriverPlugin/CCassandra/include";
 				INFOPLIST_FILE = Plugins/CassandraDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).CassandraPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -3371,8 +3435,8 @@
 					"$(PROJECT_DIR)/Libs/libcassandra.a",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libuv.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lc++",
 					"-lz",
 				);
@@ -3398,8 +3462,14 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Plugins/CassandraDriverPlugin/CCassandra/include";
 				INFOPLIST_FILE = Plugins/CassandraDriverPlugin/Info.plist;
 				INFOPLIST_KEY_NSPrincipalClass = "$(PRODUCT_MODULE_NAME).CassandraPlugin";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Libs";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Libs",
+					"$(PROJECT_DIR)/Libs/dylibs",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -3407,8 +3477,8 @@
 					"$(PROJECT_DIR)/Libs/libcassandra.a",
 					"-force_load",
 					"$(PROJECT_DIR)/Libs/libuv.a",
-					"-lssl",
-					"-lcrypto",
+					"-lssl.3",
+					"-lcrypto.3",
 					"-lc++",
 					"-lz",
 				);

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -459,6 +459,17 @@ build_for_arch() {
         echo "   TableProPluginKit framework stripped"
     fi
 
+    # Remove development rpaths (absolute source paths) from all binaries
+    echo "🔧 Stripping development rpaths..."
+    for binary in "$main_binary" \
+        "$BUILD_DIR/$OUTPUT_NAME/Contents/MacOS"/* \
+        "$PLUGINS_DIR"/*.tableplugin/Contents/MacOS/*; do
+        [ -f "$binary" ] || continue
+        otool -l "$binary" 2>/dev/null | grep "Libs/dylibs" | awk '{print $2}' | while read -r rpath; do
+            install_name_tool -delete_rpath "$rpath" "$binary" 2>/dev/null || true
+        done
+    done
+
     # Strip Sparkle helper binaries
     local sparkle_dir="$BUILD_DIR/$OUTPUT_NAME/Contents/Frameworks/Sparkle.framework/Versions/B"
     for sparkle_bin in \

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -315,6 +315,10 @@ build_for_arch() {
     prepare_libmongoc "$arch"
     prepare_hiredis "$arch"
 
+    # Create OpenSSL shared dylibs for this architecture
+    echo "📦 Creating OpenSSL shared dylibs for $arch..."
+    scripts/create-openssl-dylibs.sh "$arch"
+
     # Persistent SPM package cache (speeds up CI on self-hosted runners)
     SPM_CACHE_DIR="${HOME}/.spm-cache"
     mkdir -p "$SPM_CACHE_DIR"
@@ -472,7 +476,21 @@ build_for_arch() {
         echo "   Removed Sparkle XPC services (non-sandboxed app)"
     fi
 
-    # Bundle non-system dynamic libraries (libpq, OpenSSL, etc.)
+    # Copy shared OpenSSL dylibs into Frameworks
+    echo "📦 Copying OpenSSL shared dylibs to Frameworks/..."
+    FRAMEWORKS_EMBED_DIR="$BUILD_DIR/$OUTPUT_NAME/Contents/Frameworks"
+    mkdir -p "$FRAMEWORKS_EMBED_DIR"
+    for lib in libcrypto.3.dylib libssl.3.dylib; do
+        if [ -f "Libs/dylibs/$lib" ]; then
+            cp -f "Libs/dylibs/$lib" "$FRAMEWORKS_EMBED_DIR/$lib"
+            chmod 644 "$FRAMEWORKS_EMBED_DIR/$lib"
+            echo "   Copied $lib"
+        else
+            echo "   WARNING: Libs/dylibs/$lib not found"
+        fi
+    done
+
+    # Bundle non-system dynamic libraries (libpq, etc.)
     bundle_dylibs "$BUILD_DIR/$OUTPUT_NAME"
 
     # Sign the entire app bundle with Developer ID.

--- a/scripts/create-openssl-dylibs.sh
+++ b/scripts/create-openssl-dylibs.sh
@@ -41,6 +41,7 @@ create_dylibs_for_arch() {
         -o "$OUT_DIR/libcrypto.3${suffix}.dylib" \
         -Wl,-all_load "$crypto_static" \
         -install_name @rpath/libcrypto.3.dylib \
+        -compatibility_version 3.0.0 -current_version 3.4.0 \
         -lz -framework Security -framework CoreFoundation \
         -mmacosx-version-min="$MIN_MACOS"
 
@@ -50,6 +51,7 @@ create_dylibs_for_arch() {
         -Wl,-all_load "$ssl_static" \
         -L"$OUT_DIR" -lcrypto.3"$suffix" \
         -install_name @rpath/libssl.3.dylib \
+        -compatibility_version 3.0.0 -current_version 3.4.0 \
         -mmacosx-version-min="$MIN_MACOS"
 }
 

--- a/scripts/create-openssl-dylibs.sh
+++ b/scripts/create-openssl-dylibs.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH="${1:-both}"
+LIBS_DIR="Libs"
+OUT_DIR="$LIBS_DIR/dylibs"
+MIN_MACOS="14.0"
+
+mkdir -p "$OUT_DIR"
+
+create_dylibs_for_arch() {
+    local arch=$1
+    local suffix=""
+    if [ "$ARCH" = "both" ] && [ "$arch" != "universal" ]; then
+        suffix=".$arch"
+    fi
+
+    local crypto_static="$LIBS_DIR/libcrypto_${arch}.a"
+    local ssl_static="$LIBS_DIR/libssl_${arch}.a"
+
+    if [ ! -f "$crypto_static" ]; then
+        if [ -f "$LIBS_DIR/libcrypto.a" ] && lipo -info "$LIBS_DIR/libcrypto.a" 2>/dev/null | grep -q "$arch"; then
+            crypto_static="$LIBS_DIR/libcrypto.a"
+        else
+            echo "ERROR: No libcrypto static lib found for $arch"
+            exit 1
+        fi
+    fi
+
+    if [ ! -f "$ssl_static" ]; then
+        if [ -f "$LIBS_DIR/libssl.a" ] && lipo -info "$LIBS_DIR/libssl.a" 2>/dev/null | grep -q "$arch"; then
+            ssl_static="$LIBS_DIR/libssl.a"
+        else
+            echo "ERROR: No libssl static lib found for $arch"
+            exit 1
+        fi
+    fi
+
+    echo "Creating libcrypto.3${suffix}.dylib ($arch)..."
+    clang -arch "$arch" -shared \
+        -o "$OUT_DIR/libcrypto.3${suffix}.dylib" \
+        -Wl,-all_load "$crypto_static" \
+        -install_name @rpath/libcrypto.3.dylib \
+        -lz -framework Security -framework CoreFoundation \
+        -mmacosx-version-min="$MIN_MACOS"
+
+    echo "Creating libssl.3${suffix}.dylib ($arch)..."
+    clang -arch "$arch" -shared \
+        -o "$OUT_DIR/libssl.3${suffix}.dylib" \
+        -Wl,-all_load "$ssl_static" \
+        -L"$OUT_DIR" -lcrypto.3"$suffix" \
+        -install_name @rpath/libssl.3.dylib \
+        -mmacosx-version-min="$MIN_MACOS"
+}
+
+case "$ARCH" in
+    arm64|x86_64)
+        create_dylibs_for_arch "$ARCH"
+        echo "OpenSSL dylibs created for $ARCH in $OUT_DIR/"
+        ls -lh "$OUT_DIR"/lib*.dylib
+        ;;
+    both)
+        create_dylibs_for_arch arm64
+        create_dylibs_for_arch x86_64
+
+        echo "Creating universal dylibs..."
+        lipo -create \
+            "$OUT_DIR/libcrypto.3.arm64.dylib" \
+            "$OUT_DIR/libcrypto.3.x86_64.dylib" \
+            -output "$OUT_DIR/libcrypto.3.dylib"
+
+        lipo -create \
+            "$OUT_DIR/libssl.3.arm64.dylib" \
+            "$OUT_DIR/libssl.3.x86_64.dylib" \
+            -output "$OUT_DIR/libssl.3.dylib"
+
+        rm -f "$OUT_DIR"/*.arm64.dylib "$OUT_DIR"/*.x86_64.dylib
+        echo "Universal OpenSSL dylibs created in $OUT_DIR/"
+        ls -lh "$OUT_DIR"/lib*.dylib
+        ;;
+    *)
+        echo "Usage: $0 [arm64|x86_64|both]"
+        exit 1
+        ;;
+esac

--- a/scripts/download-libs.sh
+++ b/scripts/download-libs.sh
@@ -64,6 +64,14 @@ touch "$MARKER"
 LIB_COUNT=$(find "$LIBS_DIR" -maxdepth 1 -name '*.a' | wc -l | tr -d ' ')
 echo "Downloaded $LIB_COUNT static libraries."
 
+# --- OpenSSL shared dylibs ---
+echo "Creating OpenSSL shared dylibs for local development..."
+if [[ -f "$LIBS_DIR/libcrypto_arm64.a" || -f "$LIBS_DIR/libcrypto.a" ]]; then
+  scripts/create-openssl-dylibs.sh both
+else
+  echo "Skipping OpenSSL dylibs (no static libs found yet)."
+fi
+
 # --- iOS xcframeworks ---
 IOS_ARCHIVE="tablepro-libs-ios-v1.tar.gz"
 IOS_DIR="$LIBS_DIR/ios"


### PR DESCRIPTION
## Summary

- OpenSSL (libssl + libcrypto) was statically linked into 6+ separate binaries: main app, MySQL, PostgreSQL, Redis, MSSQL, and Cassandra plugins. Each copy adds ~3-5MB.
- Now builds shared dylibs from the existing static libs and links all targets against them. One copy in `Contents/Frameworks/` instead of 6 embedded copies.
- New `scripts/create-openssl-dylibs.sh` converts static `.a` to `.dylib` with `@rpath` install names
- `build-release.sh` creates arch-specific dylibs before build and embeds them in Frameworks
- `download-libs.sh` creates universal dylibs after downloading static libs for local dev
- Expected savings: ~10-15MB reduction in app bundle size

## Test plan

- [ ] Run `scripts/create-openssl-dylibs.sh both` and verify dylibs created in `Libs/dylibs/`
- [ ] Build Debug: verify `otool -L` shows `@rpath/libssl.3.dylib` on main binary and all plugins
- [ ] Launch app, connect to MySQL/PostgreSQL/Redis over SSL - verify connections work
- [ ] SSH tunnel connection - verify libssh2 still works (uses OpenSSL)
- [ ] Run `scripts/build-release.sh arm64` - verify dylibs embedded in `Contents/Frameworks/`