### PR TITLE
fix(windows): persist welcome, connection form, feedback window positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Welcome window, connection form, and feedback panel now remember their position and size across launches. Previously these always reopened centered on screen because `setFrameAutosaveName` was never set on the underlying `NSWindow`/`NSPanel`. They now use the same native AppKit frame autosave mechanism the main editor and Settings windows already used.
 - MCP: GET `/mcp` now opens a real SSE notification stream. Previously the GET path was routed through the request dispatcher, which had no handler for it, so the connection was closed immediately and `notifications/progress` events were dropped.
 - MCP: concurrent tool calls no longer serialize at the dispatcher loop. Each exchange is dispatched in its own child task while session-state guards still serialize per-session work.
 - MCP: server validates the `protocolVersion` requested in `initialize` against a supported set and rejects unknown versions with `-32600 invalid_request` instead of silently echoing back whatever the client sent.

--- a/TablePro/Core/Services/Infrastructure/ConnectionFormWindowFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionFormWindowFactory.swift
@@ -9,6 +9,7 @@ import SwiftUI
 @MainActor
 internal enum ConnectionFormWindowFactory {
     private static let baseIdentifier = "connection-form"
+    private static let autosaveName: NSWindow.FrameAutosaveName = "ConnectionFormWindow"
 
     internal static func openOrFront(connectionId: UUID? = nil) {
         if let existing = existingWindow(for: connectionId) {
@@ -53,8 +54,8 @@ internal enum ConnectionFormWindowFactory {
         window.standardWindowButton(.zoomButton)?.isEnabled = false
         window.styleMask.remove(.miniaturizable)
         window.collectionBehavior.insert(.fullScreenNone)
-        window.center()
         window.isReleasedWhenClosed = false
+        window.applyAutosaveName(autosaveName)
         return window
     }
 }

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -74,7 +74,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.identifier = NSUserInterfaceItemIdentifier("main")
         window.minSize = NSSize(width: 720, height: 480)
         window.isRestorable = false
-        window.setFrameAutosaveName("MainEditorWindow")
+        window.applyAutosaveName("MainEditorWindow")
         window.toolbarStyle = .unified
         // Hide the window title ("Query 1 / TablePro") embedded in the unified
         // toolbar — otherwise it claims leading space and pushes our navigation

--- a/TablePro/Core/Services/Infrastructure/WelcomeWindowFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/WelcomeWindowFactory.swift
@@ -9,6 +9,7 @@ import SwiftUI
 @MainActor
 internal enum WelcomeWindowFactory {
     private static let identifier = NSUserInterfaceItemIdentifier("welcome")
+    private static let autosaveName: NSWindow.FrameAutosaveName = "WelcomeWindow"
     private static let contentSize = NSSize(width: 700, height: 450)
 
     internal static func openOrFront() {
@@ -48,8 +49,8 @@ internal enum WelcomeWindowFactory {
         window.standardWindowButton(.zoomButton)?.isHidden = true
         window.collectionBehavior.insert(.fullScreenNone)
         window.setContentSize(contentSize)
-        window.center()
         window.isReleasedWhenClosed = false
+        window.applyAutosaveName(autosaveName)
         return window
     }
 }

--- a/TablePro/Extensions/NSWindow+FrameAutosave.swift
+++ b/TablePro/Extensions/NSWindow+FrameAutosave.swift
@@ -1,0 +1,15 @@
+//
+//  NSWindow+FrameAutosave.swift
+//  TablePro
+//
+
+import AppKit
+
+extension NSWindow {
+    func applyAutosaveName(_ name: NSWindow.FrameAutosaveName) {
+        setFrameAutosaveName(name)
+        if !setFrameUsingName(name) {
+            center()
+        }
+    }
+}

--- a/TablePro/Views/Feedback/FeedbackWindowController.swift
+++ b/TablePro/Views/Feedback/FeedbackWindowController.swift
@@ -9,6 +9,7 @@ import SwiftUI
 @MainActor
 final class FeedbackWindowController {
     static let shared = FeedbackWindowController()
+    private static let autosaveName: NSWindow.FrameAutosaveName = "FeedbackWindow"
     private var panel: NSPanel?
     private var closeObserver: NSObjectProtocol?
     private let viewModel = FeedbackViewModel()
@@ -42,7 +43,7 @@ final class FeedbackWindowController {
         panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
         panel.standardWindowButton(.zoomButton)?.isHidden = true
         panel.contentView = hostingView
-        panel.center()
+        panel.applyAutosaveName(Self.autosaveName)
         panel.makeKeyAndOrderFront(nil)
         self.panel = panel
 


### PR DESCRIPTION
## Summary

- Welcome window, connection form, and feedback panel reverted to a centered default every time they reopened, because their factories called `window.center()` and never set a frame autosave name. Only the main editor (`MainEditorWindow`) and the SwiftUI Settings scene remembered position.
- Added a small `NSWindow.applyAutosaveName(_:)` extension that wraps the native AppKit pattern (`setFrameAutosaveName` + `setFrameUsingName` with `center()` as first-launch fallback) and applied it to all four custom windows: Welcome, Connection Form (shared key for new + edit), Feedback panel, and Main Editor (refactored from inline `setFrameAutosaveName` for consistency).
- Settings window untouched: SwiftUI's `Settings { }` scene already handles position persistence.

## Test plan

- [ ] Open the welcome window, drag it to a new position, quit the app, relaunch — welcome reopens at the saved position
- [ ] Open the connection form (new connection), move it, close it, reopen — same position
- [ ] Open an edit-connection form, move it, close, then open a different connection's edit form — opens at the saved position (shared autosave key by design)
- [ ] Report an Issue panel: move it, close, reopen — same position
- [ ] Main editor window position still persists across launches (regression check)
- [ ] Fresh install (delete app domain from `defaults`): all four windows open centered on first launch