### PR TITLE
feat(welcome): align with macOS HIG and add Check for Updates link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Welcome window: "Check for Updates" link next to the version number triggers Sparkle without leaving the screen
 - Window menu: "Integrations Activity" opens a dedicated, resizable window for the MCP activity log and connected clients. The window has a sidebar (Activity Log / Connected Clients) and a unified toolbar with native search, filter menu, refresh, and export. Window size is remembered across launches.
 - Sample database (Chinook) bundled — open from welcome screen with one click; reset via File menu
 - Connection string detection — paste a `postgres://`, `mysql://`, `redis://`, or `mongodb://` URL, then click Use to auto-fill the connection form
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Welcome window UI tightened to macOS HIG: app icon shows a subtle drop shadow instead of an accent-color glow, version line uses dynamic text styles, the "Sponsor" button is removed, the "Create connection" button uses the bordered control style, and toolbar icon buttons (+ / new group) gain a hover background. Activate License now uses the link button style.
 - Settings > Integrations is now a flat preferences pane per macOS HIG. The activity log, the connected-clients list, and the setup instructions have moved out of Settings: activity and connections live in the new Integrations Activity window (Window menu), and setup instructions open in a "Connect a Client…" sheet from the Settings pane. Settings keeps only configuration: server toggle, status, port, row limits, query timeout, authentication tokens, and network options.
 - MCP: idle session timeout raised from 5 to 15 minutes.
 - MCP: complete internal rewrite of the server, stdio bridge, and protocol dispatcher for spec compliance. Public API of `MCPServerManager` and the on-disk handshake format are unchanged; clients do not need to re-pair.

