### PR TITLE
revert: tab session registry attach (#1009)

### DIFF
--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -38,14 +38,6 @@ final class QueryTabManager {
         self.tabSessionRegistry = tabSessionRegistry
     }
 
-    func attachSessionRegistryIfNeeded(_ registry: TabSessionRegistry) {
-        guard tabSessionRegistry == nil else { return }
-        tabSessionRegistry = registry
-        for tab in tabs where registry.session(for: tab.id) == nil {
-            registry.register(TabSession(queryTab: tab))
-        }
-    }
-
     private func syncTabSessionRegistry(oldTabs: [QueryTab], newTabs: [QueryTab]) {
         guard let registry = tabSessionRegistry else { return }
         let oldIds = Set(oldTabs.map(\.id))

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -342,7 +342,6 @@ final class MainContentCoordinator {
         self.changeManager = changeManager
         self.toolbarState = toolbarState
         self.tabSessionRegistry = tabSessionRegistry ?? TabSessionRegistry()
-        tabManager.attachSessionRegistryIfNeeded(self.tabSessionRegistry)
         self.queryExecutor = queryExecutor ?? QueryExecutor(connection: connection)
         let dialect = PluginManager.shared.sqlDialect(for: connection.type)
         self.queryBuilder = TableQueryBuilder(


### PR DESCRIPTION
## Summary

- Reverts #1009. The `attachSessionRegistryIfNeeded(_:)` plumbing solves a scenario that doesn't occur in shipped code.
- Production has one `MainContentCoordinator` call site, `SessionStateFactory.create`, which builds the `TabSessionRegistry` first and passes the same instance to both `QueryTabManager(... tabSessionRegistry:)` and the coordinator. The `?? TabSessionRegistry()` fallback in coordinator init is unreachable in production, so the back-fill path can never run.
- CLAUDE.md: "Don't add error handling, fallbacks, or validation for scenarios that can't happen."

## Test plan

- [ ] Open a connection, verify tabs hydrate and the `TabSessionRegistry` still contains a session per tab id (unchanged from pre-#1009 behavior, since `SessionStateFactory.create` already wires the registry into the manager at construction).
- [ ] `xcodebuild test` still passes.