### PR TITLE
fix(tabs): attach session registry to tab manager when coordinator owns it

### DIFF
--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -38,6 +38,14 @@ final class QueryTabManager {
         self.tabSessionRegistry = tabSessionRegistry
     }
 
+    func attachSessionRegistryIfNeeded(_ registry: TabSessionRegistry) {
+        guard tabSessionRegistry == nil else { return }
+        tabSessionRegistry = registry
+        for tab in tabs where registry.session(for: tab.id) == nil {
+            registry.register(TabSession(queryTab: tab))
+        }
+    }
+
     private func syncTabSessionRegistry(oldTabs: [QueryTab], newTabs: [QueryTab]) {
         guard let registry = tabSessionRegistry else { return }
         let oldIds = Set(oldTabs.map(\.id))

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -342,6 +342,7 @@ final class MainContentCoordinator {
         self.changeManager = changeManager
         self.toolbarState = toolbarState
         self.tabSessionRegistry = tabSessionRegistry ?? TabSessionRegistry()
+        tabManager.attachSessionRegistryIfNeeded(self.tabSessionRegistry)
         self.queryExecutor = queryExecutor ?? QueryExecutor(connection: connection)
         let dialect = PluginManager.shared.sqlDialect(for: connection.type)
         self.queryBuilder = TableQueryBuilder(


### PR DESCRIPTION
## Summary

- `MainContentCoordinator` may construct a `QueryTabManager` first and resolve its own `TabSessionRegistry` later (callers can pass `tabSessionRegistry: nil`, in which case the coordinator creates a fresh registry in init). When the manager was built without a registry, any tabs already on it never got a `TabSession` registered — only later mutations to `tabs` triggered `syncTabSessionRegistry`.
- Adds `QueryTabManager.attachSessionRegistryIfNeeded(_:)` to wire a registry in after construction and back-fill `TabSession` entries for the existing tabs. Coordinator init calls it once the registry is resolved.

## Test plan

- [ ] Open a connection that hydrates tabs from disk before the coordinator is built. Verify the `TabSessionRegistry` has a session for each tab (e.g. via tab session features that depend on the registry).
- [ ] Construct a `QueryTabManager` without a registry, populate `tabs`, then call `attachSessionRegistryIfNeeded`. Registry should contain one session per tab id.
- [ ] Construct with a registry pre-supplied. The new method is a no-op.