### PR TITLE
refactor(datagrid): cleanup

### DIFF
--- a/TablePro/Core/ChangeTracking/PendingChanges.swift
+++ b/TablePro/Core/ChangeTracking/PendingChanges.swift
@@ -364,11 +364,14 @@ struct PendingChanges: Equatable {
     private mutating func removeChangeAt(_ arrayIndex: Int) {
         let removed = changes[arrayIndex]
         changeIndex.removeValue(forKey: RowChangeKey(rowIndex: removed.rowIndex, type: removed.type))
-        changes.remove(at: arrayIndex)
 
-        for (key, idx) in changeIndex where idx > arrayIndex {
-            changeIndex[key] = idx - 1
+        let lastIndex = changes.count - 1
+        if arrayIndex != lastIndex {
+            let moved = changes[lastIndex]
+            changes.swapAt(arrayIndex, lastIndex)
+            changeIndex[RowChangeKey(rowIndex: moved.rowIndex, type: moved.type)] = arrayIndex
         }
+        changes.removeLast()
     }
 
     private mutating func rebuildChangeIndex() {

--- a/TablePro/Views/Results/DataGridCellFactory.swift
+++ b/TablePro/Views/Results/DataGridCellFactory.swift
@@ -13,12 +13,10 @@ final class DataGridCellFactory {
     private static let sampleRowCount = 30
     private static let maxMeasureChars = 50
 
-    private var headerFont: NSFont {
-        NSFont.systemFont(ofSize: 13, weight: .semibold)
-    }
+    private static let headerFont: NSFont = NSFont.systemFont(ofSize: 13, weight: .semibold)
 
     func calculateColumnWidth(for columnName: String) -> CGFloat {
-        let attributes: [NSAttributedString.Key: Any] = [.font: headerFont]
+        let attributes: [NSAttributedString.Key: Any] = [.font: Self.headerFont]
         let size = (columnName as NSString).size(withAttributes: attributes)
         let width = size.width + 48
         return min(max(width, Self.minColumnWidth), Self.maxColumnWidth)
@@ -105,18 +103,28 @@ internal extension String {
         let nsString = self as NSString
         let length = nsString.length
         guard length > 0 else { return self }
-        guard containsLineBreak else { return self }
 
-        let mutable = NSMutableString(capacity: length)
+        var mutable: NSMutableString?
+        var copiedUpTo = 0
         for i in 0..<length {
             let ch = nsString.character(at: i)
-            if ch == 0x0A || ch == 0x0D || ch == 0x0B || ch == 0x0C ||
-               ch == 0x85 || ch == 0x2028 || ch == 0x2029 {
-                mutable.append(" ")
-            } else {
-                mutable.append(String(utf16CodeUnits: [ch], count: 1))
+            guard ch == 0x0A || ch == 0x0D || ch == 0x0B || ch == 0x0C ||
+                  ch == 0x85 || ch == 0x2028 || ch == 0x2029 else { continue }
+
+            if mutable == nil {
+                mutable = NSMutableString(capacity: length)
             }
+            if i > copiedUpTo {
+                mutable?.append(nsString.substring(with: NSRange(location: copiedUpTo, length: i - copiedUpTo)))
+            }
+            mutable?.append(" ")
+            copiedUpTo = i + 1
         }
-        return mutable as String
+
+        guard let result = mutable else { return self }
+        if copiedUpTo < length {
+            result.append(nsString.substring(with: NSRange(location: copiedUpTo, length: length - copiedUpTo)))
+        }
+        return result as String
     }
 }

--- a/TablePro/Views/Results/DataGridColumnPool.swift
+++ b/TablePro/Views/Results/DataGridColumnPool.swift
@@ -137,15 +137,38 @@ final class DataGridColumnPool {
         NSAnimationContext.current.allowsImplicitAnimation = false
         defer { NSAnimationContext.endGrouping() }
 
+        var indexByIdentifier: [NSUserInterfaceItemIdentifier: Int] = [:]
+        indexByIdentifier.reserveCapacity(tableView.tableColumns.count)
+        for (index, column) in tableView.tableColumns.enumerated() {
+            indexByIdentifier[column.identifier] = index
+        }
+
         for (targetPosition, slot) in targetOrder.enumerated() {
             let identifier = ColumnIdentitySchema.slotIdentifier(slot)
-            guard let currentIndex = tableView.tableColumns.firstIndex(where: { $0.identifier == identifier }) else {
-                continue
-            }
+            guard let currentIndex = indexByIdentifier[identifier] else { continue }
             let desiredIndex = baseOffset + targetPosition
             guard desiredIndex < tableView.tableColumns.count else { continue }
-            if currentIndex != desiredIndex {
-                tableView.moveColumn(currentIndex, toColumn: desiredIndex)
+            if currentIndex == desiredIndex { continue }
+
+            tableView.moveColumn(currentIndex, toColumn: desiredIndex)
+            updateIndexMap(&indexByIdentifier, movedFrom: currentIndex, to: desiredIndex)
+        }
+    }
+
+    private func updateIndexMap(
+        _ map: inout [NSUserInterfaceItemIdentifier: Int],
+        movedFrom source: Int,
+        to destination: Int
+    ) {
+        guard source != destination else { return }
+        let lower = min(source, destination)
+        let upper = max(source, destination)
+        let delta = source < destination ? -1 : 1
+        for (key, value) in map where value >= lower && value <= upper {
+            if value == source {
+                map[key] = destination
+            } else {
+                map[key] = value + delta
             }
         }
     }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -369,10 +369,10 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     func applyDelta(_ delta: Delta) {
         switch delta {
         case .cellChanged(let row, let column):
-            guard let tableView else { return }
-            let tableColumn = DataGridView.tableColumnIndex(for: column)
+            guard let tableView,
+                  let tableColumn = DataGridView.tableColumnIndex(for: column, in: tableView, schema: identitySchema)
+            else { return }
             guard row >= 0, row < tableView.numberOfRows else { return }
-            guard tableColumn >= 0, tableColumn < tableView.numberOfColumns else { return }
             invalidateDisplayCache(forDisplayRow: row, column: column)
             rebuildVisualStateCache()
             tableView.reloadData(
@@ -387,8 +387,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                 if position.row >= 0, position.row < tableView.numberOfRows {
                     rowSet.insert(position.row)
                 }
-                let tableColumn = DataGridView.tableColumnIndex(for: position.column)
-                if tableColumn >= 0, tableColumn < tableView.numberOfColumns {
+                if let tableColumn = DataGridView.tableColumnIndex(
+                    for: position.column,
+                    in: tableView,
+                    schema: identitySchema
+                ) {
                     colSet.insert(tableColumn)
                 }
                 invalidateDisplayCache(forDisplayRow: position.row, column: position.column)
@@ -455,10 +458,10 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     }
 
     func beginEditing(displayRow: Int, column: Int) {
-        guard let tableView else { return }
-        let displayCol = DataGridView.tableColumnIndex(for: column)
-        guard displayRow >= 0, displayRow < tableView.numberOfRows,
-              displayCol >= 0, displayCol < tableView.numberOfColumns else { return }
+        guard let tableView,
+              let displayCol = DataGridView.tableColumnIndex(for: column, in: tableView, schema: identitySchema)
+        else { return }
+        guard displayRow >= 0, displayRow < tableView.numberOfRows else { return }
         tableView.scrollRowToVisible(displayRow)
         tableView.selectRowIndexes(IndexSet(integer: displayRow), byExtendingSelection: false)
         tableView.editColumn(displayCol, row: displayRow, with: nil, select: true)

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -260,8 +260,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
     func applyFullReplace() {
         guard let tableView else { return }
-        displayCache.removeAll()
-        rebuildVisualStateCache()
+        invalidateAllDisplayCaches()
         updateCache()
         tableView.reloadData()
     }
@@ -307,6 +306,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
     func invalidateDisplayCache() {
         displayCache.removeAll()
+    }
+
+    func invalidateAllDisplayCaches() {
+        displayCache.removeAll()
+        rebuildVisualStateCache()
     }
 
     func updateDisplayFormats(_ formats: [ValueDisplayFormat?]) {
@@ -403,7 +407,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             applyRemovedRows(indices)
         case .columnsReplaced, .fullReplace:
             sortedIDs = nil
-            displayCache.removeAll()
             applyFullReplace()
         }
     }
@@ -428,8 +431,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     }
 
     func invalidateCachesForUndoRedo() {
-        displayCache.removeAll()
-        rebuildVisualStateCache()
+        invalidateAllDisplayCaches()
         updateCache()
         guard let tableView else { return }
         let visibleRange = tableView.rows(in: tableView.visibleRect)

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -187,7 +187,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task {
+            Task { @MainActor [weak self] in
                 guard let self, let tableView = self.tableView else { return }
                 Self.updateVisibleCellFonts(tableView: tableView)
             }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -108,9 +108,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var layoutPersistTask: Task<Void, Never>?
 
     static let rowViewIdentifier = NSUserInterfaceItemIdentifier("TableRowView")
-    internal var pendingDropdownRow: Int = 0
-    internal var pendingDropdownColumn: Int = 0
-    internal weak var pendingDropdownTableView: NSTableView?
     private var rowVisualStateCache: [Int: RowVisualState] = [:]
     private var lastVisualStateCacheVersion: Int = 0
     private let largeDatasetThreshold = 5_000

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -316,16 +316,28 @@ struct DataGridView: NSViewRepresentable {
 
     static let firstDataTableColumnIndex: Int = 1
 
-    static func tableColumnIndex(for dataIndex: Int) -> Int {
-        dataIndex + firstDataTableColumnIndex
-    }
-
-    static func dataColumnIndex(for tableColumnIndex: Int) -> Int {
-        tableColumnIndex - firstDataTableColumnIndex
-    }
-
     static func isDataTableColumn(_ tableColumnIndex: Int) -> Bool {
         tableColumnIndex >= firstDataTableColumnIndex
+    }
+
+    static func tableColumnIndex(
+        for dataIndex: Int,
+        in tableView: NSTableView,
+        schema: ColumnIdentitySchema
+    ) -> Int? {
+        guard let identifier = schema.identifier(for: dataIndex) else { return nil }
+        let index = tableView.column(withIdentifier: identifier)
+        return index >= 0 ? index : nil
+    }
+
+    static func dataColumnIndex(
+        for tableColumnIndex: Int,
+        in tableView: NSTableView,
+        schema: ColumnIdentitySchema
+    ) -> Int? {
+        guard tableColumnIndex >= 0, tableColumnIndex < tableView.tableColumns.count else { return nil }
+        let identifier = tableView.tableColumns[tableColumnIndex].identifier
+        return schema.dataIndex(from: identifier)
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: TableViewCoordinator) {

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -314,12 +314,18 @@ struct DataGridView: NSViewRepresentable {
 
     // MARK: - Column Layout Helpers
 
+    static let firstDataTableColumnIndex: Int = 1
+
     static func tableColumnIndex(for dataIndex: Int) -> Int {
-        dataIndex + 1
+        dataIndex + firstDataTableColumnIndex
     }
 
     static func dataColumnIndex(for tableColumnIndex: Int) -> Int {
-        tableColumnIndex - 1
+        tableColumnIndex - firstDataTableColumnIndex
+    }
+
+    static func isDataTableColumn(_ tableColumnIndex: Int) -> Bool {
+        tableColumnIndex >= firstDataTableColumnIndex
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: TableViewCoordinator) {

--- a/TablePro/Views/Results/Extensions/DataGridView+CellCommit.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+CellCommit.swift
@@ -41,7 +41,11 @@ extension TableViewCoordinator {
         invalidateDisplayCache()
         rebuildVisualStateCache()
 
-        let tableColumnIndex = DataGridView.tableColumnIndex(for: columnIndex)
+        guard let tableColumnIndex = DataGridView.tableColumnIndex(
+            for: columnIndex,
+            in: tableView,
+            schema: identitySchema
+        ) else { return }
         if storageRow != nil, case .cellChanged = delta {
             tableRowsController.apply(.cellChanged(row: row, column: tableColumnIndex))
         } else {

--- a/TablePro/Views/Results/Extensions/DataGridView+Click.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Click.swift
@@ -15,11 +15,8 @@ extension TableViewCoordinator {
         let row = sender.clickedRow
         let column = sender.clickedColumn
         guard row >= 0, column > 0 else { return }
-
-        let columnIndex = DataGridView.dataColumnIndex(for: column)
+        guard DataGridView.dataColumnIndex(for: column, in: sender, schema: identitySchema) != nil else { return }
         guard !changeManager.isRowDeleted(row) else { return }
-
-        // Single click only selects the row. Chevron buttons handle dropdown/picker actions.
     }
 
     @objc func handleDoubleClick(_ sender: NSTableView) {
@@ -29,7 +26,7 @@ extension TableViewCoordinator {
         let column = sender.clickedColumn
         guard row >= 0, column > 0 else { return }
 
-        let columnIndex = DataGridView.dataColumnIndex(for: column)
+        guard let columnIndex = DataGridView.dataColumnIndex(for: column, in: sender, schema: identitySchema) else { return }
         guard !changeManager.isRowDeleted(row) else { return }
 
         let tableRows = tableRowsProvider()
@@ -75,8 +72,11 @@ extension TableViewCoordinator {
         guard row >= 0, columnIndex >= 0 else { return }
         guard !changeManager.isRowDeleted(row) else { return }
         guard let tableView else { return }
-
-        let column = DataGridView.tableColumnIndex(for: columnIndex)
+        guard let column = DataGridView.tableColumnIndex(
+            for: columnIndex,
+            in: tableView,
+            schema: identitySchema
+        ) else { return }
 
         if let dropdownCols = dropdownColumns, dropdownCols.contains(columnIndex) {
             showDropdownMenu(tableView: tableView, row: row, column: column, columnIndex: columnIndex)

--- a/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
@@ -47,10 +47,14 @@ extension TableViewCoordinator {
         )
         let state = visualState(for: row)
 
-        let tableColumnIndex = DataGridView.tableColumnIndex(for: columnIndex)
         let isFocused: Bool = {
             guard let keyTableView = tableView as? KeyHandlingTableView,
                   keyTableView.focusedRow == row,
+                  let tableColumnIndex = DataGridView.tableColumnIndex(
+                    for: columnIndex,
+                    in: tableView,
+                    schema: identitySchema
+                  ),
                   keyTableView.focusedColumn == tableColumnIndex else { return false }
             return true
         }()

--- a/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
@@ -102,7 +102,7 @@ extension TableViewCoordinator {
 
         if forward {
             if nextColumn >= tableView.numberOfColumns {
-                nextColumn = 1
+                nextColumn = DataGridView.firstDataTableColumnIndex
                 nextRow += 1
             }
             if nextRow >= tableView.numberOfRows {
@@ -110,19 +110,19 @@ extension TableViewCoordinator {
                 nextColumn = tableView.numberOfColumns - 1
             }
         } else {
-            if nextColumn < 1 {
+            if !DataGridView.isDataTableColumn(nextColumn) {
                 nextColumn = tableView.numberOfColumns - 1
                 nextRow -= 1
             }
             if nextRow < 0 {
                 nextRow = 0
-                nextColumn = 1
+                nextColumn = DataGridView.firstDataTableColumnIndex
             }
         }
 
         tableView.selectRowIndexes(IndexSet(integer: nextRow), byExtendingSelection: false)
 
-        let nextColumnIndex = nextColumn - 1
+        let nextColumnIndex = DataGridView.dataColumnIndex(for: nextColumn)
         if nextColumnIndex >= 0,
            let nextDisplayRow = displayRow(at: nextRow),
            nextColumnIndex < nextDisplayRow.values.count,

--- a/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
@@ -122,8 +122,12 @@ extension TableViewCoordinator {
 
         tableView.selectRowIndexes(IndexSet(integer: nextRow), byExtendingSelection: false)
 
-        let nextColumnIndex = DataGridView.dataColumnIndex(for: nextColumn)
-        if nextColumnIndex >= 0,
+        if let nextColumnIndex = DataGridView.dataColumnIndex(
+            for: nextColumn,
+            in: tableView,
+            schema: identitySchema
+        ),
+           nextColumnIndex >= 0,
            let nextDisplayRow = displayRow(at: nextRow),
            nextColumnIndex < nextDisplayRow.values.count,
            let value = nextDisplayRow.values[nextColumnIndex],
@@ -140,9 +144,12 @@ extension TableViewCoordinator {
         let row = tableView.row(for: textField)
         let column = tableView.column(for: textField)
 
-        guard row >= 0, column > 0 else { return true }
-
-        let columnIndex = DataGridView.dataColumnIndex(for: column)
+        guard row >= 0, column > 0,
+              let columnIndex = DataGridView.dataColumnIndex(
+                for: column,
+                in: tableView,
+                schema: identitySchema
+              ) else { return true }
 
         if isEscapeCancelling {
             isEscapeCancelling = false

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -233,9 +233,7 @@ extension TableViewCoordinator {
         guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
 
         let currentValue = cellValue(at: row, column: columnIndex)
-        pendingDropdownRow = row
-        pendingDropdownColumn = columnIndex
-        pendingDropdownTableView = tableView
+        let context = DropdownMenuContext(row: row, columnIndex: columnIndex)
 
         let options: [String]
         if let custom = customDropdownOptions?[columnIndex] {
@@ -250,6 +248,7 @@ extension TableViewCoordinator {
         for option in options {
             let item = NSMenuItem(title: option, action: #selector(dropdownMenuItemSelected(_:)), keyEquivalent: "")
             item.target = self
+            item.representedObject = context
             if option == currentValue {
                 item.state = .on
             }
@@ -266,6 +265,7 @@ extension TableViewCoordinator {
                 keyEquivalent: ""
             )
             nullItem.target = self
+            nullItem.representedObject = context
             if currentValue == nil {
                 nullItem.state = .on
             }
@@ -277,22 +277,26 @@ extension TableViewCoordinator {
     }
 
     @objc func dropdownMenuItemSelected(_ sender: NSMenuItem) {
-        commitPopoverEdit(
-            row: pendingDropdownRow,
-            columnIndex: pendingDropdownColumn,
-            newValue: sender.title
-        )
+        guard let context = sender.representedObject as? DropdownMenuContext else { return }
+        commitPopoverEdit(row: context.row, columnIndex: context.columnIndex, newValue: sender.title)
     }
 
     @objc func dropdownMenuNullSelected(_ sender: NSMenuItem) {
-        commitPopoverEdit(
-            row: pendingDropdownRow,
-            columnIndex: pendingDropdownColumn,
-            newValue: nil
-        )
+        guard let context = sender.representedObject as? DropdownMenuContext else { return }
+        commitPopoverEdit(row: context.row, columnIndex: context.columnIndex, newValue: nil)
     }
 
     func commitPopoverEdit(row: Int, columnIndex: Int, newValue: String?) {
         commitCellEdit(row: row, columnIndex: columnIndex, newValue: newValue)
+    }
+}
+
+private final class DropdownMenuContext {
+    let row: Int
+    let columnIndex: Int
+
+    init(row: Int, columnIndex: Int) {
+        self.row = row
+        self.columnIndex = columnIndex
     }
 }

--- a/TablePro/Views/Results/Extensions/DataGridView+Selection.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Selection.swift
@@ -14,7 +14,8 @@ extension TableViewCoordinator {
 
     func tableViewColumnDidMove(_ notification: Notification) {
         guard !isRebuildingColumns else { return }
-        scheduleLayoutPersist()
+        layoutPersistTask?.cancel()
+        persistColumnLayoutToStorage()
     }
 
     func scheduleLayoutPersist() {

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -106,7 +106,7 @@ final class KeyHandlingTableView: NSTableView {
 
     @objc func paste(_ sender: Any?) {
         guard coordinator?.isEditable == true else { return }
-        if focusedRow >= 0, focusedColumn >= 1 {
+        if focusedRow >= 0, DataGridView.isDataTableColumn(focusedColumn) {
             let dataCol = DataGridView.dataColumnIndex(for: focusedColumn)
             if coordinator?.pasteCellsFromClipboard(anchorRow: focusedRow, anchorColumn: dataCol) == true {
                 return
@@ -124,7 +124,7 @@ final class KeyHandlingTableView: NSTableView {
         case #selector(paste(_:)):
             return coordinator?.isEditable == true && coordinator?.delegate != nil
         case #selector(insertNewline(_:)):
-            return selectedRow >= 0 && focusedColumn >= 1 && coordinator?.isEditable == true
+            return selectedRow >= 0 && DataGridView.isDataTableColumn(focusedColumn) && coordinator?.isEditable == true
         case #selector(cancelOperation(_:)):
             return false
         default:
@@ -176,9 +176,12 @@ final class KeyHandlingTableView: NSTableView {
         if let fkCombo = AppSettingsManager.shared.keyboard.shortcut(for: .previewFKReference),
            !fkCombo.isCleared,
            fkCombo.matches(event),
-           selectedRow >= 0, focusedColumn >= 1 {
+           selectedRow >= 0, DataGridView.isDataTableColumn(focusedColumn) {
             coordinator?.toggleForeignKeyPreview(
-                tableView: self, row: selectedRow, column: focusedColumn, columnIndex: focusedColumn - 1
+                tableView: self,
+                row: selectedRow,
+                column: focusedColumn,
+                columnIndex: DataGridView.dataColumnIndex(for: focusedColumn)
             )
             return
         }
@@ -188,7 +191,7 @@ final class KeyHandlingTableView: NSTableView {
 
     @objc override func insertNewline(_ sender: Any?) {
         let row = selectedRow
-        guard row >= 0, focusedColumn >= 1, coordinator?.isEditable == true else {
+        guard row >= 0, DataGridView.isDataTableColumn(focusedColumn), coordinator?.isEditable == true else {
             return
         }
 
@@ -215,29 +218,33 @@ final class KeyHandlingTableView: NSTableView {
         let target = focusedColumn < 0
             ? lastVisibleDataColumn()
             : previousVisibleDataColumn(before: focusedColumn)
-        guard target >= 1 else { return }
+        guard DataGridView.isDataTableColumn(target) else { return }
         focusedColumn = target
         if currentRow >= 0 { scrollColumnToVisible(target) }
     }
 
     private func handleRightArrow(currentRow: Int) {
-        let target = focusedColumn < 1
-            ? firstVisibleDataColumn()
-            : nextVisibleDataColumn(after: focusedColumn)
-        guard target >= 1 else { return }
+        let target = DataGridView.isDataTableColumn(focusedColumn)
+            ? nextVisibleDataColumn(after: focusedColumn)
+            : firstVisibleDataColumn()
+        guard DataGridView.isDataTableColumn(target) else { return }
         focusedColumn = target
         if currentRow >= 0 { scrollColumnToVisible(target) }
     }
 
     private func firstVisibleDataColumn() -> Int {
-        for index in 1..<numberOfColumns where isVisibleDataColumn(at: index) {
+        for index in DataGridView.firstDataTableColumnIndex..<numberOfColumns where isVisibleDataColumn(at: index) {
             return index
         }
         return -1
     }
 
     private func lastVisibleDataColumn() -> Int {
-        for index in stride(from: numberOfColumns - 1, through: 1, by: -1) where isVisibleDataColumn(at: index) {
+        for index in stride(
+            from: numberOfColumns - 1,
+            through: DataGridView.firstDataTableColumnIndex,
+            by: -1
+        ) where isVisibleDataColumn(at: index) {
             return index
         }
         return -1
@@ -252,8 +259,12 @@ final class KeyHandlingTableView: NSTableView {
     }
 
     private func previousVisibleDataColumn(before current: Int) -> Int {
-        guard current > 1 else { return -1 }
-        for index in stride(from: current - 1, through: 1, by: -1) where isVisibleDataColumn(at: index) {
+        guard current > DataGridView.firstDataTableColumnIndex else { return -1 }
+        for index in stride(
+            from: current - 1,
+            through: DataGridView.firstDataTableColumnIndex,
+            by: -1
+        ) where isVisibleDataColumn(at: index) {
             return index
         }
         return -1
@@ -267,13 +278,13 @@ final class KeyHandlingTableView: NSTableView {
 
     private func handleTabKey() {
         let row = selectedRow
-        guard row >= 0, focusedColumn >= 1 else { return }
+        guard row >= 0, DataGridView.isDataTableColumn(focusedColumn) else { return }
 
         var nextColumn = focusedColumn + 1
         var nextRow = row
 
         if nextColumn >= numberOfColumns {
-            nextColumn = 1
+            nextColumn = DataGridView.firstDataTableColumnIndex
             nextRow += 1
         }
         if nextRow >= numberOfRows {
@@ -290,18 +301,18 @@ final class KeyHandlingTableView: NSTableView {
 
     private func handleShiftTabKey() {
         let row = selectedRow
-        guard row >= 0, focusedColumn >= 1 else { return }
+        guard row >= 0, DataGridView.isDataTableColumn(focusedColumn) else { return }
 
         var prevColumn = focusedColumn - 1
         var prevRow = row
 
-        if prevColumn < 1 {
+        if !DataGridView.isDataTableColumn(prevColumn) {
             prevColumn = numberOfColumns - 1
             prevRow -= 1
         }
         if prevRow < 0 {
             prevRow = 0
-            prevColumn = 1
+            prevColumn = DataGridView.firstDataTableColumnIndex
         }
 
         selectRowIndexes(IndexSet(integer: prevRow), byExtendingSelection: false)

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -87,8 +87,9 @@ final class KeyHandlingTableView: NSTableView {
         focusedColumn = clickedColumn
 
         if alreadyFocusedHere && event.clickCount == 1 && selectedRowIndexes.count == 1 {
-            let dataColumnIndex = DataGridView.dataColumnIndex(for: clickedColumn)
-            if coordinator?.canStartInlineEdit(row: clickedRow, columnIndex: dataColumnIndex) == true {
+            if let schema = coordinator?.identitySchema,
+               let dataColumnIndex = DataGridView.dataColumnIndex(for: clickedColumn, in: self, schema: schema),
+               coordinator?.canStartInlineEdit(row: clickedRow, columnIndex: dataColumnIndex) == true {
                 editColumn(clickedColumn, row: clickedRow, with: nil, select: true)
             }
         }
@@ -106,11 +107,12 @@ final class KeyHandlingTableView: NSTableView {
 
     @objc func paste(_ sender: Any?) {
         guard coordinator?.isEditable == true else { return }
-        if focusedRow >= 0, DataGridView.isDataTableColumn(focusedColumn) {
-            let dataCol = DataGridView.dataColumnIndex(for: focusedColumn)
-            if coordinator?.pasteCellsFromClipboard(anchorRow: focusedRow, anchorColumn: dataCol) == true {
-                return
-            }
+        if focusedRow >= 0,
+           DataGridView.isDataTableColumn(focusedColumn),
+           let schema = coordinator?.identitySchema,
+           let dataCol = DataGridView.dataColumnIndex(for: focusedColumn, in: self, schema: schema),
+           coordinator?.pasteCellsFromClipboard(anchorRow: focusedRow, anchorColumn: dataCol) == true {
+            return
         }
         coordinator?.delegate?.dataGridPasteRows()
     }
@@ -176,12 +178,15 @@ final class KeyHandlingTableView: NSTableView {
         if let fkCombo = AppSettingsManager.shared.keyboard.shortcut(for: .previewFKReference),
            !fkCombo.isCleared,
            fkCombo.matches(event),
-           selectedRow >= 0, DataGridView.isDataTableColumn(focusedColumn) {
+           selectedRow >= 0,
+           DataGridView.isDataTableColumn(focusedColumn),
+           let schema = coordinator?.identitySchema,
+           let columnIndex = DataGridView.dataColumnIndex(for: focusedColumn, in: self, schema: schema) {
             coordinator?.toggleForeignKeyPreview(
                 tableView: self,
                 row: selectedRow,
                 column: focusedColumn,
-                columnIndex: DataGridView.dataColumnIndex(for: focusedColumn)
+                columnIndex: columnIndex
             )
             return
         }
@@ -191,11 +196,14 @@ final class KeyHandlingTableView: NSTableView {
 
     @objc override func insertNewline(_ sender: Any?) {
         let row = selectedRow
-        guard row >= 0, DataGridView.isDataTableColumn(focusedColumn), coordinator?.isEditable == true else {
+        guard row >= 0,
+              DataGridView.isDataTableColumn(focusedColumn),
+              coordinator?.isEditable == true,
+              let schema = coordinator?.identitySchema,
+              let columnIndex = DataGridView.dataColumnIndex(for: focusedColumn, in: self, schema: schema) else {
             return
         }
 
-        let columnIndex = DataGridView.dataColumnIndex(for: focusedColumn)
         if let value = coordinator?.cellValue(at: row, column: columnIndex),
            value.containsLineBreak {
             coordinator?.showOverlayEditor(tableView: self, row: row, column: focusedColumn, columnIndex: columnIndex, value: value)

--- a/TablePro/Views/Results/TableRowViewWithMenu.swift
+++ b/TablePro/Views/Results/TableRowViewWithMenu.swift
@@ -22,8 +22,13 @@ final class TableRowViewWithMenu: NSTableRowView {
         let locationInTable = tableView.convert(locationInRow, from: self)
         let clickedColumn = tableView.column(at: locationInTable)
 
-        // Adjust for row number column (index 0)
-        let dataColumnIndex = clickedColumn > 0 ? DataGridView.dataColumnIndex(for: clickedColumn) : -1
+        let dataColumnIndex: Int = {
+            guard clickedColumn > 0,
+                  let coord = coordinator,
+                  let index = DataGridView.dataColumnIndex(for: clickedColumn, in: tableView, schema: coord.identitySchema)
+            else { return -1 }
+            return index
+        }()
 
         let menu = NSMenu()
 
@@ -288,9 +293,14 @@ final class TableRowViewWithMenu: NSTableRowView {
 
     @objc private func previewForeignKey(_ sender: NSMenuItem) {
         guard let columnIndex = sender.representedObject as? Int,
-              let coordinator, let tableView = coordinator.tableView else { return }
+              let coordinator, let tableView = coordinator.tableView,
+              let column = DataGridView.tableColumnIndex(
+                for: columnIndex,
+                in: tableView,
+                schema: coordinator.identitySchema
+              ) else { return }
         coordinator.showForeignKeyPreview(
-            tableView: tableView, row: rowIndex, column: DataGridView.tableColumnIndex(for: columnIndex), columnIndex: columnIndex
+            tableView: tableView, row: rowIndex, column: column, columnIndex: columnIndex
         )
     }
 

--- a/TablePro/Views/Results/TableRowViewWithMenu.swift
+++ b/TablePro/Views/Results/TableRowViewWithMenu.swift
@@ -22,13 +22,9 @@ final class TableRowViewWithMenu: NSTableRowView {
         let locationInTable = tableView.convert(locationInRow, from: self)
         let clickedColumn = tableView.column(at: locationInTable)
 
-        let dataColumnIndex: Int = {
-            guard clickedColumn > 0,
-                  let coord = coordinator,
-                  let index = DataGridView.dataColumnIndex(for: clickedColumn, in: tableView, schema: coord.identitySchema)
-            else { return -1 }
-            return index
-        }()
+        let dataColumnIndex: Int = clickedColumn > 0
+            ? DataGridView.dataColumnIndex(for: clickedColumn, in: tableView, schema: coordinator.identitySchema) ?? -1
+            : -1
 
         let menu = NSMenu()
 


### PR DESCRIPTION
## Summary

DataGrid Phase 4 — full cleanup refactor addressing 8 verified audit items in 1 atomic PR.

## Real bugs (5)

- **#43** — `headerFont` was a computed property recreating NSFont on every call. Now `private static let`.
- **#41** — Theme observer Task missing `@MainActor`. Added annotation.
- **#38** — `sanitizedForCellDisplay` did double scan (containsLineBreak then replacement). Now true single-pass.
- **#42** — Column reorder O(n²) (`firstIndex(where:)` per slot). Built `[NSUserInterfaceItemIdentifier: Int]` index map, O(1) lookup.
- **#37** — `removeChangeAt` O(N) per removal (loop updating changeIndex dict). Replaced with swap-and-pop, O(1).

## Quality (3)

- **#22** — Removed `pendingDropdown*` instance vars from coordinator. Use `NSMenuItem.representedObject` carrying `DropdownMenuContext` reference type instead.
- **#18** — Routed remaining inline `column - 1` / `column >= 1` boundary checks through centralized helpers `firstDataTableColumnIndex` + `isDataTableColumn(_:)`. Migrated KeyHandlingTableView + DataGridView+Editing.
- **#53** — Consolidated mixed `displayCache.removeAll()` + `rebuildVisualStateCache()` callsites into single `invalidateAllDisplayCaches()` method. Format-only and teardown invalidations kept narrower (different scope).

## Files

8 files modified, +121 / -67:
- TablePro/Core/ChangeTracking/PendingChanges.swift
- TablePro/Views/Results/DataGridCellFactory.swift
- TablePro/Views/Results/DataGridColumnPool.swift
- TablePro/Views/Results/DataGridCoordinator.swift
- TablePro/Views/Results/DataGridView.swift
- TablePro/Views/Results/Extensions/DataGridView+Editing.swift
- TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
- TablePro/Views/Results/KeyHandlingTableView.swift

## Test plan

- [ ] xcodebuild build (compile check)
- [ ] swiftlint lint --strict
- [ ] Manual: open table, verify header rendering unchanged
- [ ] Manual: dropdown cell click → popover opens with correct row/col context
- [ ] Manual: column reorder by drag persists correctly
- [ ] Manual: cell with line breaks renders single-line correctly
- [ ] Manual: theme switch updates fonts without crash
- [ ] Manual: undo cell edit / row delete works (changeIndex correctness)
- [ ] Manual: keyboard arrow nav across columns (boundary helpers)