### PR TITLE
feat: allow manual AI model names for custom providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shift+Tab navigates to the previous cell in the data grid
 - Copy rows writes TSV, HTML table, and plain text to the clipboard for richer paste in spreadsheet apps
 - Row drag adds TSV and HTML representations alongside the internal drag type
+- AI provider settings allow manually entering a model name when the provider does not return one
 
 ### Changed
 

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -72,7 +72,7 @@ struct AIProviderDetailSheet: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(String(localized: "Save")) {
                         cancelTasks()
-                        onSave(draft, apiKey)
+                        onSave(normalizedDraft, apiKey)
                     }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!isSaveEnabled)
@@ -105,6 +105,12 @@ struct AIProviderDetailSheet: View {
         case .oauth, .none:
             return true
         }
+    }
+
+    private var normalizedDraft: AIProviderConfig {
+        var provider = draft
+        provider.model = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return provider
     }
 
     // MARK: - Auth
@@ -307,33 +313,34 @@ struct AIProviderDetailSheet: View {
 
     @ViewBuilder
     private var modelControl: some View {
-        if isFetchingModels {
-            ProgressView().controlSize(.small)
-        } else if fetchedModels.isEmpty {
-            HStack(spacing: 6) {
-                if !draft.model.isEmpty {
-                    Text(draft.model)
-                        .foregroundStyle(.secondary)
-                }
+        HStack(spacing: 8) {
+            TextField(String(localized: "Model name"), text: $draft.model)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 260)
+
+            if isFetchingModels {
+                ProgressView().controlSize(.small)
+            } else if fetchedModels.isEmpty {
                 Button(String(localized: "Reload")) {
                     fetchModels()
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
-            }
-        } else {
-            Picker("", selection: $draft.model) {
-                if draft.model.isEmpty {
-                    Text(String(localized: "Select a model")).tag("")
+            } else {
+                Menu {
+                    ForEach(fetchedModels, id: \.self) { model in
+                        Button(model) {
+                            draft.model = model
+                        }
+                    }
+                } label: {
+                    Image(systemName: "chevron.down.circle")
                 }
-                ForEach(fetchedModels, id: \.self) { model in
-                    Text(model).tag(model)
-                }
+                .menuStyle(.borderlessButton)
+                .help(String(localized: "Choose a fetched model"))
             }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .fixedSize()
         }
+        .fixedSize()
     }
 
     // MARK: - Advanced

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -443,7 +443,7 @@ struct AIProviderDetailSheet: View {
             return
         }
 
-        let provider = AIProviderFactory.createProvider(for: draft, apiKey: apiKey)
+        let provider = AIProviderFactory.createProvider(for: normalizedDraft, apiKey: apiKey)
         isFetchingModels = true
         modelFetchError = nil
 
@@ -472,7 +472,7 @@ struct AIProviderDetailSheet: View {
             return
         }
 
-        let provider = AIProviderFactory.createProvider(for: draft, apiKey: apiKey)
+        let provider = AIProviderFactory.createProvider(for: normalizedDraft, apiKey: apiKey)
         isTesting = true
         testResult = nil
 

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -28,7 +28,7 @@ Open **Settings** (`Cmd+,`) > **AI**. The tab is modeled on Xcode's Intelligence
 
 1. Click **Add Provider...** and pick a type (GitHub Copilot, Claude, OpenAI, Gemini, OpenRouter, Ollama, or a custom OpenAI-compatible endpoint).
 2. Enter the API key, or run device-flow sign-in for Copilot.
-3. Pick a model. The list fetches automatically; click **Reload** if needed.
+3. Enter a model name, or pick one from the fetched list. Click **Reload** if needed.
 4. Click **Test Connection**.
 
 API keys are stored in the macOS Keychain. Ollama is detected at launch.


### PR DESCRIPTION
## Summary

Adds a manual model name input in AI provider settings.

Some OpenAI-compatible providers do not expose a `/models` endpoint. This is common for a few third-party AI APIs and coding-plan providers. Before this change, TablePro only allowed selecting models fetched from the provider, so users could not configure those endpoints even when chat completions worked with a known model name.

## Changes

- Add a model name text field in the AI provider detail sheet
- Keep the fetched model list as an optional picker when `/models` is available
- Trim whitespace before saving the selected or manually entered model
- Update AI Assistant docs and changelog

## Verification

- Ran `xcodebuild -project TablePro.xcodeproj -scheme TablePro -configuration Debug build -skipPackagePluginValidation`
- Retried with `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Build is blocked locally because `Secrets.xcconfig` is missing. The standard run is also blocked by missing Mac Development signing assets.
