### PR TITLE
refactor(datagrid): replace NotificationCenter dispatch with delegate calls for row actions

### DIFF
--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -51,23 +51,28 @@ final class DataTabGridDelegate: DataGridViewDelegate {
     }
 
     func dataGridDeleteRows(_ indices: Set<Int>) {
-        NotificationCenter.default.post(
-            name: .deleteSelectedRows,
-            object: nil,
-            userInfo: ["rowIndices": indices]
-        )
+        coordinator?.deleteSelectedRows(indices: indices)
     }
 
     func dataGridCopyRows(_ indices: Set<Int>) {
-        NotificationCenter.default.post(
-            name: .copySelectedRows,
-            object: nil,
-            userInfo: ["rowIndices": indices]
-        )
+        coordinator?.copySelectedRowsToClipboard(indices: indices)
     }
 
     func dataGridPasteRows() {
-        NotificationCenter.default.post(name: .pasteRows, object: nil)
+        var cell = editingCell?.wrappedValue
+        coordinator?.pasteRows(editingCell: &cell)
+        editingCell?.wrappedValue = cell
+    }
+
+    func dataGridDuplicateRow() {
+        guard let selectionState, let firstIndex = selectionState.indices.first else { return }
+        var cell = editingCell?.wrappedValue
+        coordinator?.duplicateSelectedRow(index: firstIndex, editingCell: &cell)
+        editingCell?.wrappedValue = cell
+    }
+
+    func dataGridExportResults() {
+        NotificationCenter.default.post(name: .exportQueryResults, object: nil)
     }
 
     func dataGridUndo() {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -807,7 +807,7 @@ struct MainEditorContentView: View {
 
     private func statusBar(tab: QueryTab) -> some View {
         MainStatusBarView(
-            tab: tab,
+            snapshot: StatusBarSnapshot(tab: tab),
             filterStateManager: filterStateManager,
             columnVisibilityManager: columnVisibilityManager,
             allColumns: tab.resultColumns,

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -7,9 +7,30 @@
 
 import SwiftUI
 
-/// Status bar at the bottom of the results section
+struct StatusBarSnapshot: Equatable {
+    let tabId: UUID?
+    let tabType: TabType?
+    let hasRows: Bool
+    let hasColumns: Bool
+    let rowCount: Int
+    let hasTableName: Bool
+    let pagination: PaginationState
+    let statusMessage: String?
+
+    init(tab: QueryTab?) {
+        self.tabId = tab?.id
+        self.tabType = tab?.tabType
+        self.hasRows = !(tab?.resultRows.isEmpty ?? true)
+        self.hasColumns = !(tab?.resultColumns.isEmpty ?? true)
+        self.rowCount = tab?.resultRows.count ?? 0
+        self.hasTableName = tab?.tableContext.tableName != nil
+        self.pagination = tab?.pagination ?? PaginationState()
+        self.statusMessage = tab?.execution.statusMessage
+    }
+}
+
 struct MainStatusBarView: View {
-    let tab: QueryTab?
+    let snapshot: StatusBarSnapshot
     let filterStateManager: FilterStateManager
     let columnVisibilityManager: ColumnVisibilityManager
     let allColumns: [String]
@@ -33,9 +54,8 @@ struct MainStatusBarView: View {
 
     var body: some View {
         HStack {
-            // Left: View mode toggle
-            if let tab = tab {
-                if tab.tabType == .table, tab.tableContext.tableName != nil {
+            if snapshot.tabId != nil {
+                if snapshot.tabType == .table, snapshot.hasTableName {
                     Picker(String(localized: "View Mode"), selection: $viewMode) {
                         Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
                         Label("Structure", systemImage: "list.bullet.rectangle").tag(ResultsViewMode.structure)
@@ -45,7 +65,7 @@ struct MainStatusBarView: View {
                     .pickerStyle(.segmented)
                     .frame(width: 260)
                     .controlSize(.small)
-                } else if !tab.resultColumns.isEmpty {
+                } else if snapshot.hasColumns {
                     Picker(String(localized: "View Mode"), selection: $viewMode) {
                         Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
                         Label("JSON", systemImage: "curlybraces").tag(ResultsViewMode.json)
@@ -60,21 +80,21 @@ struct MainStatusBarView: View {
             Spacer()
 
             // Center: Row info (selection or pagination summary) and status message
-            if let tab = tab, !tab.resultRows.isEmpty {
+            if snapshot.hasRows {
                 HStack(spacing: 4) {
-                    if tab.pagination.isLoadingMore {
+                    if snapshot.pagination.isLoadingMore {
                         ProgressView()
                             .controlSize(.mini)
                         Text("Loading…")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        Text(rowInfoText(for: tab))
+                        Text(rowInfoText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
 
-                    if tab.tabType == .query && tab.pagination.hasMoreRows && !tab.pagination.isLoadingMore {
+                    if snapshot.tabType == .query && snapshot.pagination.hasMoreRows && !snapshot.pagination.isLoadingMore {
                         Text("—")
                             .font(.caption)
                             .foregroundStyle(.quaternary)
@@ -100,7 +120,7 @@ struct MainStatusBarView: View {
                         .foregroundStyle(.secondary)
                     }
 
-                    if let statusMessage = tab.execution.statusMessage {
+                    if let statusMessage = snapshot.statusMessage {
                         Text("·")
                             .foregroundStyle(.tertiary)
                         Text(statusMessage)
@@ -115,7 +135,7 @@ struct MainStatusBarView: View {
             // Right: Columns, Filters toggle and Pagination controls
             HStack(spacing: 8) {
                 // Columns visibility button (works for both table and query tabs)
-                if let tab = tab, !tab.resultColumns.isEmpty {
+                if snapshot.hasColumns {
                     Button {
                         showColumnPopover.toggle()
                     } label: {
@@ -141,7 +161,7 @@ struct MainStatusBarView: View {
                 }
 
                 // Filters toggle button
-                if let tab = tab, tab.tabType == .table, tab.tableContext.tableName != nil {
+                if snapshot.tabType == .table, snapshot.hasTableName {
                     Toggle(isOn: Binding(
                         get: { filterStateManager.isVisible },
                         set: { _ in filterStateManager.toggle() }
@@ -163,10 +183,10 @@ struct MainStatusBarView: View {
                 }
 
                 // Pagination controls for table tabs
-                if let tab = tab, tab.tabType == .table, tab.tableContext.tableName != nil,
-                   let total = tab.pagination.totalRowCount, total > 0 {
+                if snapshot.tabType == .table, snapshot.hasTableName,
+                   let total = snapshot.pagination.totalRowCount, total > 0 {
                     PaginationControlsView(
-                        pagination: tab.pagination,
+                        pagination: snapshot.pagination,
                         onFirst: onFirstPage,
                         onPrevious: onPreviousPage,
                         onNext: onNextPage,
@@ -181,16 +201,16 @@ struct MainStatusBarView: View {
         .padding(.horizontal, 0)
         .padding(.vertical, 4)
         .background(Color(nsColor: .controlBackgroundColor))
-        .onChange(of: tab?.id) { _, _ in
+        .onChange(of: snapshot.tabId) { _, _ in
             showColumnPopover = false
         }
     }
 
     /// Generate row info text based on selection and pagination state
-    private func rowInfoText(for tab: QueryTab) -> String {
-        let loadedCount = tab.resultRows.count
+    private var rowInfoText: String {
+        let loadedCount = snapshot.rowCount
         let selectedCount = selectedRowIndices.count
-        let pagination = tab.pagination
+        let pagination = snapshot.pagination
         let total = pagination.totalRowCount
 
         if selectedCount > 0 {
@@ -199,7 +219,7 @@ struct MainStatusBarView: View {
             } else {
                 return String(format: String(localized: "%d of %d rows selected"), selectedCount, loadedCount)
             }
-        } else if tab.tabType == .query && pagination.hasMoreRows {
+        } else if snapshot.tabType == .query && pagination.hasMoreRows {
             let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
             if let total = total, total > 0 {
                 let formattedTotal = total.formatted(.number.grouping(.automatic))
@@ -207,7 +227,7 @@ struct MainStatusBarView: View {
                 return String(format: String(localized: "%@ of %@%@ rows"), formattedCount, prefix, formattedTotal)
             }
             return String(format: String(localized: "%@ rows (more available)"), formattedCount)
-        } else if tab.tabType == .table, let total = total, total > 0 {
+        } else if snapshot.tabType == .table, let total = total, total > 0 {
             let formattedTotal = total.formatted(.number.grouping(.automatic))
             let prefix = pagination.isApproximateRowCount ? "~" : ""
 

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -268,7 +268,22 @@ extension MainContentView {
             }
         }
 
-        // Lazy-load full values for excluded columns when a single row is selected
+    }
+
+    func lazyLoadExcludedColumnsIfNeeded() {
+        guard let tab = coordinator.tabManager.selectedTab else { return }
+        let selectedIndices = coordinator.selectionState.indices
+
+        let excludedNames: Set<String>
+        if let tableName = tab.tableContext.tableName {
+            excludedNames = Set(coordinator.columnExclusions(for: tableName).map(\.columnName))
+        } else {
+            excludedNames = []
+        }
+
+        let capturedCoordinator = coordinator
+        let capturedEditState = rightPanelState.editState
+
         if !excludedNames.isEmpty,
             selectedIndices.count == 1,
             let tableName = tab.tableContext.tableName,

--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -62,13 +62,16 @@ extension MainContentView {
 
     // MARK: - Inspector Context
 
-    func scheduleInspectorUpdate() {
+    func scheduleInspectorUpdate(lazyLoadExcludedColumns: Bool = false) {
         updateSidebarEditState()
         inspectorUpdateTask?.cancel()
         inspectorUpdateTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(50))
             guard !Task.isCancelled else { return }
             updateInspectorContext()
+            if lazyLoadExcludedColumns {
+                lazyLoadExcludedColumnsIfNeeded()
+            }
         }
     }
 

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -425,7 +425,7 @@ struct MainContentView: View {
                 {
                     coordinator.inspectorProxy?.showInspector()
                 }
-                scheduleInspectorUpdate()
+                scheduleInspectorUpdate(lazyLoadExcludedColumns: true)
             },
             onFilterColumn: { columnName in
                 filterStateManager.addFilterForColumn(columnName)

--- a/TablePro/Views/Results/DataGridCellFactory.swift
+++ b/TablePro/Views/Results/DataGridCellFactory.swift
@@ -228,6 +228,7 @@ final class DataGridCellFactory {
             }
         }
 
+<<<<<<< HEAD
         if showFK {
             gridCellView.textFieldTrailing?.constant = -22
         } else if showChevron {

--- a/TablePro/Views/Results/DataGridCellFactory.swift
+++ b/TablePro/Views/Results/DataGridCellFactory.swift
@@ -228,7 +228,6 @@ final class DataGridCellFactory {
             }
         }
 
-<<<<<<< HEAD
         if showFK {
             gridCellView.textFieldTrailing?.constant = -22
         } else if showChevron {

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -273,8 +273,7 @@ struct DataGridView: NSViewRepresentable {
         // Only do full reload if row/column count changed, columns changed, or result version changed
         // For cell edits (versionChanged but same count), use granular reload
         let structureChanged = oldRowCount != newRowCount || oldColumnCount != newColumnCount
-        let resultVersionChanged = previousIdentity.map { $0.resultVersion != resultVersion } ?? false
-        let needsFullReload = structureChanged || resultVersionChanged
+        let needsFullReload = structureChanged
 
         coordinator.rowProvider = rowProvider
 
@@ -564,19 +563,14 @@ struct DataGridView: NSViewRepresentable {
                 }
             }
         } else if versionChanged {
-            // Granular reload: only reload rows that changed
             let changedRows = changeManager.consumeChangedRowIndices()
             if changedRows.count > 500 {
-                // Too many changed rows — full reload is faster than granular
                 tableView.reloadData()
             } else if !changedRows.isEmpty {
-                // Some rows changed → granular reload for performance
                 let rowIndexSet = IndexSet(changedRows)
                 let columnIndexSet = IndexSet(integersIn: 0..<tableView.numberOfColumns)
                 tableView.reloadData(forRowIndexes: rowIndexSet, columnIndexes: columnIndexSet)
-            } else {
-                // Version changed but no specific rows tracked → full reload
-                // Covers: undo/redo operations, cleared changes (refresh), etc.
+            } else if !changeManager.hasChanges {
                 tableView.reloadData()
             }
         }

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -21,6 +21,8 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridSort(column: Int, ascending: Bool, isMultiSort: Bool)
     func dataGridFilterColumn(_ columnName: String)
     func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo)
+    func dataGridDuplicateRow()
+    func dataGridExportResults()
     func dataGridHideColumn(_ columnName: String)
     func dataGridShowAllColumns()
     func dataGridRefresh()
@@ -42,6 +44,8 @@ extension DataGridViewDelegate {
     func dataGridSort(column: Int, ascending: Bool, isMultiSort: Bool) {}
     func dataGridFilterColumn(_ columnName: String) {}
     func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo) {}
+    func dataGridDuplicateRow() {}
+    func dataGridExportResults() {}
     func dataGridHideColumn(_ columnName: String) {}
     func dataGridShowAllColumns() {}
     func dataGridRefresh() {}

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -66,13 +66,8 @@ final class KeyHandlingTableView: NSTableView {
         let clickedRow = row(at: point)
         let clickedColumn = column(at: point)
 
-        // Double-click in empty area adds a new row
         if event.clickCount == 2 && clickedRow == -1 && coordinator?.isEditable == true {
-            if let delegate = coordinator?.delegate {
-                delegate.dataGridAddRow()
-            } else {
-                NotificationCenter.default.post(name: .addNewRow, object: nil)
-            }
+            coordinator?.delegate?.dataGridAddRow()
             return
         }
 
@@ -106,30 +101,14 @@ final class KeyHandlingTableView: NSTableView {
 
     // MARK: - Standard Edit Menu Actions
 
-    /// Delete selected rows - called from menu or keyboard shortcut
     @objc func delete(_ sender: Any?) {
         guard coordinator?.isEditable == true else { return }
         guard !selectedRowIndexes.isEmpty else { return }
-
-        if let delegate = coordinator?.delegate {
-            delegate.dataGridDeleteRows(Set(selectedRowIndexes))
-        } else {
-            NotificationCenter.default.post(
-                name: .deleteSelectedRows,
-                object: nil,
-                userInfo: ["rowIndices": Set(selectedRowIndexes)]
-            )
-        }
+        coordinator?.delegate?.dataGridDeleteRows(Set(selectedRowIndexes))
     }
 
-    /// Copy selected rows to clipboard
     @objc func copy(_ sender: Any?) {
-        let indices = Set(selectedRowIndexes)
-        if let delegate = coordinator?.delegate {
-            delegate.dataGridCopyRows(indices)
-        } else {
-            coordinator?.copyRows(at: indices)
-        }
+        coordinator?.delegate?.dataGridCopyRows(Set(selectedRowIndexes))
     }
 
     /// Paste rows from clipboard

--- a/TablePro/Views/Results/TableRowViewWithMenu.swift
+++ b/TablePro/Views/Results/TableRowViewWithMenu.swift
@@ -199,19 +199,11 @@ final class TableRowViewWithMenu: NSTableRowView {
         } else {
             [rowIndex]
         }
-        if let delegate = coordinator?.delegate {
-            delegate.dataGridDeleteRows(indices)
-        } else {
-            NotificationCenter.default.post(
-                name: .deleteSelectedRows,
-                object: nil,
-                userInfo: ["rowIndices": indices]
-            )
-        }
+        coordinator?.delegate?.dataGridDeleteRows(indices)
     }
 
     @objc private func duplicateRow() {
-        NotificationCenter.default.post(name: .duplicateRow, object: nil)
+        coordinator?.delegate?.dataGridDuplicateRow()
     }
 
     @objc private func undoDeleteRow() {
@@ -220,15 +212,6 @@ final class TableRowViewWithMenu: NSTableRowView {
 
     @objc private func undoInsertRow() {
         coordinator?.undoInsertRow(at: rowIndex)
-    }
-
-    @objc private func copyRow() {
-        coordinator?.copyRows(at: [rowIndex])
-    }
-
-    @objc private func copySelectedRows() {
-        guard let selectedIndices = coordinator?.selectedRowIndices else { return }
-        coordinator?.copyRows(at: selectedIndices)
     }
 
     @objc private func copySelectedOrCurrentRowWithHeaders() {
@@ -244,19 +227,11 @@ final class TableRowViewWithMenu: NSTableRowView {
         let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
             ? coordinator.selectedRowIndices
             : [rowIndex]
-        if let delegate = coordinator.delegate {
-            delegate.dataGridCopyRows(indices)
-        } else {
-            coordinator.copyRows(at: indices)
-        }
+        coordinator.delegate?.dataGridCopyRows(indices)
     }
 
     @objc private func pasteRows() {
-        if let delegate = coordinator?.delegate {
-            delegate.dataGridPasteRows()
-        } else {
-            NotificationCenter.default.post(name: .pasteRows, object: nil)
-        }
+        coordinator?.delegate?.dataGridPasteRows()
     }
 
     @objc private func copyCellValue(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary

- Removed dual-path action dispatch (delegate + NotificationCenter fallback) from all DataGrid row actions
- All actions now use delegate-only calls: delete, copy, paste, duplicate, add row
- Added `dataGridDuplicateRow()` and `dataGridExportResults()` to `DataGridViewDelegate` protocol
- Deleted dead `copyRow()` and `copySelectedRows()` methods from `TableRowViewWithMenu`
- `DataTabGridDelegate` now calls coordinator methods directly instead of posting NC notifications
- Export keeps NC (window-level command, not a grid action)
- 4 files changed, net -28 lines

## Test plan

- [ ] Delete rows via context menu and Delete key
- [ ] Copy rows via context menu and Cmd+C
- [ ] Paste rows via context menu and Cmd+V
- [ ] Duplicate row via context menu
- [ ] Double-click empty area to add row
- [ ] Undo/redo after each operation
- [ ] Export results from context menu