### PR TITLE
test: repair test target after datagrid refactors

### DIFF
--- a/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
+++ b/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
@@ -41,7 +41,8 @@ struct SQLStatementGenerator {
         self.primaryKeyColumns = primaryKeyColumns
         self.databaseType = databaseType
         self.parameterStyle = parameterStyle ?? Self.defaultParameterStyle(for: databaseType)
-        self.quoteIdentifierFn = quoteIdentifier ?? quoteIdentifierFromDialect(dialect)
+        let resolvedDialect = resolveSQLDialect(for: databaseType, explicit: dialect)
+        self.quoteIdentifierFn = quoteIdentifier ?? quoteIdentifierFromDialect(resolvedDialect)
     }
 
     private static func defaultParameterStyle(for databaseType: DatabaseType) -> ParameterStyle {

--- a/TablePro/Core/Plugins/TableOperationStatementProvider.swift
+++ b/TablePro/Core/Plugins/TableOperationStatementProvider.swift
@@ -1,0 +1,19 @@
+//
+//  TableOperationStatementProvider.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Source of dialect-specific table operation SQL (TRUNCATE, DROP, FK toggles).
+/// Conformance is provided by PluginDriverAdapter for runtime use, and
+/// can be substituted by tests to exercise table-operation paths without a
+/// live driver session.
+protocol TableOperationStatementProvider: AnyObject {
+    func truncateTableStatements(table: String, schema: String?, cascade: Bool) -> [String]
+    func dropObjectStatement(name: String, objectType: String, schema: String?, cascade: Bool) -> String
+    func foreignKeyDisableStatements() -> [String]?
+    func foreignKeyEnableStatements() -> [String]?
+}
+
+extension PluginDriverAdapter: TableOperationStatementProvider {}

--- a/TablePro/Core/Utilities/SQL/DialectQuoteHelper.swift
+++ b/TablePro/Core/Utilities/SQL/DialectQuoteHelper.swift
@@ -24,3 +24,14 @@ func quoteIdentifierFromDialect(_ dialect: SQLDialectDescriptor?) -> (String) ->
         return "\(q)\(escaped)\(q)"
     }
 }
