### PR TITLE
fix: connection URL parsing, SSH key resolution, and export compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Connection URL parsing: SSH `user:password@host` split, `safeModeLevel` from TablePlus URLs, case-insensitive query params
+- Connection URL export: SSH password, Redis database index, MongoDB auth params (`authSource`, `authMechanism`, `replicaSet`), and multi-host
+- SSH Private Key auth resolves keys from `~/.ssh/config` and default locations (`id_ed25519`, `id_rsa`, `id_ecdsa`) when no explicit key path is set
+
 ### Changed
 
 - Inspector: dense field list, PK/FK key icons, Set NULL/DEFAULT in picker dropdowns, toolbar tracking separator
 - OpenSSL shared as dylib across app and plugins, saving ~15MB in bundle size
+
+### Fixed
+
+- Connection form: `usePrivateKey=true` from URL no longer disables Test/Create buttons
+- Transient connections from URL clean up keychain entries on connection failure
 
 ## [0.36.0] - 2026-04-27
 

--- a/TablePro/AppDelegate+ConnectionHandler.swift
+++ b/TablePro/AppDelegate+ConnectionHandler.swift
@@ -549,16 +549,7 @@ extension AppDelegate {
             tagId = ConnectionURLParser.tagId(fromEnvName: envName)
         }
 
