### PR TITLE
refactor: decompose QueryTab into focused sub-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- QueryTab decomposed into focused sub-types: TabExecutionState, TabTableContext, TabQueryContent, TabDisplayState
 - Inspector: dense field list, PK/FK key icons, Set NULL/DEFAULT in picker dropdowns, toolbar tracking separator
 - OpenSSL shared as dylib across app and plugins, saving ~15MB in bundle size
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -328,7 +328,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                     let isView = table.type == .view
                     if let preview = WindowLifecycleMonitor.shared.previewWindow(for: connectionId),
                        let previewCoordinator = MainContentCoordinator.coordinator(for: preview.windowId) {
-                        if previewCoordinator.tabManager.selectedTab?.tableName == table.name {
+                        if previewCoordinator.tabManager.selectedTab?.tableContext.tableName == table.name {
                             previewCoordinator.promotePreviewTab()
                         } else {
                             previewCoordinator.promotePreviewTab()

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -89,11 +89,11 @@ enum SessionStateFactory {
                             )
                         }
                         if let index = tabMgr.selectedTabIndex {
-                            tabMgr.tabs[index].isView = payload.isView
-                            tabMgr.tabs[index].isEditable = !payload.isView
-                            tabMgr.tabs[index].schemaName = payload.schemaName
+                            tabMgr.tabs[index].tableContext.isView = payload.isView
+                            tabMgr.tabs[index].tableContext.isEditable = !payload.isView
+                            tabMgr.tabs[index].tableContext.schemaName = payload.schemaName
                             if payload.showStructure {
-                                tabMgr.tabs[index].resultsViewMode = .structure
+                                tabMgr.tabs[index].display.resultsViewMode = .structure
                             }
                             if let initialFilter = payload.initialFilterState {
                                 tabMgr.tabs[index].filterState = initialFilter

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -139,10 +139,10 @@ internal final class TabPersistenceCoordinator {
 
     private func convertToPersistedTab(_ tab: QueryTab) -> PersistedTab {
         let persistedQuery: String
-        if (tab.query as NSString).length > QueryTab.maxPersistableQuerySize {
+        if (tab.content.query as NSString).length > TabQueryContent.maxPersistableQuerySize {
             persistedQuery = ""
         } else {
-            persistedQuery = tab.query
+            persistedQuery = tab.content.query
         }
 
         return PersistedTab(
@@ -150,11 +150,11 @@ internal final class TabPersistenceCoordinator {
             title: tab.title,
             query: persistedQuery,
             tabType: tab.tabType,
-            tableName: tab.tableName,
-            isView: tab.isView,
-            databaseName: tab.databaseName,
-            schemaName: tab.schemaName,
-            sourceFileURL: tab.sourceFileURL
+            tableName: tab.tableContext.tableName,
+            isView: tab.tableContext.isView,
+            databaseName: tab.tableContext.databaseName,
+            schemaName: tab.tableContext.schemaName,
+            sourceFileURL: tab.content.sourceFileURL
         )
     }
 }

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -192,7 +192,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private func updateUserActivity(coordinator: MainContentCoordinator) {
         let connection = coordinator.connection
         let selectedTab = coordinator.tabManager.selectedTab
-        let tableName: String? = (selectedTab?.tabType == .table) ? selectedTab?.tableName : nil
+        let tableName: String? = (selectedTab?.tabType == .table) ? selectedTab?.tableContext.tableName : nil
         let activityType = tableName != nil ? "com.TablePro.viewTable" : "com.TablePro.viewConnection"
 
         // Recreate when the activity type flips between viewConnection and

--- a/TablePro/Core/Storage/TabDiskActor.swift
+++ b/TablePro/Core/Storage/TabDiskActor.swift
@@ -113,7 +113,7 @@ internal actor TabDiskActor {
 
     /// Save the last query text for a connection. Skips if query exceeds 500KB.
     internal func saveLastQuery(_ query: String, for connectionId: UUID) {
-        guard (query as NSString).length < QueryTab.maxPersistableQuerySize else { return }
+        guard (query as NSString).length < TabQueryContent.maxPersistableQuerySize else { return }
 
         let fileURL = lastQueryFileURL(for: connectionId)
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/TablePro/Models/Query/EditorTabPayload.swift
+++ b/TablePro/Models/Query/EditorTabPayload.swift
@@ -149,17 +149,17 @@ internal struct EditorTabPayload: Codable, Hashable {
         self.id = UUID()
         self.connectionId = connectionId
         self.tabType = tab.tabType
-        self.tableName = tab.tableName
-        self.databaseName = tab.databaseName
-        self.schemaName = tab.schemaName
-        self.initialQuery = tab.query
-        self.isView = tab.isView
-        self.showStructure = tab.resultsViewMode == .structure
+        self.tableName = tab.tableContext.tableName
+        self.databaseName = tab.tableContext.databaseName
+        self.schemaName = tab.tableContext.schemaName
+        self.initialQuery = tab.content.query
+        self.isView = tab.tableContext.isView
+        self.showStructure = tab.display.resultsViewMode == .structure
         self.skipAutoExecute = skipAutoExecute
         self.isPreview = false
         self.initialFilterState = nil
-        self.sourceFileURL = tab.sourceFileURL
-        self.erDiagramSchemaKey = tab.erDiagramSchemaKey
+        self.sourceFileURL = tab.content.sourceFileURL
+        self.erDiagramSchemaKey = tab.display.erDiagramSchemaKey
         self.tabTitle = tab.title
         self.intent = .openContent
     }

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -1,10 +1,3 @@
-//
-//  QueryTab.swift
-//  TablePro
-//
-//  Model for query tabs
-//
-
 import Foundation
 import Observation
 import os
@@ -16,19 +9,19 @@ enum ResultsViewMode: String, Equatable {
     case json
 }
 
-/// Represents a single tab (query or table)
 struct QueryTab: Identifiable, Equatable {
     let id: UUID
     var title: String
-    var query: String
-    var lastExecutedAt: Date?
     var tabType: TabType
+    var isPreview: Bool
 
-    // Results — stored in a reference-type buffer to avoid CoW duplication
-    // of large data when the struct is mutated (MEM-1 fix)
+    var content: TabQueryContent
+    var execution: TabExecutionState
+    var tableContext: TabTableContext
+    var display: TabDisplayState
+
     var rowBuffer: RowBuffer
 
-    // Backward-compatible computed accessors for result data
     var resultColumns: [String] {
         get { rowBuffer.columns }
         set { rowBuffer.columns = newValue }
@@ -64,90 +57,16 @@ struct QueryTab: Identifiable, Equatable {
         set { rowBuffer.rows = newValue }
     }
 
-    var executionTime: TimeInterval?
-    var statusMessage: String?
-    var rowsAffected: Int  // Number of rows affected by non-SELECT queries
-    var errorMessage: String?
-    var isExecuting: Bool
-
-    // Editing support
-    var tableName: String?
-    var primaryKeyColumns: [String] = []  // Detected PKs from schema (set by Phase 2 metadata)
-    /// First PK column, for UI contexts that need a single column (filters, ORDER BY)
-    var primaryKeyColumn: String? { primaryKeyColumns.first }
-    var isEditable: Bool
-    var isView: Bool  // True for database views (read-only)
-    var databaseName: String  // Database this tab was opened in (for multi-database restore)
-    var schemaName: String?  // Schema this tab was opened in (for multi-schema restore, e.g. PostgreSQL)
-    var resultsViewMode: ResultsViewMode = .data
-    var erDiagramSchemaKey: String?
-    var explainText: String?
-    var explainExecutionTime: TimeInterval?
-    var explainPlan: QueryPlan?
-
-    // Per-tab change tracking (preserves changes when switching tabs)
     var pendingChanges: TabPendingChanges
-
-    // Per-tab row selection (preserves selection when switching tabs)
     var selectedRowIndices: Set<Int>
-
-    // Per-tab sort state (column sorting)
     var sortState: SortState
-
-    // Track if user has interacted with this tab (sort, edit, select, etc)
-    // Prevents tab from being replaced when opening new tables
-    var hasUserInteraction: Bool
-
-    // Pagination state for lazy loading (table tabs only)
-    var pagination: PaginationState
-
-    // Per-tab filter state (preserves filters when switching tabs)
     var filterState: TabFilterState
-
-    // Per-tab column layout (widths/order persist across reloads within tab session)
     var columnLayout: ColumnLayoutState
-
-    // Whether this tab is a preview (temporary) tab that gets replaced on next navigation
-    var isPreview: Bool
-
-    var queryParameters: [QueryParameter] = []
-    var isParameterPanelVisible: Bool = false
-
-    // Multi-result-set support (Phase 0: added alongside existing single-result properties)
-    var resultSets: [ResultSet] = []
-    var activeResultSetId: UUID?
-    var isResultsCollapsed: Bool = false
-
-    var activeResultSet: ResultSet? {
-        guard let id = activeResultSetId else { return resultSets.last }
-        return resultSets.first { $0.id == id }
-    }
-
-    var sourceFileURL: URL?
-
-    // Snapshot of file content at last save/load (nil for non-file tabs).
-    // Used to detect unsaved changes via isFileDirty.
-    var savedFileContent: String?
-
-    // Version counter incremented when resultRows changes (used for sort caching)
+    var pagination: PaginationState
+    var hasUserInteraction: Bool
     var resultVersion: Int
-
-    // Version counter incremented when FK/metadata arrives (Phase 2), used to invalidate caches
     var metadataVersion: Int
-
-    // Version counter incremented on pagination changes, used to scroll grid to top
     var paginationVersion: Int
-
-    /// Whether the editor content differs from the last saved/loaded file content.
-    /// Returns false for tabs not backed by a file.
-    /// Uses O(1) length pre-check to avoid O(n) string comparison on every keystroke.
-    var isFileDirty: Bool {
-        guard sourceFileURL != nil, let saved = savedFileContent else { return false }
-        let queryNS = query as NSString
-        let savedNS = saved as NSString
-        if queryNS.length != savedNS.length { return true }
-        return queryNS != savedNS
-    }
 
     init(
         id: UUID = UUID(),
@@ -158,77 +77,57 @@ struct QueryTab: Identifiable, Equatable {
     ) {
         self.id = id
         self.title = title
-        self.query = query
         self.tabType = tabType
-        self.lastExecutedAt = nil
+        self.isPreview = false
+        self.content = TabQueryContent(query: query)
+        self.execution = TabExecutionState()
+        self.tableContext = TabTableContext(tableName: tableName, isEditable: tabType == .table)
+        self.display = TabDisplayState()
         self.rowBuffer = RowBuffer()
-        self.executionTime = nil
-        self.statusMessage = nil
-        self.rowsAffected = 0
-        self.errorMessage = nil
-        self.isExecuting = false
-        self.tableName = tableName
-        self.primaryKeyColumns = []
-        self.isEditable = tabType == .table
-        self.isView = false
-        self.databaseName = ""
-        self.schemaName = nil
-        self.resultsViewMode = .data
         self.pendingChanges = TabPendingChanges()
         self.selectedRowIndices = []
         self.sortState = SortState()
-        self.hasUserInteraction = false
-        self.pagination = PaginationState()
         self.filterState = TabFilterState()
         self.columnLayout = ColumnLayoutState()
-        self.isPreview = false
-        self.sourceFileURL = nil
+        self.pagination = PaginationState()
+        self.hasUserInteraction = false
         self.resultVersion = 0
         self.metadataVersion = 0
         self.paginationVersion = 0
     }
 
-    /// Initialize from persisted tab state (used when restoring tabs)
     init(from persisted: PersistedTab) {
         self.id = persisted.id
         self.title = persisted.title
-        self.query = persisted.query
         self.tabType = persisted.tabType
-        self.tableName = persisted.tableName
-        self.primaryKeyColumns = []
-
-        // Initialize runtime state with defaults
-        self.lastExecutedAt = nil
+        self.isPreview = false
+        self.content = TabQueryContent(
+            query: persisted.query,
+            queryParameters: persisted.queryParameters ?? [],
+            sourceFileURL: persisted.sourceFileURL
+        )
+        self.execution = TabExecutionState()
+        self.tableContext = TabTableContext(
+            tableName: persisted.tableName,
+            databaseName: persisted.databaseName,
+            schemaName: persisted.schemaName,
+            isEditable: persisted.tabType == .table && !persisted.isView,
+            isView: persisted.isView
+        )
+        self.display = TabDisplayState(erDiagramSchemaKey: persisted.erDiagramSchemaKey)
         self.rowBuffer = RowBuffer()
-        self.executionTime = nil
-        self.statusMessage = nil
-        self.rowsAffected = 0
-        self.errorMessage = nil
-        self.isExecuting = false
-        self.isEditable = persisted.tabType == .table && !persisted.isView
-        self.isView = persisted.isView
-        self.databaseName = persisted.databaseName
-        self.schemaName = persisted.schemaName
-        self.resultsViewMode = .data
-        self.erDiagramSchemaKey = persisted.erDiagramSchemaKey
         self.pendingChanges = TabPendingChanges()
         self.selectedRowIndices = []
         self.sortState = SortState()
-        self.hasUserInteraction = false
-        self.pagination = PaginationState()
         self.filterState = TabFilterState()
         self.columnLayout = ColumnLayoutState()
-        self.isPreview = false
-        self.queryParameters = persisted.queryParameters ?? []
-        self.isParameterPanelVisible = false
-        self.sourceFileURL = persisted.sourceFileURL
+        self.pagination = PaginationState()
+        self.hasUserInteraction = false
         self.resultVersion = 0
         self.metadataVersion = 0
         self.paginationVersion = 0
     }
 
-    /// Build a clean base query for a table tab (no filters/sort).
-    /// Used when restoring table tabs from persistence to avoid stale WHERE clauses.
     @MainActor static func buildBaseTableQuery(
         tableName: String,
         databaseType: DatabaseType,
@@ -238,7 +137,6 @@ struct QueryTab: Identifiable, Equatable {
         let quote = quoteIdentifier ?? quoteIdentifierFromDialect(PluginManager.shared.sqlDialect(for: databaseType))
         let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
 
-        // Use plugin's query builder when available (NoSQL drivers like etcd, Redis)
         if let pluginDriver = PluginManager.shared.queryBuildingDriver(for: databaseType),
            let pluginQuery = pluginDriver.buildBrowseQuery(
                table: tableName, sortColumns: [], columns: [], limit: pageSize, offset: 0
@@ -269,18 +167,12 @@ struct QueryTab: Identifiable, Equatable {
         }
     }
 
-    /// Maximum query size to persist (500KB). Queries larger than this are typically
-    /// imported SQL dumps — serializing them to JSON blocks the main thread.
-    static let maxPersistableQuerySize = 500_000
-
-    /// Convert tab to persisted format for storage
     func toPersistedTab() -> PersistedTab {
-        // Truncate very large queries to prevent JSON encoding from blocking main thread
         let persistedQuery: String
-        if (query as NSString).length > Self.maxPersistableQuerySize {
+        if (content.query as NSString).length > TabQueryContent.maxPersistableQuerySize {
             persistedQuery = ""
         } else {
-            persistedQuery = query
+            persistedQuery = content.query
         }
 
         return PersistedTab(
@@ -288,35 +180,29 @@ struct QueryTab: Identifiable, Equatable {
             title: title,
             query: persistedQuery,
             tabType: tabType,
-            tableName: tableName,
-            isView: isView,
-            databaseName: databaseName,
-            schemaName: schemaName,
-            sourceFileURL: sourceFileURL,
-            erDiagramSchemaKey: erDiagramSchemaKey,
-            queryParameters: queryParameters.isEmpty ? nil : queryParameters
+            tableName: tableContext.tableName,
+            isView: tableContext.isView,
+            databaseName: tableContext.databaseName,
+            schemaName: tableContext.schemaName,
+            sourceFileURL: content.sourceFileURL,
+            erDiagramSchemaKey: display.erDiagramSchemaKey,
+            queryParameters: content.queryParameters.isEmpty ? nil : content.queryParameters
         )
     }
 
     static func == (lhs: QueryTab, rhs: QueryTab) -> Bool {
         lhs.id == rhs.id
             && lhs.title == rhs.title
-            && lhs.isExecuting == rhs.isExecuting
-            && lhs.errorMessage == rhs.errorMessage
-            && lhs.executionTime == rhs.executionTime
+            && lhs.execution == rhs.execution
             && lhs.resultVersion == rhs.resultVersion
             && lhs.paginationVersion == rhs.paginationVersion
             && lhs.pagination == rhs.pagination
             && lhs.sortState == rhs.sortState
-            && lhs.resultsViewMode == rhs.resultsViewMode
-            && lhs.isEditable == rhs.isEditable
-            && lhs.isView == rhs.isView
+            && lhs.display == rhs.display
+            && lhs.tableContext.isEditable == rhs.tableContext.isEditable
+            && lhs.tableContext.isView == rhs.tableContext.isView
             && lhs.tabType == rhs.tabType
-            && lhs.rowsAffected == rhs.rowsAffected
             && lhs.isPreview == rhs.isPreview
             && lhs.hasUserInteraction == rhs.hasUserInteraction
-            && lhs.isResultsCollapsed == rhs.isResultsCollapsed
-            && lhs.resultSets.map(\.id) == rhs.resultSets.map(\.id)
-            && lhs.activeResultSetId == rhs.activeResultSetId
     }
 }

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -62,9 +62,9 @@ final class QueryTabManager {
 
     func addTab(initialQuery: String? = nil, title: String? = nil, databaseName: String = "", sourceFileURL: URL? = nil) {
         if let sourceFileURL,
-           let existingIndex = tabs.firstIndex(where: { $0.sourceFileURL == sourceFileURL }) {
+           let existingIndex = tabs.firstIndex(where: { $0.content.sourceFileURL == sourceFileURL }) {
             if let query = initialQuery {
-                tabs[existingIndex].query = query
+                tabs[existingIndex].content.query = query
             }
             selectedTabId = tabs[existingIndex].id
             return
@@ -74,14 +74,14 @@ final class QueryTabManager {
         var newTab = QueryTab(title: tabTitle, tabType: .query)
 
         if let query = initialQuery {
-            newTab.query = query
+            newTab.content.query = query
             newTab.hasUserInteraction = true
         }
 
-        newTab.databaseName = databaseName
-        newTab.sourceFileURL = sourceFileURL
+        newTab.tableContext.databaseName = databaseName
+        newTab.content.sourceFileURL = sourceFileURL
         if sourceFileURL != nil {
-            newTab.savedFileContent = newTab.query
+            newTab.content.savedFileContent = newTab.content.query
         }
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -93,9 +93,8 @@ final class QueryTabManager {
         databaseName: String = "",
         quoteIdentifier: ((String) -> String)? = nil
     ) {
-        // Check if table tab already exists (match on databaseName)
         if let existingTab = tabs.first(where: {
-            $0.tabType == .table && $0.tableName == tableName && $0.databaseName == databaseName
+            $0.tabType == .table && $0.tableContext.tableName == tableName && $0.tableContext.databaseName == databaseName
         }) {
             selectedTabId = existingTab.id
             return
@@ -112,7 +111,7 @@ final class QueryTabManager {
             tableName: tableName
         )
         newTab.pagination = PaginationState(pageSize: pageSize)
-        newTab.databaseName = databaseName
+        newTab.tableContext.databaseName = databaseName
         tabs.append(newTab)
         selectedTabId = newTab.id
     }
@@ -120,8 +119,8 @@ final class QueryTabManager {
     func addCreateTableTab(databaseName: String = "") {
         let tabTitle = String(localized: "Create Table")
         var newTab = QueryTab(title: tabTitle, tabType: .createTable)
-        newTab.databaseName = databaseName
-        newTab.isEditable = false
+        newTab.tableContext.databaseName = databaseName
+        newTab.tableContext.isEditable = false
         newTab.hasUserInteraction = true
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -130,9 +129,9 @@ final class QueryTabManager {
     func addERDiagramTab(schemaKey: String, databaseName: String = "") {
         let tabTitle = String(localized: "ER Diagram")
         var newTab = QueryTab(title: tabTitle, tabType: .erDiagram)
-        newTab.databaseName = databaseName
-        newTab.erDiagramSchemaKey = schemaKey
-        newTab.isEditable = false
+        newTab.tableContext.databaseName = databaseName
+        newTab.display.erDiagramSchemaKey = schemaKey
+        newTab.tableContext.isEditable = false
         newTab.hasUserInteraction = true
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -145,7 +144,7 @@ final class QueryTabManager {
         }
         let tabTitle = String(localized: "Server Dashboard")
         var newTab = QueryTab(title: tabTitle, tabType: .serverDashboard)
-        newTab.isEditable = false
+        newTab.tableContext.isEditable = false
         newTab.hasUserInteraction = true
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -158,8 +157,8 @@ final class QueryTabManager {
         }
         let tabTitle = String(localized: "Terminal")
         var newTab = QueryTab(title: tabTitle, tabType: .terminal)
-        newTab.databaseName = databaseName
-        newTab.isEditable = false
+        newTab.tableContext.databaseName = databaseName
+        newTab.tableContext.isEditable = false
         newTab.hasUserInteraction = true
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -182,7 +181,7 @@ final class QueryTabManager {
             tableName: tableName
         )
         newTab.pagination = PaginationState(pageSize: pageSize)
-        newTab.databaseName = databaseName
+        newTab.tableContext.databaseName = databaseName
         newTab.isPreview = true
         tabs.append(newTab)
         selectedTabId = newTab.id
@@ -212,30 +211,29 @@ final class QueryTabManager {
         )
         let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
 
-        // Build locally and write back once to avoid 14 CoW copies (UI-11).
         var tab = tabs[selectedIndex]
         tab.rowBuffer = RowBuffer()
         tab.tabType = .table
         tab.title = tableName
-        tab.tableName = tableName
-        tab.query = query
+        tab.tableContext.tableName = tableName
+        tab.content.query = query
         tab.resultVersion += 1
-        tab.executionTime = nil
-        tab.statusMessage = nil
-        tab.errorMessage = nil
-        tab.lastExecutedAt = nil
-        tab.resultsViewMode = .data
+        tab.execution.executionTime = nil
+        tab.execution.statusMessage = nil
+        tab.execution.errorMessage = nil
+        tab.execution.lastExecutedAt = nil
+        tab.display.resultsViewMode = .data
         tab.sortState = SortState()
         tab.selectedRowIndices = []
         tab.pendingChanges = TabPendingChanges()
         tab.hasUserInteraction = false
-        tab.isView = isView
-        tab.isEditable = !isView
+        tab.tableContext.isView = isView
+        tab.tableContext.isEditable = !isView
         tab.filterState = TabFilterState()
         tab.columnLayout = ColumnLayoutState()
         tab.pagination = PaginationState(pageSize: pageSize)
-        tab.databaseName = databaseName
-        tab.schemaName = schemaName
+        tab.tableContext.databaseName = databaseName
+        tab.tableContext.schemaName = schemaName
         tab.isPreview = isPreview
         tabs[selectedIndex] = tab
         return true

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -237,6 +237,14 @@ struct TabExecutionState: Equatable {
     var errorMessage: String?
     var rowsAffected: Int = 0
     var lastExecutedAt: Date?
+
+    static func == (lhs: TabExecutionState, rhs: TabExecutionState) -> Bool {
+        lhs.isExecuting == rhs.isExecuting
+            && lhs.executionTime == rhs.executionTime
+            && lhs.statusMessage == rhs.statusMessage
+            && lhs.errorMessage == rhs.errorMessage
+            && lhs.rowsAffected == rhs.rowsAffected
+    }
 }
 
 struct TabTableContext: Equatable {

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -229,3 +229,64 @@ struct ColumnLayoutState: Equatable {
     var columnOrder: [String]?
     var hiddenColumns: Set<String> = []
 }
+
+struct TabExecutionState: Equatable {
+    var isExecuting: Bool = false
+    var executionTime: TimeInterval?
+    var statusMessage: String?
+    var errorMessage: String?
+    var rowsAffected: Int = 0
+    var lastExecutedAt: Date?
+}
+
+struct TabTableContext: Equatable {
+    var tableName: String?
+    var databaseName: String = ""
+    var schemaName: String?
+    var primaryKeyColumns: [String] = []
+    var isEditable: Bool = false
+    var isView: Bool = false
+
+    var primaryKeyColumn: String? { primaryKeyColumns.first }
+}
+
+struct TabQueryContent: Equatable {
+    var query: String = ""
+    var queryParameters: [QueryParameter] = []
+    var isParameterPanelVisible: Bool = false
+    var sourceFileURL: URL?
+    var savedFileContent: String?
+
+    static let maxPersistableQuerySize = 500_000
+
+    var isFileDirty: Bool {
+        guard sourceFileURL != nil, let saved = savedFileContent else { return false }
+        let queryNS = query as NSString
+        let savedNS = saved as NSString
+        if queryNS.length != savedNS.length { return true }
+        return queryNS != savedNS
+    }
+}
+
+struct TabDisplayState: Equatable {
+    var resultsViewMode: ResultsViewMode = .data
+    var erDiagramSchemaKey: String?
+    var explainText: String?
+    var explainExecutionTime: TimeInterval?
+    var explainPlan: QueryPlan?
+    var isResultsCollapsed: Bool = false
+    var resultSets: [ResultSet] = []
+    var activeResultSetId: UUID?
+
+    var activeResultSet: ResultSet? {
+        guard let id = activeResultSetId else { return resultSets.last }
+        return resultSets.first { $0.id == id }
+    }
+
+    static func == (lhs: TabDisplayState, rhs: TabDisplayState) -> Bool {
+        lhs.resultsViewMode == rhs.resultsViewMode
+            && lhs.isResultsCollapsed == rhs.isResultsCollapsed
+            && lhs.resultSets.map(\.id) == rhs.resultSets.map(\.id)
+            && lhs.activeResultSetId == rhs.activeResultSetId
+    }
+}

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -169,7 +169,7 @@ struct MainEditorContentView: View {
             guard let tab = tabManager.selectedTab else { return }
             cacheRowProvider(for: tab)
         }
-        .onChange(of: tabManager.selectedTab?.activeResultSetId) { _, _ in
+        .onChange(of: tabManager.selectedTab?.display.activeResultSetId) { _, _ in
             guard let tab = tabManager.selectedTab else { return }
             cacheRowProvider(for: tab)
         }
@@ -247,7 +247,7 @@ struct MainEditorContentView: View {
                         guard erDiagramViewModels[tab.id] == nil else { return }
                         let vm = ERDiagramViewModel(
                             connectionId: connection.id,
-                            schemaKey: tab.erDiagramSchemaKey ?? tab.databaseName
+                            schemaKey: tab.display.erDiagramSchemaKey ?? tab.tableContext.databaseName
                         )
                         erDiagramViewModels[tab.id] = vm
                     }
@@ -262,7 +262,7 @@ struct MainEditorContentView: View {
     private func queryTabContent(tab: QueryTab) -> some View {
         @Bindable var bindableCoordinator = coordinator
         QuerySplitView(
-            isBottomCollapsed: tab.isResultsCollapsed,
+            isBottomCollapsed: tab.display.isResultsCollapsed,
             autosaveName: "QuerySplit-\(connectionId)-\(tab.id)",
             topContent: {
                 VStack(spacing: 0) {
@@ -316,7 +316,7 @@ struct MainEditorContentView: View {
 
     private func updateHasQueryText() {
         if let tab = tabManager.selectedTab, tab.tabType == .query {
-            coordinator.toolbarState.hasQueryText = !tab.query.trimmingCharacters(in: .whitespacesAndNewlines)
+            coordinator.toolbarState.hasQueryText = !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty
         } else {
             coordinator.toolbarState.hasQueryText = false
@@ -326,7 +326,7 @@ struct MainEditorContentView: View {
     private func queryTextBinding(for tab: QueryTab) -> Binding<String> {
         let tabId = tab.id
         return Binding(
-            get: { tab.query },
+            get: { tab.content.query },
             set: { newValue in
                 // Find this tab by ID, not by selectedTabIndex. During tab switch,
                 // flushTextUpdate() fires on the OLD tab's EditorCoordinator when
@@ -336,11 +336,11 @@ struct MainEditorContentView: View {
                     index < tabManager.tabs.count
                 else { return }
 
-                tabManager.tabs[index].query = newValue
+                tabManager.tabs[index].content.query = newValue
 
                 // Update window dirty indicator and toolbar for file-backed tabs
-                if tabManager.tabs[index].sourceFileURL != nil {
-                    let isDirty = tabManager.tabs[index].isFileDirty
+                if tabManager.tabs[index].content.sourceFileURL != nil {
+                    let isDirty = tabManager.tabs[index].content.isFileDirty
                     Task { @MainActor in
                         if let window = NSApp.keyWindow {
                             window.isDocumentEdited = isDirty
@@ -351,7 +351,7 @@ struct MainEditorContentView: View {
                 // Skip persistence for very large queries (e.g., imported SQL dumps).
                 // JSON-encoding 40MB freezes the main thread.
                 let queryLength = (newValue as NSString).length
-                guard queryLength < QueryTab.maxPersistableQuerySize else { return }
+                guard queryLength < TabQueryContent.maxPersistableQuerySize else { return }
 
                 coordinator.persistence.saveLastQuery(newValue)
             }
@@ -361,10 +361,10 @@ struct MainEditorContentView: View {
     private func parameterBinding(for tab: QueryTab) -> Binding<[QueryParameter]> {
         let tabId = tab.id
         return Binding(
-            get: { tab.queryParameters },
+            get: { tab.content.queryParameters },
             set: { newValue in
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-                tabManager.tabs[index].queryParameters = newValue
+                tabManager.tabs[index].content.queryParameters = newValue
             }
         )
     }
@@ -372,10 +372,10 @@ struct MainEditorContentView: View {
     private func parameterVisibilityBinding(for tab: QueryTab) -> Binding<Bool> {
         let tabId = tab.id
         return Binding(
-            get: { tab.isParameterPanelVisible },
+            get: { tab.content.isParameterPanelVisible },
             set: { newValue in
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-                tabManager.tabs[index].isParameterPanelVisible = newValue
+                tabManager.tabs[index].content.isParameterPanelVisible = newValue
             }
         )
     }
@@ -392,9 +392,9 @@ struct MainEditorContentView: View {
     @ViewBuilder
     private func resultsSection(tab: QueryTab) -> some View {
         VStack(spacing: 0) {
-            switch tab.resultsViewMode {
+            switch tab.display.resultsViewMode {
             case .structure:
-                if let tableName = tab.tableName {
+                if let tableName = tab.tableContext.tableName {
                     TableStructureView(
                         tableName: tableName, connection: connection,
                         toolbarState: coordinator.toolbarState, coordinator: coordinator
@@ -410,44 +410,44 @@ struct MainEditorContentView: View {
                     selectedRowIndices: selectedRowIndices
                 )
             case .data:
-                if let explainText = tab.explainText {
-                    ExplainResultView(text: explainText, executionTime: tab.explainExecutionTime, plan: tab.explainPlan)
+                if let explainText = tab.display.explainText {
+                    ExplainResultView(text: explainText, executionTime: tab.display.explainExecutionTime, plan: tab.display.explainPlan)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     // Result tab bar (when multiple result sets)
-                    if tab.resultSets.count > 1 {
+                    if tab.display.resultSets.count > 1 {
                         resultTabBar(tab: tab)
                         Divider()
                     }
 
                     // Inline error banner (when active result set has error)
-                    if let error = tab.activeResultSet?.errorMessage {
+                    if let error = tab.display.activeResultSet?.errorMessage {
                         InlineErrorBanner(
                             message: error,
-                            onDismiss: { tab.activeResultSet?.errorMessage = nil }
+                            onDismiss: { tab.display.activeResultSet?.errorMessage = nil }
                         )
                         Divider()
                     }
 
                     // Content: success view OR filter+grid
-                    if let rs = tab.activeResultSet, rs.resultColumns.isEmpty,
-                       rs.errorMessage == nil, tab.lastExecutedAt != nil, !tab.isExecuting
+                    if let rs = tab.display.activeResultSet, rs.resultColumns.isEmpty,
+                       rs.errorMessage == nil, tab.execution.lastExecutedAt != nil, !tab.execution.isExecuting
                     {
                         ResultSuccessView(
                             rowsAffected: rs.rowsAffected,
                             executionTime: rs.executionTime,
                             statusMessage: rs.statusMessage
                         )
-                    } else if tab.resultColumns.isEmpty && tab.errorMessage == nil
-                        && tab.lastExecutedAt != nil && !tab.isExecuting
+                    } else if tab.resultColumns.isEmpty && tab.execution.errorMessage == nil
+                        && tab.execution.lastExecutedAt != nil && !tab.execution.isExecuting
                     {
-                        if tab.resultSets.isEmpty {
+                        if tab.display.resultSets.isEmpty {
                             Spacer()
                         } else {
                             ResultSuccessView(
-                                rowsAffected: tab.rowsAffected,
-                                executionTime: tab.executionTime,
-                                statusMessage: tab.statusMessage
+                                rowsAffected: tab.execution.rowsAffected,
+                                executionTime: tab.execution.executionTime,
+                                statusMessage: tab.execution.statusMessage
                             )
                         }
                     } else {
@@ -465,10 +465,10 @@ struct MainEditorContentView: View {
                         }
 
                         if tab.tabType == .query && !tab.resultColumns.isEmpty
-                            && tab.resultRows.isEmpty && tab.lastExecutedAt != nil
-                            && !tab.isExecuting && !filterStateManager.hasAppliedFilters
+                            && tab.resultRows.isEmpty && tab.execution.lastExecutedAt != nil
+                            && !tab.execution.isExecuting && !filterStateManager.hasAppliedFilters
                         {
-                            emptyResultView(executionTime: tab.activeResultSet?.executionTime ?? tab.executionTime)
+                            emptyResultView(executionTime: tab.display.activeResultSet?.executionTime ?? tab.execution.executionTime)
                         } else {
                             dataGridView(tab: tab)
                         }
@@ -476,7 +476,7 @@ struct MainEditorContentView: View {
                 }
             }
 
-            if tab.explainText == nil {
+            if tab.display.explainText == nil {
                 statusBar(tab: tab)
             }
         }
@@ -485,12 +485,12 @@ struct MainEditorContentView: View {
 
     private func resultTabBar(tab: QueryTab) -> some View {
         ResultTabBar(
-            resultSets: tab.resultSets,
+            resultSets: tab.display.resultSets,
             activeResultSetId: Binding(
-                get: { tab.activeResultSetId },
+                get: { tab.display.activeResultSetId },
                 set: { newId in
                     if let tabIdx = coordinator.tabManager.selectedTabIndex {
-                        coordinator.tabManager.tabs[tabIdx].activeResultSetId = newId
+                        coordinator.tabManager.tabs[tabIdx].display.activeResultSetId = newId
                     }
                 }
             ),
@@ -499,7 +499,7 @@ struct MainEditorContentView: View {
             },
             onPin: { id in
                 guard let tabIdx = coordinator.tabManager.selectedTabIndex else { return }
-                coordinator.tabManager.tabs[tabIdx].resultSets.first { $0.id == id }?.isPinned.toggle()
+                coordinator.tabManager.tabs[tabIdx].display.resultSets.first { $0.id == id }?.isPinned.toggle()
                 coordinator.tabManager.tabs[tabIdx].resultVersion += 1
             }
         )
@@ -519,8 +519,8 @@ struct MainEditorContentView: View {
 
     @ViewBuilder
     private func dataGridView(tab: QueryTab) -> some View {
-        let isEditable = tab.isEditable && !tab.isView && !coordinator.safeModeLevel.blocksAllWrites
-        let showEmptySpaceMenu = isEditable && tab.tableName != nil
+        let isEditable = tab.tableContext.isEditable && !tab.tableContext.isView && !coordinator.safeModeLevel.blocksAllWrites
+        let showEmptySpaceMenu = isEditable && tab.tableContext.tableName != nil
 
         // Update delegate state for current render
         let _ = { // swiftlint:disable:this redundant_discardable_let
@@ -546,7 +546,7 @@ struct MainEditorContentView: View {
             configuration: DataGridConfiguration(
                 connectionId: connection.id,
                 databaseType: connection.type,
-                tableName: tab.tableName,
+                tableName: tab.tableContext.tableName,
                 primaryKeyColumns: changeManager.primaryKeyColumns,
                 tabType: tab.tabType,
                 showRowNumbers: AppSettingsManager.shared.dataGrid.showRowNumbers,
@@ -599,7 +599,7 @@ struct MainEditorContentView: View {
         let provider: InMemoryRowProvider
 
         // Use active ResultSet data when available (multi-statement results)
-        if let rs = tab.activeResultSet, !rs.resultColumns.isEmpty {
+        if let rs = tab.display.activeResultSet, !rs.resultColumns.isEmpty {
             provider = InMemoryRowProvider(
                 rowBuffer: rs.rowBuffer,
                 sortIndices: sortIndicesForTab(tab),
@@ -639,7 +639,7 @@ struct MainEditorContentView: View {
         var detected: [ValueDisplayFormat?] = Array(repeating: nil, count: columns.count)
         if settings.enableSmartValueDetection {
             let sampleRows: [[String?]]? = {
-                let rows = tab.activeResultSet?.resultRows ?? tab.resultRows
+                let rows = tab.display.activeResultSet?.resultRows ?? tab.resultRows
                 return rows.isEmpty ? nil : Array(rows.prefix(10))
             }()
             detected = ValueDisplayDetector.detect(
@@ -655,14 +655,14 @@ struct MainEditorContentView: View {
                     autoMap[columns[i]] = format
                 }
             }
-            service.setAutoDetectedFormats(autoMap, connectionId: connectionId, tableName: tab.tableName)
+            service.setAutoDetectedFormats(autoMap, connectionId: connectionId, tableName: tab.tableContext.tableName)
         } else {
-            service.clearAutoDetectedFormats(connectionId: connectionId, tableName: tab.tableName)
+            service.clearAutoDetectedFormats(connectionId: connectionId, tableName: tab.tableContext.tableName)
         }
 
         // Merge with stored overrides (override > detection > nil)
         let connId = connectionId
-        let tblName = tab.tableName
+        let tblName = tab.tableContext.tableName
         var merged = detected
 
         if let tblName {
@@ -689,7 +689,7 @@ struct MainEditorContentView: View {
         let rowBuffer: RowBuffer
         let rows: [[String?]]
         let colTypes: [ColumnType]
-        if let rs = tab.activeResultSet, !rs.resultColumns.isEmpty {
+        if let rs = tab.display.activeResultSet, !rs.resultColumns.isEmpty {
             rowBuffer = rs.rowBuffer
             rows = rs.resultRows
             colTypes = rs.columnTypes
@@ -820,11 +820,11 @@ struct MainEditorContentView: View {
 
     private func resultsViewModeBinding(for tab: QueryTab) -> Binding<ResultsViewMode> {
         Binding(
-            get: { tab.resultsViewMode },
+            get: { tab.display.resultsViewMode },
             set: { newValue in
                 Task { @MainActor in
                     if let index = tabManager.selectedTabIndex {
-                        tabManager.tabs[index].resultsViewMode = newValue
+                        tabManager.tabs[index].display.resultsViewMode = newValue
                     }
                 }
             }

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -35,7 +35,7 @@ struct MainStatusBarView: View {
         HStack {
             // Left: View mode toggle
             if let tab = tab {
-                if tab.tabType == .table, tab.tableName != nil {
+                if tab.tabType == .table, tab.tableContext.tableName != nil {
                     Picker(String(localized: "View Mode"), selection: $viewMode) {
                         Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
                         Label("Structure", systemImage: "list.bullet.rectangle").tag(ResultsViewMode.structure)
@@ -100,7 +100,7 @@ struct MainStatusBarView: View {
                         .foregroundStyle(.secondary)
                     }
 
-                    if let statusMessage = tab.statusMessage {
+                    if let statusMessage = tab.execution.statusMessage {
                         Text("·")
                             .foregroundStyle(.tertiary)
                         Text(statusMessage)
@@ -141,7 +141,7 @@ struct MainStatusBarView: View {
                 }
 
                 // Filters toggle button
-                if let tab = tab, tab.tabType == .table, tab.tableName != nil {
+                if let tab = tab, tab.tabType == .table, tab.tableContext.tableName != nil {
                     Toggle(isOn: Binding(
                         get: { filterStateManager.isVisible },
                         set: { _ in filterStateManager.toggle() }
@@ -163,7 +163,7 @@ struct MainStatusBarView: View {
                 }
 
                 // Pagination controls for table tabs
-                if let tab = tab, tab.tabType == .table, tab.tableName != nil,
+                if let tab = tab, tab.tabType == .table, tab.tableContext.tableName != nil,
                    let total = tab.pagination.totalRowCount, total > 0 {
                     PaginationControlsView(
                         pagination: tab.pagination,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
@@ -26,9 +26,9 @@ extension MainContentCoordinator {
     /// Accepts the plugin-kit `ExplainVariant` type for generic dispatch.
     func runVariantExplain(_ variant: ExplainVariant) {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
-        let fullQuery = tabManager.tabs[index].query
+        let fullQuery = tabManager.tabs[index].content.query
 
         let sql: String
         if tabManager.tabs[index].tabType == .table {
@@ -62,7 +62,7 @@ extension MainContentCoordinator {
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
 
             if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                tabManager.tabs[idx].isExecuting = true
+                tabManager.tabs[idx].execution.isExecuting = true
             }
             toolbarState.setExecuting(true)
 
@@ -76,21 +76,21 @@ extension MainContentCoordinator {
                 }.joined(separator: "\n")
 
                 if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].explainText = text
-                    tabManager.tabs[idx].explainExecutionTime = duration
+                    tabManager.tabs[idx].display.explainText = text
+                    tabManager.tabs[idx].display.explainExecutionTime = duration
 
                     if let parser = QueryPlanParserFactory.parser(for: connection.type) {
-                        tabManager.tabs[idx].explainPlan = parser.parse(rawText: text)
+                        tabManager.tabs[idx].display.explainPlan = parser.parse(rawText: text)
                     } else {
-                        tabManager.tabs[idx].explainPlan = nil
+                        tabManager.tabs[idx].display.explainPlan = nil
                     }
-                    tabManager.tabs[idx].isExecuting = false
+                    tabManager.tabs[idx].execution.isExecuting = false
                 }
             } catch {
                 if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].explainText = "Error: \(error.localizedDescription)"
-                    tabManager.tabs[idx].explainPlan = nil
-                    tabManager.tabs[idx].isExecuting = false
+                    tabManager.tabs[idx].display.explainText = "Error: \(error.localizedDescription)"
+                    tabManager.tabs[idx].display.explainPlan = nil
+                    tabManager.tabs[idx].execution.isExecuting = false
                 }
             }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnLayout.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnLayout.swift
@@ -9,7 +9,7 @@ extension MainContentCoordinator {
     func saveColumnLayoutForTable() {
         guard let index = tabManager.selectedTabIndex else { return }
         let tab = tabManager.tabs[index]
-        guard tab.tabType == .table, let tableName = tab.tableName, !tableName.isEmpty else { return }
+        guard tab.tabType == .table, let tableName = tab.tableContext.tableName, !tableName.isEmpty else { return }
 
         ColumnLayoutStorage.shared.save(tab.columnLayout, for: tableName, connectionId: connectionId)
         columnVisibilityManager.saveLastHiddenColumns(for: tableName, connectionId: connectionId)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
@@ -87,7 +87,7 @@ extension MainContentCoordinator {
             }
         }
 
-        if let tableName = tabManager.selectedTab?.tableName {
+        if let tableName = tabManager.selectedTab?.tableContext.tableName {
             filterStateManager.saveLastFilters(for: tableName)
         }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ERDiagram.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ERDiagram.swift
@@ -18,7 +18,7 @@ extension MainContentCoordinator {
         let schemaKey = "\(dbName).\(schemaName ?? "default")"
 
         if let existing = Self.coordinator(forConnection: connectionId, tabMatching: {
-            $0.tabType == .erDiagram && $0.erDiagramSchemaKey == schemaKey
+            $0.tabType == .erDiagram && $0.display.erDiagramSchemaKey == schemaKey
         }) {
             existing.contentWindow?.makeKeyAndOrderFront(nil)
             return

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -9,10 +9,10 @@ import Foundation
 extension MainContentCoordinator {
     func runAllStatements() {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
         guard tabManager.tabs[index].tabType == .query else { return }
 
-        let fullQuery = tabManager.tabs[index].query
+        let fullQuery = tabManager.tabs[index].content.query
         guard !fullQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let statements = SQLStatementScanner.allStatements(in: fullQuery)
@@ -25,12 +25,12 @@ extension MainContentCoordinator {
             if !detectedNames.isEmpty {
                 let reconciled = detectAndReconcileParameters(
                     sql: combinedSQL,
-                    existing: tabManager.tabs[index].queryParameters
+                    existing: tabManager.tabs[index].content.queryParameters
                 )
-                tabManager.tabs[index].queryParameters = reconciled
+                tabManager.tabs[index].content.queryParameters = reconciled
 
-                if !tabManager.tabs[index].isParameterPanelVisible {
-                    tabManager.tabs[index].isParameterPanelVisible = true
+                if !tabManager.tabs[index].content.isParameterPanelVisible {
+                    tabManager.tabs[index].content.isParameterPanelVisible = true
                     return
                 }
 
@@ -48,7 +48,7 @@ extension MainContentCoordinator {
         if level == .readOnly {
             let writeStatements = statements.filter { isWriteQuery($0) }
             if !writeStatements.isEmpty {
-                tabManager.tabs[index].errorMessage =
+                tabManager.tabs[index].execution.errorMessage =
                     String(localized: "Cannot execute write queries: connection is read-only")
                 return
             }
@@ -96,7 +96,7 @@ extension MainContentCoordinator {
                     }
                 case .blocked(let reason):
                     if index < tabManager.tabs.count {
-                        tabManager.tabs[index].errorMessage = reason
+                        tabManager.tabs[index].execution.errorMessage = reason
                     }
                 }
             }
@@ -119,7 +119,7 @@ extension MainContentCoordinator {
         if level == .readOnly {
             let writeStatements = statements.filter { isWriteQuery($0) }
             if !writeStatements.isEmpty {
-                tabManager.tabs[index].errorMessage =
+                tabManager.tabs[index].execution.errorMessage =
                     String(localized: "Cannot execute write queries: connection is read-only")
                 return
             }
@@ -161,7 +161,7 @@ extension MainContentCoordinator {
                     executeParameterizedAfterSafeMode(statements, parameters: parameters)
                 case .blocked(let reason):
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].errorMessage = reason
+                        tabManager.tabs[idx].execution.errorMessage = reason
                     }
                 }
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -42,9 +42,9 @@ extension MainContentCoordinator {
         // Fast path: referenced table is already the active tab — just apply filter
         if let current = tabManager.selectedTab,
            current.tabType == .table,
-           current.tableName == referencedTable,
-           current.databaseName == currentDatabase,
-           current.schemaName == targetSchema {
+           current.tableContext.tableName == referencedTable,
+           current.tableContext.databaseName == currentDatabase,
+           current.tableContext.schemaName == targetSchema {
             applyFKFilter(filter, for: referencedTable)
             // Persist so tab switch restore picks it up
             if let idx = tabManager.selectedTabIndex {
@@ -106,7 +106,7 @@ extension MainContentCoordinator {
                 limit: tab.pagination.pageSize,
                 offset: tab.pagination.currentOffset
             )
-            tabManager.tabs[tabIndex].query = filteredQuery
+            tabManager.tabs[tabIndex].content.query = filteredQuery
 
             updateFilterState(filter, for: referencedTable)
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Favorites.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Favorites.swift
@@ -16,12 +16,12 @@ extension MainContentCoordinator {
 
         if let tabIndex = tabManager.selectedTabIndex,
            tabManager.tabs[tabIndex].tabType == .query {
-            let existing = tabManager.tabs[tabIndex].query
+            let existing = tabManager.tabs[tabIndex].content.query
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if existing.isEmpty {
-                tabManager.tabs[tabIndex].query = favorite.query
+                tabManager.tabs[tabIndex].content.query = favorite.query
             } else {
-                tabManager.tabs[tabIndex].query += "\n\n" + favorite.query
+                tabManager.tabs[tabIndex].content.query += "\n\n" + favorite.query
             }
         } else {
             runFavoriteInNewTab(favorite)
@@ -31,7 +31,7 @@ extension MainContentCoordinator {
     func saveCurrentQueryAsFavorite() {
         guard let tab = tabManager.selectedTab,
               tab.tabType == .query else { return }
-        let query = tab.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return }
         NotificationCenter.default.post(
             name: .saveAsFavoriteRequested,
@@ -49,8 +49,8 @@ extension MainContentCoordinator {
 
         if let tabIndex = tabManager.selectedTabIndex,
            tabManager.tabs[tabIndex].tabType == .query,
-           tabManager.tabs[tabIndex].query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            tabManager.tabs[tabIndex].query = favorite.query
+           tabManager.tabs[tabIndex].content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            tabManager.tabs[tabIndex].content.query = favorite.query
             return
         }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -13,7 +13,7 @@ extension MainContentCoordinator {
     func applyFilters(_ filters: [TableFilter]) {
         guard let tabIndex = tabManager.selectedTabIndex,
               tabIndex < tabManager.tabs.count,
-              let tableName = tabManager.tabs[tabIndex].tableName else { return }
+              let tableName = tabManager.tabs[tabIndex].tableContext.tableName else { return }
 
         let capturedTabIndex = tabIndex
         let capturedTableName = tableName
@@ -38,7 +38,7 @@ extension MainContentCoordinator {
                 columnExclusions: exclusions
             )
 
-            self.tabManager.tabs[capturedTabIndex].query = newQuery
+            self.tabManager.tabs[capturedTabIndex].content.query = newQuery
 
             if !capturedFilters.isEmpty {
                 self.filterStateManager.saveLastFilters(for: capturedTableName)
@@ -54,7 +54,7 @@ extension MainContentCoordinator {
     func clearFiltersAndReload() {
         guard let tabIndex = tabManager.selectedTabIndex,
               tabIndex < tabManager.tabs.count,
-              let tableName = tabManager.tabs[tabIndex].tableName else { return }
+              let tableName = tabManager.tabs[tabIndex].tableContext.tableName else { return }
 
         let capturedTabIndex = tabIndex
         let capturedTableName = tableName
@@ -73,7 +73,7 @@ extension MainContentCoordinator {
                 columnExclusions: exclusions
             )
 
-            self.tabManager.tabs[capturedTabIndex].query = newQuery
+            self.tabManager.tabs[capturedTabIndex].content.query = newQuery
             self.tabManager.tabs[capturedTabIndex].filterState = self.filterStateManager.saveToTabState()
             self.runQuery()
         }
@@ -90,7 +90,7 @@ extension MainContentCoordinator {
 
     func rebuildTableQuery(at tabIndex: Int) {
         guard tabIndex < tabManager.tabs.count,
-              let tableName = tabManager.tabs[tabIndex].tableName else { return }
+              let tableName = tabManager.tabs[tabIndex].tableContext.tableName else { return }
 
         let tab = tabManager.tabs[tabIndex]
         let hasFilters = filterStateManager.hasAppliedFilters
@@ -119,6 +119,6 @@ extension MainContentCoordinator {
             )
         }
 
-        tabManager.tabs[tabIndex].query = newQuery
+        tabManager.tabs[tabIndex].content.query = newQuery
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
@@ -23,9 +23,9 @@ extension MainContentCoordinator {
         }
         toolbarState.setExecuting(false)
         for idx in tabManager.tabs.indices {
-            if tabManager.tabs[idx].isExecuting || tabManager.tabs[idx].pagination.isLoadingMore {
+            if tabManager.tabs[idx].execution.isExecuting || tabManager.tabs[idx].pagination.isLoadingMore {
                 var tab = tabManager.tabs[idx]
-                tab.isExecuting = false
+                tab.execution.isExecuting = false
                 tab.pagination.isLoadingMore = false
                 tabManager.tabs[idx] = tab
             }
@@ -38,7 +38,7 @@ extension MainContentCoordinator {
         guard let idx = tabManager.selectedTabIndex else { return }
         let tab = tabManager.tabs[idx]
         guard !tab.pagination.isLoadingMore,
-              !tab.isExecuting,
+              !tab.execution.isExecuting,
               tab.pagination.hasMoreRows,
               let baseQuery = tab.pagination.baseQueryForMore else { return }
 
@@ -104,7 +104,7 @@ extension MainContentCoordinator {
                     if !pagedResult.hasMore {
                         tab.pagination.baseQueryForMore = nil
                     }
-                    if let rs = tab.activeResultSet {
+                    if let rs = tab.display.activeResultSet {
                         rs.resultVersion = tab.resultVersion
                     }
                     tabManager.tabs[idx] = tab
@@ -134,7 +134,7 @@ extension MainContentCoordinator {
         guard let idx = tabManager.selectedTabIndex else { return }
         let tab = tabManager.tabs[idx]
         guard !tab.pagination.isLoadingMore,
-              !tab.isExecuting,
+              !tab.execution.isExecuting,
               tab.pagination.hasMoreRows,
               let baseQuery = tab.pagination.baseQueryForMore else { return }
 
@@ -220,10 +220,10 @@ extension MainContentCoordinator {
 
                     var tab = tabManager.tabs[idx]
                     tab.rowBuffer.rows = result.rows
-                    tab.executionTime = result.executionTime
+                    tab.execution.executionTime = result.executionTime
                     tab.resultVersion += 1
                     tab.pagination.resetLoadMore()
-                    if let rs = tab.activeResultSet {
+                    if let rs = tab.display.activeResultSet {
                         rs.resultVersion = tab.resultVersion
                     }
                     tabManager.tabs[idx] = tab

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
@@ -1,11 +1,3 @@
-//
-//  MainContentCoordinator+MultiStatement.swift
-//  TablePro
-//
-//  Multi-statement SQL execution support for MainContentCoordinator.
-//  Executes each statement sequentially, stopping on first error.
-//
-
 import AppKit
 import Foundation
 import os
@@ -15,21 +7,18 @@ private let multiStatementLogger = Logger(subsystem: "com.TablePro", category: "
 extension MainContentCoordinator {
     // MARK: - Multi-Statement Execution
 
-    /// Execute multiple SQL statements sequentially within a transaction,
-    /// stopping on first error with automatic rollback.
-    /// Displays results from the last SELECT statement (if any).
     func executeMultipleStatements(_ statements: [String]) {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
         currentQueryTask?.cancel()
         queryGeneration += 1
         let capturedGeneration = queryGeneration
 
         var tab = tabManager.tabs[index]
-        tab.isExecuting = true
-        tab.executionTime = nil
-        tab.errorMessage = nil
+        tab.execution.isExecuting = true
+        tab.execution.executionTime = nil
+        tab.execution.errorMessage = nil
         tabManager.tabs[index] = tab
         toolbarState.setExecuting(true)
 
@@ -57,7 +46,6 @@ extension MainContentCoordinator {
                     try await driver.beginTransaction()
                 }
 
-                /// Rollback transaction and reset executing state for early exits.
                 @MainActor func rollbackAndResetState() async {
                     if useTransaction {
                         do {
@@ -67,7 +55,7 @@ extension MainContentCoordinator {
                         }
                     }
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].isExecuting = false
+                        tabManager.tabs[idx].execution.isExecuting = false
                     }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
@@ -90,16 +78,13 @@ extension MainContentCoordinator {
                     cumulativeTime += result.executionTime
                     totalRowsAffected += result.rowsAffected
 
-                    // Keep the last result that has columns (i.e. a SELECT)
                     if !result.columns.isEmpty {
                         lastSelectResult = result
                         lastSelectSQL = sql
                     }
 
-                    // Build a ResultSet for this statement
                     let stmtTableName = await MainActor.run { extractTableName(from: sql) }
                     let rs = ResultSet(label: stmtTableName ?? "Result \(stmtIndex + 1)")
-                    // Deep copy to prevent C buffer retention issues
                     rs.rowBuffer = RowBuffer(
                         rows: result.rows.map { row in row.map { $0.map { String($0) } } },
                         columns: result.columns.map { String($0) },
@@ -112,7 +97,6 @@ extension MainContentCoordinator {
                     rs.resultVersion = 1
                     newResultSets.append(rs)
 
-                    // Record with semicolon preserved for history/favorites
                     let historySQL = sql.hasSuffix(";") ? sql : sql + ";"
                     await MainActor.run {
                         QueryHistoryManager.shared.recordQuery(
@@ -131,7 +115,6 @@ extension MainContentCoordinator {
                     try await driver.commitTransaction()
                 }
 
-                // All statements succeeded — update tab with results
                 await MainActor.run {
                     applyMultiStatementResults(
                         tabId: tabId,
@@ -152,13 +135,11 @@ extension MainContentCoordinator {
                     }
                 }
 
-                // Always reset isExecuting even if generation is stale —
-                // skipping this leaves the tab permanently stuck in "executing" state.
                 if capturedGeneration != queryGeneration {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
                         if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                            tabManager.tabs[idx].isExecuting = false
+                            tabManager.tabs[idx].execution.isExecuting = false
                         }
                         currentQueryTask = nil
                         toolbarState.setExecuting(false)
@@ -170,7 +151,6 @@ extension MainContentCoordinator {
                 let contextMsg = "Statement \(failedStmtIndex)/\(totalCount) failed: "
                     + error.localizedDescription
 
-                // Add an error ResultSet for the failed statement
                 let errorRS = ResultSet(label: "Error \(failedStmtIndex)")
                 errorRS.errorMessage = error.localizedDescription
                 newResultSets.append(errorRS)
@@ -181,14 +161,13 @@ extension MainContentCoordinator {
 
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
                         var errTab = tabManager.tabs[idx]
-                        errTab.errorMessage = contextMsg
-                        errTab.isExecuting = false
-                        errTab.executionTime = cumulativeTime
+                        errTab.execution.errorMessage = contextMsg
+                        errTab.execution.isExecuting = false
+                        errTab.execution.executionTime = cumulativeTime
 
-                        // Attach accumulated ResultSets (successful + error)
-                        let pinnedResults = errTab.resultSets.filter(\.isPinned)
-                        errTab.resultSets = pinnedResults + newResultSets
-                        errTab.activeResultSetId = newResultSets.last?.id
+                        let pinnedResults = errTab.display.resultSets.filter(\.isPinned)
+                        errTab.display.resultSets = pinnedResults + newResultSets
+                        errTab.display.activeResultSetId = newResultSets.last?.id
 
                         tabManager.tabs[idx] = errTab
                     }
@@ -230,10 +209,9 @@ extension MainContentCoordinator {
         toolbarState.setExecuting(false)
         toolbarState.lastQueryDuration = cumulativeTime
 
-        // Always reset isExecuting even if generation is stale
         if capturedGeneration != queryGeneration {
             if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                tabManager.tabs[idx].isExecuting = false
+                tabManager.tabs[idx].execution.isExecuting = false
             }
             return
         }
@@ -249,10 +227,8 @@ extension MainContentCoordinator {
             let safeRows = selectResult.rows.map { row in
                 row.map { $0.map { String($0) } }
             }
-            // For table tabs, preserve existing tableName instead of re-extracting
-            // from SQL — extractTableName can fail on schema-qualified/quoted names
             let tableName: String?
-            if updatedTab.tabType == .table, let existing = updatedTab.tableName {
+            if updatedTab.tabType == .table, let existing = updatedTab.tableContext.tableName {
                 tableName = existing
             } else {
                 tableName = lastSelectSQL.flatMap { extractTableName(from: $0) }
@@ -261,31 +237,30 @@ extension MainContentCoordinator {
             updatedTab.resultColumns = safeColumns
             updatedTab.columnTypes = safeColumnTypes
             updatedTab.resultRows = safeRows
-            updatedTab.tableName = tableName
-            updatedTab.isEditable = tableName != nil && updatedTab.isEditable
+            updatedTab.tableContext.tableName = tableName
+            updatedTab.tableContext.isEditable = tableName != nil && updatedTab.tableContext.isEditable
         } else {
             updatedTab.resultColumns = []
             updatedTab.columnTypes = []
             updatedTab.resultRows = []
-            // Preserve tableName for table tabs even when no SELECT result
             if updatedTab.tabType != .table {
-                updatedTab.tableName = nil
+                updatedTab.tableContext.tableName = nil
             }
-            updatedTab.isEditable = false
+            updatedTab.tableContext.isEditable = false
         }
 
         updatedTab.resultVersion += 1
-        updatedTab.executionTime = cumulativeTime
-        updatedTab.rowsAffected = totalRowsAffected
-        updatedTab.isExecuting = false
-        updatedTab.lastExecutedAt = Date()
-        updatedTab.errorMessage = nil
+        updatedTab.execution.executionTime = cumulativeTime
+        updatedTab.execution.rowsAffected = totalRowsAffected
+        updatedTab.execution.isExecuting = false
+        updatedTab.execution.lastExecutedAt = Date()
+        updatedTab.execution.errorMessage = nil
 
-        let pinnedResults = updatedTab.resultSets.filter(\.isPinned)
-        updatedTab.resultSets = pinnedResults + newResultSets
-        updatedTab.activeResultSetId = newResultSets.last?.id
-        if updatedTab.isResultsCollapsed {
-            updatedTab.isResultsCollapsed = false
+        let pinnedResults = updatedTab.display.resultSets.filter(\.isPinned)
+        updatedTab.display.resultSets = pinnedResults + newResultSets
+        updatedTab.display.activeResultSetId = newResultSets.last?.id
+        if updatedTab.display.isResultsCollapsed {
+            updatedTab.display.isResultsCollapsed = false
         }
         toolbarState.isResultsCollapsed = false
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -39,10 +39,10 @@ extension MainContentCoordinator {
         // Fast path: if this table is already the active tab in the same database, skip all work
         if let current = tabManager.selectedTab,
            current.tabType == .table,
-           current.tableName == tableName,
-           current.databaseName == currentDatabase {
+           current.tableContext.tableName == tableName,
+           current.tableContext.databaseName == currentDatabase {
             if showStructure, let idx = tabManager.selectedTabIndex {
-                tabManager.tabs[idx].resultsViewMode = .structure
+                tabManager.tabs[idx].display.resultsViewMode = .structure
             }
             return
         }
@@ -92,9 +92,9 @@ extension MainContentCoordinator {
                 )
             }
             if let tabIndex = tabManager.selectedTabIndex {
-                tabManager.tabs[tabIndex].isView = isView
-                tabManager.tabs[tabIndex].isEditable = !isView
-                tabManager.tabs[tabIndex].schemaName = currentSchema
+                tabManager.tabs[tabIndex].tableContext.isView = isView
+                tabManager.tabs[tabIndex].tableContext.isEditable = !isView
+                tabManager.tabs[tabIndex].tableContext.schemaName = currentSchema
                 tabManager.tabs[tabIndex].pagination.reset()
                 toolbarState.isTableTab = true
             }
@@ -113,7 +113,7 @@ extension MainContentCoordinator {
         // In-place navigation: replace current tab content rather than
         // opening new native window tabs (e.g. Redis database switching).
         if navigationModel == .inPlace {
-            if let oldTab = tabManager.selectedTab, let oldTableName = oldTab.tableName {
+            if let oldTab = tabManager.selectedTab, let oldTableName = oldTab.tableContext.tableName {
                 filterStateManager.saveLastFilters(for: oldTableName)
             }
             if tabManager.replaceTabContent(
@@ -185,13 +185,13 @@ extension MainContentCoordinator {
             if let previewCoordinator = Self.coordinator(for: preview.windowId) {
                 // Skip if preview tab already shows this table
                 if let current = previewCoordinator.tabManager.selectedTab,
-                   current.tableName == tableName,
-                   current.databaseName == databaseName {
+                   current.tableContext.tableName == tableName,
+                   current.tableContext.databaseName == databaseName {
                     preview.window.makeKeyAndOrderFront(nil)
                     return
                 }
                 if let oldTab = previewCoordinator.tabManager.selectedTab,
-                   let oldTableName = oldTab.tableName {
+                   let oldTableName = oldTab.tableContext.tableName {
                     previewCoordinator.filterStateManager.saveLastFilters(for: oldTableName)
                 }
                 previewCoordinator.tabManager.replaceTabContent(
@@ -204,7 +204,7 @@ extension MainContentCoordinator {
                 )
                 previewCoordinator.filterStateManager.clearAll()
                 if let tabIndex = previewCoordinator.tabManager.selectedTabIndex {
-                    previewCoordinator.tabManager.tabs[tabIndex].resultsViewMode = showStructure ? .structure : .data
+                    previewCoordinator.tabManager.tabs[tabIndex].display.resultsViewMode = showStructure ? .structure : .data
                     previewCoordinator.tabManager.tabs[tabIndex].pagination.reset()
                     previewCoordinator.toolbarState.isTableTab = true
                 }
@@ -228,20 +228,20 @@ extension MainContentCoordinator {
                 return true
             }
             // Empty/default query tab (no user content, no results, never executed)
-            if tab.tabType == .query && tab.lastExecutedAt == nil
-                && tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if tab.tabType == .query && tab.execution.lastExecutedAt == nil
+                && tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 return true
             }
             return false
         }()
         if let selectedTab = tabManager.selectedTab, isReusableTab {
             // Skip if already showing this table
-            if selectedTab.tableName == tableName, selectedTab.databaseName == databaseName {
+            if selectedTab.tableContext.tableName == tableName, selectedTab.tableContext.databaseName == databaseName {
                 return
             }
             // If preview tab has active work, promote it and open new tab instead
             let hasUnsavedQuery = tabManager.selectedTab.map { tab in
-                tab.tabType == .query && !tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                tab.tabType == .query && !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             } ?? false
             let previewHasWork = changeManager.hasChanges
                 || filterStateManager.hasAppliedFilters
@@ -261,7 +261,7 @@ extension MainContentCoordinator {
                 WindowManager.shared.openTab(payload: payload)
                 return
             }
-            if let oldTableName = selectedTab.tableName {
+            if let oldTableName = selectedTab.tableContext.tableName {
                 filterStateManager.saveLastFilters(for: oldTableName)
             }
             tabManager.replaceTabContent(
@@ -274,7 +274,7 @@ extension MainContentCoordinator {
             )
             filterStateManager.clearAll()
             if let tabIndex = tabManager.selectedTabIndex {
-                tabManager.tabs[tabIndex].resultsViewMode = showStructure ? .structure : .data
+                tabManager.tabs[tabIndex].display.resultsViewMode = showStructure ? .structure : .data
                 tabManager.tabs[tabIndex].pagination.reset()
                 toolbarState.isTableTab = true
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -188,9 +188,9 @@ extension MainContentCoordinator {
             return false
         }
         let tab = tabManager.tabs[idx]
-        guard tab.tableName == tableName,
+        guard tab.tableContext.tableName == tableName,
               !tab.columnDefaults.isEmpty,
-              !tab.primaryKeyColumns.isEmpty else {
+              !tab.tableContext.primaryKeyColumns.isEmpty else {
             return false
         }
         // Ensure every ENUM/SET column has its allowed values loaded
@@ -252,13 +252,13 @@ extension MainContentCoordinator {
         updatedTab.columnTypes = columnTypes
         updatedTab.resultRows = rows
         updatedTab.resultVersion += 1
-        updatedTab.executionTime = executionTime
-        updatedTab.rowsAffected = rowsAffected
-        updatedTab.statusMessage = statusMessage
-        updatedTab.isExecuting = false
-        updatedTab.lastExecutedAt = Date()
-        updatedTab.tableName = tableName
-        updatedTab.isEditable = isEditable
+        updatedTab.execution.executionTime = executionTime
+        updatedTab.execution.rowsAffected = rowsAffected
+        updatedTab.execution.statusMessage = statusMessage
+        updatedTab.execution.isExecuting = false
+        updatedTab.execution.lastExecutedAt = Date()
+        updatedTab.tableContext.tableName = tableName
+        updatedTab.tableContext.isEditable = isEditable
         // Populate enum values from column types for the enum popover
         for (index, colType) in updatedTab.columnTypes.enumerated() {
             if case .enumType(_, let values) = colType, let vals = values, index < updatedTab.resultColumns.count {
@@ -286,11 +286,11 @@ extension MainContentCoordinator {
         // Create a ResultSet for this single-statement execution
         let rs = ResultSet(label: tableName ?? "Result")
         rs.rowBuffer = updatedTab.rowBuffer
-        rs.executionTime = updatedTab.executionTime
-        rs.rowsAffected = updatedTab.rowsAffected
-        rs.statusMessage = updatedTab.statusMessage
-        rs.tableName = updatedTab.tableName
-        rs.isEditable = updatedTab.isEditable
+        rs.executionTime = updatedTab.execution.executionTime
+        rs.rowsAffected = updatedTab.execution.rowsAffected
+        rs.statusMessage = updatedTab.execution.statusMessage
+        rs.tableName = updatedTab.tableContext.tableName
+        rs.isEditable = updatedTab.tableContext.isEditable
         rs.resultVersion = updatedTab.resultVersion
         rs.metadataVersion = updatedTab.metadataVersion
         rs.columnTypes = updatedTab.columnTypes
@@ -300,9 +300,9 @@ extension MainContentCoordinator {
         rs.columnNullable = updatedTab.columnNullable
 
         // Keep pinned results, replace unpinned
-        let pinned = updatedTab.resultSets.filter(\.isPinned)
-        updatedTab.resultSets = pinned + [rs]
-        updatedTab.activeResultSetId = rs.id
+        let pinned = updatedTab.display.resultSets.filter(\.isPinned)
+        updatedTab.display.resultSets = pinned + [rs]
+        updatedTab.display.activeResultSetId = rs.id
 
         // Update progressive loading state
         if let context = queryPageContext {
@@ -315,8 +315,8 @@ extension MainContentCoordinator {
         }
 
         // Auto-expand results panel when new data arrives
-        if updatedTab.isResultsCollapsed {
-            updatedTab.isResultsCollapsed = false
+        if updatedTab.display.isResultsCollapsed {
+            updatedTab.display.isResultsCollapsed = false
         }
         toolbarState.isResultsCollapsed = false
 
@@ -337,11 +337,11 @@ extension MainContentCoordinator {
             resolvedPKs = [defaultPK]
         } else {
             // Preserve existing PKs when metadata is cached and not re-fetched
-            resolvedPKs = tabManager.tabs[idx].primaryKeyColumns
+            resolvedPKs = tabManager.tabs[idx].tableContext.primaryKeyColumns
         }
 
         if !resolvedPKs.isEmpty {
-            tabManager.tabs[idx].primaryKeyColumns = resolvedPKs
+            tabManager.tabs[idx].tableContext.primaryKeyColumns = resolvedPKs
         }
 
         if tabManager.selectedTabId == tabId {
@@ -556,9 +556,9 @@ extension MainContentCoordinator {
         currentQueryTask = nil
         if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
             var errTab = tabManager.tabs[idx]
-            errTab.errorMessage = error.localizedDescription
-            errTab.isExecuting = false
-            errTab.lastExecutedAt = Date()
+            errTab.execution.errorMessage = error.localizedDescription
+            errTab.execution.isExecuting = false
+            errTab.execution.lastExecutedAt = Date()
             tabManager.tabs[idx] = errTab
         }
         toolbarState.setExecuting(false)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
@@ -29,7 +29,7 @@ extension MainContentCoordinator {
             !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if let firstMissing = missing.first {
-            tabManager.tabs[index].errorMessage = String(
+            tabManager.tabs[index].execution.errorMessage = String(
                 format: String(localized: "Missing value for parameter: %@"),
                 ":\(firstMissing.name)"
             )
@@ -60,7 +60,7 @@ extension MainContentCoordinator {
         originalParameters: [QueryParameter]
     ) {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
         if currentQueryTask != nil {
             currentQueryTask?.cancel()
@@ -75,11 +75,11 @@ extension MainContentCoordinator {
         let capturedGeneration = queryGeneration
 
         var tab = tabManager.tabs[index]
-        tab.isExecuting = true
-        tab.executionTime = nil
-        tab.errorMessage = nil
-        tab.explainText = nil
-        tab.explainPlan = nil
+        tab.execution.isExecuting = true
+        tab.execution.executionTime = nil
+        tab.execution.errorMessage = nil
+        tab.display.explainText = nil
+        tab.display.explainPlan = nil
         tabManager.tabs[index] = tab
         toolbarState.setExecuting(true)
 
@@ -210,7 +210,7 @@ extension MainContentCoordinator {
                     guard let self else { return }
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
                         var tab = tabManager.tabs[idx]
-                        tab.isExecuting = false
+                        tab.execution.isExecuting = false
                         tab.pagination.isLoadingMore = false
                         tabManager.tabs[idx] = tab
                     }
@@ -225,13 +225,13 @@ extension MainContentCoordinator {
 
     func executeMultipleStatementsWithParameters(_ statements: [String], parameters: [QueryParameter]) {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
         let missing = parameters.filter {
             !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if let firstMissing = missing.first {
-            tabManager.tabs[index].errorMessage = String(
+            tabManager.tabs[index].execution.errorMessage = String(
                 format: String(localized: "Missing value for parameter: %@"),
                 ":\(firstMissing.name)"
             )
@@ -247,9 +247,9 @@ extension MainContentCoordinator {
         let capturedGeneration = queryGeneration
 
         var tab = tabManager.tabs[index]
-        tab.isExecuting = true
-        tab.executionTime = nil
-        tab.errorMessage = nil
+        tab.execution.isExecuting = true
+        tab.execution.executionTime = nil
+        tab.execution.errorMessage = nil
         tabManager.tabs[index] = tab
         toolbarState.setExecuting(true)
 
@@ -286,7 +286,7 @@ extension MainContentCoordinator {
                         }
                     }
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].isExecuting = false
+                        tabManager.tabs[idx].execution.isExecuting = false
                     }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
@@ -416,7 +416,7 @@ extension MainContentCoordinator {
 
             if capturedGeneration != queryGeneration || Task.isCancelled {
                 if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].isExecuting = false
+                    tabManager.tabs[idx].execution.isExecuting = false
                 }
                 return
             }
@@ -470,7 +470,7 @@ extension MainContentCoordinator {
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].isExecuting = false
+                    tabManager.tabs[idx].execution.isExecuting = false
                 }
                 currentQueryTask = nil
                 toolbarState.setExecuting(false)
@@ -494,13 +494,13 @@ extension MainContentCoordinator {
 
             if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
                 var errTab = tabManager.tabs[idx]
-                errTab.errorMessage = contextMsg
-                errTab.isExecuting = false
-                errTab.executionTime = cumulativeTime
+                errTab.execution.errorMessage = contextMsg
+                errTab.execution.isExecuting = false
+                errTab.execution.executionTime = cumulativeTime
 
-                let pinnedResults = errTab.resultSets.filter(\.isPinned)
-                errTab.resultSets = pinnedResults + capturedResultSets
-                errTab.activeResultSetId = capturedResultSets.last?.id
+                let pinnedResults = errTab.display.resultSets.filter(\.isPinned)
+                errTab.display.resultSets = pinnedResults + capturedResultSets
+                errTab.display.activeResultSetId = capturedResultSets.last?.id
 
                 tabManager.tabs[idx] = errTab
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -17,7 +17,7 @@ extension MainContentCoordinator {
     ) {
         // If showing structure view, let it handle refresh notifications
         if let tabIndex = tabManager.selectedTabIndex,
-           tabManager.tabs[tabIndex].resultsViewMode == .structure {
+           tabManager.tabs[tabIndex].display.resultsViewMode == .structure {
             return
         }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
@@ -16,7 +16,7 @@ extension MainContentCoordinator {
               tabIndex < tabManager.tabs.count else { return }
 
         let tab = tabManager.tabs[tabIndex]
-        guard tab.isEditable, tab.tableName != nil else { return }
+        guard tab.tableContext.isEditable, tab.tableContext.tableName != nil else { return }
 
         guard let result = rowOperationsManager.addNewRow(
             columns: tab.resultColumns,
@@ -34,7 +34,7 @@ extension MainContentCoordinator {
         guard !safeModeLevel.blocksAllWrites,
               let tabIndex = tabManager.selectedTabIndex,
               tabIndex < tabManager.tabs.count,
-              tabManager.tabs[tabIndex].isEditable,
+              tabManager.tabs[tabIndex].tableContext.isEditable,
               !indices.isEmpty else { return }
 
         let nextRow = rowOperationsManager.deleteSelectedRows(
@@ -58,7 +58,7 @@ extension MainContentCoordinator {
               tabIndex < tabManager.tabs.count else { return }
 
         let tab = tabManager.tabs[tabIndex]
-        guard tab.isEditable, tab.tableName != nil,
+        guard tab.tableContext.isEditable, tab.tableContext.tableName != nil,
               index < tab.resultRows.count else { return }
 
         guard let result = rowOperationsManager.duplicateRow(

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SQLPreview.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SQLPreview.swift
@@ -16,7 +16,7 @@ extension MainContentCoordinator {
         pendingDeletes: Set<String>,
         tableOperationOptions: [String: TableOperationOptions]
     ) {
-        if tabManager.selectedTab?.resultsViewMode == .structure {
+        if tabManager.selectedTab?.display.resultsViewMode == .structure {
             // Structure view handles its own preview via direct call
             structureActions?.previewSQL?()
         } else {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
@@ -19,7 +19,7 @@ extension MainContentCoordinator {
     ) {
         guard !safeModeLevel.blocksAllWrites else {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].errorMessage = String(localized: "Cannot save changes: connection is read-only")
+                tabManager.tabs[index].execution.errorMessage = String(localized: "Cannot save changes: connection is read-only")
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -44,7 +44,7 @@ extension MainContentCoordinator {
             )
         } catch {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].errorMessage = error.localizedDescription
+                tabManager.tabs[index].execution.errorMessage = error.localizedDescription
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -53,7 +53,7 @@ extension MainContentCoordinator {
 
         guard !allStatements.isEmpty else {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].errorMessage = String(localized: "Could not generate SQL for changes.")
+                tabManager.tabs[index].execution.errorMessage = String(localized: "Could not generate SQL for changes.")
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -182,7 +182,7 @@ extension MainContentCoordinator {
             do {
                 guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
                     if let index = tabManager.selectedTabIndex {
-                        tabManager.tabs[index].errorMessage = String(localized: "Not connected to database")
+                        tabManager.tabs[index].execution.errorMessage = String(localized: "Not connected to database")
                     }
                     throw DatabaseError.notConnected
                 }
@@ -233,7 +233,7 @@ extension MainContentCoordinator {
                 changeManager.clearChangesAndUndoHistory()
                 if let index = tabManager.selectedTabIndex {
                     tabManager.tabs[index].pendingChanges = TabPendingChanges()
-                    tabManager.tabs[index].errorMessage = nil
+                    tabManager.tabs[index].execution.errorMessage = nil
                 }
 
                 if clearTableOps {
@@ -241,7 +241,7 @@ extension MainContentCoordinator {
                     if !deletedTables.isEmpty {
                         let tabIdsToRemove = Set(
                             tabManager.tabs
-                                .filter { $0.tabType == .table && deletedTables.contains($0.tableName ?? "") }
+                                .filter { $0.tabType == .table && deletedTables.contains($0.tableContext.tableName ?? "") }
                                 .map(\.id)
                         )
 
@@ -293,7 +293,7 @@ extension MainContentCoordinator {
                 )
 
                 if let index = tabManager.selectedTabIndex {
-                    tabManager.tabs[index].errorMessage = String(format: String(localized: "Save failed: %@"), error.localizedDescription)
+                    tabManager.tabs[index].execution.errorMessage = String(format: String(localized: "Save failed: %@"), error.localizedDescription)
                 }
 
                 // Show error alert to user

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -15,23 +15,23 @@ extension MainContentCoordinator {
 
     func closeResultSet(id: UUID) {
         guard let tabIdx = tabManager.selectedTabIndex else { return }
-        let rs = tabManager.tabs[tabIdx].resultSets.first { $0.id == id }
+        let rs = tabManager.tabs[tabIdx].display.resultSets.first { $0.id == id }
         guard rs?.isPinned != true else { return }
-        tabManager.tabs[tabIdx].resultSets.removeAll { $0.id == id }
-        if tabManager.tabs[tabIdx].activeResultSetId == id {
-            tabManager.tabs[tabIdx].activeResultSetId = tabManager.tabs[tabIdx].resultSets.last?.id
+        tabManager.tabs[tabIdx].display.resultSets.removeAll { $0.id == id }
+        if tabManager.tabs[tabIdx].display.activeResultSetId == id {
+            tabManager.tabs[tabIdx].display.activeResultSetId = tabManager.tabs[tabIdx].display.resultSets.last?.id
         }
-        if tabManager.tabs[tabIdx].resultSets.isEmpty {
+        if tabManager.tabs[tabIdx].display.resultSets.isEmpty {
             tabManager.tabs[tabIdx].rowBuffer = RowBuffer()
             tabManager.tabs[tabIdx].resultColumns = []
             tabManager.tabs[tabIdx].columnTypes = []
             tabManager.tabs[tabIdx].resultRows = []
-            tabManager.tabs[tabIdx].errorMessage = nil
-            tabManager.tabs[tabIdx].rowsAffected = 0
-            tabManager.tabs[tabIdx].executionTime = nil
-            tabManager.tabs[tabIdx].statusMessage = nil
+            tabManager.tabs[tabIdx].execution.errorMessage = nil
+            tabManager.tabs[tabIdx].execution.rowsAffected = 0
+            tabManager.tabs[tabIdx].execution.executionTime = nil
+            tabManager.tabs[tabIdx].execution.statusMessage = nil
             tabManager.tabs[tabIdx].resultVersion += 1
-            tabManager.tabs[tabIdx].isResultsCollapsed = true
+            tabManager.tabs[tabIdx].display.isResultsCollapsed = true
             toolbarState.isResultsCollapsed = true
         }
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarSave.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarSave.swift
@@ -16,7 +16,7 @@ extension MainContentCoordinator {
     ) async throws {
         guard let tab = tabManager.selectedTab,
             !selectedRowIndices.isEmpty,
-            tab.tableName != nil
+            tab.tableContext.tableName != nil
         else {
             return
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -37,7 +37,7 @@ extension MainContentCoordinator {
                 tabManager.tabs[oldIndex].pendingChanges = changeManager.saveState()
             }
             tabManager.tabs[oldIndex].filterState = filterStateManager.saveToTabState()
-            if let tableName = tabManager.tabs[oldIndex].tableName {
+            if let tableName = tabManager.tabs[oldIndex].tableContext.tableName {
                 filterStateManager.saveLastFilters(for: tableName)
             }
             saveColumnVisibilityToTab()
@@ -67,20 +67,18 @@ extension MainContentCoordinator {
 
             selectedRowIndices = newTab.selectedRowIndices
             toolbarState.isTableTab = newTab.tabType == .table
-            toolbarState.isResultsCollapsed = newTab.isResultsCollapsed
+            toolbarState.isResultsCollapsed = newTab.display.isResultsCollapsed
 
-            // Configure change manager without triggering reload yet — we'll fire a single
-            // reloadVersion bump below after everything is set up.
             let pendingState = newTab.pendingChanges
             if pendingState.hasChanges {
-                changeManager.restoreState(from: pendingState, tableName: newTab.tableName ?? "", databaseType: connection.type)
+                changeManager.restoreState(from: pendingState, tableName: newTab.tableContext.tableName ?? "", databaseType: connection.type)
             } else {
                 changeManager.configureForTable(
-                    tableName: newTab.tableName ?? "",
+                    tableName: newTab.tableContext.tableName ?? "",
                     columns: newTab.resultColumns,
-                    primaryKeyColumns: newTab.primaryKeyColumns.isEmpty
+                    primaryKeyColumns: newTab.tableContext.primaryKeyColumns.isEmpty
                         ? newTab.resultColumns.prefix(1).map { $0 }
-                        : newTab.primaryKeyColumns,
+                        : newTab.tableContext.primaryKeyColumns,
                     databaseType: connection.type,
                     triggerReload: false
                 )
@@ -91,7 +89,7 @@ extension MainContentCoordinator {
                 "[switch] handleTabChange phases: saveOutgoing=\(saveMs)ms evict=\(evictMs)ms restoreIncoming=\(restoreMs)ms"
             )
 
-            if !newTab.databaseName.isEmpty {
+            if !newTab.tableContext.databaseName.isEmpty {
                 let currentDatabase: String
                 if let session = DatabaseManager.shared.session(for: connectionId) {
                     currentDatabase = session.activeDatabase
@@ -99,13 +97,13 @@ extension MainContentCoordinator {
                     currentDatabase = connection.database
                 }
 
-                if newTab.databaseName != currentDatabase {
+                if newTab.tableContext.databaseName != currentDatabase {
                     Self.lifecycleLogger.debug(
-                        "[switch] handleTabChange triggering switchDatabase from=\(currentDatabase, privacy: .public) to=\(newTab.databaseName, privacy: .public)"
+                        "[switch] handleTabChange triggering switchDatabase from=\(currentDatabase, privacy: .public) to=\(newTab.tableContext.databaseName, privacy: .public)"
                     )
                     changeManager.reloadVersion += 1
                     Task {
-                        await switchDatabase(to: newTab.databaseName)
+                        await switchDatabase(to: newTab.tableContext.databaseName)
                     }
                     return  // switchDatabase will re-execute the query
                 }
@@ -114,22 +112,22 @@ extension MainContentCoordinator {
             // If the tab shows isExecuting but has no results, the previous query was
             // likely cancelled when the user rapidly switched away. Force-clear the stale
             // flag so the lazy-load check below can re-execute the query.
-            if newTab.isExecuting && newTab.resultRows.isEmpty && newTab.lastExecutedAt == nil {
+            if newTab.execution.isExecuting && newTab.resultRows.isEmpty && newTab.execution.lastExecutedAt == nil {
                 let tabId = newId
                 Task { [weak self] in
                     guard let self,
                           let idx = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }),
-                          self.tabManager.tabs[idx].isExecuting else { return }
-                    self.tabManager.tabs[idx].isExecuting = false
+                          self.tabManager.tabs[idx].execution.isExecuting else { return }
+                    self.tabManager.tabs[idx].execution.isExecuting = false
                 }
             }
 
             let isEvicted = newTab.rowBuffer.isEvicted
             let needsLazyQuery = newTab.tabType == .table
                 && (newTab.resultRows.isEmpty || isEvicted)
-                && (newTab.lastExecutedAt == nil || isEvicted)
-                && newTab.errorMessage == nil
-                && !newTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && (newTab.execution.lastExecutedAt == nil || isEvicted)
+                && newTab.execution.errorMessage == nil
+                && !newTab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
             if needsLazyQuery {
                 if let session = DatabaseManager.shared.session(for: connectionId), session.isConnected {
@@ -160,14 +158,13 @@ extension MainContentCoordinator {
             !activeTabIds.contains($0.id)
                 && !$0.rowBuffer.isEvicted
                 && !$0.resultRows.isEmpty
-                && $0.lastExecutedAt != nil
+                && $0.execution.lastExecutedAt != nil
                 && !$0.pendingChanges.hasChanges
         }
 
-        // Sort by oldest first, breaking ties by largest estimated footprint first
         let sorted = candidates.sorted {
-            let t0 = $0.lastExecutedAt ?? .distantFuture
-            let t1 = $1.lastExecutedAt ?? .distantFuture
+            let t0 = $0.execution.lastExecutedAt ?? .distantFuture
+            let t1 = $1.execution.lastExecutedAt ?? .distantFuture
             if t0 != t1 { return t0 < t1 }
             let size0 = MemoryPressureAdvisor.estimatedFootprint(
                 rowCount: $0.rowBuffer.rows.count,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -42,9 +42,9 @@ extension MainContentCoordinator {
             tabManager.selectedTab.map { tab in
                 tab.tabType == .table
                     && (tab.resultRows.isEmpty || tab.rowBuffer.isEvicted)
-                    && (tab.lastExecutedAt == nil || tab.rowBuffer.isEvicted)
-                    && tab.errorMessage == nil
-                    && !tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    && (tab.execution.lastExecutedAt == nil || tab.rowBuffer.isEvicted)
+                    && tab.execution.errorMessage == nil
+                    && !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             } ?? false
         // Skip lazy-load if this is a menu-interaction bounce (resign+become within 200ms).
         let isMenuBounce = Date().timeIntervalSince(lastResignKeyDate) < 0.2

--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -23,7 +23,7 @@ extension MainContentView {
 
         let service = ValueDisplayFormatService.shared
         let connId = coordinator.connection.id
-        let tblName = tab.tableName
+        let tblName = tab.tableContext.tableName
 
         for (i, col) in tab.resultColumns.enumerated() {
             var value = i < row.count ? row[i] : nil
@@ -49,7 +49,7 @@ extension MainContentView {
     var isSidebarEditable: Bool {
         guard !coordinator.safeModeLevel.blocksAllWrites,
               let tab = coordinator.tabManager.selectedTab,
-              tab.tabType == .table || tab.tableName != nil,
+              tab.tabType == .table || tab.tableContext.tableName != nil,
               !selectedRowIndices.isEmpty else {
             return false
         }
@@ -86,10 +86,10 @@ extension MainContentView {
     /// Binding for resultsViewMode state
     var resultsViewModeBinding: Binding<ResultsViewMode> {
         Binding(
-            get: { coordinator.tabManager.selectedTab?.resultsViewMode ?? .data },
+            get: { coordinator.tabManager.selectedTab?.display.resultsViewMode ?? .data },
             set: { newValue in
                 if let index = coordinator.tabManager.selectedTabIndex {
-                    coordinator.tabManager.tabs[index].resultsViewMode = newValue
+                    coordinator.tabManager.tabs[index].display.resultsViewMode = newValue
                 }
             }
         )
@@ -110,7 +110,7 @@ extension MainContentView {
     /// Uses `resultVersion` instead of the full `resultRows` array to avoid deep equality checks.
     var inspectorTrigger: InspectorTrigger {
         InspectorTrigger(
-            tableName: currentTab?.tableName,
+            tableName: currentTab?.tableContext.tableName,
             resultVersion: currentTab?.resultVersion ?? -1,
             metadataVersion: currentTab?.metadataVersion ?? -1,
             metadataTableName: coordinator.tableMetadata?.tableName

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -94,14 +94,14 @@ extension MainContentView {
 
         // Reconfigure if columns changed OR table name changed (switching tables)
         let columnsChanged = changeManager.columns != newColumns
-        let tableChanged = changeManager.tableName != (tab.tableName ?? "")
+        let tableChanged = changeManager.tableName != (tab.tableContext.tableName ?? "")
 
         guard columnsChanged || tableChanged else { return }
 
         changeManager.configureForTable(
-            tableName: tab.tableName ?? "",
+            tableName: tab.tableContext.tableName ?? "",
             columns: newColumns,
-            primaryKeyColumns: tab.primaryKeyColumns,
+            primaryKeyColumns: tab.tableContext.primaryKeyColumns,
             databaseType: connection.type
         )
     }
@@ -126,7 +126,7 @@ extension MainContentView {
 
         let result = SidebarNavigationResult.resolve(
             clickedTableName: tableName,
-            currentTabTableName: tabManager.selectedTab?.tableName,
+            currentTabTableName: tabManager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !tabManager.tabs.isEmpty,
             isPreviewTabMode: isPreviewMode,
             hasPreviewTab: hasPreview
@@ -155,7 +155,7 @@ extension MainContentView {
         guard coordinator.isKeyWindow else { return }
         let liveTables = DatabaseManager.shared.session(for: connection.id)?.tables ?? []
         let target: Set<TableInfo>
-        if let currentTableName = tabManager.selectedTab?.tableName,
+        if let currentTableName = tabManager.selectedTab?.tableContext.tableName,
             let match = liveTables.first(where: { $0.name == currentTableName })
         {
             target = [match]
@@ -211,13 +211,13 @@ extension MainContentView {
         }
 
         let excludedNames: Set<String>
-        if let tableName = tab.tableName {
+        if let tableName = tab.tableContext.tableName {
             excludedNames = Set(coordinator.columnExclusions(for: tableName).map(\.columnName))
         } else {
             excludedNames = []
         }
 
-        let pkColumns = Set(tab.primaryKeyColumns)
+        let pkColumns = Set(tab.tableContext.primaryKeyColumns)
         let fkColumns = Set(tab.columnForeignKeys.keys)
 
         rightPanelState.editState.configure(
@@ -271,8 +271,8 @@ extension MainContentView {
         // Lazy-load full values for excluded columns when a single row is selected
         if !excludedNames.isEmpty,
             selectedRowIndices.count == 1,
-            let tableName = tab.tableName,
-            let pkColumn = tab.primaryKeyColumn,
+            let tableName = tab.tableContext.tableName,
+            let pkColumn = tab.tableContext.primaryKeyColumn,
             let rowIndex = selectedRowIndices.first,
             rowIndex < tab.resultRows.count
         {

--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -12,7 +12,7 @@ extension MainContentView {
     // MARK: - Helper Methods
 
     func loadTableMetadataIfNeeded() async {
-        guard let tableName = currentTab?.tableName,
+        guard let tableName = currentTab?.tableContext.tableName,
             coordinator.tableMetadata?.tableName != tableName
         else { return }
         await coordinator.loadTableMetadata(tableName: tableName)
@@ -28,12 +28,12 @@ extension MainContentView {
             guard !hasPendingEdits else { return }
             coordinator.needsLazyLoad = false
             if let selectedTab = tabManager.selectedTab,
-                !selectedTab.databaseName.isEmpty,
-                selectedTab.databaseName != session.activeDatabase
+                !selectedTab.tableContext.databaseName.isEmpty,
+                selectedTab.tableContext.databaseName != session.activeDatabase
             {
-                Task { await coordinator.switchDatabase(to: selectedTab.databaseName) }
+                Task { await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName) }
             } else if let selectedTab = tabManager.selectedTab,
-                let tabSchema = selectedTab.schemaName,
+                let tabSchema = selectedTab.tableContext.schemaName,
                 !tabSchema.isEmpty,
                 tabSchema != session.currentSchema
             {
@@ -73,12 +73,12 @@ extension MainContentView {
 
     func updateInspectorContext() {
         rightPanelState.inspectorContext = InspectorContext(
-            tableName: currentTab?.tableName,
+            tableName: currentTab?.tableContext.tableName,
             tableMetadata: coordinator.tableMetadata,
             selectedRowData: selectedRowDataForSidebar,
             isEditable: isSidebarEditable,
             isRowDeleted: isSelectedRowDeleted,
-            currentQuery: coordinator.tabManager.selectedTab?.query,
+            currentQuery: coordinator.tabManager.selectedTab?.content.query,
             queryResults: cachedQueryResultsSummary()
         )
     }

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -46,18 +46,18 @@ extension MainContentView {
             }
             if let selectedTab = tabManager.selectedTab,
                 selectedTab.tabType == .table,
-                !selectedTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                !selectedTab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             {
                 if let session = DatabaseManager.shared.activeSessions[connection.id],
                     session.isConnected
                 {
-                    if !selectedTab.databaseName.isEmpty,
-                        selectedTab.databaseName != session.activeDatabase
+                    if !selectedTab.tableContext.databaseName.isEmpty,
+                        selectedTab.tableContext.databaseName != session.activeDatabase
                     {
-                        await coordinator.switchDatabase(to: selectedTab.databaseName)
+                        await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName)
                     } else {
                         if !selectedTab.filterState.appliedFilters.isEmpty,
-                            let tableName = selectedTab.tableName,
+                            let tableName = selectedTab.tableContext.tableName,
                             let tabIndex = tabManager.selectedTabIndex
                         {
                             let filteredQuery = coordinator.queryBuilder.buildFilteredQuery(
@@ -67,9 +67,9 @@ extension MainContentView {
                                 limit: selectedTab.pagination.pageSize,
                                 offset: selectedTab.pagination.currentOffset
                             )
-                            tabManager.tabs[tabIndex].query = filteredQuery
+                            tabManager.tabs[tabIndex].content.query = filteredQuery
                         }
-                        if let tableName = selectedTab.tableName {
+                        if let tableName = selectedTab.tableContext.tableName {
                             coordinator.restoreColumnLayoutForTable(tableName)
                         }
                         coordinator.executeTableTabQueryDirectly()
@@ -114,11 +114,11 @@ extension MainContentView {
         if !result.tabs.isEmpty {
             var restoredTabs = result.tabs
             for i in restoredTabs.indices where restoredTabs[i].tabType == .table {
-                if let tableName = restoredTabs[i].tableName {
-                    restoredTabs[i].query = QueryTab.buildBaseTableQuery(
+                if let tableName = restoredTabs[i].tableContext.tableName {
+                    restoredTabs[i].content.query = QueryTab.buildBaseTableQuery(
                         tableName: tableName,
                         databaseType: connection.type,
-                        schemaName: restoredTabs[i].schemaName
+                        schemaName: restoredTabs[i].tableContext.schemaName
                     )
                 }
             }
@@ -150,17 +150,17 @@ extension MainContentView {
             }
 
             if firstTab.tabType == .table,
-                !firstTab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                !firstTab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             {
                 if let session = DatabaseManager.shared.activeSessions[connection.id],
                     session.isConnected
                 {
-                    if !firstTab.databaseName.isEmpty,
-                        firstTab.databaseName != session.activeDatabase
+                    if !firstTab.tableContext.databaseName.isEmpty,
+                        firstTab.tableContext.databaseName != session.activeDatabase
                     {
-                        Task { await coordinator.switchDatabase(to: firstTab.databaseName) }
+                        Task { await coordinator.switchDatabase(to: firstTab.tableContext.databaseName) }
                     } else {
-                        if let tableName = firstTab.tableName {
+                        if let tableName = firstTab.tableContext.tableName {
                             coordinator.restoreColumnLayoutForTable(tableName)
                         }
                         coordinator.executeTableTabQueryDirectly()
@@ -180,7 +180,7 @@ extension MainContentView {
             || !pendingTruncates.isEmpty
             || !pendingDeletes.isEmpty
             || toolbarState.hasStructureChanges
-        let hasFileChanges = tabManager.selectedTab?.isFileDirty ?? false
+        let hasFileChanges = tabManager.selectedTab?.content.isFileDirty ?? false
         toolbarState.hasDataPendingChanges = hasDataChanges
         toolbarState.hasPendingChanges = hasDataChanges || hasFileChanges
     }
@@ -196,17 +196,17 @@ extension MainContentView {
             windowTitle = String(localized: "ER Diagram")
         } else if selectedTab?.tabType == .terminal {
             windowTitle = String(localized: "Terminal")
-        } else if let fileURL = selectedTab?.sourceFileURL {
+        } else if let fileURL = selectedTab?.content.sourceFileURL {
             windowTitle = fileURL.deletingPathExtension().lastPathComponent
         } else {
             let langName = PluginManager.shared.queryLanguageName(for: connection.type)
             let queryLabel = String(format: String(localized: "%@ Query"), langName)
-            windowTitle = (selectedTab?.tabType == .table ? selectedTab?.tableName : nil)
+            windowTitle = (selectedTab?.tabType == .table ? selectedTab?.tableContext.tableName : nil)
                 ?? selectedTab?.title
                 ?? (tabManager.tabs.isEmpty ? connection.name : queryLabel)
         }
-        viewWindow?.representedURL = selectedTab?.sourceFileURL
-        viewWindow?.isDocumentEdited = selectedTab?.isFileDirty ?? false
+        viewWindow?.representedURL = selectedTab?.content.sourceFileURL
+        viewWindow?.isDocumentEdited = selectedTab?.content.isFileDirty ?? false
     }
 
     /// Configure the hosting NSWindow — called by WindowAccessor when the window is available.
@@ -238,8 +238,8 @@ extension MainContentView {
         coordinator.isKeyWindow = window.isKeyWindow
 
         // Native proxy icon (Cmd+click shows path in Finder) and dirty dot
-        window.representedURL = tabManager.selectedTab?.sourceFileURL
-        window.isDocumentEdited = tabManager.selectedTab?.isFileDirty ?? false
+        window.representedURL = tabManager.selectedTab?.content.sourceFileURL
+        window.isDocumentEdited = tabManager.selectedTab?.content.isFileDirty ?? false
 
         // Update command actions window reference now that it's available
         commandActions?.window = window

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -232,7 +232,7 @@ final class MainContentCommandActions {
     }
 
     func copySelectedRows() {
-        if coordinator?.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.copyRows?()
         } else {
             let indices = selectedRowIndices.wrappedValue
@@ -251,7 +251,7 @@ final class MainContentCommandActions {
     }
 
     func pasteRows() {
-        if coordinator?.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.pasteRows?()
         } else {
             var indices = selectedRowIndices.wrappedValue
@@ -282,7 +282,7 @@ final class MainContentCommandActions {
     }
 
     var isCurrentTabEditable: Bool {
-        coordinator?.tabManager.selectedTab?.isEditable == true
+        coordinator?.tabManager.selectedTab?.tableContext.isEditable == true
     }
 
     var isTableTab: Bool {
@@ -298,7 +298,7 @@ final class MainContentCommandActions {
     }
 
     var hasQueryText: Bool {
-        !(coordinator?.tabManager.selectedTab?.query.isEmpty ?? true)
+        !(coordinator?.tabManager.selectedTab?.content.query.isEmpty ?? true)
     }
 
     /// Whether there are pending data changes that the SQL preview can show.
@@ -325,7 +325,7 @@ final class MainContentCommandActions {
         let hasPendingTableOps = !pendingTruncates.wrappedValue.isEmpty
             || !pendingDeletes.wrappedValue.isEmpty
         let hasSidebarEdits = rightPanelState.editState.hasEdits
-        let hasFileDirty = coordinator?.tabManager.selectedTab?.isFileDirty ?? false
+        let hasFileDirty = coordinator?.tabManager.selectedTab?.content.isFileDirty ?? false
         return hasEditedCells || hasPendingTableOps || hasSidebarEdits || hasFileDirty
     }
 
@@ -410,7 +410,7 @@ final class MainContentCommandActions {
         }
 
         // Structure view saves via direct coordinator call
-        if coordinator.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator.structureActions?.saveChanges?()
             performClose()
             return
@@ -439,7 +439,7 @@ final class MainContentCommandActions {
         }
 
         // File save (query editor with source file)
-        if coordinator.tabManager.selectedTab?.isFileDirty == true {
+        if coordinator.tabManager.selectedTab?.content.isFileDirty == true {
             saveFileToSourceURL()
             performClose()
             return
@@ -450,13 +450,13 @@ final class MainContentCommandActions {
 
     private func saveFileToSourceURL() {
         guard let tab = coordinator?.tabManager.selectedTab,
-              let url = tab.sourceFileURL else { return }
-        let content = tab.query
+              let url = tab.content.sourceFileURL else { return }
+        let content = tab.content.query
         Task {
             do {
                 try await SQLFileService.writeFile(content: content, to: url)
                 if let index = coordinator?.tabManager.tabs.firstIndex(where: { $0.id == tab.id }) {
-                    coordinator?.tabManager.tabs[index].savedFileContent = content
+                    coordinator?.tabManager.tabs[index].content.savedFileContent = content
                 }
             } catch {
                 // File may have been deleted or become inaccessible
@@ -530,7 +530,7 @@ final class MainContentCommandActions {
 
     func saveChanges() {
         // Check if we're in structure view mode
-        if coordinator?.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.saveChanges?()
         } else if coordinator?.changeManager.hasChanges == true
             || !pendingTruncates.wrappedValue.isEmpty
@@ -555,13 +555,13 @@ final class MainContentCommandActions {
         }
         // File save: write query back to source file
         else if let tab = coordinator?.tabManager.selectedTab,
-                tab.sourceFileURL != nil, tab.isFileDirty {
+                tab.content.sourceFileURL != nil, tab.content.isFileDirty {
             saveFileToSourceURL()
         }
         // Save As: untitled query tab with content
         else if let tab = coordinator?.tabManager.selectedTab,
-                tab.tabType == .query, tab.sourceFileURL == nil,
-                !tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                tab.tabType == .query, tab.content.sourceFileURL == nil,
+                !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             saveFileAs()
         }
     }
@@ -569,15 +569,15 @@ final class MainContentCommandActions {
     func saveFileAs() {
         guard let tab = coordinator?.tabManager.selectedTab,
               tab.tabType == .query else { return }
-        let content = tab.query
-        let suggestedName = tab.sourceFileURL?.lastPathComponent ?? "\(tab.title).sql"
+        let content = tab.content.query
+        let suggestedName = tab.content.sourceFileURL?.lastPathComponent ?? "\(tab.title).sql"
         Task {
             guard let url = await SQLFileService.showSavePanel(suggestedName: suggestedName) else { return }
             do {
                 try await SQLFileService.writeFile(content: content, to: url)
                 if let index = coordinator?.tabManager.tabs.firstIndex(where: { $0.id == tab.id }) {
-                    coordinator?.tabManager.tabs[index].sourceFileURL = url
-                    coordinator?.tabManager.tabs[index].savedFileContent = content
+                    coordinator?.tabManager.tabs[index].content.sourceFileURL = url
+                    coordinator?.tabManager.tabs[index].content.savedFileContent = content
                     coordinator?.tabManager.tabs[index].title = url.deletingPathExtension().lastPathComponent
                 }
             } catch {
@@ -598,13 +598,13 @@ final class MainContentCommandActions {
     }
 
     func aiExplainQuery() {
-        guard let query = coordinator?.tabManager.selectedTab?.query, !query.isEmpty else { return }
+        guard let query = coordinator?.tabManager.selectedTab?.content.query, !query.isEmpty else { return }
         coordinator?.showAIChatPanel()
         coordinator?.aiViewModel?.handleExplainSelection(query)
     }
 
     func aiOptimizeQuery() {
-        guard let query = coordinator?.tabManager.selectedTab?.query, !query.isEmpty else { return }
+        guard let query = coordinator?.tabManager.selectedTab?.content.query, !query.isEmpty else { return }
         coordinator?.showAIChatPanel()
         coordinator?.aiViewModel?.handleOptimizeSelection(query)
     }
@@ -631,7 +631,7 @@ final class MainContentCommandActions {
 
     var canSaveAsFavorite: Bool {
         guard let tab = coordinator?.tabManager.selectedTab else { return false }
-        return tab.tabType == .query && !tab.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return tab.tabType == .query && !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     func previewSQL() {
@@ -664,12 +664,12 @@ final class MainContentCommandActions {
 
         do {
             let result = try formatter.format(
-                tab.query,
+                tab.content.query,
                 dialect: dbType,
                 cursorOffset: 0,
                 options: options
             )
-            coordinator.tabManager.tabs[tabIndex].query = result.formattedSQL
+            coordinator.tabManager.tabs[tabIndex].content.query = result.formattedSQL
         } catch {
             Self.logger.error("SQL Formatting error: \(error.localizedDescription, privacy: .public)")
         }
@@ -687,34 +687,34 @@ final class MainContentCommandActions {
 
     func toggleResults() {
         guard let coordinator, let tabIndex = coordinator.tabManager.selectedTabIndex else { return }
-        coordinator.tabManager.tabs[tabIndex].isResultsCollapsed.toggle()
-        coordinator.toolbarState.isResultsCollapsed = coordinator.tabManager.tabs[tabIndex].isResultsCollapsed
+        coordinator.tabManager.tabs[tabIndex].display.isResultsCollapsed.toggle()
+        coordinator.toolbarState.isResultsCollapsed = coordinator.tabManager.tabs[tabIndex].display.isResultsCollapsed
     }
 
     func previousResultTab() {
         guard let coordinator, let tabIndex = coordinator.tabManager.selectedTabIndex else { return }
         let tab = coordinator.tabManager.tabs[tabIndex]
-        guard tab.resultSets.count > 1,
-              let currentId = tab.activeResultSetId ?? tab.resultSets.last?.id,
-              let currentIndex = tab.resultSets.firstIndex(where: { $0.id == currentId }),
+        guard tab.display.resultSets.count > 1,
+              let currentId = tab.display.activeResultSetId ?? tab.display.resultSets.last?.id,
+              let currentIndex = tab.display.resultSets.firstIndex(where: { $0.id == currentId }),
               currentIndex > 0 else { return }
-        coordinator.tabManager.tabs[tabIndex].activeResultSetId = tab.resultSets[currentIndex - 1].id
+        coordinator.tabManager.tabs[tabIndex].display.activeResultSetId = tab.display.resultSets[currentIndex - 1].id
     }
 
     func nextResultTab() {
         guard let coordinator, let tabIndex = coordinator.tabManager.selectedTabIndex else { return }
         let tab = coordinator.tabManager.tabs[tabIndex]
-        guard tab.resultSets.count > 1,
-              let currentId = tab.activeResultSetId ?? tab.resultSets.last?.id,
-              let currentIndex = tab.resultSets.firstIndex(where: { $0.id == currentId }),
-              currentIndex < tab.resultSets.count - 1 else { return }
-        coordinator.tabManager.tabs[tabIndex].activeResultSetId = tab.resultSets[currentIndex + 1].id
+        guard tab.display.resultSets.count > 1,
+              let currentId = tab.display.activeResultSetId ?? tab.display.resultSets.last?.id,
+              let currentIndex = tab.display.resultSets.firstIndex(where: { $0.id == currentId }),
+              currentIndex < tab.display.resultSets.count - 1 else { return }
+        coordinator.tabManager.tabs[tabIndex].display.activeResultSetId = tab.display.resultSets[currentIndex + 1].id
     }
 
     func closeResultTab() {
         guard let coordinator else { return }
         let tab = coordinator.tabManager.selectedTab
-        guard let activeId = tab?.activeResultSetId ?? tab?.resultSets.last?.id else { return }
+        guard let activeId = tab?.display.activeResultSetId ?? tab?.display.resultSets.last?.id else { return }
         coordinator.closeResultSet(id: activeId)
     }
 
@@ -731,7 +731,7 @@ final class MainContentCommandActions {
     // MARK: - Undo/Redo (Group A — Called Directly)
 
     func undoChange() {
-        if coordinator?.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.undo?()
         } else {
             var indices = selectedRowIndices.wrappedValue
@@ -741,7 +741,7 @@ final class MainContentCommandActions {
     }
 
     func redoChange() {
-        if coordinator?.tabManager.selectedTab?.resultsViewMode == .structure {
+        if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.redo?()
         } else {
             coordinator?.redoLastChange()

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -724,11 +724,10 @@ final class MainContentCoordinator {
 
     func runQuery() {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
-        let fullQuery = tabManager.tabs[index].query
+        let fullQuery = tabManager.tabs[index].content.query
 
-        // For table tabs, use the full query. For query tabs, extract at cursor
         let sql: String
         if tabManager.tabs[index].tabType == .table {
             sql = fullQuery
@@ -762,12 +761,12 @@ final class MainContentCoordinator {
             if !detectedNames.isEmpty {
                 let reconciled = detectAndReconcileParameters(
                     sql: combinedSQL,
-                    existing: tabManager.tabs[index].queryParameters
+                    existing: tabManager.tabs[index].content.queryParameters
                 )
-                tabManager.tabs[index].queryParameters = reconciled
+                tabManager.tabs[index].content.queryParameters = reconciled
 
-                if !tabManager.tabs[index].isParameterPanelVisible {
-                    tabManager.tabs[index].isParameterPanelVisible = true
+                if !tabManager.tabs[index].content.isParameterPanelVisible {
+                    tabManager.tabs[index].content.isParameterPanelVisible = true
                     return
                 }
 
@@ -791,14 +790,14 @@ final class MainContentCoordinator {
     /// checks but still respect safe mode levels that apply to all queries.
     func executeTableTabQueryDirectly() {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
-        let sql = tabManager.tabs[index].query
+        let sql = tabManager.tabs[index].content.query
         guard !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let level = safeModeLevel
         if level.appliesToAllQueries && level.requiresConfirmation,
-           tabManager.tabs[index].lastExecutedAt == nil
+           tabManager.tabs[index].execution.lastExecutedAt == nil
         {
             guard !isShowingSafeModePrompt else { return }
             isShowingSafeModePrompt = true
@@ -818,7 +817,7 @@ final class MainContentCoordinator {
                     executeQueryInternal(sql)
                 case .blocked(let reason):
                     if index < tabManager.tabs.count {
-                        tabManager.tabs[index].errorMessage = reason
+                        tabManager.tabs[index].execution.errorMessage = reason
                     }
                 }
             }
@@ -833,7 +832,7 @@ final class MainContentCoordinator {
         if let tabIndex = tabManager.selectedTabIndex,
            tabIndex < tabManager.tabs.count,
            tabManager.tabs[tabIndex].tabType == .query {
-            tabManager.tabs[tabIndex].query = query
+            tabManager.tabs[tabIndex].content.query = query
             tabManager.tabs[tabIndex].hasUserInteraction = true
         } else {
             let payload = EditorTabPayload(
@@ -849,11 +848,11 @@ final class MainContentCoordinator {
         if let tabIndex = tabManager.selectedTabIndex,
            tabIndex < tabManager.tabs.count,
            tabManager.tabs[tabIndex].tabType == .query {
-            let existingQuery = tabManager.tabs[tabIndex].query
+            let existingQuery = tabManager.tabs[tabIndex].content.query
             if existingQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                tabManager.tabs[tabIndex].query = query
+                tabManager.tabs[tabIndex].content.query = query
             } else {
-                tabManager.tabs[tabIndex].query = existingQuery + "\n\n" + query
+                tabManager.tabs[tabIndex].content.query = existingQuery + "\n\n" + query
             }
             tabManager.tabs[tabIndex].hasUserInteraction = true
         } else if tabManager.tabs.isEmpty {
@@ -871,11 +870,10 @@ final class MainContentCoordinator {
     /// Run EXPLAIN on the current query (database-type-aware prefix)
     func runExplainQuery() {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
-        let fullQuery = tabManager.tabs[index].query
+        let fullQuery = tabManager.tabs[index].content.query
 
-        // Extract query the same way as runQuery()
         let sql: String
         if tabManager.tabs[index].tabType == .table {
             sql = fullQuery
@@ -935,7 +933,7 @@ final class MainContentCoordinator {
         guard let adapter = DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter,
               let explainSQL = adapter.buildExplainQuery(stmt) else {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].errorMessage = String(localized: "EXPLAIN is not supported for this database type.")
+                tabManager.tabs[index].execution.errorMessage = String(localized: "EXPLAIN is not supported for this database type.")
             }
             return
         }
@@ -967,7 +965,7 @@ final class MainContentCoordinator {
         _ sql: String
     ) {
         guard let index = tabManager.selectedTabIndex else { return }
-        guard !tabManager.tabs[index].isExecuting else { return }
+        guard !tabManager.tabs[index].execution.isExecuting else { return }
 
         if currentQueryTask != nil {
             currentQueryTask?.cancel()
@@ -984,11 +982,11 @@ final class MainContentCoordinator {
         // Batch mutations into a single array write to avoid multiple @Published
         // notifications — each notification triggers a full SwiftUI update cycle.
         var tab = tabManager.tabs[index]
-        tab.isExecuting = true
-        tab.executionTime = nil
-        tab.errorMessage = nil
-        tab.explainText = nil
-        tab.explainPlan = nil
+        tab.execution.isExecuting = true
+        tab.execution.executionTime = nil
+        tab.execution.errorMessage = nil
+        tab.display.explainText = nil
+        tab.display.explainPlan = nil
         tabManager.tabs[index] = tab
         toolbarState.setExecuting(true)
 
@@ -1088,7 +1086,7 @@ final class MainContentCoordinator {
                     // Always reset isExecuting even if generation is stale
                     if capturedGeneration != queryGeneration || Task.isCancelled {
                         if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                            tabManager.tabs[idx].isExecuting = false
+                            tabManager.tabs[idx].execution.isExecuting = false
                         }
                         return
                     }
@@ -1146,7 +1144,7 @@ final class MainContentCoordinator {
                     guard let self else { return }
                     if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
                         var tab = tabManager.tabs[idx]
-                        tab.isExecuting = false
+                        tab.execution.isExecuting = false
                         tab.pagination.isLoadingMore = false
                         tabManager.tabs[idx] = tab
                     }
@@ -1163,7 +1161,7 @@ final class MainContentCoordinator {
     @MainActor
     internal func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
         if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-            tabManager.tabs[idx].isExecuting = false
+            tabManager.tabs[idx].execution.isExecuting = false
         }
         currentQueryTask = nil
         toolbarState.setExecuting(false)
@@ -1175,9 +1173,9 @@ final class MainContentCoordinator {
             || (DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter)?
                 .queryBuildingPluginDriver != nil
         if usesNoSQLBrowsing {
-            let name = tabManager.selectedTab?.tableName
+            let name = tabManager.selectedTab?.tableContext.tableName
             return (name, name != nil)
-        } else if tab.tabType == .table, let existingName = tab.tableName {
+        } else if tab.tabType == .table, let existingName = tab.tableContext.tableName {
             return (existingName, true)
         } else {
             let name = extractTableName(from: sql)
@@ -1337,14 +1335,14 @@ final class MainContentCoordinator {
             if tab.pagination.hasMoreRows {
                 let columnName = tab.resultColumns[columnIndex]
                 let direction = currentSort.columns.first?.direction == .ascending ? "ASC" : "DESC"
-                let baseQuery = tab.pagination.baseQueryForMore ?? tab.query
+                let baseQuery = tab.pagination.baseQueryForMore ?? tab.content.query
                 let strippedQuery = Self.stripTrailingOrderBy(from: baseQuery)
                 let quotedColumn = queryBuilder.quoteIdentifier(columnName)
                 let orderQuery = "\(strippedQuery) ORDER BY \(quotedColumn) \(direction)"
                 tabManager.tabs[tabIndex].sortState = currentSort
                 tabManager.tabs[tabIndex].hasUserInteraction = true
                 tabManager.tabs[tabIndex].pagination.resetLoadMore()
-                tabManager.tabs[tabIndex].query = orderQuery
+                tabManager.tabs[tabIndex].content.query = orderQuery
                 runQuery()
                 return
             }
@@ -1362,7 +1360,7 @@ final class MainContentCoordinator {
                 // Sort on background thread to avoid UI freeze
                 activeSortTasks[tabId]?.cancel()
                 activeSortTasks.removeValue(forKey: tabId)
-                tabManager.tabs[tabIndex].isExecuting = true
+                tabManager.tabs[tabIndex].execution.isExecuting = true
                 toolbarState.setExecuting(true)
                 querySortCache.removeValue(forKey: tabId)
 
@@ -1389,8 +1387,8 @@ final class MainContentCoordinator {
                             resultVersion: resultVersion
                         )
                         var sortedTab = self.tabManager.tabs[idx]
-                        sortedTab.isExecuting = false
-                        sortedTab.executionTime = sortDuration
+                        sortedTab.execution.isExecuting = false
+                        sortedTab.execution.executionTime = sortDuration
                         self.tabManager.tabs[idx] = sortedTab
                         self.toolbarState.setExecuting(false)
                         self.toolbarState.lastQueryDuration = sortDuration
@@ -1408,7 +1406,7 @@ final class MainContentCoordinator {
 
         let tabId = tab.id
         let capturedSort = currentSort
-        let capturedQuery = tab.query
+        let capturedQuery = tab.content.query
         let capturedColumns = tab.resultColumns
         confirmDiscardChangesIfNeeded(action: .sort) { [weak self] confirmed in
             guard let self, confirmed,
@@ -1421,7 +1419,7 @@ final class MainContentCoordinator {
                 sortState: capturedSort,
                 columns: capturedColumns
             )
-            self.tabManager.tabs[idx].query = newQuery
+            self.tabManager.tabs[idx].content.query = newQuery
             self.runQuery()
         }
     }

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -166,7 +166,7 @@ struct MainContentView: View {
             )
         case .exportQueryResults:
             if let tab = coordinator.tabManager.selectedTab {
-                let fileName = tab.tableName ?? "query_results"
+                let fileName = tab.tableContext.tableName ?? "query_results"
                 if tab.pagination.hasMoreRows, let baseQuery = tab.pagination.baseQueryForMore {
                     ExportDialog(
                         isPresented: dismissBinding,
@@ -230,7 +230,7 @@ struct MainContentView: View {
             pendingTruncates: pendingTruncates,
             pendingDeletes: pendingDeletes,
             hasStructureChanges: toolbarState.hasStructureChanges,
-            isFileDirty: tabManager.selectedTab?.isFileDirty ?? false
+            isFileDirty: tabManager.selectedTab?.content.isFileDirty ?? false
         )
     }
 
@@ -242,10 +242,10 @@ struct MainContentView: View {
                     configureWindow(window)
                 }
             }
-            .task(id: currentTab?.tableName) {
+            .task(id: currentTab?.tableContext.tableName) {
                 // Only load metadata after the tab has executed at least once —
                 // avoids a redundant DB query racing with the initial data query
-                guard currentTab?.lastExecutedAt != nil else { return }
+                guard currentTab?.execution.lastExecutedAt != nil else { return }
                 await loadTableMetadataIfNeeded()
             }
             .onChange(of: inspectorTrigger) {
@@ -288,7 +288,7 @@ struct MainContentView: View {
                     let liveTables = DatabaseManager.shared
                         .session(for: connectionId)?.tables ?? []
                     let target: Set<TableInfo>
-                    if let currentTableName = tabManager.selectedTab?.tableName,
+                    if let currentTableName = tabManager.selectedTab?.tableContext.tableName,
                        let match = liveTables.first(where: { $0.name == currentTableName }) {
                         target = [match]
                     } else {
@@ -378,7 +378,7 @@ struct MainContentView: View {
                 let syncAction = SidebarSyncAction.resolveOnTablesLoad(
                     newTables: newTables,
                     selectedTables: sidebarState.selectedTables,
-                    currentTabTableName: tabManager.selectedTab?.tableName
+                    currentTabTableName: tabManager.selectedTab?.tableContext.tableName
                 )
                 if case .select(let tableName) = syncAction,
                     let match = newTables.first(where: { $0.name == tableName })

--- a/TableProTests/Core/Database/MultiConnectionTests.swift
+++ b/TableProTests/Core/Database/MultiConnectionTests.swift
@@ -281,6 +281,6 @@ struct CoordinatorConnectionIsolationTests {
         coordinator.openTableTab("orders")
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.databaseName == "db_a")
+        #expect(tabManager.tabs.first?.tableContext.databaseName == "db_a")
     }
 }

--- a/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
@@ -59,7 +59,7 @@ struct TabPersistenceCoordinatorTests {
         for (original, restored) in zip(tabs, result.tabs) {
             #expect(restored.id == original.id)
             #expect(restored.title == original.title)
-            #expect(restored.query == original.query)
+            #expect(restored.content.query == original.content.query)
             #expect(restored.tabType == original.tabType)
         }
 
@@ -120,7 +120,7 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.tabs.count == 2)
         #expect(result.selectedTabId == selectedId)
         #expect(result.tabs[0].title == "P1")
-        #expect(result.tabs[1].tableName == "users")
+        #expect(result.tabs[1].tableContext.tableName == "users")
         #expect(result.source == .disk)
 
         coordinator.clearSavedState()
@@ -157,7 +157,7 @@ struct TabPersistenceCoordinatorTests {
         let coordinator = makeCoordinator()
         let largeQuery = String(repeating: "A", count: 600_000)
         var tab = QueryTab(id: UUID(), title: "Big", query: largeQuery, tabType: .query)
-        tab.query = largeQuery
+        tab.content.query = largeQuery
 
         coordinator.saveNow(tabs: [tab], selectedTabId: tab.id)
         await sleep()
@@ -165,7 +165,7 @@ struct TabPersistenceCoordinatorTests {
         let result = await coordinator.restoreFromDisk()
 
         #expect(result.tabs.count == 1)
-        #expect(result.tabs[0].query == "")
+        #expect(result.tabs[0].content.query == "")
         #expect(result.tabs[0].title == "Big")
 
         coordinator.clearSavedState()
@@ -297,8 +297,8 @@ struct TabPersistenceCoordinatorTests {
         let coordinator = makeCoordinator()
 
         var tab = QueryTab(id: UUID(), title: "users", query: "SELECT * FROM users", tabType: .table, tableName: "users")
-        tab.isView = true
-        tab.databaseName = "production"
+        tab.tableContext.isView = true
+        tab.tableContext.databaseName = "production"
 
         coordinator.saveNow(tabs: [tab], selectedTabId: tab.id)
         await sleep()
@@ -307,9 +307,9 @@ struct TabPersistenceCoordinatorTests {
 
         #expect(result.tabs.count == 1)
         let restored = result.tabs[0]
-        #expect(restored.tableName == "users")
-        #expect(restored.isView == true)
-        #expect(restored.databaseName == "production")
+        #expect(restored.tableContext.tableName == "users")
+        #expect(restored.tableContext.isView == true)
+        #expect(restored.tableContext.databaseName == "production")
         #expect(restored.id == tab.id)
         #expect(restored.tabType == .table)
 

--- a/TableProTests/Models/EditorTabPayloadTests.swift
+++ b/TableProTests/Models/EditorTabPayloadTests.swift
@@ -134,10 +134,10 @@ struct EditorTabPayloadTests {
         let payload = EditorTabPayload(from: tab, connectionId: connectionId)
         #expect(payload.connectionId == connectionId)
         #expect(payload.tabType == tab.tabType)
-        #expect(payload.tableName == tab.tableName)
-        #expect(payload.databaseName == tab.databaseName)
-        #expect(payload.initialQuery == tab.query)
-        #expect(payload.isView == tab.isView)
-        #expect(payload.showStructure == (tab.resultsViewMode == .structure))
+        #expect(payload.tableName == tab.tableContext.tableName)
+        #expect(payload.databaseName == tab.tableContext.databaseName)
+        #expect(payload.initialQuery == tab.content.query)
+        #expect(payload.isView == tab.tableContext.isView)
+        #expect(payload.showStructure == (tab.display.resultsViewMode == .structure))
     }
 }

--- a/TableProTests/Models/PreviewTabTests.swift
+++ b/TableProTests/Models/PreviewTabTests.swift
@@ -43,7 +43,7 @@ struct PreviewTabTests {
         manager.addPreviewTableTab(tableName: "users", databaseType: .mysql, databaseName: "mydb")
         #expect(manager.tabs.count == 1)
         #expect(manager.selectedTab?.isPreview == true)
-        #expect(manager.selectedTab?.tableName == "users")
+        #expect(manager.selectedTab?.tableContext.tableName == "users")
     }
 
     @Test("replaceTabContent can set isPreview flag")
@@ -59,7 +59,7 @@ struct PreviewTabTests {
         )
         #expect(replaced == true)
         #expect(manager.selectedTab?.isPreview == true)
-        #expect(manager.selectedTab?.tableName == "orders")
+        #expect(manager.selectedTab?.tableContext.tableName == "orders")
     }
 
     @Test("replaceTabContent defaults to non-preview")

--- a/TableProTests/Models/SQLFileDeduplicationTests.swift
+++ b/TableProTests/Models/SQLFileDeduplicationTests.swift
@@ -20,16 +20,16 @@ struct QueryTabSourceFileURLTests {
     func storesSourceFileURL() {
         var tab = QueryTab(title: "Test", tabType: .query)
         let url = URL(fileURLWithPath: "/tmp/test.sql")
-        tab.sourceFileURL = url
+        tab.content.sourceFileURL = url
 
-        #expect(tab.sourceFileURL == url)
+        #expect(tab.content.sourceFileURL == url)
     }
 
     @Test("QueryTab sourceFileURL defaults to nil")
     func defaultsToNil() {
         let tab = QueryTab(title: "Test", tabType: .query)
 
-        #expect(tab.sourceFileURL == nil)
+        #expect(tab.content.sourceFileURL == nil)
     }
 }
 
@@ -46,7 +46,7 @@ struct QueryTabManagerDeduplicationTests {
         tabManager.addTab(initialQuery: "SELECT 1", sourceFileURL: url)
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.sourceFileURL == url)
+        #expect(tabManager.tabs.first?.content.sourceFileURL == url)
     }
 
     @Test("addTab with same sourceFileURL selects existing tab instead of creating duplicate")
@@ -96,7 +96,7 @@ struct QueryTabManagerDeduplicationTests {
         tabManager.addTab(initialQuery: "SELECT 2", sourceFileURL: url)
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.query == "SELECT 2")
+        #expect(tabManager.tabs.first?.content.query == "SELECT 2")
     }
 }
 
@@ -149,7 +149,7 @@ struct SessionStateFactorySourceFileURLTests {
         let state = SessionStateFactory.create(connection: conn, payload: payload)
 
         #expect(state.tabManager.tabs.count == 1)
-        #expect(state.tabManager.tabs.first?.sourceFileURL == url)
+        #expect(state.tabManager.tabs.first?.content.sourceFileURL == url)
     }
 }
 

--- a/TableProTests/Views/Main/CommandActionsDispatchTests.swift
+++ b/TableProTests/Views/Main/CommandActionsDispatchTests.swift
@@ -57,7 +57,7 @@ struct CommandActionsDispatchTests {
         actions.loadQueryIntoEditor("SELECT 1")
 
         let tab = coordinator.tabManager.selectedTab
-        #expect(tab?.query == "SELECT 1")
+        #expect(tab?.content.query == "SELECT 1")
     }
 
     // MARK: - insertQueryFromAI
@@ -70,7 +70,7 @@ struct CommandActionsDispatchTests {
         actions.insertQueryFromAI("SELECT 2")
 
         let tab = coordinator.tabManager.selectedTab
-        #expect(tab?.query == "SELECT 2")
+        #expect(tab?.content.query == "SELECT 2")
     }
 
     @Test("insertQueryFromAI appends to existing query")
@@ -80,13 +80,13 @@ struct CommandActionsDispatchTests {
 
         // Set an initial query on the tab
         if let idx = coordinator.tabManager.selectedTabIndex {
-            coordinator.tabManager.tabs[idx].query = "SELECT 1"
+            coordinator.tabManager.tabs[idx].content.query = "SELECT 1"
         }
 
         actions.insertQueryFromAI("SELECT 2")
 
         let tab = coordinator.tabManager.selectedTab
-        #expect(tab?.query == "SELECT 1\n\nSELECT 2")
+        #expect(tab?.content.query == "SELECT 1\n\nSELECT 2")
     }
 
     // MARK: - copySelectedRows (structure mode)
@@ -98,7 +98,7 @@ struct CommandActionsDispatchTests {
 
         // Enable structure mode on the selected tab
         if let idx = coordinator.tabManager.selectedTabIndex {
-            coordinator.tabManager.tabs[idx].resultsViewMode = .structure
+            coordinator.tabManager.tabs[idx].display.resultsViewMode = .structure
         }
 
         // Install a spy handler
@@ -121,7 +121,7 @@ struct CommandActionsDispatchTests {
 
         // Enable structure mode on the selected tab
         if let idx = coordinator.tabManager.selectedTabIndex {
-            coordinator.tabManager.tabs[idx].resultsViewMode = .structure
+            coordinator.tabManager.tabs[idx].display.resultsViewMode = .structure
         }
 
         // Install a spy handler

--- a/TableProTests/Views/Main/CoordinatorEditorLoadTests.swift
+++ b/TableProTests/Views/Main/CoordinatorEditorLoadTests.swift
@@ -46,7 +46,7 @@ struct CoordinatorEditorLoadTests {
 
         coordinator.loadQueryIntoEditor("SELECT * FROM users")
 
-        #expect(tabManager.tabs[0].query == "SELECT * FROM users")
+        #expect(tabManager.tabs[0].content.query == "SELECT * FROM users")
     }
 
     @Test("loadQueryIntoEditor sets hasUserInteraction to true")
@@ -71,13 +71,13 @@ struct CoordinatorEditorLoadTests {
         defer { coordinator.teardown() }
 
         tabManager.addTableTab(tableName: "users")
-        let originalQuery = tabManager.tabs[0].query
+        let originalQuery = tabManager.tabs[0].content.query
 
         // Falls through to WindowOpener path; table tab unchanged
         coordinator.loadQueryIntoEditor("SELECT * FROM users")
 
         #expect(tabManager.tabs[0].tabType == .table)
-        #expect(tabManager.tabs[0].query == originalQuery)
+        #expect(tabManager.tabs[0].content.query == originalQuery)
     }
 
     @Test("loadQueryIntoEditor does nothing when no tabs exist")
@@ -103,11 +103,11 @@ struct CoordinatorEditorLoadTests {
         defer { coordinator.teardown() }
 
         tabManager.addTab()
-        tabManager.tabs[0].query = ""
+        tabManager.tabs[0].content.query = ""
 
         coordinator.insertQueryFromAI("SELECT * FROM users")
 
-        #expect(tabManager.tabs[0].query == "SELECT * FROM users")
+        #expect(tabManager.tabs[0].content.query == "SELECT * FROM users")
     }
 
     @Test("insertQueryFromAI appends with separator when tab has existing text")
@@ -120,7 +120,7 @@ struct CoordinatorEditorLoadTests {
 
         coordinator.insertQueryFromAI("SELECT 2")
 
-        #expect(tabManager.tabs[0].query == "SELECT 1\n\nSELECT 2")
+        #expect(tabManager.tabs[0].content.query == "SELECT 1\n\nSELECT 2")
     }
 
     @Test("insertQueryFromAI treats whitespace-only text as empty")
@@ -130,11 +130,11 @@ struct CoordinatorEditorLoadTests {
         defer { coordinator.teardown() }
 
         tabManager.addTab()
-        tabManager.tabs[0].query = "   \n  \t  "
+        tabManager.tabs[0].content.query = "   \n  \t  "
 
         coordinator.insertQueryFromAI("SELECT * FROM orders")
 
-        #expect(tabManager.tabs[0].query == "SELECT * FROM orders")
+        #expect(tabManager.tabs[0].content.query == "SELECT * FROM orders")
     }
 
     @Test("insertQueryFromAI sets hasUserInteraction to true")
@@ -158,12 +158,12 @@ struct CoordinatorEditorLoadTests {
         defer { coordinator.teardown() }
 
         tabManager.addTableTab(tableName: "orders")
-        let originalQuery = tabManager.tabs[0].query
+        let originalQuery = tabManager.tabs[0].content.query
 
         coordinator.insertQueryFromAI("SELECT * FROM orders")
 
         #expect(tabManager.tabs[0].tabType == .table)
-        #expect(tabManager.tabs[0].query == originalQuery)
+        #expect(tabManager.tabs[0].content.query == originalQuery)
     }
 
     @Test("insertQueryFromAI does nothing when no tabs exist")

--- a/TableProTests/Views/Main/EvictionTests.swift
+++ b/TableProTests/Views/Main/EvictionTests.swift
@@ -35,7 +35,7 @@ struct EvictionTests {
         let rows = TestFixtures.makeRows(count: 10)
         tabManager.tabs[index].rowBuffer.rows = rows
         tabManager.tabs[index].rowBuffer.columns = ["id", "name", "email"]
-        tabManager.tabs[index].lastExecutedAt = Date()
+        tabManager.tabs[index].execution.lastExecutedAt = Date()
     }
 
     @Test("evictInactiveRowData evicts loaded tabs without pending changes")

--- a/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
+++ b/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
@@ -52,11 +52,11 @@ struct MultiConnectionNavigationTests {
             Issue.record("Expected selected tab index")
             return
         }
-        #expect(tabManager.tabs[idx].resultsViewMode != .structure)
+        #expect(tabManager.tabs[idx].display.resultsViewMode != .structure)
 
         coordinator.openTableTab("users", showStructure: true)
 
-        #expect(tabManager.tabs[idx].resultsViewMode == .structure)
+        #expect(tabManager.tabs[idx].display.resultsViewMode == .structure)
     }
 
     // MARK: - openTableTab: isView marks tab correctly
@@ -75,8 +75,8 @@ struct MultiConnectionNavigationTests {
             Issue.record("Expected a tab to be added")
             return
         }
-        #expect(tab.isView == true)
-        #expect(tab.isEditable == false)
+        #expect(tab.tableContext.isView == true)
+        #expect(tab.tableContext.isEditable == false)
     }
 
     // MARK: - openTableTab: databaseName from connection
@@ -95,7 +95,7 @@ struct MultiConnectionNavigationTests {
             Issue.record("Expected a tab to be added")
             return
         }
-        #expect(tab.databaseName == "primary_db")
+        #expect(tab.tableContext.databaseName == "primary_db")
     }
 
     // Note: sidebarLoadingState guard test lives in SwitchDatabaseTests.swift
@@ -113,8 +113,8 @@ struct MultiConnectionNavigationTests {
         coordinator.openTableTab("accounts")
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.tableName == "accounts")
-        #expect(tabManager.tabs.first?.databaseName == "pg_db")
+        #expect(tabManager.tabs.first?.tableContext.tableName == "accounts")
+        #expect(tabManager.tabs.first?.tableContext.databaseName == "pg_db")
     }
 
     @Test("openTableTab with sqlite connection adds tab")
@@ -128,8 +128,8 @@ struct MultiConnectionNavigationTests {
         coordinator.openTableTab("items")
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.tableName == "items")
-        #expect(tabManager.tabs.first?.databaseName == "local.db")
+        #expect(tabManager.tabs.first?.tableContext.tableName == "items")
+        #expect(tabManager.tabs.first?.tableContext.databaseName == "local.db")
     }
 
     // MARK: - SidebarNavigationResult: skip for all database types
@@ -141,7 +141,7 @@ struct MultiConnectionNavigationTests {
         manager.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "mydb")
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "users",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .skip)
@@ -154,7 +154,7 @@ struct MultiConnectionNavigationTests {
         manager.addTableTab(tableName: "accounts", databaseType: .postgresql, databaseName: "pgdb")
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "accounts",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .skip)
@@ -167,7 +167,7 @@ struct MultiConnectionNavigationTests {
         manager.addTableTab(tableName: "items", databaseType: .sqlite, databaseName: "local.db")
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "items",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .skip)
@@ -223,8 +223,8 @@ struct MultiConnectionNavigationTests {
 
         #expect(tabManagerA.tabs.count == 1)
         #expect(tabManagerB.tabs.count == 2)
-        #expect(tabManagerA.tabs.first?.tableName == "users")
-        #expect(tabManagerB.tabs.first?.tableName == "orders")
+        #expect(tabManagerA.tabs.first?.tableContext.tableName == "users")
+        #expect(tabManagerB.tabs.first?.tableContext.tableName == "orders")
     }
 
     @Test("openTableTab on coordinator A does not affect coordinator B's tabs")
@@ -244,6 +244,6 @@ struct MultiConnectionNavigationTests {
 
         #expect(tabManagerA.tabs.count == 1)
         #expect(tabManagerB.tabs.count == tabCountBefore)
-        #expect(tabManagerB.tabs.first?.tableName == "orders")
+        #expect(tabManagerB.tabs.first?.tableContext.tableName == "orders")
     }
 }

--- a/TableProTests/Views/Main/OpenTableTabTests.swift
+++ b/TableProTests/Views/Main/OpenTableTabTests.swift
@@ -42,6 +42,6 @@ struct OpenTableTabTests {
         coordinator.openTableTab("users")
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.tableName == "users")
+        #expect(tabManager.tabs.first?.tableContext.tableName == "users")
     }
 }

--- a/TableProTests/Views/Main/SaveCompletionTests.swift
+++ b/TableProTests/Views/Main/SaveCompletionTests.swift
@@ -42,7 +42,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        #expect(tabManager.tabs.first?.errorMessage == nil)
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
     }
 
     // MARK: - Read-Only Connection
@@ -64,7 +64,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        let errorMessage = tabManager.tabs.first?.errorMessage
+        let errorMessage = tabManager.tabs.first?.execution.errorMessage
         #expect(errorMessage != nil)
         #expect(errorMessage?.contains("read-only") == true)
     }
@@ -107,7 +107,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        let errorMessage = tabManager.tabs.first?.errorMessage
+        let errorMessage = tabManager.tabs.first?.execution.errorMessage
         #expect(errorMessage != nil)
     }
 
@@ -128,7 +128,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        let errorMessage = tabManager.tabs.first?.errorMessage
+        let errorMessage = tabManager.tabs.first?.execution.errorMessage
         #expect(errorMessage != nil)
         #expect(errorMessage?.contains("read-only") == true)
         #expect(truncates.contains("users"))
@@ -167,7 +167,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        #expect(tabManager.tabs.first?.errorMessage == nil)
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
         #expect(truncates.isEmpty)
         #expect(deletes.isEmpty)
     }
@@ -226,7 +226,7 @@ struct SaveCompletionTests {
             tableOperationOptions: &options
         )
 
-        #expect(tabManager.tabs.first?.errorMessage == nil)
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
         #expect(truncates.isEmpty)
         #expect(deletes.isEmpty)
     }
@@ -257,8 +257,8 @@ struct SaveCompletionTests {
         let (coordinator, tabManager, _) = makeCoordinator(safeModeLevel: .readOnly)
         tabManager.addTab(databaseName: "testdb")
         if let index = tabManager.selectedTabIndex {
-            tabManager.tabs[index].isEditable = true
-            tabManager.tabs[index].tableName = "users"
+            tabManager.tabs[index].tableContext.isEditable = true
+            tabManager.tabs[index].tableContext.tableName = "users"
         }
 
         var selectedRows: Set<Int> = []
@@ -283,8 +283,8 @@ struct SaveCompletionTests {
         let (coordinator, tabManager, _) = makeCoordinator(safeModeLevel: .alert)
         tabManager.addTab(databaseName: "testdb")
         if let index = tabManager.selectedTabIndex {
-            tabManager.tabs[index].isEditable = true
-            tabManager.tabs[index].tableName = "users"
+            tabManager.tabs[index].tableContext.isEditable = true
+            tabManager.tabs[index].tableContext.tableName = "users"
         }
 
         var selectedRows: Set<Int> = []
@@ -292,6 +292,6 @@ struct SaveCompletionTests {
 
         // Alert level doesn't block row staging — only gates at execution time
         coordinator.addNewRow(selectedRowIndices: &selectedRows, editingCell: &editingCell)
-        #expect(tabManager.tabs.first?.errorMessage == nil)
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
     }
 }

--- a/TableProTests/Views/Main/SessionStateFactoryTests.swift
+++ b/TableProTests/Views/Main/SessionStateFactoryTests.swift
@@ -49,7 +49,7 @@ struct SessionStateFactoryTests {
         let state = SessionStateFactory.create(connection: conn, payload: payload)
 
         #expect(state.tabManager.tabs.count == 1)
-        #expect(state.tabManager.tabs.first?.tableName == "users")
+        #expect(state.tabManager.tabs.first?.tableContext.tableName == "users")
         #expect(state.tabManager.tabs.first?.tabType == .table)
     }
 
@@ -67,7 +67,7 @@ struct SessionStateFactoryTests {
         let state = SessionStateFactory.create(connection: conn, payload: payload)
 
         #expect(state.tabManager.tabs.count == 1)
-        #expect(state.tabManager.tabs.first?.query == query)
+        #expect(state.tabManager.tabs.first?.content.query == query)
         #expect(state.tabManager.tabs.first?.tabType == .query)
     }
 
@@ -88,7 +88,7 @@ struct SessionStateFactoryTests {
             Issue.record("Expected at least one tab")
             return
         }
-        #expect(tab.resultsViewMode == .structure)
+        #expect(tab.display.resultsViewMode == .structure)
     }
 
     @Test("Payload with isView sets isView and clears isEditable")
@@ -108,8 +108,8 @@ struct SessionStateFactoryTests {
             Issue.record("Expected at least one tab")
             return
         }
-        #expect(tab.isView == true)
-        #expect(tab.isEditable == false)
+        #expect(tab.tableContext.isView == true)
+        #expect(tab.tableContext.isEditable == false)
     }
 
     @Test("Nil payload creates empty tab manager")
@@ -164,7 +164,7 @@ struct SessionStateFactoryTests {
 
         // Equivalent content
         #expect(state1.tabManager.tabs.count == state2.tabManager.tabs.count)
-        #expect(state1.tabManager.tabs.first?.tableName == state2.tabManager.tabs.first?.tableName)
+        #expect(state1.tabManager.tabs.first?.tableContext.tableName == state2.tabManager.tabs.first?.tableContext.tableName)
     }
 
     @Test("Coordinator receives the factory's tabManager")

--- a/TableProTests/Views/Main/TabEvictionTests.swift
+++ b/TableProTests/Views/Main/TabEvictionTests.swift
@@ -28,7 +28,7 @@ struct TabEvictionTests {
         hasUnsavedChanges: Bool = false
     ) -> QueryTab {
         var tab = QueryTab(id: id, title: "Test", query: "SELECT 1", tabType: tabType)
-        tab.lastExecutedAt = lastExecutedAt
+        tab.execution.lastExecutedAt = lastExecutedAt
 
         if rowCount > 0 {
             let rows = makeTestRows(count: rowCount)
@@ -117,7 +117,7 @@ struct TabEvictionTests {
 
         let isCandidate = !tab.rowBuffer.isEvicted
             && !tab.resultRows.isEmpty
-            && tab.lastExecutedAt != nil
+            && tab.execution.lastExecutedAt != nil
             && !tab.pendingChanges.hasChanges
 
         #expect(isCandidate == false)
@@ -139,7 +139,7 @@ struct TabEvictionTests {
             !activeTabIds.contains($0.id)
                 && !$0.rowBuffer.isEvicted
                 && !$0.resultRows.isEmpty
-                && $0.lastExecutedAt != nil
+                && $0.execution.lastExecutedAt != nil
                 && !$0.pendingChanges.hasChanges
         }
 
@@ -164,12 +164,12 @@ struct TabEvictionTests {
             !activeTabIds.contains($0.id)
                 && !$0.rowBuffer.isEvicted
                 && !$0.resultRows.isEmpty
-                && $0.lastExecutedAt != nil
+                && $0.execution.lastExecutedAt != nil
                 && !$0.pendingChanges.hasChanges
         }
 
         let sorted = candidates.sorted {
-            ($0.lastExecutedAt ?? .distantFuture) < ($1.lastExecutedAt ?? .distantFuture)
+            ($0.execution.lastExecutedAt ?? .distantFuture) < ($1.execution.lastExecutedAt ?? .distantFuture)
         }
 
         let maxInactiveLoaded = 2
@@ -210,12 +210,12 @@ struct TabEvictionTests {
             !activeTabIds.contains($0.id)
                 && !$0.rowBuffer.isEvicted
                 && !$0.resultRows.isEmpty
-                && $0.lastExecutedAt != nil
+                && $0.execution.lastExecutedAt != nil
                 && !$0.pendingChanges.hasChanges
         }
 
         let sorted = candidates.sorted {
-            ($0.lastExecutedAt ?? .distantFuture) < ($1.lastExecutedAt ?? .distantFuture)
+            ($0.execution.lastExecutedAt ?? .distantFuture) < ($1.execution.lastExecutedAt ?? .distantFuture)
         }
 
         let maxInactiveLoaded = 2

--- a/TableProTests/Views/SidebarNavigationResultTests.swift
+++ b/TableProTests/Views/SidebarNavigationResultTests.swift
@@ -161,7 +161,7 @@ struct SidebarNavigationResultTests {
         // Fresh manager has no tabs
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "users",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .openInPlace)
@@ -174,7 +174,7 @@ struct SidebarNavigationResultTests {
         manager.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "mydb")
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "users",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .skip)
@@ -187,7 +187,7 @@ struct SidebarNavigationResultTests {
         manager.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "mydb")
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "orders",
-            currentTabTableName: manager.selectedTab?.tableName,
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .revertAndOpenNewWindow)
@@ -200,7 +200,7 @@ struct SidebarNavigationResultTests {
         manager.addTab(databaseName: "mydb")   // query tab — no tableName
         let result = SidebarNavigationResult.resolve(
             clickedTableName: "products",
-            currentTabTableName: manager.selectedTab?.tableName,  // nil for query tab
+            currentTabTableName: manager.selectedTab?.tableContext.tableName,  // nil for query tab
             hasExistingTabs: !manager.tabs.isEmpty
         )
         #expect(result == .revertAndOpenNewWindow)
@@ -238,7 +238,7 @@ struct SidebarNavigationResultTests {
     func syncClearsSelectionForQueryTab() {
         let manager = QueryTabManager()
         manager.addTab(databaseName: "mydb")          // query tab: tableName == nil
-        let currentTableName = manager.selectedTab?.tableName
+        let currentTableName = manager.selectedTab?.tableContext.tableName
         // When tableName is nil, syncSidebarToCurrentTab sets selectedTables = []
         #expect(currentTableName == nil)
     }
@@ -248,7 +248,7 @@ struct SidebarNavigationResultTests {
     func syncSetsSelectionForTableTab() {
         let manager = QueryTabManager()
         manager.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "mydb")
-        let currentTableName = manager.selectedTab?.tableName
+        let currentTableName = manager.selectedTab?.tableContext.tableName
         #expect(currentTableName == "users")
         // syncSidebarToCurrentTab will find "users" in tables and set selectedTables = [users]
     }

--- a/TableProTests/Views/SwitchDatabaseTests.swift
+++ b/TableProTests/Views/SwitchDatabaseTests.swift
@@ -108,7 +108,7 @@ struct SwitchDatabaseTests {
         coordinator.openTableTab("users")
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.tabs.first?.tableName == "users")
+        #expect(tabManager.tabs.first?.tableContext.tableName == "users")
     }
 
     // MARK: - openTableTab fast path (same table + same database)


### PR DESCRIPTION
## Summary

- QueryTab decomposed from 28+ property monolith into 4 focused sub-types: `TabExecutionState`, `TabTableContext`, `TabQueryContent`, `TabDisplayState`
- NO forwarding accessors, NO backward compatibility. All 256+ call sites across 55 files migrated to clean sub-type paths
- `tab.isExecuting` → `tab.execution.isExecuting`, `tab.tableName` → `tab.tableContext.tableName`, `tab.query` → `tab.content.query`, etc.
- Updated `==`, both `init` methods, `toPersistedTab()`, all coordinator extensions, views, and tests
- Net -84 lines (600 added, 684 removed)

## Test plan

- [ ] Build passes
- [ ] All existing tests pass
- [ ] Open table tab, verify data loads and displays correctly
- [ ] Execute query, verify execution state (spinner, timing, error) works
- [ ] Edit cell, save changes, verify change tracking works
- [ ] Switch tabs, verify state is preserved (sort, filter, selection, pending changes)
- [ ] Open file, edit, verify dirty state detection works
- [ ] Run EXPLAIN, verify explain display works
- [ ] Multi-statement query, verify result set tabs work