+
+/// Resolve a SQL dialect for a given database type, falling back to the
+/// plugin metadata registry when no explicit dialect is supplied.
+/// Returns nil for NoSQL databases (no SQL dialect registered).
+func resolveSQLDialect(
+    for databaseType: DatabaseType,
+    explicit: SQLDialectDescriptor? = nil
+) -> SQLDialectDescriptor? {
+    if let explicit { return explicit }
+    return PluginMetadataRegistry.shared.snapshot(forTypeId: databaseType.pluginTypeId)?.editor.sqlDialect
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
@@ -10,9 +10,12 @@ import Foundation
 extension MainContentCoordinator {
     // MARK: - Plugin Adapter Access
 
-    /// Returns the current connection's PluginDriverAdapter, if available.
-    private var currentPluginDriverAdapter: PluginDriverAdapter? {
-        DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter
+    /// Returns the current connection's TableOperationStatementProvider, if available.
+    /// Defaults to the live `PluginDriverAdapter` resolved via DatabaseManager;
+    /// `tableOperationOverride` lets tests substitute a fake without a live session.
+    private var currentPluginDriverAdapter: TableOperationStatementProvider? {
+        if let override = tableOperationOverride { return override }
+        return DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter
     }
 
     // MARK: - Table Operation SQL Generation

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -99,6 +99,10 @@ final class MainContentCoordinator {
     /// Stable identifier for this coordinator's window (set by MainContentView on appear)
     var windowId: UUID?
 
+    /// Test seam: when set, replaces the live PluginDriverAdapter for table operation SQL.
+    /// Production code never assigns this; tests inject a fake to exercise truncate/drop paths.
+    @ObservationIgnored var tableOperationOverride: TableOperationStatementProvider?
+
     /// Direct reference to sidebar viewmodel — eliminates global notification broadcasts
     weak var sidebarViewModel: SidebarViewModel?
 

--- a/TableProTests/Core/ChangeTracking/AnyChangeManagerTests.swift
+++ b/TableProTests/Core/ChangeTracking/AnyChangeManagerTests.swift
@@ -18,7 +18,7 @@ struct AnyChangeManagerTests {
     func dataManagerHasChangesForwards() {
         let dataManager = DataChangeManager()
         dataManager.configureForTable(tableName: "users", columns: ["id", "name"], primaryKeyColumns: ["id"])
-        let wrapper = AnyChangeManager(dataManager: dataManager)
+        let wrapper = AnyChangeManager(dataManager)
 
         #expect(wrapper.hasChanges == false)
 
@@ -32,7 +32,7 @@ struct AnyChangeManagerTests {
     func dataManagerReloadVersionForwards() {
         let dataManager = DataChangeManager()
         dataManager.configureForTable(tableName: "users", columns: ["id", "name"], primaryKeyColumns: ["id"])
-        let wrapper = AnyChangeManager(dataManager: dataManager)
+        let wrapper = AnyChangeManager(dataManager)
 
         let initialVersion = wrapper.reloadVersion
         dataManager.reloadVersion += 1
@@ -44,7 +44,7 @@ struct AnyChangeManagerTests {
     func isRowDeletedDelegatesCorrectly() {
         let dataManager = DataChangeManager()
         dataManager.configureForTable(tableName: "users", columns: ["id", "name"], primaryKeyColumns: ["id"])
-        let wrapper = AnyChangeManager(dataManager: dataManager)
+        let wrapper = AnyChangeManager(dataManager)
 
         #expect(wrapper.isRowDeleted(0) == false)
 
@@ -57,12 +57,12 @@ struct AnyChangeManagerTests {
     func recordCellChangeForwards() {
         let dataManager = DataChangeManager()
         dataManager.configureForTable(tableName: "users", columns: ["id", "name"], primaryKeyColumns: ["id"])
-        let wrapper = AnyChangeManager(dataManager: dataManager)
+        let wrapper = AnyChangeManager(dataManager)
 
         wrapper.recordCellChange(rowIndex: 0, columnIndex: 1, columnName: "name", oldValue: "Alice", newValue: "Bob", originalRow: ["1", "Alice"])
 
         #expect(dataManager.hasChanges == true)
-        #expect(!wrapper.changes.isEmpty)
+        #expect(!wrapper.rowChanges.isEmpty)
     }
 
     @Test("No retain cycle — wrapper can be deallocated")
@@ -73,7 +73,7 @@ struct AnyChangeManagerTests {
         weak var weakWrapper: AnyChangeManager?
 
         do {
-            let wrapper = AnyChangeManager(dataManager: dataManager)
+            let wrapper = AnyChangeManager(dataManager)
             weakWrapper = wrapper
             #expect(weakWrapper != nil)
         }
@@ -86,7 +86,7 @@ struct AnyChangeManagerTests {
     @Test("StructureChangeManager wrapper: isRowDeleted always returns false")
     func structureManagerIsRowDeletedAlwaysFalse() {
         let structureManager = StructureChangeManager()
-        let wrapper = AnyChangeManager(structureManager: structureManager)
+        let wrapper = AnyChangeManager(structureManager)
 
         #expect(wrapper.isRowDeleted(0) == false)
         #expect(wrapper.isRowDeleted(100) == false)
@@ -95,7 +95,7 @@ struct AnyChangeManagerTests {
     @Test("StructureChangeManager wrapper: consumeChangedRowIndices returns empty set")
     func structureManagerConsumeChangedRowIndicesEmpty() {
         let structureManager = StructureChangeManager()
-        let wrapper = AnyChangeManager(structureManager: structureManager)
+        let wrapper = AnyChangeManager(structureManager)
 
         let indices = wrapper.consumeChangedRowIndices()
         #expect(indices.isEmpty)
@@ -104,7 +104,7 @@ struct AnyChangeManagerTests {
     @Test("StructureChangeManager wrapper: hasChanges forwards correctly when false")
     func structureManagerHasChangesForwardsFalse() {
         let structureManager = StructureChangeManager()
-        let wrapper = AnyChangeManager(structureManager: structureManager)
+        let wrapper = AnyChangeManager(structureManager)
 
         #expect(wrapper.hasChanges == false)
     }
@@ -112,7 +112,7 @@ struct AnyChangeManagerTests {
     @Test("StructureChangeManager wrapper: hasChanges forwards correctly when true")
     func structureManagerHasChangesForwardsTrue() {
         let structureManager = StructureChangeManager()
-        let wrapper = AnyChangeManager(structureManager: structureManager)
+        let wrapper = AnyChangeManager(structureManager)
 
         structureManager.addNewColumn()
 
@@ -122,7 +122,7 @@ struct AnyChangeManagerTests {
     @Test("StructureChangeManager wrapper: reloadVersion forwards correctly")
     func structureManagerReloadVersionForwards() {
         let structureManager = StructureChangeManager()
-        let wrapper = AnyChangeManager(structureManager: structureManager)
+        let wrapper = AnyChangeManager(structureManager)
 
         let initialVersion = wrapper.reloadVersion
         structureManager.reloadVersion = 5

--- a/TableProTests/Helpers/FakeTableOperationProvider.swift
+++ b/TableProTests/Helpers/FakeTableOperationProvider.swift
@@ -1,0 +1,25 @@
+//
+//  FakeTableOperationProvider.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+
+/// Minimal test double for `TableOperationStatementProvider`.
+/// Returns ANSI-style SQL so tests can drive coordinator save paths without a live driver.
+final class FakeTableOperationProvider: TableOperationStatementProvider {
+    func truncateTableStatements(table: String, schema: String?, cascade: Bool) -> [String] {
+        let qualified = schema.map { "\($0).\(table)" } ?? table
+        return ["TRUNCATE TABLE \(qualified)\(cascade ? " CASCADE" : "")"]
+    }
+
+    func dropObjectStatement(name: String, objectType: String, schema: String?, cascade: Bool) -> String {
+        let qualified = schema.map { "\($0).\(name)" } ?? name
+        return "DROP \(objectType) \(qualified)\(cascade ? " CASCADE" : "")"
+    }
+
+    func foreignKeyDisableStatements() -> [String]? { nil }
+
+    func foreignKeyEnableStatements() -> [String]? { nil }
+}

--- a/TableProTests/Views/Main/CommandActionsDispatchTests.swift
+++ b/TableProTests/Views/Main/CommandActionsDispatchTests.swift
@@ -20,7 +20,6 @@ struct CommandActionsDispatchTests {
         let state = SessionStateFactory.create(connection: connection, payload: nil)
         let coordinator = state.coordinator
 
-        var selectedRowIndices: Set<Int> = []
         var selectedTables: Set<TableInfo> = []
         var pendingTruncates: Set<String> = []
         var pendingDeletes: Set<String> = []
@@ -32,7 +31,7 @@ struct CommandActionsDispatchTests {
             coordinator: coordinator,
             filterStateManager: state.filterStateManager,
             connection: connection,
-            selectedRowIndices: Binding(get: { selectedRowIndices }, set: { selectedRowIndices = $0 }),
+            selectionState: coordinator.selectionState,
             selectedTables: Binding(get: { selectedTables }, set: { selectedTables = $0 }),
             pendingTruncates: Binding(get: { pendingTruncates }, set: { pendingTruncates = $0 }),
             pendingDeletes: Binding(get: { pendingDeletes }, set: { pendingDeletes = $0 }),

--- a/TableProTests/Views/Main/CommandActionsDispatchTests.swift
+++ b/TableProTests/Views/Main/CommandActionsDispatchTests.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import SwiftUI
-import Testing
 @testable import TablePro
+import Testing
 
 @MainActor @Suite("CommandActions Dispatch")
 struct CommandActionsDispatchTests {
@@ -24,7 +24,7 @@ struct CommandActionsDispatchTests {
         var pendingTruncates: Set<String> = []
         var pendingDeletes: Set<String> = []
         var tableOperationOptions: [String: TableOperationOptions] = [:]
-        var editingCell: CellPosition? = nil
+        var editingCell: CellPosition?
         let rightPanelState = RightPanelState()
 
         let actions = MainContentCommandActions(

--- a/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
+++ b/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
@@ -17,7 +17,7 @@ struct MainStatusBarLayoutTests {
         let filterManager = FilterStateManager()
         let colVisManager = ColumnVisibilityManager()
         let view = MainStatusBarView(
-            tab: nil,
+            snapshot: StatusBarSnapshot(tab: nil),
             filterStateManager: filterManager,
             columnVisibilityManager: colVisManager,
             allColumns: [],
@@ -31,7 +31,6 @@ struct MainStatusBarLayoutTests {
             onOffsetChange: { _ in },
             onPaginationGo: {}
         )
-        // Smoke test: view constructs without error
         #expect(type(of: view.body) != Never.self)
     }
 }

--- a/TableProTests/Views/Main/SaveCompletionTests.swift
+++ b/TableProTests/Views/Main/SaveCompletionTests.swift
@@ -261,20 +261,19 @@ struct SaveCompletionTests {
             tabManager.tabs[index].tableContext.tableName = "users"
         }
 
-        var selectedRows: Set<Int> = []
         var editingCell: CellPosition?
 
-        coordinator.addNewRow(selectedRowIndices: &selectedRows, editingCell: &editingCell)
-        #expect(selectedRows.isEmpty)
+        coordinator.addNewRow(editingCell: &editingCell)
+        #expect(coordinator.selectionState.indices.isEmpty)
         #expect(editingCell == nil)
 
-        selectedRows = [0]
-        coordinator.deleteSelectedRows(indices: Set([0]), selectedRowIndices: &selectedRows)
-        #expect(selectedRows == [0])
+        coordinator.selectionState.indices = [0]
+        coordinator.deleteSelectedRows(indices: Set([0]))
+        #expect(coordinator.selectionState.indices == [0])
 
-        selectedRows = []
-        coordinator.duplicateSelectedRow(index: 0, selectedRowIndices: &selectedRows, editingCell: &editingCell)
-        #expect(selectedRows.isEmpty)
+        coordinator.selectionState.indices = []
+        coordinator.duplicateSelectedRow(index: 0, editingCell: &editingCell)
+        #expect(coordinator.selectionState.indices.isEmpty)
         #expect(editingCell == nil)
     }
 
@@ -287,11 +286,9 @@ struct SaveCompletionTests {
             tabManager.tabs[index].tableContext.tableName = "users"
         }
 
-        var selectedRows: Set<Int> = []
         var editingCell: CellPosition?
 
-        // Alert level doesn't block row staging — only gates at execution time
-        coordinator.addNewRow(selectedRowIndices: &selectedRows, editingCell: &editingCell)
+        coordinator.addNewRow(editingCell: &editingCell)
         #expect(tabManager.tabs.first?.execution.errorMessage == nil)
     }
 }

--- a/TableProTests/Views/Main/SaveCompletionTests.swift
+++ b/TableProTests/Views/Main/SaveCompletionTests.swift
@@ -22,6 +22,7 @@ struct SaveCompletionTests {
         var conn = TestFixtures.makeConnection(type: type)
         conn.safeModeLevel = safeModeLevel
         let state = SessionStateFactory.create(connection: conn, payload: nil)
+        state.coordinator.tableOperationOverride = FakeTableOperationProvider()
         return (state.coordinator, state.tabManager, state.changeManager)
     }
 


### PR DESCRIPTION
## Summary

Repairs the `TableProTests` target so it compiles and runs again. The target had been broken across PRs #914, #915, #917, #918 (datagrid refactors), and surfacing those compile errors also exposed a pre-existing dialect-quoting issue in `SQLStatementGenerator`. Three focused commits, scoped narrowly to unblock other PRs (including the upcoming raycast-integration work).

## In scope (this PR)

**1. Compile fix for 4 test files** — `7868fce6`. The datagrid refactors renamed APIs but missed:
- `MainStatusBarLayoutTests.swift` — `tab:` arg replaced with `snapshot: StatusBarSnapshot(tab: nil)` (#918).
- `CommandActionsDispatchTests.swift` — removed `selectedRowIndices:` binding param, pass `selectionState:` (#914).
- `SaveCompletionTests.swift` — coordinator row ops no longer take `selectedRowIndices: inout`, use `coordinator.selectionState.indices` (#914).
- `AnyChangeManagerTests.swift` — `AnyChangeManager(dataManager:)` and `AnyChangeManager(structureManager:)` collapsed into `AnyChangeManager(_ manager: any ChangeManaging)` (#915); `wrapper.changes` is now `wrapper.rowChanges`.

**2. Source-side dialect derivation** — `27e63c47`. Once the test target compiled, `SQLStatementGenerator*Tests` (51 cases) ran for the first time and 100% failed because tests construct the generator with `dialect: nil` and assert on identifier quoting. `quoteIdentifierFromDialect(nil)` returns identity. Added `resolveSQLDialect(for:explicit:)` in `DialectQuoteHelper.swift` that falls back to `PluginMetadataRegistry.shared.snapshot(forTypeId:)?.editor.sqlDialect` when no explicit dialect is supplied, and wired `SQLStatementGenerator.init` through it. Production behavior is unchanged for callers that already pass a dialect; production code that previously had to look up the dialect manually still can. Result: `SQLStatementGeneratorTests` 49/51 green (the 2 remaining are LIMIT 1 / TOP 1 — see follow-ups).

**3. `FakeTableOperationProvider` test seam** — `57a397fb`. Three `SaveCompletionTests` exited via the empty-statements error path because `currentPluginDriverAdapter` is nil in tests (no live driver session). Extracted a `TableOperationStatementProvider` protocol covering the four methods `MainContentCoordinator+TableOperations.swift` calls (`truncateTableStatements`, `dropObjectStatement`, `foreignKeyDisableStatements`, `foreignKeyEnableStatements`); `PluginDriverAdapter` adopts it via empty extension. Added `tableOperationOverride: TableOperationStatementProvider?` on `MainContentCoordinator` (test-only seam, never assigned in production). `FakeTableOperationProvider` returns ANSI-style SQL. Result: `SaveCompletionTests` 13/13 green.

## Verification

```
xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginValidation \
  -only-testing:TableProTests/SaveCompletionTests \
  -only-testing:TableProTests/CommandActionsDispatchTests \
  -only-testing:TableProTests/MainStatusBarLayoutTests \
  -only-testing:TableProTests/AnyChangeManagerTests \
  -only-testing:TableProTests/SQLStatementGeneratorTests
```

All 100% green except the 2 LIMIT-1 cases (see follow-ups). swiftlint --strict clean on all touched files.

## Known pre-existing failures (NOT in this PR)

After the test target started compiling and the dialect fix landed, the full target run reports approximately **280 pre-existing failures** previously masked by compile errors. These are out of scope; each warrants its own ticket. Buckets:

- **~30 tests assert absent `LIMIT 1` / `TOP (1)` / `ALTER TABLE ... DELETE WHERE` codegen.** No such codegen exists in `TablePro/Core/ChangeTracking/SQLStatementGenerator.swift`. Either the safety-limit feature was removed and tests weren't deleted, or it was never implemented. Affected: `SQLStatementGeneratorTests` (2), `SQLStatementGeneratorNoPKTests`, `SQLStatementGeneratorMSSQLTests`, `DataChangeManagerClickHouseTests`.
- **~80 tests crash with `<external symbol>` under parallel test execution.** Tests touch `DatabaseManager.shared` / `PluginManager.shared` / global state and race when xcodebuild spawns multiple test host processes. Fix is either `-parallel-testing-enabled NO` or removing shared-state coupling. Affected: `RowProviderSyncTests`, `SidebarFieldTests`, `JSONEditorHighlightTests`, `EvictionTests`, `BlobFormattingTests`, `ColumnTypeBadgeLabelTests`, others.
- **~5 outdated string/enum mappings** — `DatabaseTypeCassandraTests/scylladbIconName` (`scylladb-icon` vs `cassandra-icon`), `SafeModeLevelTests/iconNames` (`lock.open.fill` vs `lock.open`), `ConnectionURLFormatterTests` MariaDB scheme, `ConnectionSharingTests` `Private Key` vs `privateKey`. Tests didn't track UI/serialization renames.
- **~3 SSH path duplication bugs** — `SSHConfigParserTests/testSSHTokensInIdentityFile`, `SSHConfigurationTests/testTildeExpansionWithSubpath`. Real product bug: tilde expansion produces double-slashes (`$HOME//.ssh/...`).
- **~30 test-logic / suspected-product bugs** — `GroupStorageTests`, `EtcdQueryBuilderTests/emptyPrefix`, `DataChangeManagerExtendedTests/Full undo/redo chain`. Need individual investigation per test.
- **~10 MSSQL-plugin-not-loaded** — `TableQueryBuilderMSSQLTests` produces `LIMIT 200 OFFSET 0` (PostgreSQL-style) instead of `OFFSET ... FETCH NEXT`. Plugin not registered in tests, so dialect lookup falls back to defaults.

I have not opened separate tickets for these — happy to do so if the team wants, but they would need product-owner triage first (especially bucket 1, where the right answer might be deleting the tests rather than building features).

## Test plan

- [x] `SaveCompletionTests` — 13/13 green
- [x] `CommandActionsDispatchTests` — green
- [x] `MainStatusBarLayoutTests` — green
- [x] `AnyChangeManagerTests` — green
- [x] `SQLStatementGeneratorTests` — 49/51 green (2 LIMIT-1 are out-of-scope)
- [x] swiftlint --strict on all touched files — 0 violations
- [x] No production behavior change from the dialect fix (verified by inspection: existing callers all pass an explicit dialect from `PluginManager.shared.sqlDialect(for:)`)