### PR TITLE
chore: clean up dead code from #956 refactor

### DIFF
--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
@@ -19,9 +19,6 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
     // Table description cache to avoid repeated DescribeTable calls
     private var _tableDescriptionCache: [String: TableDescription] = [:]
 
-    // Pagination state per query
-    private var _paginationStates: [String: PaginationState] = [:]
-
     private var connection: DynamoDBConnection? {
         lock.withLock { _connection }
     }
@@ -82,7 +79,6 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
             _connection?.disconnect()
             _connection = nil
             _tableDescriptionCache.removeAll()
-            _paginationStates.removeAll()
         }
     }
 
@@ -490,21 +486,7 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
             extractKeySchema(from: _tableDescriptionCache[table])
         }
 
-        let typeNames: [String] = lock.withLock {
-            let matchingState = _paginationStates.values.first { state in
-                if let parsed = DynamoDBQueryBuilder.parseScanQuery(state.queryKey) {
-                    return parsed.tableName == table
-                }
-                if let parsed = DynamoDBQueryBuilder.parseQueryQuery(state.queryKey) {
-                    return parsed.tableName == table
-                }
-                return false
-            }
-            if let state = matchingState {
-                return state.columnTypeNames
-            }
-            return columns.map { _ in "S" }
-        }
+        let typeNames: [String] = columns.map { _ in "S" }
 
         let generator = DynamoDBStatementGenerator(
             tableName: table,
@@ -817,60 +799,6 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         throw DynamoDBError.serverError("Invalid tagged query format")
     }
 
