### PR TITLE
fix(datagrid): route Cmd+V to row paste when clipboard holds copied rows

### DIFF
--- a/TablePro/Core/Services/Infrastructure/ClipboardService.swift
+++ b/TablePro/Core/Services/Infrastructure/ClipboardService.swift
@@ -12,12 +12,14 @@ import UniformTypeIdentifiers
 protocol ClipboardProvider {
     func readText() -> String?
     func writeText(_ text: String)
-    func writeTabular(tsv: String, html: String)
+    func writeRows(tsv: String, html: String?)
     var hasText: Bool { get }
+    var hasGridRows: Bool { get }
 }
 
 struct NSPasteboardClipboardProvider: ClipboardProvider {
     private static let tsvType = NSPasteboard.PasteboardType("public.utf8-tab-separated-values-text")
+    private static let gridRowsType = NSPasteboard.PasteboardType("com.TablePro.gridRows")
 
     func readText() -> String? {
         NSPasteboard.general.string(forType: .string)
@@ -30,16 +32,23 @@ struct NSPasteboardClipboardProvider: ClipboardProvider {
         pb.setString(text, forType: NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier))
     }
 
-    func writeTabular(tsv: String, html: String) {
+    func writeRows(tsv: String, html: String?) {
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(tsv, forType: .string)
         pb.setString(tsv, forType: Self.tsvType)
-        pb.setString(html, forType: .html)
+        if let html {
+            pb.setString(html, forType: .html)
+        }
+        pb.setString("1", forType: Self.gridRowsType)
     }
 
     var hasText: Bool {
         NSPasteboard.general.string(forType: .string) != nil
+    }
+
+    var hasGridRows: Bool {
+        NSPasteboard.general.types?.contains(Self.gridRowsType) == true
     }
 }
 

--- a/TablePro/Core/Services/Query/RowOperationsManager.swift
+++ b/TablePro/Core/Services/Query/RowOperationsManager.swift
@@ -281,7 +281,7 @@ final class RowOperationsManager {
             result.append("\n(truncated, showing first \(Self.maxClipboardRows) of \(totalSelected) rows)")
         }
 
-        ClipboardService.shared.writeText(result)
+        ClipboardService.shared.writeRows(tsv: result, html: nil)
     }
 
     func pasteRowsFromClipboard(

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -49,7 +49,7 @@ extension TableViewCoordinator {
 
         let tsv = tsvRows.joined(separator: "\n")
         let html = HtmlTableEncoder.encode(rows: htmlRows)
-        ClipboardService.shared.writeTabular(tsv: tsv, html: html)
+        ClipboardService.shared.writeRows(tsv: tsv, html: html)
     }
 
     func copyRowsWithHeaders(at indices: Set<Int>) {
@@ -69,7 +69,7 @@ extension TableViewCoordinator {
 
         let tsv = tsvRows.joined(separator: "\n")
         let html = HtmlTableEncoder.encode(rows: htmlRows, headers: columns)
-        ClipboardService.shared.writeTabular(tsv: tsv, html: html)
+        ClipboardService.shared.writeRows(tsv: tsv, html: html)
     }
 
     @MainActor

--- a/TablePro/Views/Results/Extensions/DataGridView+CellPaste.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+CellPaste.swift
@@ -8,6 +8,7 @@ import AppKit
 extension TableViewCoordinator {
     func pasteCellsFromClipboard(anchorRow: Int, anchorColumn: Int) -> Bool {
         guard isEditable else { return false }
+        if ClipboardService.shared.hasGridRows { return false }
         guard let text = ClipboardService.shared.readText(), !text.isEmpty else { return false }
 
         let grid = text.components(separatedBy: "\n")
@@ -15,8 +16,13 @@ extension TableViewCoordinator {
             .map { $0.components(separatedBy: "\t") }
         guard !grid.isEmpty, grid[0].count > 1 || grid.count > 1 else { return false }
 
+        let dataColumnCount = tableRowsProvider().columns.count
+        if dataColumnCount > 0, grid.allSatisfy({ $0.count == dataColumnCount }) {
+            return false
+        }
+
         let maxRow = min(anchorRow + grid.count, cachedRowCount)
-        let maxCol = min(anchorColumn + (grid.first?.count ?? 0), tableRowsProvider().columns.count)
+        let maxCol = min(anchorColumn + (grid.first?.count ?? 0), dataColumnCount)
         guard anchorRow < maxRow, anchorColumn < maxCol else { return false }
 
         let undoManager = tableView?.window?.undoManager

--- a/TableProTests/Core/Services/RowOperationsManagerCopyTests.swift
+++ b/TableProTests/Core/Services/RowOperationsManagerCopyTests.swift
@@ -5,18 +5,22 @@ import Testing
 private final class MockClipboardProvider: ClipboardProvider {
     var lastWrittenText: String?
     var textToRead: String?
+    var lastWasGridRows = false
 
     func readText() -> String? { textToRead }
 
     func writeText(_ text: String) {
         lastWrittenText = text
+        lastWasGridRows = false
     }
 
-    func writeTabular(tsv: String, html: String) {
+    func writeRows(tsv: String, html: String?) {
         lastWrittenText = tsv
+        lastWasGridRows = true
     }
 
     var hasText: Bool { textToRead != nil }
+    var hasGridRows: Bool { lastWasGridRows }
 }
 
 @MainActor

--- a/TableProTests/Views/Results/Extensions/CellPasteRoutingTests.swift
+++ b/TableProTests/Views/Results/Extensions/CellPasteRoutingTests.swift
@@ -1,0 +1,103 @@
+//
+//  CellPasteRoutingTests.swift
+//  TableProTests
+//
+//  Locks the contract that pasteCellsFromClipboard defers to row paste
+//  when the clipboard carries the in-app gridRows tag or has a row-shaped
+//  TSV. Without these checks, Cmd+V on a focused cell after Cmd+C on a row
+//  silently overwrites the row's tail columns.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import TablePro
+
+@MainActor
+private final class StubClipboard: ClipboardProvider {
+    var text: String?
+    var hasGridRowsValue = false
+
+    func readText() -> String? { text }
+    func writeText(_ text: String) { self.text = text; hasGridRowsValue = false }
+    func writeRows(tsv: String, html: String?) { self.text = tsv; hasGridRowsValue = true }
+    var hasText: Bool { text != nil }
+    var hasGridRows: Bool { hasGridRowsValue }
+}
+
+@Suite("pasteCellsFromClipboard routing")
+@MainActor
+struct CellPasteRoutingTests {
+    private func makeCoordinator(columns: [String], rowCount: Int) -> TableViewCoordinator {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil
+        )
+        let columnTypes: [ColumnType] = Array(repeating: .text(rawType: nil), count: columns.count)
+        let rows = (0..<rowCount).map { i in (0..<columns.count).map { c in "r\(i)c\(c)" } }
+        let tableRows = TableRows.from(queryRows: rows, columns: columns, columnTypes: columnTypes)
+        coordinator.tableRowsProvider = { tableRows }
+        coordinator.updateCache()
+        return coordinator
+    }
+
+    @Test("Defers to row paste when clipboard has gridRows tag")
+    func defersOnGridRowsTag() {
+        let stub = StubClipboard()
+        stub.text = "anything\twith\ttabs"
+        stub.hasGridRowsValue = true
+        ClipboardService.shared = stub
+
+        let coordinator = makeCoordinator(columns: ["a", "b", "c"], rowCount: 5)
+        let result = coordinator.pasteCellsFromClipboard(anchorRow: 0, anchorColumn: 0)
+
+        #expect(result == false)
+    }
+
+    @Test("Defers to row paste when every TSV line matches column count")
+    func defersOnRowShapedTSV() {
+        let stub = StubClipboard()
+        stub.text = "x\ty\tz\nq\tw\te"
+        stub.hasGridRowsValue = false
+        ClipboardService.shared = stub
+
+        let coordinator = makeCoordinator(columns: ["a", "b", "c"], rowCount: 5)
+        let result = coordinator.pasteCellsFromClipboard(anchorRow: 0, anchorColumn: 0)
+
+        #expect(result == false)
+    }
+
+    @Test("Cell pastes shape-mismatched TSV into focused range")
+    func cellPastesShapeMismatchedTSV() {
+        let stub = StubClipboard()
+        stub.text = "x\ty"
+        stub.hasGridRowsValue = false
+        ClipboardService.shared = stub
+
+        let coordinator = makeCoordinator(columns: ["a", "b", "c", "d", "e"], rowCount: 5)
+        let result = coordinator.pasteCellsFromClipboard(anchorRow: 0, anchorColumn: 0)
+
+        #expect(result == true)
+    }
+
+    @Test("Returns false when not editable")
+    func refusesWhenReadOnly() {
+        let stub = StubClipboard()
+        stub.text = "x\ty"
+        ClipboardService.shared = stub
+
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: false,
+            selectedRowIndices: .constant([]),
+            delegate: nil
+        )
+
+        let result = coordinator.pasteCellsFromClipboard(anchorRow: 0, anchorColumn: 0)
+
+        #expect(result == false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a Cmd+C / Cmd+V asymmetry: Cmd+C copies the selected rows (row-level), but Cmd+V was always cell-pasting whenever a cell had focus — so copying a row then pasting silently overwrote the row's tail columns with the source row's leading values instead of inserting a new row.

## Root cause

`KeyHandlingTableView.paste(_:)` chose between cell paste and row paste based purely on whether a cell was focused:

```swift
if focusedRow >= 0, focusedColumn >= 1 {
    pasteCellsFromClipboard(...)
} else {
    dataGridPasteRows()
}
```

Clicking any cell sets focus, but `copy(_:)` always uses `selectedRowIndexes`. Net effect: copy works at row level, paste at cell level, and the round trip mangles cells.

## Fix

`pasteCellsFromClipboard` now defers to row paste on two signals:

1. **Pasteboard tag**: `ClipboardProvider` gains `writeRows(tsv:html:?)` which writes the TSV (and optional HTML) plus a `com.TablePro.gridRows` pasteboard type. `hasGridRows` reads it. Migrates `RowOperationsManager.copySelectedRowsToClipboard` and `TableViewCoordinator.copyRows` / `copyRowsWithHeaders` to use it. Drops the now-unused `writeTabular`.
2. **Shape heuristic**: if every line of the clipboard TSV has exactly `numberOfDataColumns` values, treat it as full rows. Catches external row-shaped data (e.g., from another DB tool) that the user clearly meant as an insert.

Cell paste continues to work for shape-mismatched TSV (external spreadsheet selections, single-column copies, etc.).

## Audit of other paste paths (no changes needed)

- `TableRowViewWithMenu` right-click row > Paste → already calls `dataGridPasteRows` directly
- `MainContentCommandActions.pasteRows` (menu / `.pasteRows` notification) → already calls `coordinator?.pasteRows()` directly

Only the Cmd+V keyboard path needed routing fix.

## Test plan

- [x] Build clean
- [x] `RowOperationsManagerCopyTests` pass (mock updated to new protocol)
- [x] Manual: Cmd+C on row, Cmd+V → inserts new row ✓
- [x] Manual: Cmd+C on multiple rows, Cmd+V → inserts N rows ✓
- [x] Manual: Cmd+C on single cell, Cmd+V into another cell → cell paste ✓
- [x] Manual: paste TSV from external (Excel) into cell selection → cell paste ✓
- [x] Manual: right-click row > Paste → inserts (unchanged) ✓