### PR TITLE
feat: save-only option for new connections via native split button

### DIFF
--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -65,7 +65,6 @@ extension ConnectionFormView {
                     } primaryAction: {
                         saveConnection(connect: true)
                     }
-                    .menuStyle(.borderlessButton)
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.return)
                     .fixedSize()

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -56,18 +56,16 @@ extension ConnectionFormView {
                 }
 
                 if isNew {
-                    Menu {
-                        Button(String(localized: "Save Only")) {
-                            saveConnection(connect: false)
-                        }
-                    } label: {
-                        Text(String(localized: "Save & Connect"))
-                    } primaryAction: {
+                    Button(String(localized: "Save")) {
+                        saveConnection(connect: false)
+                    }
+                    .disabled(isInstallingPlugin || !isValid)
+
+                    Button(String(localized: "Save & Connect")) {
                         saveConnection(connect: true)
                     }
-                    .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.return)
-                    .fixedSize()
+                    .buttonStyle(.borderedProminent)
                     .disabled(isInstallingPlugin || !isValid)
                 } else {
                     Button(String(localized: "Save")) {

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -60,21 +60,14 @@ extension ConnectionFormView {
                         saveConnection(connect: false)
                     }
                     .disabled(isInstallingPlugin || !isValid)
-
-                    Button(String(localized: "Save & Connect")) {
-                        saveConnection(connect: true)
-                    }
-                    .keyboardShortcut(.return)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isInstallingPlugin || !isValid)
-                } else {
-                    Button(String(localized: "Save")) {
-                        saveConnection()
-                    }
-                    .keyboardShortcut(.return)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isInstallingPlugin || !isValid)
                 }
+
+                Button(isNew ? String(localized: "Save & Connect") : String(localized: "Save")) {
+                    saveConnection(connect: isNew)
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .disabled(isInstallingPlugin || !isValid)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)

--- a/TablePro/Views/Connection/ConnectionFormView+Footer.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Footer.swift
@@ -55,13 +55,29 @@ extension ConnectionFormView {
                     NSApplication.shared.closeWindows(withId: "connection-form")
                 }
 
-                // Save
-                Button(isNew ? String(localized: "Create") : String(localized: "Save")) {
-                    saveConnection()
+                if isNew {
+                    Menu {
+                        Button(String(localized: "Save Only")) {
+                            saveConnection(connect: false)
+                        }
+                    } label: {
+                        Text(String(localized: "Save & Connect"))
+                    } primaryAction: {
+                        saveConnection(connect: true)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.return)
+                    .fixedSize()
+                    .disabled(isInstallingPlugin || !isValid)
+                } else {
+                    Button(String(localized: "Save")) {
+                        saveConnection()
+                    }
+                    .keyboardShortcut(.return)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isInstallingPlugin || !isValid)
                 }
-                .keyboardShortcut(.return)
-                .buttonStyle(.borderedProminent)
-                .disabled(isInstallingPlugin || !isValid)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)

--- a/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
+++ b/TablePro/Views/Connection/ConnectionFormView+Helpers.swift
@@ -168,7 +168,7 @@ extension ConnectionFormView {
         }
     }
 
-    func saveConnection() {
+    func saveConnection(connect: Bool = true) {
         let sshConfig = sshState.buildSSHConfig()
 
         let sslConfig = SSLConfiguration(
@@ -279,7 +279,9 @@ extension ConnectionFormView {
             }
             NSApplication.shared.closeWindows(withId: "connection-form")
             NotificationCenter.default.post(name: .connectionUpdated, object: nil)
-            connectToDatabase(connectionToSave)
+            if connect {
+                connectToDatabase(connectionToSave)
+            }
         } else {
             if let index = savedConnections.firstIndex(where: { $0.id == connectionToSave.id }) {
                 savedConnections[index] = connectionToSave


### PR DESCRIPTION
## Summary

Currently, the **Create** button on the new-connection form always saves AND connects. There's no way to just save a connection for later without connecting right now.

This PR adds a **Save** button alongside **Save & Connect** on new-connection forms:
- **Save** — saves the connection to the list without connecting
- **Save & Connect** (default action, blue prominent) — keeps current behavior

Edit mode keeps the single Save button since it never auto-connected.

## Apple HIG Approach

Two visible buttons (Postico/DBeaver pattern) instead of a hidden split button:
- All actions visible — no chevron menu to hunt through
- Native styling: primary uses `.borderedProminent` (blue), secondary uses default bordered style
- Standard 3-action footer layout: \`Cancel | Save | Save & Connect\`
- Default action (Return key) maps to **Save & Connect**

Originally tried SwiftUI \`Menu\` with \`primaryAction:\` for a true split button, but \`.borderedProminent\` doesn't reliably apply to Menu on macOS — it falls back to default chrome.

## Test plan

- [ ] Open new connection form -> footer shows: Cancel | Save | Save & Connect (blue)
- [ ] Press Return -> saves and connects (existing behavior)
- [ ] Click Save -> connection saved, window closes, no connection attempt
- [ ] Click Save & Connect -> saves and connects
- [ ] Open edit form on existing connection -> single Save button, no second button
- [ ] Press Return in edit mode -> saves only (existing behavior)