### PR TITLE
fix: Native Search Field focus regression when clearing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash on macOS 26 when opening SQL Preview (NSColor.cgColor calls deprecated colorSpaceName)
 - Connection form: `usePrivateKey=true` from URL no longer disables Test/Create buttons
 - Transient connections from URL clean up keychain entries on connection failure
+- Native Search Field focus regression when clearing text
 
 ## [0.36.0] - 2026-04-27
 

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -60,7 +60,6 @@ struct NativeSearchField: NSViewRepresentable {
 
         func searchFieldDidEndSearching(_ sender: NSSearchField) {
             text.wrappedValue = ""
-            sender.window?.makeFirstResponder(nil)
         }
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {


### PR DESCRIPTION
## Summary

All Native Search Field will lost focus when clearing input text

## Root cause 

searchFieldDidEndSearching(_:) fires both on Escape key press and on clearing the field. The sender.window?.makeFirstResponder(nil) call was intended to dismiss the field after a search submission, but it also fires when the user simply clicks the clear button — stealing focus from whatever element the user was interacting with.

## Test plan

- [x] Input  and clear in `Search for connection` / `Search databases` / `Search tables, views, databases` / `Search shortcuts`

#911 