### PR TITLE
fix(postgresql): Use template0 to fix database creation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connection form: `usePrivateKey=true` from URL no longer disables Test/Create buttons
 - Transient connections from URL clean up keychain entries on connection failure
 - Native Search Field focus regression when clearing text
+- Using the template0 database to resolve database creation failures in PostgreSQL
 
 ## [0.36.0] - 2026-04-27
 

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -837,7 +837,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 throw LibPQPluginError(message: "Invalid collation", sqlState: nil, detail: nil)
             }
             let escapedCollation = collation.replacingOccurrences(of: "'", with: "''")
-            query += " LC_COLLATE '\(escapedCollation)'"
+            query += "  TEMPLATE 'template0' LC_COLLATE '\(escapedCollation)'"
         }
         _ = try await execute(query: query)
     }


### PR DESCRIPTION
## Summary

Use template0 as the template database to prevent collation‑mismatch failures when creating a new PostgreSQL database.

## Root cause

When creating a database, PostgreSQL defaults to copying template1. The new database must have LC_COLLATE and LC_CTYPE values that exactly match those of the template database. In tablepro, LC_COLLATE can only choose one from `en_US.UTF-8` / `C` / `POSIX` / `C.UTF-8`, which leads to not being able to match the LC_COLLATE in template1 completely. This causes an error.

## Test plan

- [x] Test all LC_COLLATE sets to create a database and verify the final created data LC_COLLATE value


closed #927