-    private func executePaginatedTaggedQuery(
-        _ query: String, offset: Int, limit: Int,
-        conn: DynamoDBConnection, startTime: Date
-    ) async throws -> PluginQueryResult {
-        let queryKey = query
-
-        // If offset is 0, start a fresh scan/query
-        if offset == 0 {
-            lock.withLock { _paginationStates.removeValue(forKey: queryKey) }
-        }
-
-        var state = lock.withLock { _paginationStates[queryKey] }
-
-        // If we have cached items that cover the requested range, serve from cache
-        if let existingState = state {
-            let end = min(offset + limit, existingState.allItems.count)
-            if offset < existingState.allItems.count {
-                let pageItems = Array(existingState.allItems[offset..<end])
-                let rows = DynamoDBItemFlattener.flatten(items: pageItems, columns: existingState.discoveredColumns)
-                return PluginQueryResult(
-                    columns: existingState.discoveredColumns,
-                    columnTypeNames: existingState.columnTypeNames,
-                    rows: rows,
-                    rowsAffected: 0,
-                    executionTime: Date().timeIntervalSince(startTime)
-                )
-            }
-
-            // Need more items but exhausted
-            if existingState.isExhausted {
-                return emptyResult(columns: existingState.discoveredColumns,
-                                   typeNames: existingState.columnTypeNames,
-                                   startTime: startTime)
-            }
-        }
-
-        // Fetch more items from DynamoDB
-        if let parsed = DynamoDBQueryBuilder.parseScanQuery(query) {
-            return try await fetchMoreScanItems(
-                parsed: parsed, queryKey: queryKey, offset: offset, limit: limit,
-                existingState: state, conn: conn, startTime: startTime
-            )
-        }
-
-        if let parsed = DynamoDBQueryBuilder.parseQueryQuery(query) {
-            return try await fetchMoreQueryItems(
-                parsed: parsed, queryKey: queryKey, offset: offset, limit: limit,
-                existingState: state, conn: conn, startTime: startTime
-            )
-        }
-
-        return try await executeTaggedQuery(query, conn: conn, startTime: startTime)
-    }
-
     // MARK: - Scan Execution
 
     private func executeScan(
@@ -983,161 +911,6 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         return PluginQueryResult(
             columns: columns,
             columnTypeNames: typeNames,
-            rows: rows,
-            rowsAffected: 0,
-            executionTime: Date().timeIntervalSince(startTime)
-        )
-    }
-
-    // MARK: - Paginated Fetch Helpers
-
-    private func fetchMoreScanItems(
-        parsed: DynamoDBParsedScanQuery,
-        queryKey: String,
-        offset: Int,
-        limit: Int,
-        existingState: PaginationState?,
-        conn: DynamoDBConnection,
-        startTime: Date
-    ) async throws -> PluginQueryResult {
-        let keySchema = try await cachedKeySchema(parsed.tableName, conn: conn)
-        var state = existingState ?? PaginationState(
-            queryKey: queryKey,
-            allItems: [],
-            lastEvaluatedKey: nil,
-            isExhausted: false,
-            discoveredColumns: [],
-            columnTypeNames: [],
-            keySchema: keySchema
-        )
-
-        // Fetch until we have enough items or exhaust the table
-        let needed = offset + limit
-        while state.allItems.count < needed && !state.isExhausted {
-            let batchSize = min(needed - state.allItems.count, 1000)
-            let response = try await conn.scan(
-                tableName: parsed.tableName,
-                limit: batchSize,
-                exclusiveStartKey: state.lastEvaluatedKey
-            )
-
-            var newItems = response.Items ?? []
-
-            if !parsed.filters.isEmpty {
-                newItems = applyClientFilters(
-                    items: newItems, filters: parsed.filters, logicMode: parsed.logicMode
-                )
-            }
-
-            state.allItems.append(contentsOf: newItems)
-            state.lastEvaluatedKey = response.LastEvaluatedKey
-
-            if response.LastEvaluatedKey == nil {
-                state.isExhausted = true
-            }
-
-            if state.allItems.count >= Self.maxItems {
-                state.isExhausted = true
-                state.allItems = Array(state.allItems.prefix(Self.maxItems))
-            }
-        }
-
-        // Update discovered columns from all items
-        state.discoveredColumns = DynamoDBItemFlattener.unionColumns(from: state.allItems, keySchema: keySchema)
-        state.columnTypeNames = DynamoDBItemFlattener.columnTypeNames(
-            for: state.discoveredColumns, items: state.allItems
-        )
-
-        lock.withLock { _paginationStates[queryKey] = state }
-
-        // Serve the requested page
-        let end = min(offset + limit, state.allItems.count)
-        guard offset < state.allItems.count else {
-            return emptyResult(columns: state.discoveredColumns, typeNames: state.columnTypeNames, startTime: startTime)
-        }
-        let pageItems = Array(state.allItems[offset..<end])
-        let rows = DynamoDBItemFlattener.flatten(items: pageItems, columns: state.discoveredColumns)
-
-        return PluginQueryResult(
-            columns: state.discoveredColumns,
-            columnTypeNames: state.columnTypeNames,
-            rows: rows,
-            rowsAffected: 0,
-            executionTime: Date().timeIntervalSince(startTime)
-        )
-    }
-
-    private func fetchMoreQueryItems(
-        parsed: DynamoDBParsedQueryQuery,
-        queryKey: String,
-        offset: Int,
-        limit: Int,
-        existingState: PaginationState?,
-        conn: DynamoDBConnection,
-        startTime: Date
-    ) async throws -> PluginQueryResult {
-        let keySchema = try await cachedKeySchema(parsed.tableName, conn: conn)
-        var state = existingState ?? PaginationState(
-            queryKey: queryKey,
-            allItems: [],
-            lastEvaluatedKey: nil,
-            isExhausted: false,
-            discoveredColumns: [],
-            columnTypeNames: [],
-            keySchema: keySchema
-        )
-
-        var expressionValues: [String: DynamoDBAttributeValue] = [:]
-        switch parsed.partitionKeyType {
-        case "N":
-            expressionValues[":pkval"] = .number(parsed.partitionKeyValue)
-        default:
-            expressionValues[":pkval"] = .string(parsed.partitionKeyValue)
-        }
-        let keyCondition = "\(parsed.partitionKeyName) = :pkval"
-
-        let needed = offset + limit
-        while state.allItems.count < needed && !state.isExhausted {
-            let batchSize = min(needed - state.allItems.count, 1000)
-            let response = try await conn.query(
-                tableName: parsed.tableName,
-                keyConditionExpression: keyCondition,
-                expressionAttributeValues: expressionValues,
-                limit: batchSize,
-                exclusiveStartKey: state.lastEvaluatedKey
-            )
-
-            let fetchedItems = response.Items ?? []
-            state.allItems.append(contentsOf: fetchedItems)
-            state.lastEvaluatedKey = response.LastEvaluatedKey
-
-            if response.LastEvaluatedKey == nil {
-                state.isExhausted = true
-            }
-
-            if state.allItems.count >= Self.maxItems {
-                state.isExhausted = true
-                state.allItems = Array(state.allItems.prefix(Self.maxItems))
-            }
-        }
-
-        state.discoveredColumns = DynamoDBItemFlattener.unionColumns(from: state.allItems, keySchema: keySchema)
-        state.columnTypeNames = DynamoDBItemFlattener.columnTypeNames(
-            for: state.discoveredColumns, items: state.allItems
-        )
-
-        lock.withLock { _paginationStates[queryKey] = state }
-
-        let end = min(offset + limit, state.allItems.count)
-        guard offset < state.allItems.count else {
-            return emptyResult(columns: state.discoveredColumns, typeNames: state.columnTypeNames, startTime: startTime)
-        }
-        let pageItems = Array(state.allItems[offset..<end])
-        let rows = DynamoDBItemFlattener.flatten(items: pageItems, columns: state.discoveredColumns)
-
-        return PluginQueryResult(
-            columns: state.discoveredColumns,
-            columnTypeNames: state.columnTypeNames,
             rows: rows,
             rowsAffected: 0,
             executionTime: Date().timeIntervalSince(startTime)
@@ -1444,31 +1217,9 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         }
     }
 
