### PR TITLE
fix(windows): prevent Settings from auto-opening on launch

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -176,8 +176,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if response == .alertFirstButtonReturn {
-                UserDefaults.standard.set(SettingsTab.plugins.rawValue, forKey: "selectedSettingsTab")
-                NotificationCenter.default.post(name: .openSettingsWindow, object: nil)
+                WindowOpener.shared.openSettings(tab: .plugins)
             }
         }
     }

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -44,10 +44,6 @@ extension Notification.Name {
 
     static let pluginsRejected = Notification.Name("pluginsRejected")
 
-    // MARK: - Settings Window
-
-    static let openSettingsWindow = Notification.Name("com.TablePro.openSettingsWindow")
-
     // MARK: - Feedback
 
     static let showFeedbackWindow = Notification.Name("com.TablePro.showFeedbackWindow")

--- a/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
@@ -56,8 +56,7 @@ internal final class LaunchIntentRouter {
     private func installPlugin(_ url: URL) async throws {
         let entry = try await PluginManager.shared.installPlugin(from: url)
         Self.logger.info("Installed plugin '\(entry.name, privacy: .public)' from Finder")
-        UserDefaults.standard.set(SettingsTab.plugins.rawValue, forKey: "selectedSettingsTab")
-        NotificationCenter.default.post(name: .openSettingsWindow, object: nil)
+        WindowOpener.shared.openSettings(tab: .plugins)
     }
 
     private func presentError(_ error: Error, for intent: LaunchIntent) async {

--- a/TablePro/Core/Services/Infrastructure/WindowOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowOpener.swift
@@ -17,6 +17,7 @@ internal final class WindowOpener {
     @ObservationIgnored private var openWelcomeAction: (() -> Void)?
     @ObservationIgnored private var openConnectionFormAction: ((UUID?) -> Void)?
     @ObservationIgnored private var openIntegrationsActivityAction: (() -> Void)?
+    @ObservationIgnored private var openSettingsAction: (() -> Void)?
     @ObservationIgnored
     private var presentTypeChooserAction: ((DatabaseType?, @escaping (DatabaseType) -> Void) -> Void)?
     @ObservationIgnored private var pendingCalls: [() -> Void] = []
@@ -26,6 +27,13 @@ internal final class WindowOpener {
 
     internal func openWelcome() {
         run { $0.openWelcomeAction?() }
+    }
+
+    internal func openSettings(tab: SettingsTab? = nil) {
+        if let tab {
+            UserDefaults.standard.set(tab.rawValue, forKey: "selectedSettingsTab")
+        }
+        run { $0.openSettingsAction?() }
     }
 
     internal func orderOutWelcome() {
@@ -77,11 +85,13 @@ internal final class WindowOpener {
         openWelcome: @escaping () -> Void,
         openConnectionForm: @escaping (UUID?) -> Void,
         openIntegrationsActivity: @escaping () -> Void,
+        openSettings: @escaping () -> Void,
         presentTypeChooser: @escaping (DatabaseType?, @escaping (DatabaseType) -> Void) -> Void
     ) {
         openWelcomeAction = openWelcome
         openConnectionFormAction = openConnectionForm
         openIntegrationsActivityAction = openIntegrationsActivity
+        openSettingsAction = openSettings
         presentTypeChooserAction = presentTypeChooser
         isWired = true
         let drained = pendingCalls

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -634,17 +634,10 @@ struct TableProApp: App {
     }
 
     var body: some Scene {
-        Settings {
-            SettingsView()
-                .environment(updaterBridge)
-                .background(SettingsNotificationBridge())
-                .background(WindowOpenerBridge())
-                .background(WindowChromeConfigurator(restorable: false))
-        }
-
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
                 .frame(width: 700, height: 450)
+                .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,
                     fullScreenable: false,
@@ -675,6 +668,11 @@ struct TableProApp: App {
                 updaterBridge: updaterBridge,
                 commandRegistry: commandRegistry
             )
+        }
+
+        Settings {
+            SettingsView()
+                .environment(updaterBridge)
         }
     }
 }
@@ -720,7 +718,7 @@ private struct MCPServerMenuItem: View {
 
     var body: some View {
         Button(menuTitle) {
-            NotificationCenter.default.post(name: .openSettingsWindow, object: nil)
+            WindowOpener.shared.openSettings()
         }
     }
 
@@ -739,23 +737,5 @@ private struct MCPServerMenuItem: View {
         case .starting:
             return String(localized: "Integrations: Starting...")
         }
-    }
-}
-
-// MARK: - Settings Notification Bridge
-
-/// Forwards `.openSettingsWindow` notifications to SwiftUI's `openSettings`
-/// action. Lives inside the Settings scene because `\.openSettings` is only
-/// available there.
-private struct SettingsNotificationBridge: View {
-    @Environment(\.openSettings)
-    private var openSettings
-
-    var body: some View {
-        Color.clear
-            .frame(width: 0, height: 0)
-            .onReceive(NotificationCenter.default.publisher(for: .openSettingsWindow)) { _ in
-                openSettings()
-            }
     }
 }

--- a/TablePro/Views/Components/SyncStatusIndicator.swift
+++ b/TablePro/Views/Components/SyncStatusIndicator.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct SyncStatusIndicator: View {
-    @Environment(\.openSettings) private var openSettings
     private let syncCoordinator = SyncCoordinator.shared
     @State private var showActivationSheet = false
 
@@ -124,8 +123,7 @@ struct SyncStatusIndicator: View {
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
             showActivationSheet = true
         default:
-            UserDefaults.standard.set(SettingsTab.account.rawValue, forKey: "selectedSettingsTab")
-            openSettings()
+            WindowOpener.shared.openSettings(tab: .account)
         }
     }
 }

--- a/TablePro/Views/Infrastructure/WindowChromeConfigurator.swift
+++ b/TablePro/Views/Infrastructure/WindowChromeConfigurator.swift
@@ -13,26 +13,42 @@ internal struct WindowChromeConfigurator: NSViewRepresentable {
     var hideZoomButton: Bool = false
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
-        let restorable = self.restorable
-        let fullScreenable = self.fullScreenable
-        let hideMiniaturizeButton = self.hideMiniaturizeButton
-        let hideZoomButton = self.hideZoomButton
-        Task { @MainActor [weak view] in
-            guard let window = view?.window else { return }
-            window.isRestorable = restorable
-            if !fullScreenable {
-                window.collectionBehavior.insert(.fullScreenNone)
-            }
-            if hideMiniaturizeButton {
-                window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-            }
-            if hideZoomButton {
-                window.standardWindowButton(.zoomButton)?.isHidden = true
-            }
-        }
+        let view = ChromeHostView()
+        view.apply(configuration: self)
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let host = nsView as? ChromeHostView else { return }
+        host.apply(configuration: self)
+    }
+}
+
+private final class ChromeHostView: NSView {
+    private var pending: WindowChromeConfigurator?
+
+    func apply(configuration: WindowChromeConfigurator) {
+        pending = configuration
+        applyToCurrentWindow()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        applyToCurrentWindow()
+    }
+
+    private func applyToCurrentWindow() {
+        guard let window, let config = pending else { return }
+
+        window.isRestorable = config.restorable
+
+        if config.fullScreenable {
+            window.collectionBehavior.remove(.fullScreenNone)
+        } else {
+            window.collectionBehavior.insert(.fullScreenNone)
+        }
+
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = config.hideMiniaturizeButton
+        window.standardWindowButton(.zoomButton)?.isHidden = config.hideZoomButton
+    }
 }

--- a/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
+++ b/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 internal struct WindowOpenerBridge: View {
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         Color.clear
@@ -19,6 +20,7 @@ internal struct WindowOpenerBridge: View {
             openWelcome: { openWindow(id: SceneId.welcome) },
             openConnectionForm: { id in openWindow(id: SceneId.connectionForm, value: id) },
             openIntegrationsActivity: { openWindow(id: SceneId.integrationsActivity) },
+            openSettings: { openSettings() },
             presentTypeChooser: { initialType, onSelected in
                 let payload = DatabaseTypeChooserPayload(
                     initialType: initialType,


### PR DESCRIPTION
## Summary

- Settings window opened alongside Welcome on every launch after PR #988 migrated Welcome / Connection Form / Integrations Activity to SwiftUI scenes
- Root cause: `Settings { ... }` was the first scene in `var body: some Scene`, and SwiftUI on macOS 14/15 auto-launches the first declared scene even when it's a `Settings` scene — contrary to documentation. Compounding this, `.background(SettingsNotificationBridge())` read `@Environment(\.openSettings)` from inside the Settings scene, which forced the scene to materialize during `NSApplicationMain`
- Confirmed via window-lifecycle tracing with stack captures: at `applicationDidFinishLaunching` enter, the only window present was `com_apple_SwiftUI_Settings_window` opened by SwiftUI's runApp before user code ran

## Fix

- Reorder scenes: `Window("Welcome", ...)` first (default-launches), `Settings { ... }` last
- Centralize Settings opening through `WindowOpener.shared.openSettings(tab:)` — wired via the existing `WindowOpenerBridge` inside the Welcome scene using `\.openSettings`
- Delete the `.openSettingsWindow` notification round-trip and `SettingsNotificationBridge`; collapse 3 callsites onto the single `WindowOpener.shared.openSettings(tab:)` call
- Convert `WindowChromeConfigurator` from an async `Task` (which ran after window creation) to a synchronous `viewDidMoveToWindow` hook on a private `ChromeHostView` subclass — `isRestorable = false` now lands before AppKit can encode restoration state, and the configurator is symmetric (toggling `fullScreenable` back on now removes `.fullScreenNone`)

## Test plan

- [x] Cold launch with all caches cleared: only Welcome appears (verified via WindowOpenTracer stack-trace capture; Settings appears only on Cmd+,)
- [x] Cmd+, opens Settings as expected
- [x] Plugin-rejected dialog → "Open Plugin Settings" routes to Settings on plugins tab
- [x] iCloud sync chip in Welcome routes to Settings on account tab
- [x] Drop a `.tableplugin` on Finder → installs and opens Settings on plugins tab
- [x] Welcome window chrome (no miniaturize, no zoom, no fullscreen) still applied
- [x] swiftlint --strict on changed files: 0 violations
- [x] xcodebuild Debug arm64: BUILD SUCCEEDED