-        let resolvedSafeMode: SafeModeLevel
-        if let level = parsed.safeModeLevel {
-            switch level {
-            case 1: resolvedSafeMode = .alert
-            case 2: resolvedSafeMode = .readOnly
-            default: resolvedSafeMode = .silent
-            }
-        } else {
-            resolvedSafeMode = .silent
-        }
+        let resolvedSafeMode = parsed.safeModeLevel.flatMap(SafeModeLevel.from(urlInteger:)) ?? .silent
 
         var connection = DatabaseConnection(
             name: parsed.connectionName ?? parsed.suggestedName,

--- a/TablePro/AppDelegate+ConnectionHandler.swift
+++ b/TablePro/AppDelegate+ConnectionHandler.swift
@@ -41,10 +41,13 @@ extension AppDelegate {
         }
 
         let connection: DatabaseConnection
+        let isTransient: Bool
         if let matched = matchedConnection {
             connection = matched
+            isTransient = false
         } else {
             connection = buildTransientConnection(from: parsed)
+            isTransient = true
         }
 
         if !parsed.password.isEmpty {
@@ -98,6 +101,10 @@ extension AppDelegate {
                 self.handlePostConnectionActions(parsed, connectionId: connection.id)
             } catch {
                 connectionLogger.error("Database URL connect failed: \(error.localizedDescription)")
+                if isTransient {
+                    ConnectionStorage.shared.deletePassword(for: connection.id)
+                    ConnectionStorage.shared.deleteSSHPassword(for: connection.id)
+                }
                 await self.handleConnectionFailure(error)
             }
         }

--- a/TablePro/AppDelegate+ConnectionHandler.swift
+++ b/TablePro/AppDelegate+ConnectionHandler.swift
@@ -51,6 +51,10 @@ extension AppDelegate {
             ConnectionStorage.shared.savePassword(parsed.password, for: connection.id)
         }
 
+        if let sshPass = parsed.sshPassword, !sshPass.isEmpty {
+            ConnectionStorage.shared.saveSSHPassword(sshPass, for: connection.id)
+        }
+
         // Check if already connected or connecting (by ID or by params).
         // This catches duplicates from URL handler, auto-reconnect, or any other source.
         if DatabaseManager.shared.activeSessions[connection.id] != nil {
@@ -545,6 +549,17 @@ extension AppDelegate {
             tagId = ConnectionURLParser.tagId(fromEnvName: envName)
         }
 
+        let resolvedSafeMode: SafeModeLevel
+        if let level = parsed.safeModeLevel {
+            switch level {
+            case 1: resolvedSafeMode = .alert
+            case 2: resolvedSafeMode = .readOnly
+            default: resolvedSafeMode = .silent
+            }
+        } else {
+            resolvedSafeMode = .silent
+        }
+
         var connection = DatabaseConnection(
             name: parsed.connectionName ?? parsed.suggestedName,
             host: parsed.host,
@@ -556,6 +571,7 @@ extension AppDelegate {
             sslConfig: sslConfig,
             color: color,
             tagId: tagId,
+            safeModeLevel: resolvedSafeMode,
             mongoAuthSource: parsed.authSource,
             mongoUseSrv: parsed.useSrv,
             mongoAuthMechanism: parsed.mongoQueryParams["authMechanism"],

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -482,20 +482,27 @@ internal enum LibSSH2TunnelFactory {
             return PasswordAuthenticator(password: sshPassword)
 
         case .privateKey:
-            let primary = buildKeyFileAuthenticator(
-                keyPath: config.privateKeyPath,
-                providedPassphrase: credentials.keyPassphrase,
-                configEntry: configEntry,
-                canPrompt: true
-            )
+            let keyPaths = resolveIdentityFiles(config: config, configEntry: configEntry)
+            guard !keyPaths.isEmpty else {
+                throw SSHTunnelError.authenticationFailed
+            }
+            var authenticators: [any SSHAuthenticator] = keyPaths.map { keyPath in
+                buildKeyFileAuthenticator(
+                    keyPath: keyPath,
+                    providedPassphrase: credentials.keyPassphrase,
+                    configEntry: configEntry,
+                    canPrompt: true
+                )
+            }
             if config.totpMode != .none {
-                let totpAuth = KeyboardInteractiveAuthenticator(
+                authenticators.append(KeyboardInteractiveAuthenticator(
                     password: nil,
                     totpProvider: buildTOTPProvider(config: config, credentials: credentials)
-                )
-                return CompositeAuthenticator(authenticators: [primary, totpAuth])
+                ))
             }
-            return primary
+            return authenticators.count == 1
+                ? authenticators[0]
+                : CompositeAuthenticator(authenticators: authenticators)
 
         case .sshAgent:
             // Resolve agent socket: UI config > SSH config IdentityAgent > system default
@@ -634,13 +641,31 @@ internal enum LibSSH2TunnelFactory {
 
         switch jumpHost.authMethod {
         case .privateKey:
-            return KeyFileAuthenticator(
-                keyPath: jumpHost.privateKeyPath,
-                providedPassphrase: nil,
-                canPrompt: true,
-                useKeychain: configEntry?.useKeychain ?? true,
-                addKeysToAgent: configEntry?.addKeysToAgent ?? false
+            let keyPaths = resolveJumpIdentityFiles(
+                privateKeyPath: jumpHost.privateKeyPath,
+                configEntry: configEntry
             )
+            guard let firstPath = keyPaths.first else {
+                throw SSHTunnelError.authenticationFailed
+            }
+            if keyPaths.count == 1 {
+                return KeyFileAuthenticator(
+                    keyPath: firstPath,
+                    providedPassphrase: nil,
+                    canPrompt: true,
+                    useKeychain: configEntry?.useKeychain ?? true,
+                    addKeysToAgent: configEntry?.addKeysToAgent ?? false
+                )
+            }
+            return CompositeAuthenticator(authenticators: keyPaths.map { path in
+                KeyFileAuthenticator(
+                    keyPath: path,
+                    providedPassphrase: nil,
+                    canPrompt: true,
+                    useKeychain: configEntry?.useKeychain ?? true,
+                    addKeysToAgent: configEntry?.addKeysToAgent ?? false
+                )
+            })
         case .sshAgent:
             let socketPath = configEntry?.identityAgent
             let agent = AgentAuthenticator(socketPath: socketPath)
@@ -684,11 +709,32 @@ internal enum LibSSH2TunnelFactory {
         // Fall back to default key paths
         let sshDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".ssh", isDirectory: true)
-        return ["id_ed25519", "id_rsa", "id_ecdsa"]
+        return defaultKeyPaths(sshDir: sshDir)
+    }
+
+    private static func resolveJumpIdentityFiles(
+        privateKeyPath: String,
+        configEntry: SSHConfigEntry?
+    ) -> [String] {
+        if !privateKeyPath.isEmpty {
+            return [privateKeyPath]
+        }
+        if let files = configEntry?.identityFiles, !files.isEmpty {
+            return files
+        }
+        if configEntry?.identitiesOnly == true {
+            return []
+        }
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh", isDirectory: true)
+        return defaultKeyPaths(sshDir: sshDir)
+    }
+
+    private static func defaultKeyPaths(sshDir: URL) -> [String] {
+        ["id_ed25519", "id_rsa", "id_ecdsa"]
             .map { sshDir.appendingPathComponent($0).path }
             .filter { FileManager.default.isReadableFile(atPath: $0) }
     }
-
 
     private static func buildTOTPProvider(
         config: SSHConfiguration,

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -482,7 +482,7 @@ internal enum LibSSH2TunnelFactory {
             return PasswordAuthenticator(password: sshPassword)
 
         case .privateKey:
-            let keyPaths = resolveIdentityFiles(config: config, configEntry: configEntry)
+            let keyPaths = resolveIdentityFiles(privateKeyPath: config.privateKeyPath, configEntry: configEntry)
             guard !keyPaths.isEmpty else {
                 throw SSHTunnelError.authenticationFailed
             }
@@ -518,7 +518,7 @@ internal enum LibSSH2TunnelFactory {
             var authenticators: [any SSHAuthenticator] = [AgentAuthenticator(socketPath: socketPath)]
 
             // Fallback: try key files if agent has no loaded identities
-            for keyPath in resolveIdentityFiles(config: config, configEntry: configEntry) {
+            for keyPath in resolveIdentityFiles(privateKeyPath: config.privateKeyPath, configEntry: configEntry) {
                 authenticators.append(buildKeyFileAuthenticator(
                     keyPath: keyPath,
                     providedPassphrase: credentials.keyPassphrase,
@@ -641,23 +641,11 @@ internal enum LibSSH2TunnelFactory {
 
         switch jumpHost.authMethod {
         case .privateKey:
-            let keyPaths = resolveJumpIdentityFiles(
-                privateKeyPath: jumpHost.privateKeyPath,
-                configEntry: configEntry
-            )
-            guard let firstPath = keyPaths.first else {
+            let keyPaths = resolveIdentityFiles(privateKeyPath: jumpHost.privateKeyPath, configEntry: configEntry)
+            guard !keyPaths.isEmpty else {
                 throw SSHTunnelError.authenticationFailed
             }
-            if keyPaths.count == 1 {
-                return KeyFileAuthenticator(
-                    keyPath: firstPath,
-                    providedPassphrase: nil,
-                    canPrompt: true,
-                    useKeychain: configEntry?.useKeychain ?? true,
-                    addKeysToAgent: configEntry?.addKeysToAgent ?? false
-                )
-            }
-            return CompositeAuthenticator(authenticators: keyPaths.map { path in
+            let authenticators = keyPaths.map { path in
                 KeyFileAuthenticator(
                     keyPath: path,
                     providedPassphrase: nil,
@@ -665,7 +653,10 @@ internal enum LibSSH2TunnelFactory {
                     useKeychain: configEntry?.useKeychain ?? true,
                     addKeysToAgent: configEntry?.addKeysToAgent ?? false
                 )
-            })
+            }
+            return authenticators.count == 1
+                ? authenticators[0]
+                : CompositeAuthenticator(authenticators: authenticators)
         case .sshAgent:
             let socketPath = configEntry?.identityAgent
             let agent = AgentAuthenticator(socketPath: socketPath)
@@ -685,34 +676,10 @@ internal enum LibSSH2TunnelFactory {
 
     /// Resolve identity file paths for key file authentication.
     /// Priority: user-configured path > SSH config IdentityFile(s) > default key paths.
+    /// Resolve identity file paths for key authentication.
+    /// Priority: explicit privateKeyPath > SSH config IdentityFile(s) > default key paths.
     /// Respects `IdentitiesOnly` — skips default paths when set.
-    /// Returns multiple paths when SSH config has multiple IdentityFile directives.
     private static func resolveIdentityFiles(
-        config: SSHConfiguration,
-        configEntry: SSHConfigEntry?
-    ) -> [String] {
-        // User-configured path in the connection UI always takes priority
-        if !config.privateKeyPath.isEmpty {
-            return [config.privateKeyPath]
-        }
-
-        // SSH config IdentityFile(s) — try all in order
-        if let files = configEntry?.identityFiles, !files.isEmpty {
-            return files
-        }
-
-        // When IdentitiesOnly is set, don't try default key paths
-        if configEntry?.identitiesOnly == true {
-            return []
-        }
-
-        // Fall back to default key paths
-        let sshDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".ssh", isDirectory: true)
-        return defaultKeyPaths(sshDir: sshDir)
-    }
-
-    private static func resolveJumpIdentityFiles(
         privateKeyPath: String,
         configEntry: SSHConfigEntry?
     ) -> [String] {
@@ -727,11 +694,7 @@ internal enum LibSSH2TunnelFactory {
         }
         let sshDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".ssh", isDirectory: true)
-        return defaultKeyPaths(sshDir: sshDir)
-    }
-
-    private static func defaultKeyPaths(sshDir: URL) -> [String] {
-        ["id_ed25519", "id_rsa", "id_ecdsa"]
+        return ["id_ed25519", "id_rsa", "id_ecdsa"]
             .map { sshDir.appendingPathComponent($0).path }
             .filter { FileManager.default.isReadableFile(atPath: $0) }
     }

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -674,11 +674,6 @@ internal enum LibSSH2TunnelFactory {
         }
     }
 
-    /// Resolve identity file paths for key file authentication.
-    /// Priority: user-configured path > SSH config IdentityFile(s) > default key paths.
-    /// Resolve identity file paths for key authentication.
-    /// Priority: explicit privateKeyPath > SSH config IdentityFile(s) > default key paths.
-    /// Respects `IdentitiesOnly` — skips default paths when set.
     private static func resolveIdentityFiles(
         privateKeyPath: String,
         configEntry: SSHConfigEntry?

--- a/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLFormatter.swift
@@ -25,7 +25,7 @@ struct ConnectionURLFormatter {
 
         let ssh = connection.resolvedSSHConfig
         if ssh.enabled {
-            return formatSSH(connection, sshConfig: ssh, scheme: scheme, password: password)
+            return formatSSH(connection, sshConfig: ssh, scheme: scheme, password: password, sshPassword: sshPassword)
         }
 
         return formatStandard(connection, scheme: scheme, password: password)
@@ -56,12 +56,17 @@ struct ConnectionURLFormatter {
         _ connection: DatabaseConnection,
         sshConfig ssh: SSHConfiguration,
         scheme: String,
-        password: String?
+        password: String?,
+        sshPassword: String?
     ) -> String {
         var result = "\(scheme)+ssh://"
 
         if !ssh.username.isEmpty {
-            result += "\(percentEncodeUserinfo(ssh.username))@"
+            result += percentEncodeUserinfo(ssh.username)
+            if let sshPassword, !sshPassword.isEmpty {
+                result += ":\(percentEncodeUserinfo(sshPassword))"
+            }
+            result += "@"
         }
         result += ssh.host
         if ssh.port != 22 {
@@ -83,9 +88,12 @@ struct ConnectionURLFormatter {
             result += ":\(connection.port)"
         }
 
-        let sshPathComponent = connection.type == .oracle
+        var sshPathComponent = connection.type == .oracle
             ? (connection.oracleServiceName ?? connection.database)
             : connection.database
+        if connection.type == .redis, let redisDb = connection.redisDatabase, redisDb > 0 {
+            sshPathComponent = String(redisDb)
+        }
         result += "/\(sshPathComponent)"
 
         let query = buildQueryString(connection, sshConfig: ssh)
@@ -111,14 +119,22 @@ struct ConnectionURLFormatter {
             result += "@"
         }
 
-        result += connection.host
-        if connection.port != connection.type.defaultPort {
-            result += ":\(connection.port)"
+        if connection.type.pluginTypeId == "MongoDB",
+           let mongoHosts = connection.additionalFields["mongoHosts"], !mongoHosts.isEmpty {
+            result += mongoHosts
+        } else {
+            result += connection.host
+            if connection.port != connection.type.defaultPort {
+                result += ":\(connection.port)"
+            }
         }
 
-        let pathComponent = connection.type == .oracle
+        var pathComponent = connection.type == .oracle
             ? (connection.oracleServiceName ?? connection.database)
             : connection.database
+        if connection.type == .redis, let redisDb = connection.redisDatabase, redisDb > 0 {
+            pathComponent = String(redisDb)
+        }
         result += "/\(pathComponent)"
 
         let query = buildQueryString(connection)
@@ -178,6 +194,19 @@ struct ConnectionURLFormatter {
             params.append("env=\(encoded)")
         }
 
+        if let authSource = connection.mongoAuthSource, !authSource.isEmpty {
+            params.append("authSource=\(percentEncodeQueryValue(authSource))")
+        }
+        if let authMech = connection.mongoAuthMechanism, !authMech.isEmpty {
+            params.append("authMechanism=\(percentEncodeQueryValue(authMech))")
+        }
+        if let replicaSet = connection.mongoReplicaSet, !replicaSet.isEmpty {
+            params.append("replicaSet=\(percentEncodeQueryValue(replicaSet))")
+        }
+        if connection.mongoUseSrv {
+            params.append("mongoUseSrv=true")
+        }
+
         return params.joined(separator: "&")
     }
 
@@ -209,5 +238,12 @@ struct ConnectionURLFormatter {
         var allowed = CharacterSet.urlUserAllowed
         allowed.remove(charactersIn: ":@")
         return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    private static func percentEncodeQueryValue(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)?
+            .replacingOccurrences(of: "&", with: "%26")
+            .replacingOccurrences(of: "=", with: "%3D")
+            ?? value
     }
 }

--- a/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
+++ b/TablePro/Core/Utilities/Connection/ConnectionURLParser.swift
@@ -18,6 +18,7 @@ struct ParsedConnectionURL {
     let sshHost: String?
     let sshPort: Int?
     let sshUsername: String?
+    let sshPassword: String?
     let usePrivateKey: Bool?
     let useSSHAgent: Bool?
     let agentSocket: String?
@@ -33,6 +34,7 @@ struct ParsedConnectionURL {
     let filterValue: String?
     let filterCondition: String?
     let oracleServiceName: String?
+    let safeModeLevel: Int?
     let useSrv: Bool
     let mongoQueryParams: [String: String]
     let multiHost: String?
@@ -118,6 +120,7 @@ struct ConnectionURLParser {
                 sshHost: nil,
                 sshPort: nil,
                 sshUsername: nil,
+                sshPassword: nil,
                 usePrivateKey: nil,
                 useSSHAgent: nil,
                 agentSocket: nil,
@@ -133,6 +136,7 @@ struct ConnectionURLParser {
                 filterValue: nil,
                 filterCondition: nil,
                 oracleServiceName: nil,
+                safeModeLevel: nil,
                 useSrv: false,
                 mongoQueryParams: [:],
                 multiHost: nil
@@ -221,6 +225,7 @@ struct ConnectionURLParser {
             sshHost: nil,
             sshPort: nil,
             sshUsername: nil,
+            sshPassword: nil,
             usePrivateKey: nil,
             useSSHAgent: nil,
             agentSocket: nil,
@@ -236,6 +241,7 @@ struct ConnectionURLParser {
             filterValue: ext.filterValue,
             filterCondition: ext.filterCondition,
             oracleServiceName: oracleServiceName,
+            safeModeLevel: ext.safeModeLevel,
             useSrv: ext.useSrv,
             mongoQueryParams: ext.mongoQueryParams,
             multiHost: nil
@@ -297,10 +303,19 @@ struct ConnectionURLParser {
         let dbPart = String(mainPart[mainPart.index(after: firstSlash)...])
 
         var sshUsername: String?
+        var sshPassword: String?
         var sshHostPort: String
         if let atIndex = sshPart.firstIndex(of: "@") {
-            sshUsername = String(sshPart[sshPart.startIndex..<atIndex])
-                .removingPercentEncoding
+            let userinfo = String(sshPart[sshPart.startIndex..<atIndex])
+            if let colonIndex = userinfo.firstIndex(of: ":") {
+                sshUsername = String(userinfo[userinfo.startIndex..<colonIndex])
+                    .removingPercentEncoding
+                let rawPass = String(userinfo[userinfo.index(after: colonIndex)...])
+                    .removingPercentEncoding ?? ""
+                sshPassword = rawPass.isEmpty ? nil : rawPass
+            } else {
+                sshUsername = userinfo.removingPercentEncoding
+            }
             sshHostPort = String(sshPart[sshPart.index(after: atIndex)...])
         } else {
             sshHostPort = sshPart
@@ -386,6 +401,7 @@ struct ConnectionURLParser {
             sshHost: sshHost,
             sshPort: sshPort,
             sshUsername: sshUsername,
+            sshPassword: sshPassword,
             usePrivateKey: ext.usePrivateKey,
             useSSHAgent: ext.useSSHAgent,
             agentSocket: ext.agentSocket,
@@ -401,6 +417,7 @@ struct ConnectionURLParser {
             filterValue: ext.filterValue,
             filterCondition: ext.filterCondition,
             oracleServiceName: oracleServiceName,
+            safeModeLevel: ext.safeModeLevel,
             useSrv: ext.useSrv,
             mongoQueryParams: ext.mongoQueryParams,
             multiHost: nil
@@ -482,6 +499,7 @@ struct ConnectionURLParser {
             sshHost: nil,
             sshPort: nil,
             sshUsername: nil,
+            sshPassword: nil,
             usePrivateKey: nil,
             useSSHAgent: nil,
             agentSocket: nil,
@@ -497,6 +515,7 @@ struct ConnectionURLParser {
             filterValue: ext.filterValue,
             filterCondition: ext.filterCondition,
             oracleServiceName: nil,
+            safeModeLevel: ext.safeModeLevel,
             useSrv: isSrv,
             mongoQueryParams: ext.mongoQueryParams,
             multiHost: multiHost
@@ -521,6 +540,7 @@ struct ConnectionURLParser {
         var filterOperation: String?
         var filterValue: String?
         var filterCondition: String?
+        var safeModeLevel: Int?
         var useSrv: Bool = false
         var mongoQueryParams: [String: String] = [:]
     }
@@ -544,15 +564,16 @@ struct ConnectionURLParser {
             guard let key = parts.first else { continue }
             let value = parts.count > 1 ? String(parts[1]) : nil
             guard let value else { continue }
-            if String(key) == "usePrivateKey" {
+            let keyStr = String(key).lowercased()
+            if keyStr == "useprivatekey" {
                 ext.usePrivateKey = value.lowercased() == "true"
                 continue
             }
-            if String(key) == "useSSHAgent" {
+            if keyStr == "usesshagent" {
                 ext.useSSHAgent = value.lowercased() == "true"
                 continue
             }
-            if String(key) == "agentSocket" {
+            if keyStr == "agentsocket" {
                 ext.agentSocket = value.removingPercentEncoding ?? value
                 continue
             }
@@ -561,13 +582,14 @@ struct ConnectionURLParser {
         return ext
     }
 
-    private static func applyQueryParam(key: String, value: String, to ext: inout ExtendedParams, dbType: DatabaseType? = nil) {
+    private static func applyQueryParam(key rawKey: String, value: String, to ext: inout ExtendedParams, dbType: DatabaseType? = nil) {
+        let key = rawKey.lowercased()
         switch key {
         case "sslmode":
             ext.sslMode = parseSSLMode(value)
-        case "authSource", "authsource":
+        case "authsource":
             ext.authSource = value
-        case "statusColor", "statuscolor":
+        case "statuscolor":
             ext.statusColor = value
         case "env":
             ext.envTag = value.removingPercentEncoding ?? value
@@ -593,7 +615,7 @@ struct ConnectionURLParser {
         case "condition", "raw", "query":
             ext.filterCondition = value.replacingOccurrences(of: "+", with: " ")
                 .removingPercentEncoding ?? value
-        case "tLSMode", "tlsmode":
+        case "tlsmode":
             if ext.sslMode == nil, let intValue = Int(value) {
                 ext.sslMode = parseTlsModeInteger(intValue)
             }
@@ -601,13 +623,15 @@ struct ConnectionURLParser {
             if value.lowercased() == "true" && ext.sslMode == nil {
                 ext.sslMode = .required
             }
-        case "authMechanism", "authmechanism":
+        case "authmechanism":
             ext.mongoQueryParams["authMechanism"] = value
-        case "replicaSet", "replicaset":
+        case "replicaset":
             ext.mongoQueryParams["replicaSet"] = value
+        case "safemodelevel":
+            ext.safeModeLevel = Int(value)
         default:
             if dbType == .mongodb {
-                ext.mongoQueryParams[key] = value
+                ext.mongoQueryParams[rawKey] = value
             }
         }
     }

--- a/TablePro/Models/Connection/SSHTypes.swift
+++ b/TablePro/Models/Connection/SSHTypes.swift
@@ -95,7 +95,7 @@ struct SSHJumpHost: Codable, Hashable, Identifiable {
 
     var isValid: Bool {
         !host.isEmpty && !username.isEmpty &&
-        (authMethod == .sshAgent || !privateKeyPath.isEmpty)
+        (authMethod == .sshAgent || authMethod == .privateKey || !privateKeyPath.isEmpty)
     }
 
     var proxyJumpString: String {
@@ -129,7 +129,7 @@ struct SSHConfiguration: Codable, Hashable {
         case .password:
             authValid = true
         case .privateKey:
-            authValid = !privateKeyPath.isEmpty
+            authValid = true
         case .sshAgent:
             authValid = true
         case .keyboardInteractive:

--- a/TablePro/Models/Connection/SafeModeLevel.swift
+++ b/TablePro/Models/Connection/SafeModeLevel.swift
@@ -78,4 +78,13 @@ internal extension SafeModeLevel {
         case .safeMode, .safeModeFull, .readOnly: return Color(nsColor: .systemRed)
         }
     }
+
+    static func from(urlInteger value: Int) -> SafeModeLevel? {
+        switch value {
+        case 0: return .silent
+        case 1: return .alert
+        case 2: return .readOnly
+        default: return nil
+        }
+    }
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -6287,6 +6287,9 @@
         }
       }
     },
+    "Auto-detects from ~/.ssh/config and default key locations." : {
+
+    },
     "Auto-indent" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -14984,6 +14987,9 @@
         }
       }
     },
+    "Edit Values..." : {
+
+    },
     "Edit View Definition" : {
       "localizations" : {
         "tr" : {
@@ -18323,6 +18329,7 @@
       }
     },
     "FIELDS" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -35176,6 +35183,9 @@
         }
       }
     },
+    "Search fields..." : {
+
+    },
     "Search for connection..." : {
       "localizations" : {
         "tr" : {
@@ -35199,6 +35209,7 @@
       }
     },
     "Search for field..." : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -14987,9 +14987,6 @@
         }
       }
     },
-    "Edit Values..." : {
-
-    },
     "Edit View Definition" : {
       "localizations" : {
         "tr" : {
@@ -18329,7 +18326,6 @@
       }
     },
     "FIELDS" : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -35183,9 +35179,6 @@
         }
       }
     },
-    "Search fields..." : {
-
-    },
     "Search for connection..." : {
       "localizations" : {
         "tr" : {
@@ -35209,7 +35202,6 @@
       }
     },
     "Search for field..." : {
-      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -635,13 +635,8 @@ extension ConnectionFormView {
             } else if name.isEmpty {
                 name = parsed.suggestedName
             }
-            if let level = parsed.safeModeLevel {
-                switch level {
-                case 0: safeModeLevel = .silent
-                case 1: safeModeLevel = .alert
-                case 2: safeModeLevel = .readOnly
-                default: break
-                }
+            if let level = parsed.safeModeLevel, let mode = SafeModeLevel.from(urlInteger: level) {
+                safeModeLevel = mode
             }
         case .failure(let error):
             urlParseError = error.localizedDescription

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -60,7 +60,7 @@ extension ConnectionFormView {
             let sshValid = !sshState.host.isEmpty && !sshState.username.isEmpty && sshPortValid
             let authValid =
                 sshState.authMethod == .password || sshState.authMethod == .sshAgent
-                || sshState.authMethod == .keyboardInteractive || !sshState.privateKeyPath.isEmpty
+                || sshState.authMethod == .keyboardInteractive || sshState.authMethod == .privateKey
             let jumpValid = sshState.jumpHosts.allSatisfy(\.isValid)
             return basicValid && sshValid && authValid && jumpValid
         }
@@ -564,6 +564,9 @@ extension ConnectionFormView {
                 sshState.host = sshHostValue
                 sshState.port = parsed.sshPort.map(String.init) ?? "22"
                 sshState.username = parsed.sshUsername ?? ""
+                if let sshPass = parsed.sshPassword, !sshPass.isEmpty {
+                    sshState.password = sshPass
+                }
                 if parsed.usePrivateKey == true {
                     sshState.authMethod = .privateKey
                 }
@@ -631,6 +634,14 @@ extension ConnectionFormView {
                 name = connectionName
             } else if name.isEmpty {
                 name = parsed.suggestedName
+            }
+            if let level = parsed.safeModeLevel {
+                switch level {
+                case 0: safeModeLevel = .silent
+                case 1: safeModeLevel = .alert
+                case 2: safeModeLevel = .readOnly
+                default: break
+                }
             }
         case .failure(let error):
             urlParseError = error.localizedDescription

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -209,6 +209,11 @@ struct ConnectionSSHTunnelView: View {
                         }
                     }
                     SecureField(String(localized: "Passphrase"), text: $sshState.keyPassphrase)
+                    if sshState.privateKeyPath.isEmpty {
+                        Text(String(localized: "Auto-detects from ~/.ssh/config and default key locations."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 

--- a/TableProTests/Core/SSH/SSHConfigurationTests.swift
+++ b/TableProTests/Core/SSH/SSHConfigurationTests.swift
@@ -26,19 +26,19 @@ struct SSHConfigurationTests {
         #expect(config.isValid == true)
     }
 
-    @Test("Private key auth requires non-empty key path")
-    func testPrivateKeyAuthRequiresPath() {
-        let invalid = SSHConfiguration(
+    @Test("Private key auth valid without explicit key path")
+    func testPrivateKeyAuthValidWithoutPath() {
+        let config = SSHConfiguration(
             enabled: true, host: "example.com", username: "admin",
             authMethod: .privateKey, privateKeyPath: ""
         )
-        #expect(invalid.isValid == false)
+        #expect(config.isValid == true)
 
-        let valid = SSHConfiguration(
+        let withPath = SSHConfiguration(
             enabled: true, host: "example.com", username: "admin",
             authMethod: .privateKey, privateKeyPath: "~/.ssh/id_rsa"
         )
-        #expect(valid.isValid == true)
+        #expect(withPath.isValid == true)
     }
 
     @Test("SSH Agent auth is valid without any key path")

--- a/TableProTests/Core/Utilities/ConnectionURLFormatterTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLFormatterTests.swift
@@ -172,6 +172,22 @@ struct ConnectionURLFormatterTests {
         #expect(url == "mysql+ssh://sshuser@sshhost:1234/dbuser:dbpass@127.0.0.1/db")
     }
 
+    @Test("SSH tunnel URL with SSH password")
+    func testSSHTunnelURLWithSSHPassword() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "sshhost"
+        sshConfig.port = 1_234
+        sshConfig.username = "sshuser"
+
+        let conn = DatabaseConnection(
+            name: "", host: "127.0.0.1", port: 3_306, database: "db",
+            username: "dbuser", type: .mysql, sshConfig: sshConfig
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "dbpass", sshPassword: "sshpass")
+        #expect(url == "mysql+ssh://sshuser:sshpass@sshhost:1234/dbuser:dbpass@127.0.0.1/db")
+    }
+
     @Test("SSH with default port omitted")
     func testSSHDefaultPortOmitted() {
         var sshConfig = SSHConfiguration()
@@ -285,6 +301,34 @@ struct ConnectionURLFormatterTests {
         #expect(parsed.connectionName == "Production DB")
     }
 
+    @Test("Round-trip with SSH password")
+    func testRoundTripWithSSHPassword() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "jumpbox.example.com"
+        sshConfig.port = 2_222
+        sshConfig.username = "deploy"
+
+        let original = DatabaseConnection(
+            name: "Test", host: "10.0.0.5", port: 5_433, database: "appdb",
+            username: "admin", type: .postgresql, sshConfig: sshConfig
+        )
+        let password = "s3cret"
+        let sshPassword = "sshpass"
+
+        let url = ConnectionURLFormatter.format(original, password: password, sshPassword: sshPassword)
+        let parseResult = ConnectionURLParser.parse(url)
+
+        guard case .success(let parsed) = parseResult else {
+            Issue.record("Expected successful parse"); return
+        }
+
+        #expect(parsed.sshUsername == "deploy")
+        #expect(parsed.sshPassword == "sshpass")
+        #expect(parsed.username == "admin")
+        #expect(parsed.password == password)
+    }
+
     // MARK: - MariaDB
 
     @Test("MariaDB uses mariadb scheme")
@@ -344,5 +388,72 @@ struct ConnectionURLFormatterTests {
         let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
         #expect(url.contains("useSSHAgent=true"))
         #expect(!url.contains("agentSocket"))
+    }
+
+    // MARK: - Redis Database Index
+
+    @Test("Redis URL includes database index")
+    func testRedisURLIncludesDatabaseIndex() {
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 6_379, database: "",
+            username: "", type: .redis, redisDatabase: 3
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "redis://localhost/3")
+    }
+
+    @Test("Redis URL omits database index when zero")
+    func testRedisURLOmitsDatabaseIndexWhenZero() {
+        let conn = DatabaseConnection(
+            name: "", host: "localhost", port: 6_379, database: "",
+            username: "", type: .redis, redisDatabase: 0
+        )
+        let url = ConnectionURLFormatter.format(conn, password: nil, sshPassword: nil)
+        #expect(url == "redis://localhost/")
+    }
+
+    // MARK: - MongoDB Auth Params
+
+    @Test("MongoDB URL includes authSource")
+    func testMongoDBAuthSource() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 27_017, database: "mydb",
+            username: "user", type: .mongodb, mongoAuthSource: "admin"
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("authSource=admin"))
+    }
+
+    @Test("MongoDB URL includes authMechanism")
+    func testMongoDBAuthMechanism() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 27_017, database: "mydb",
+            username: "user", type: .mongodb, mongoAuthMechanism: "SCRAM-SHA-256"
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("authMechanism=SCRAM-SHA-256"))
+    }
+
+    @Test("MongoDB URL includes replicaSet")
+    func testMongoDBReplicaSet() {
+        let conn = DatabaseConnection(
+            name: "", host: "host", port: 27_017, database: "mydb",
+            username: "user", type: .mongodb, mongoReplicaSet: "rs0"
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("replicaSet=rs0"))
+    }
+
+    // MARK: - MongoDB Multi-Host
+
+    @Test("MongoDB URL uses multi-host from additionalFields")
+    func testMongoDBMultiHost() {
+        let conn = DatabaseConnection(
+            name: "", host: "host1", port: 27_017, database: "mydb",
+            username: "user", type: .mongodb,
+            additionalFields: ["mongoHosts": "host1:27017,host2:27018,host3:27019"]
+        )
+        let url = ConnectionURLFormatter.format(conn, password: "pass", sshPassword: nil)
+        #expect(url.contains("host1:27017,host2:27018,host3:27019"))
     }
 }

--- a/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
@@ -444,6 +444,68 @@ struct ConnectionURLParserTests {
         #expect(parsed.usePrivateKey == true)
     }
 
+    @Test("SSH URL with SSH password")
+    func testSSHURLWithSSHPassword() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root:sshpass@jumphost:22/dbuser:dbpass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sshUsername == "root")
+        #expect(parsed.sshPassword == "sshpass")
+        #expect(parsed.sshHost == "jumphost")
+        #expect(parsed.sshPort == 22)
+        #expect(parsed.username == "dbuser")
+        #expect(parsed.password == "dbpass")
+    }
+
+    @Test("SSH URL without SSH password")
+    func testSSHURLWithoutSSHPassword() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root@jumphost:22/dbuser:dbpass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sshUsername == "root")
+        #expect(parsed.sshPassword == nil)
+    }
+
+    @Test("SSH URL with percent-encoded SSH password")
+    func testSSHURLWithPercentEncodedSSHPassword() {
+        let result = ConnectionURLParser.parse("mysql+ssh://root:p%40ss%3Aword@jumphost:22/dbuser@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sshUsername == "root")
+        #expect(parsed.sshPassword == "p@ss:word")
+    }
+
+    @Test("SafeModeLevel parsed from URL")
+    func testSafeModeLevelParsed() {
+        let result = ConnectionURLParser.parse("mysql://root:pass@localhost/db?safeModeLevel=2")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.safeModeLevel == 2)
+    }
+
+    @Test("SafeModeLevel nil when absent")
+    func testSafeModeLevelNilWhenAbsent() {
+        let result = ConnectionURLParser.parse("mysql://root:pass@localhost/db")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.safeModeLevel == nil)
+    }
+
+    @Test("Query params are case-insensitive")
+    func testQueryParamsCaseInsensitive() {
+        let result = ConnectionURLParser.parse("postgresql://user:pass@host/db?SSLMODE=require&STATUSCOLOR=FF3B30")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.sslMode == .required)
+        #expect(parsed.statusColor == "FF3B30")
+    }
+
     @Test("Non-SSH URL has nil SSH fields")
     func testNonSSHURLHasNilSSHFields() {
         let result = ConnectionURLParser.parse("mysql://root:pass@localhost:3306/db")
@@ -453,6 +515,7 @@ struct ConnectionURLParserTests {
         #expect(parsed.sshHost == nil)
         #expect(parsed.sshPort == nil)
         #expect(parsed.sshUsername == nil)
+        #expect(parsed.sshPassword == nil)
         #expect(parsed.usePrivateKey == nil)
         #expect(parsed.connectionName == nil)
     }

--- a/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
+++ b/TableProTests/Core/Utilities/ConnectionURLParserTests.swift
@@ -496,6 +496,26 @@ struct ConnectionURLParserTests {
         #expect(parsed.safeModeLevel == nil)
     }
 
+    @Test("SafeModeLevel mapping for invalid integer")
+    func testSafeModeLevelInvalidValue() {
+        #expect(SafeModeLevel.from(urlInteger: 99) == nil)
+        #expect(SafeModeLevel.from(urlInteger: -1) == nil)
+        #expect(SafeModeLevel.from(urlInteger: 0) == .silent)
+        #expect(SafeModeLevel.from(urlInteger: 1) == .alert)
+        #expect(SafeModeLevel.from(urlInteger: 2) == .readOnly)
+    }
+
+    @Test("Redis URL parses database index from path")
+    func testRedisDatabaseIndexParsed() {
+        let result = ConnectionURLParser.parse("redis://localhost:6379/3")
+        guard case .success(let parsed) = result else {
+            Issue.record("Expected success"); return
+        }
+        #expect(parsed.type == .redis)
+        #expect(parsed.redisDatabase == 3)
+        #expect(parsed.database == "")
+    }
+
     @Test("Query params are case-insensitive")
     func testQueryParamsCaseInsensitive() {
         let result = ConnectionURLParser.parse("postgresql://user:pass@host/db?SSLMODE=require&STATUSCOLOR=FF3B30")


### PR DESCRIPTION
## Summary
- Fix SSH `user:password@host` not split (full `user:pass` went into SSH username field)
- Fix `usePrivateKey=true` from TablePlus URLs correctly sets Private Key auth with auto-key resolution
- Fix SSH password not included in URL export, now round-trips correctly
- Fix formatter missing Redis database index, MongoDB auth params, and multi-host in exported URLs
- Add `safeModeLevel` parsing from TablePlus URLs
- Case-insensitive query parameter handling
- Private Key auth resolves keys from `~/.ssh/config` and default locations (`id_ed25519`, `id_rsa`, `id_ecdsa`) when no explicit path set
- Add help text hint in SSH form when key path is empty

## Test plan
- [ ] Paste `postgresql+ssh://root@host:24700/postgres:pass@localhost/db?usePrivateKey=true` -- SSH tab shows Private Key auth, buttons enabled
- [ ] Paste `mariadb+ssh://root:sshpass@host:22/dbuser:dbpass@localhost/db` -- SSH user=root, password=sshpass (not full string in user field)
- [ ] Paste `mysql://root:pass@localhost/db?safeModeLevel=2` -- safe mode set to Read Only
- [ ] Paste `postgresql://user:pass@host/db?SSLMODE=require` -- SSL mode set (case-insensitive)
- [ ] Copy URL from Redis connection with db index 3 -- URL contains `/3`
- [ ] Copy URL from MongoDB connection with authSource -- URL contains `?authSource=...`
- [ ] SSH Private Key auth with empty key path connects using `~/.ssh/config` or default keys