--- a/TablePro/Core/Services/Infrastructure/UpdaterBridge.swift
+++ b/TablePro/Core/Services/Infrastructure/UpdaterBridge.swift
@@ -11,6 +11,8 @@ import Sparkle
 @Observable
 @MainActor
 final class UpdaterBridge {
+    static let shared = UpdaterBridge()
+
     @ObservationIgnored private let controller: SPUStandardUpdaterController
     var canCheckForUpdates = false
 
@@ -21,7 +23,7 @@ final class UpdaterBridge {
         observation = nil
     }
 
-    init() {
+    private init() {
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -627,7 +627,7 @@ struct TableProApp: App {
     var appDelegate
 
     @State private var settingsManager = AppSettingsManager.shared
-    @State private var updaterBridge = UpdaterBridge()
+    @State private var updaterBridge = UpdaterBridge.shared
     @State private var commandRegistry = CommandActionsRegistry.shared
 
     init() {

--- a/TablePro/Views/Connection/WelcomeLeftPanel.swift
+++ b/TablePro/Views/Connection/WelcomeLeftPanel.swift
@@ -9,6 +9,8 @@ struct WelcomeLeftPanel: View {
     let onActivateLicense: () -> Void
     let onCreateConnection: () -> Void
 
+    private let updaterBridge = UpdaterBridge.shared
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -16,53 +18,28 @@ struct WelcomeLeftPanel: View {
             VStack(spacing: 16) {
                 Image(nsImage: NSApp.applicationIconImage)
                     .resizable()
-                    .frame(width: 80, height: 80)
-                    .shadow(color: Color.accentColor.opacity(0.4), radius: 20, x: 0, y: 0)
+                    .frame(width: 96, height: 96)
+                    .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
 
                 VStack(spacing: 6) {
                     Text("TablePro")
-                        .font(.system(size: 24, weight: .semibold))
+                        .font(.title2.weight(.semibold))
 
-                    Text("Version \(Bundle.main.appVersion)")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                    versionLine
 
-                    if LicenseManager.shared.status.isValid {
-                        Label("Pro", systemImage: "checkmark.seal.fill")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(Color(nsColor: .systemGreen))
-                    } else {
-                        Button(action: onActivateLicense) {
-                            Text("Activate License")
-                                .font(.subheadline)
-                        }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.secondary)
-                    }
+                    licenseLine
                 }
             }
 
             Spacer()
-                .frame(height: 48)
+                .frame(height: 32)
 
-            VStack(spacing: 12) {
-                Button {
-                    if let url = URL(string: "https://github.com/sponsors/datlechin") {
-                        NSWorkspace.shared.open(url)
-                    }
-                } label: {
-                    Label("Sponsor TablePro", systemImage: "heart")
-                }
-                .buttonStyle(.plain)
-                .font(.subheadline)
-                .foregroundStyle(.pink)
-
-                Button(action: onCreateConnection) {
-                    Label("Create connection...", systemImage: "plus.circle")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .buttonStyle(WelcomeButtonStyle())
+            Button(action: onCreateConnection) {
+                Label("Create connection...", systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
             .padding(.horizontal, 32)
 
             Spacer()
@@ -79,30 +56,69 @@ struct WelcomeLeftPanel: View {
                     KeyboardHint(keys: "⌘,", label: nil)
                 }
             }
-            .font(.subheadline)
+            .font(.caption)
             .foregroundStyle(.tertiary)
             .padding(.horizontal, 12)
             .padding(.bottom, 20)
         }
         .frame(width: 260)
     }
+
+    private var versionLine: some View {
+        HStack(spacing: 6) {
+            Text("Version \(Bundle.main.appVersion)")
+                .foregroundStyle(.secondary)
+            Text(verbatim: "·")
+                .foregroundStyle(.tertiary)
+            Button {
+                updaterBridge.checkForUpdates()
+            } label: {
+                Text("Check for Updates...")
+            }
+            .buttonStyle(.link)
+            .disabled(!updaterBridge.canCheckForUpdates)
+        }
+        .font(.callout)
+    }
+
+    @ViewBuilder
+    private var licenseLine: some View {
+        if LicenseManager.shared.status.isValid {
+            Label("Pro", systemImage: "checkmark.seal.fill")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Color(nsColor: .systemGreen))
+        } else {
+            HoverAccentButton(action: onActivateLicense) {
+                Text("Activate License")
+                    .font(.subheadline)
+            }
+        }
+    }
 }
 
-struct WelcomeButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.body)
-            .foregroundStyle(.primary)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(
-                        Color(
-                            nsColor: configuration.isPressed
-                                ? .controlBackgroundColor : .quaternaryLabelColor))
-            )
+private struct HoverAccentButton<Label: View>: View {
+    let action: () -> Void
+    @ViewBuilder let label: () -> Label
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            label()
+                .foregroundStyle(isHovering
+                    ? AnyShapeStyle(Color.accentColor)
+                    : AnyShapeStyle(HierarchicalShapeStyle.secondary))
+                .underline(isHovering, color: .accentColor)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovering = hovering
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
     }
 }
 
@@ -118,7 +134,7 @@ struct KeyboardHint: View {
                 .padding(.vertical, 2)
                 .background(
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(Color(nsColor: .quaternaryLabelColor))
+                        .fill(.tertiary.opacity(0.4))
                 )
             if let label {
                 Text(label)

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -31,9 +31,8 @@ struct WelcomeWindowView: View {
                     .transition(.move(edge: .trailing))
             }
         }
-        .background(.background)
+        .background(VisualEffectBackground(material: .underWindowBackground, blendingMode: .behindWindow))
         .ignoresSafeArea()
-        .frame(minWidth: 600, idealWidth: 700, minHeight: 400, idealHeight: 450)
         .onAppear {
             vm.setUp()
             focus = .search
@@ -182,32 +181,26 @@ struct WelcomeWindowView: View {
 
     private var rightPanel: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 8) {
-                Button(action: { ConnectionFormWindowFactory.openOrFront() }) {
-                    Image(systemName: "plus")
-                        .font(.callout.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .frame(
-                            width: 24,
-                            height: 24
-                        )
-                }
-                .buttonStyle(.borderless)
-                .help(String(localized: "New Connection (⌘N)"))
-                .accessibilityLabel(String(localized: "New Connection"))
+            HStack(spacing: 0) {
+                HStack(spacing: 4) {
+                    WelcomeToolbarButton(
+                        systemImage: "plus",
+                        help: String(localized: "New Connection (⌘N)"),
+                        accessibilityLabel: String(localized: "New Connection")
+                    ) {
+                        ConnectionFormWindowFactory.openOrFront()
+                    }
 
-                Button(action: { vm.pendingMoveToNewGroup = []; vm.activeSheet = .newGroup(parentId: nil) }) {
-                    Image(systemName: "folder.badge.plus")
-                        .font(.callout.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .frame(
-                            width: 24,
-                            height: 24
-                        )
+                    WelcomeToolbarButton(
+                        systemImage: "folder.badge.plus",
+                        help: String(localized: "New Group"),
+                        accessibilityLabel: String(localized: "New Group")
+                    ) {
+                        vm.pendingMoveToNewGroup = []
+                        vm.activeSheet = .newGroup(parentId: nil)
+                    }
                 }
-                .buttonStyle(.borderless)
-                .help(String(localized: "New Group"))
-                .accessibilityLabel(String(localized: "New Group"))
+                .padding(.trailing, 12)
 
                 NativeSearchField(
                     text: $vm.searchText,
@@ -370,7 +363,7 @@ struct WelcomeWindowView: View {
                 DatabaseType(rawValue: linked.connection.type).iconImage
                     .frame(width: 28, height: 28)
                 Image(systemName: "folder.fill")
-                    .font(.system(size: 8))
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
                     .offset(x: 2, y: 2)
             }
@@ -493,7 +486,7 @@ private struct TreeRowsView<ConnectionContent: View>: View {
                 .foregroundStyle(.secondary)
 
             Text("\(vm.connectionCountByGroup[group.id] ?? 0)")
-                .font(.system(size: 9))
+                .font(.caption2)
                 .foregroundStyle(.tertiary)
 
             Spacer()
@@ -594,6 +587,56 @@ private struct TreeRowsView<ConnectionContent: View>: View {
         } label: {
             Label(String(localized: "Delete Group"), systemImage: "trash")
         }
+    }
+}
+
+// MARK: - Visual Effect Background
+
+private struct VisualEffectBackground: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .followsWindowActiveState
+        view.isEmphasized = true
+        return view
+    }
+
+    func updateNSView(_ view: NSVisualEffectView, context: Context) {
+        view.material = material
+        view.blendingMode = blendingMode
+    }
+}
+
+// MARK: - Toolbar Button
+
+private struct WelcomeToolbarButton: View {
+    let systemImage: String
+    let help: String
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .frame(width: 28, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovering ? AnyShapeStyle(.quaternary) : AnyShapeStyle(.clear))
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .onHover { isHovering = $0 }
+        .help(help)
+        .accessibilityLabel(accessibilityLabel)
     }
 }
 

--- a/TablePro/Views/Settings/GeneralSettingsView.swift
+++ b/TablePro/Views/Settings/GeneralSettingsView.swift
@@ -112,7 +112,7 @@ struct GeneralSettingsView: View {
         settings: .constant(.default),
         tabSettings: .constant(.default),
         historySettings: .constant(.default),
-        updaterBridge: UpdaterBridge(),
+        updaterBridge: UpdaterBridge.shared,
         onResetAll: {}
     )
     .frame(width: 450, height: 500)

--- a/TablePro/Views/Settings/SettingsView.swift
+++ b/TablePro/Views/Settings/SettingsView.swift
@@ -67,5 +67,5 @@ struct SettingsView: View {
 
 #Preview {
     SettingsView()
-        .environment(UpdaterBridge())
+        .environment(UpdaterBridge.shared)
 }


### PR DESCRIPTION
## Summary

- Add **Check for Updates...** link next to Version in the welcome window left panel — Sparkle integration via shared `UpdaterBridge` singleton.
- HIG cleanup throughout the welcome window: app icon shadow, dynamic type, button styles, spacing semantics, toolbar hover states, window vibrancy.
- Promote `UpdaterBridge` to `static let shared` so the welcome window can read it without threading a parameter through every factory call site.
- Remove the Sponsor button.

## HIG fixes

| # | Item | Before | After |
|---|---|---|---|
| 1 | App icon shadow | Accent-color glow (`radius: 20`) | Subtle drop shadow (black 18%, `radius: 8, y: 4`) |
| 2 | Hardcoded font sizes | `.system(size: 24/9/8)` | `.title2`, `.caption2` (Dynamic Type) |
| 3 | Sponsor button | Pink `.plain` styled link | Removed |
| 4 | Create connection button | Custom `WelcomeButtonStyle` with `quaternaryLabelColor` background | `.bordered .controlSize(.large)` |
| 5 | KeyboardHint keycap | `Color(nsColor: .quaternaryLabelColor)` | `.tertiary` shape style |
| 6 | Toolbar `+` / `folder.badge.plus` | `.borderless`, `.secondary` foreground, no hover, 24×24 | `.body` font, `.primary` foreground, hover background, 28×28 (HIG min hit target), `contentShape(Rectangle())` for full hit area |
| 7 | Toolbar spacing | Flat `HStack(spacing: 2/4)` | Nested HStack: 4pt within action cluster, 12pt group separator before search field |
| 8 | Window frame | Dead `frame(minWidth:idealWidth:...)` modifier (styleMask non-resizable) | Removed; window factory `setContentSize` is single source of truth |
| 9 | Activate License | `.buttonStyle(.link)` (always blue) | `HoverAccentButton` — `.plain` + `.secondary` text + accent on hover + `NSCursor.pointingHand` |
| 10 | Window background | `.background(.background)` (opaque) | `NSVisualEffectView` with `.underWindowBackground` material + `.behindWindow` blending + `followsWindowActiveState` |

## Bug fixes (caught from screenshots)

- **`.foregroundStyle(.secondary)` parent override on `.link` button**: parent HStack `.foregroundStyle` propagates to button labels, overriding `.link`'s accent color. The new Check for Updates link was rendering grey instead of accent. Moved `.foregroundStyle` to specific `Text` views only — link now reads its native accent color.
- **Toolbar icons too dim in dark mode**: `.secondary` foreground for SF Symbols on dark background failed to surface affordance. Bumped to `.primary` at rest (Apple Mail / Notes / Finder pattern); hover adds subtle background.

## Architecture note

`UpdaterBridge` becomes a singleton because Sparkle's `SPUStandardUpdaterController` starts the updater on init — multiple instances cause race conditions on feed parsing and update prompts. `static let shared` matches existing storage classes (`ConnectionStorage.shared`, `LicenseManager.shared`, `AppSettingsManager.shared`).

## Test plan

- [ ] Welcome window opens with vibrant background (drag onto colored wallpaper to verify blur)
- [ ] App icon has subtle drop shadow, no accent glow
- [ ] Version line: `Version X.Y.Z · Check for Updates...` — link is accent blue when enabled, dim when Sparkle is mid-check
- [ ] Activate License: secondary grey at rest; hover turns accent blue + underline + pointing hand cursor
- [ ] Toolbar `+` and folder buttons: visible at rest in dark mode; hover adds background; 28×28 hit target works on edges
- [ ] Spacing: tight 4pt cluster between `+` and folder; clear 12pt gap before search field
- [ ] Click "Check for Updates..." opens Sparkle dialog (or "You're up to date" message)
- [ ] Vibrancy dims when window loses focus (`followsWindowActiveState`)
- [ ] No Sponsor button visible
- [ ] Dynamic Type: bump system text size in Settings → welcome text scales
- [ ] Light mode + dark mode parity
- [ ] `swiftlint lint --strict` passes