### PR TITLE
refactor(datagrid): merge sortCache into coordinator.querySortCache

### DIFF
--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -10,17 +10,6 @@ import AppKit
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Cache for sorted query result rows to avoid re-sorting on every SwiftUI body evaluation.
-/// Stores a permutation of `RowID` so the grid keeps the same display order even after
-/// inserts and deletes mutate the underlying TableRows storage.
-private struct SortedRowsCache {
-    let sortedIDs: [RowID]
-    let columnIndex: Int
-    let direction: SortDirection
-    let schemaVersion: Int
-}
-
-/// Main editor content with tab bar and content switching
 struct MainEditorContentView: View {
     // MARK: - Dependencies
 
@@ -57,10 +46,6 @@ struct MainEditorContentView: View {
     let onLimitChange: (Int) -> Void
     let onOffsetChange: (Int) -> Void
     let onPaginationGo: () -> Void
-
-    // MARK: - Sort Cache
-
-    @State private var sortCache: [UUID: SortedRowsCache] = [:]
 
     @State private var cachedChangeManager: AnyChangeManager?
     @State private var erDiagramViewModels: [UUID: ERDiagramViewModel] = [:]
@@ -118,14 +103,7 @@ struct MainEditorContentView: View {
             favoriteDialogQuery = FavoriteDialogQuery(query: query)
         }
         .onChange(of: tabManager.tabStructureVersion) { _, _ in
-            let newIds = tabManager.tabIds
-            guard !sortCache.isEmpty || !erDiagramViewModels.isEmpty
-                || !serverDashboardViewModels.isEmpty else {
-                coordinator.cleanupSortCache(openTabIds: Set(newIds))
-                return
-            }
-            let openTabIds = Set(newIds)
-            sortCache = sortCache.filter { openTabIds.contains($0.key) }
+            let openTabIds = Set(tabManager.tabIds)
             coordinator.cleanupSortCache(openTabIds: openTabIds)
             erDiagramViewModels = erDiagramViewModels.filter { openTabIds.contains($0.key) }
             serverDashboardViewModels = serverDashboardViewModels.filter { openTabIds.contains($0.key) }
@@ -140,7 +118,6 @@ struct MainEditorContentView: View {
             refreshDataTabDelegateMutableRefs()
             coordinator.dataTabDelegate = dataTabDelegate
             coordinator.onTeardown = { [self] in
-                sortCache.removeAll()
                 cachedChangeManager = nil
                 coordinator.dataTabDelegate = nil
             }
@@ -636,14 +613,6 @@ struct MainEditorContentView: View {
             return nil
         }
 
-        if let cached = sortCache[tab.id],
-            cached.columnIndex == (tab.sortState.columnIndex ?? -1),
-            cached.direction == tab.sortState.direction,
-            cached.schemaVersion == tab.schemaVersion
-        {
-            return cached.sortedIDs
-        }
-
         let sortColumns = tab.sortState.columns
         let storageRows = resolvedRows.rows
         let sortedIndices = Array(storageRows.indices).sorted { idx1, idx2 in
@@ -666,7 +635,7 @@ struct MainEditorContentView: View {
         }
         let sortedIDs = sortedIndices.map { storageRows[$0].id }
 
-        sortCache[tab.id] = SortedRowsCache(
+        coordinator.querySortCache[tab.id] = QuerySortCacheEntry(
             sortedIDs: sortedIDs,
             columnIndex: tab.sortState.columnIndex ?? -1,
             direction: tab.sortState.direction,

--- a/TableProTests/Views/Main/SortCacheInvalidationTests.swift
+++ b/TableProTests/Views/Main/SortCacheInvalidationTests.swift
@@ -1,0 +1,98 @@
+//
+//  SortCacheInvalidationTests.swift
+//  TableProTests
+//
+//  Locks the contract that row mutations invalidate querySortCache for the
+//  affected tab. Pre-merge, only the coordinator-side cache was invalidated;
+//  the view-side @State sortCache stayed stale, so a sorted small table
+//  returned out-of-date sortedIDs after add / undo / paste / delete. After
+//  the merge there is one cache and these tests guard the invalidation set.
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+@Suite("querySortCache invalidation on row mutations")
+@MainActor
+struct SortCacheInvalidationTests {
+    private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager, UUID) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            filterStateManager: FilterStateManager(),
+            columnVisibilityManager: ColumnVisibilityManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        tabManager.addTableTab(tableName: "users")
+        let tabIndex = tabManager.selectedTabIndex ?? 0
+        tabManager.tabs[tabIndex].tableContext.isEditable = true
+        let tabId = tabManager.tabs[tabIndex].id
+        return (coordinator, tabManager, tabId)
+    }
+
+    private func seedCache(_ coordinator: MainContentCoordinator, for tabId: UUID) {
+        coordinator.querySortCache[tabId] = QuerySortCacheEntry(
+            sortedIDs: [.existing(0), .existing(1), .existing(2)],
+            columnIndex: 1,
+            direction: .ascending,
+            schemaVersion: 0
+        )
+    }
+
+    private func seedRows(_ coordinator: MainContentCoordinator, for tabId: UUID, count: Int) {
+        let columns = ["id", "name"]
+        let rows = (0..<count).map { i in ["\(i)", "name\(i)"] }
+        let columnTypes: [ColumnType] = Array(repeating: .text(rawType: nil), count: columns.count)
+        let tableRows = TableRows.from(queryRows: rows, columns: columns, columnTypes: columnTypes)
+        coordinator.setActiveTableRows(tableRows, for: tabId)
+    }
+
+    @Test("addNewRow clears querySortCache for the tab")
+    func addNewRowInvalidatesCache() {
+        let (coordinator, _, tabId) = makeCoordinator()
+        seedRows(coordinator, for: tabId, count: 3)
+        seedCache(coordinator, for: tabId)
+
+        coordinator.addNewRow()
+
+        #expect(coordinator.querySortCache[tabId] == nil)
+    }
+
+    @Test("deleteSelectedRows clears querySortCache when physically removing inserted rows")
+    func physicalDeleteInvalidatesCache() {
+        let (coordinator, _, tabId) = makeCoordinator()
+        seedRows(coordinator, for: tabId, count: 3)
+        coordinator.addNewRow()
+        let insertedIndex = coordinator.tableRowsStore.tableRows(for: tabId).count - 1
+        seedCache(coordinator, for: tabId)
+
+        coordinator.deleteSelectedRows(indices: [insertedIndex])
+
+        #expect(coordinator.querySortCache[tabId] == nil)
+    }
+
+    @Test("deleteSelectedRows preserves querySortCache on soft delete of existing rows")
+    func softDeletePreservesCache() {
+        let (coordinator, _, tabId) = makeCoordinator()
+        seedRows(coordinator, for: tabId, count: 5)
+        seedCache(coordinator, for: tabId)
+
+        coordinator.deleteSelectedRows(indices: [0, 1])
+
+        #expect(coordinator.querySortCache[tabId] != nil)
+    }
+
+    @Test("duplicateSelectedRow clears querySortCache for the tab")
+    func duplicateRowInvalidatesCache() {
+        let (coordinator, _, tabId) = makeCoordinator()
+        seedRows(coordinator, for: tabId, count: 3)
+        seedCache(coordinator, for: tabId)
+
+        coordinator.duplicateSelectedRow(index: 0)
+
+        #expect(coordinator.querySortCache[tabId] == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Drops the duplicate sort cache. `MainEditorContentView` had a `@State var sortCache: [UUID: SortedRowsCache]` for the sync inline-sort path (≤1000 rows). `MainContentCoordinator` had `@ObservationIgnored var querySortCache: [UUID: QuerySortCacheEntry]` for the async background-sort path. The two structs were byte-identical (`sortedIDs: [RowID]`, `columnIndex: Int`, `direction: SortDirection`, `schemaVersion: Int`).

Both writes now go to `coordinator.querySortCache`. The view-side cache is gone.

## Stale-sort bug fixed as a side effect

Row-mutation invalidations in `MainContentCoordinator+RowOperations` (six call sites: `addNewRow`, `deleteSelectedRows`, `duplicateSelectedRow`, `undoInsertRow`, `handleUndoResult`, `pasteRows`) called `querySortCache.removeValue(forKey: tabId)` but never touched the view-side `sortCache`. A small (≤1000-row) sorted table that received an add / delete / undo / paste would return stale `sortedIDs` until the user clicked the column header again. After the merge, both paths share one cache and one invalidation set.

## Drops

- `private struct SortedRowsCache` (was duplicate of `QuerySortCacheEntry`)
- `@State private var sortCache` in `MainEditorContentView`
- The conditional view-side cleanup in `onChange(of: tabStructureVersion)`
- `sortCache.removeAll()` from the `onTeardown` handler
- The sync-cache lookup branch in `sortedIDsForTab`

`coordinator.cleanupSortCache(openTabIds:)` and `querySortCache.removeAll()` (called on coordinator teardown at MainContentCoordinator.swift:585) cover both paths uniformly.

Net **−33 / +2 LOC**.

## Test plan

- [x] Build clean
- [x] Manual: small table (≤1000 rows) sort by header — sorts ✓
- [x] Manual: large table (>1000 rows) sort by header — async sort ✓
- [x] Manual: sort + edit a cell — sorted view stays correct
- [x] Manual: sort + add row — new row appears at end of sorted view
- [x] Manual: switch tabs and back — sort persists