-    private func emptyResult(columns: [String], typeNames: [String], startTime: Date) -> PluginQueryResult {
-        PluginQueryResult(
-            columns: columns.isEmpty ? ["Result"] : columns,
-            columnTypeNames: typeNames.isEmpty ? ["String"] : typeNames,
-            rows: [],
-            rowsAffected: 0,
-            executionTime: Date().timeIntervalSince(startTime)
-        )
-    }
-
     private func formatBytes(_ bytes: Int64) -> String {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .binary
         return formatter.string(fromByteCount: bytes)
     }
-}
-
-// MARK: - Pagination State
-
-private struct PaginationState {
-    let queryKey: String
-    var allItems: [[String: DynamoDBAttributeValue]]
-    var lastEvaluatedKey: [String: DynamoDBAttributeValue]?
-    var isExhausted: Bool
-    var discoveredColumns: [String]
-    var columnTypeNames: [String]
-    var keySchema: [(name: String, keyType: String)]
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -987,35 +987,6 @@
         }
       }
     },
-    "%@ of %@%@ rows" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ of %2$@%3$@ rows"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/%@%@ satır"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ trên %@%@ dòng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/%@%@ 行"
-          }
-        }
-      }
-    },
     "%@ on %@ completed successfully." : {
       "localizations" : {
         "en" : {
@@ -1109,29 +1080,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 行"
-          }
-        }
-      }
-    },
-    "%@ rows (more available)" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ satır (daha fazla mevcut)"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ dòng (còn thêm)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 行（还有更多）"
           }
         }
       }
@@ -2136,64 +2084,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 个表，%lld 个关系"
-          }
-        }
-      }
-    },
-    "%lld-%lld of %@ rows" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld-%2$lld of %3$@ rows"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld-%lld / %@ satır"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld-%2$lld trong %3$@ dòng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld-%lld / %@ 行"
-          }
-        }
-      }
-    },
-    "%lld-%lld of %@%@ rows" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld-%2$lld of %3$@%4$@ rows"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld-%lld / %@%@ satır"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld-%2$lld của %3$@%4$@ dòng"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld-%lld / %@%@ 行"
           }
         }
       }
