### PR TITLE
fix(datagrid): restore sort chevron via SF Symbols

### DIFF
--- a/TablePro/Views/Results/SortableHeaderCell.swift
+++ b/TablePro/Views/Results/SortableHeaderCell.swift
@@ -79,12 +79,11 @@ final class SortableHeaderCell: NSTableHeaderCell {
     }
 
     private static func indicatorImage(for direction: SortDirection) -> NSImage? {
-        switch direction {
-        case .ascending:
-            return NSImage(named: NSImage.Name("NSAscendingSortIndicator"))
-        case .descending:
-            return NSImage(named: NSImage.Name("NSDescendingSortIndicator"))
-        }
+        let symbolName = direction == .ascending ? "chevron.up" : "chevron.down"
+        let config = NSImage.SymbolConfiguration(pointSize: priorityFontSize, weight: .semibold)
+            .applying(.init(paletteColors: [.secondaryLabelColor]))
+        return NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(config)
     }
 
     private static func drawTintedIndicator(image: NSImage?, in rect: NSRect) {


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #945. Sort chevrons stopped rendering after switching from `NSImageView` overlays to direct cell drawing.

The private AppKit images `NSAscendingSortIndicator` / `NSDescendingSortIndicator` only render via `NSImageView` (with `contentTintColor`) or AppKit's internal `NSTableHeaderCell.drawSortIndicator`. They do not produce pixels when drawn via raw `NSImage.draw(in:from:operation:...)` in a cell's graphics context. PR #945's `drawInterior` reserved layout space for the indicator (which is why column titles got truncated when sorted) but the chevron itself never appeared.

PR #942's commit history shows the previous author hit this exact issue and worked around it with overlays. #945 unknowingly reintroduced the regression.

## Fix

Replace the private images with SF Symbols (`chevron.up` / `chevron.down`) configured with palette tint `.secondaryLabelColor`. SF Symbols draw reliably via `image.draw(in:)` and the palette config handles tinting in both Light and Dark modes.

```swift
private static func indicatorImage(for direction: SortDirection) -> NSImage? {
    let symbolName = direction == .ascending ? "chevron.up" : "chevron.down"
    let config = NSImage.SymbolConfiguration(pointSize: priorityFontSize, weight: .semibold)
        .applying(.init(paletteColors: [.secondaryLabelColor]))
    return NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
        .withSymbolConfiguration(config)
}
```

One file changed, 5 insertions / 6 deletions.

## Test plan

- [ ] Click a column header to sort: chevron appears next to title
- [ ] Shift-click a second column: both columns show chevrons (primary alone, secondary with priority number "2")
- [ ] Click sorted descending column third time: chevron disappears (sort cleared)
- [ ] Toggle Light / Dark mode: chevron tints to `secondaryLabelColor` correctly in both
- [ ] \`xcodebuild build\` — clean
- [ ] \`swiftlint lint --strict\` — 0 violations