### PR TITLE
refactor(datagrid): consolidate resolvedTableRowsForTab into the existing helper

### DIFF
--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -518,7 +518,7 @@ struct MainEditorContentView: View {
         let tabId = tab.id
         DataGridView(
             tableRowsProvider: { [coordinator] in
-                resolvedTableRowsForTab(coordinator: coordinator, tabId: tabId)
+                coordinator.tableRowsStore.existingTableRows(for: tabId) ?? TableRows()
             },
             tableRowsMutator: { [coordinator] mutate in
                 coordinator.mutateActiveTableRows(for: tabId) { rows in
@@ -555,11 +555,6 @@ struct MainEditorContentView: View {
 
     private func resolvedTableRows(for tab: QueryTab) -> TableRows {
         coordinator.tableRowsStore.existingTableRows(for: tab.id) ?? TableRows()
-    }
-
-    @MainActor
-    private func resolvedTableRowsForTab(coordinator: MainContentCoordinator, tabId: UUID) -> TableRows {
-        coordinator.tableRowsStore.existingTableRows(for: tabId) ?? TableRows()
     }
 
     private func displayFormats(for tab: QueryTab) -> [ValueDisplayFormat?] {


### PR DESCRIPTION
## Summary

Drops the duplicate `resolvedTableRowsForTab(coordinator:tabId:)` helper in `MainEditorContentView`. Both helpers returned the same one-liner — the duplicate existed because the `dataGridView` closure captures `[coordinator]` and didn't have a `QueryTab` in scope.

Inlined the store read directly in the closure (already a one-liner, no helper needed). `resolvedTableRows(for tab:)` stays for the four other call sites that operate on a `QueryTab`.

## Test plan

- [x] Build clean
- [x] Manual: open table, switch tabs, verify data displays correctly

Net **−5 LOC**. One less duplicate.