@@ -15586,29 +15476,6 @@
         }
       }
     },
-    "Enforce query result limit" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorgu sonuç limitini uygula"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Áp dụng giới hạn kết quả truy vấn"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "强制查询结果限制"
-          }
-        }
-      }
-    },
     "Engine" : {
       "localizations" : {
         "tr" : {
@@ -23671,29 +23538,6 @@
         }
       }
     },
-    "Limit initial query results and load more on demand" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İlk sorgu sonuçlarını sınırla ve istendiğinde daha fazla yükle"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giới hạn kết quả truy vấn ban đầu và tải thêm khi cần"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "限制初始查询结果并按需加载更多"
-          }
-        }
-      }
-    },
     "Line %lld: %@" : {
       "localizations" : {
         "en" : {
@@ -23875,29 +23719,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载模型"
-          }
-        }
-      }
-    },
-    "Load More" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Daha Fazla Yükle"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tải thêm"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "加载更多"
           }
         }
       }
@@ -32089,29 +31910,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Query result row cap must be between %1$@ and %2$@"
-          }
-        }
-      }
-    },
-    "Query results exceeding this limit show Load More / Fetch All buttons" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu limiti aşan sorgu sonuçları Daha Fazla Yükle / Tümünü Getir düğmelerini gösterir"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kết quả truy vấn vượt quá giới hạn sẽ hiển thị nút Tải thêm / Tải tất cả"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "超过此限制的查询结果将显示“加载更多”/“获取全部”按钮"
           }
         }
       }


### PR DESCRIPTION
## Summary

Post-merge cleanup of dead code left behind by the #956 query execution refactor (PR #960).

- Removes three unreachable DynamoDB methods (`executePaginatedTaggedQuery`, `fetchMoreScanItems`, `fetchMoreQueryItems`) plus the private `PaginationState` struct and continuation-token cache that supported them. Simplifies one consumer block in `generateStatements` from a 14-line cache lookup to a one-liner.
- Removes 8 stale localization keys for the old Load More UI: `%@ of %@%@ rows`, `%lld-%lld of %@ rows`, `%lld-%lld of %@%@ rows`, `%@ rows (more available)`, `Load More`, `Enforce query result limit`, `Limit initial query results and load more on demand`, `Query results exceeding this limit show Load More / Fetch All buttons`.

Net: 451 lines deleted, no behavior change.

## Out of scope (intentional)

- `Packages/TableProCore/Sources/TableProPluginKit/` (iOS package mirror) still has the old paged API. Not linked into the macOS app, only into `TableProMobile.xcodeproj`. Migrating the iOS PluginKit is iOS-team work; the two PluginKits will need to be unified later.

## Test plan

Pure code deletion, no behavior change. Verify by build:

- [ ] `xcodebuild -project TablePro.xcodeproj -scheme TablePro -configuration Debug build -skipPackagePluginValidation` passes
- [ ] DynamoDB connection still works (connect, list tables, scan / query, no regression in existing pagination of `fetchScanItems` / `fetchQueryItems`)
- [ ] Settings UI still labels the row cap correctly (no missing-translation warnings from the removed catalog keys)

## Verification grep

Should return zero hits in `TablePro/`, `Plugins/`, and `TableProTests/`:

```
rg -t swift "fetchFirstPage|fetchNextPage|fetchRows\(query|fetchRowCount|stripLimitOffset|limitRegex|offsetRegex|stripMSSQLOffsetFetch|stripOracleOffsetFetch|PluginPagedResult|PagedQueryResult|loadMoreOffset|loadMoreRows|enforceQueryResultLimit|queryResultLimit"
rg "Load More" --type swift
```