### PR TITLE
test(favorites): cover linked node cases in filterTree helper

### DIFF
--- a/TableProTests/ViewModels/FavoritesSidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/FavoritesSidebarViewModelTests.swift
@@ -285,6 +285,30 @@ struct FavoriteNodeTests {
                     return .folder(folder, children: filteredChildren)
                 }
                 return nil
+            case .linkedFavorite(let linked):
+                if linked.name.localizedCaseInsensitiveContains(searchText) ||
+                    (linked.keyword?.localizedCaseInsensitiveContains(searchText) == true) ||
+                    linked.relativePath.localizedCaseInsensitiveContains(searchText) {
+                    return node
+                }
+                return nil
+            case .linkedFolder(let folder):
+                let filteredChildren = filterTree(node.children ?? [], searchText: searchText)
+                if !filteredChildren.isEmpty || folder.name.localizedCaseInsensitiveContains(searchText) {
+                    return .linkedFolder(folder, children: filteredChildren)
+                }
+                return nil
+            case .linkedSubfolder(let folderId, let displayName, let pathPrefix):
+                let filteredChildren = filterTree(node.children ?? [], searchText: searchText)
+                if !filteredChildren.isEmpty || displayName.localizedCaseInsensitiveContains(searchText) {
+                    return .linkedSubfolder(
+                        folderId: folderId,
+                        displayName: displayName,
+                        pathPrefix: pathPrefix,
+                        children: filteredChildren
+                    )
+                }
+                return nil
             }
         }
     }


### PR DESCRIPTION
## Summary

- The local `filterTree` helper inside `FavoriteNodeTests` only switched over `.favorite` and `.folder`, leaving the three linked-folder cases (`.linkedFavorite`, `.linkedFolder`, `.linkedSubfolder`) introduced in #997 implicitly falling through. Any test that fed a tree containing linked nodes would silently drop them or hit a non-exhaustive switch warning.
- Adds the missing arms with the same matching logic as the production filter: linked favorites match on name / keyword / relativePath, linked folders and subfolders match on display name and recurse into children.

## Test plan

- [ ] `xcodebuild test -only-testing:TableProTests/FavoriteNodeTests` passes.
- [ ] Add a new test case with a linked-folder tree and a search term hitting a nested file. Helper returns the expected pruned tree.