### PR TITLE
perf(launch): defer non-critical services to first activation

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -12,6 +12,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private static let logger = Logger(subsystem: "com.TablePro", category: "AppDelegate")
     static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
+    private var hasRunPostLaunchActivation = false
+
     // MARK: - URL & File Open
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -51,17 +53,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         MemoryPressureAdvisor.startMonitoring()
         PluginManager.shared.loadPlugins()
-        ConnectionStorage.shared.migratePluginSecureFieldsIfNeeded()
-
-        Task {
-            LicenseManager.shared.startPeriodicValidation()
-        }
-
-        AnalyticsService.shared.startPeriodicHeartbeat()
-
-        SyncCoordinator.shared.start()
-        LinkedFolderWatcher.shared.start()
-        SQLFolderWatcher.shared.start()
 
         NSWorkspace.shared.notificationCenter.addObserver(
             self, selector: #selector(handleSystemDidWake),
@@ -103,7 +94,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
+        runPostLaunchActivationIfNeeded()
         SyncCoordinator.shared.syncIfNeeded()
+    }
+
+    private func runPostLaunchActivationIfNeeded() {
+        guard !hasRunPostLaunchActivation else { return }
+        hasRunPostLaunchActivation = true
+
+        ConnectionStorage.shared.migratePluginSecureFieldsIfNeeded()
+        AnalyticsService.shared.startPeriodicHeartbeat()
+        SyncCoordinator.shared.start()
+        LinkedFolderWatcher.shared.start()
+
+        Task {
+            LicenseManager.shared.startPeriodicValidation()
+        }
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
+++ b/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
@@ -26,11 +26,14 @@ final class LinkedFolderWatcher {
     private(set) var linkedConnections: [LinkedConnection] = []
     private var watchSources: [UUID: DispatchSourceFileSystemObject] = [:]
     private var debounceTask: Task<Void, Never>?
+    private var hasStarted = false
 
     private init() {}
 
     func start() {
+        guard !hasStarted else { return }
         guard LicenseManager.shared.isFeatureAvailable(.linkedFolders) else { return }
+        hasStarted = true
         let folders = LinkedFolderStorage.shared.loadFolders()
         scheduleScan(folders)
         setupWatchers(for: folders)
@@ -40,6 +43,7 @@ final class LinkedFolderWatcher {
         cancelAllWatchers()
         debounceTask?.cancel()
         debounceTask = nil
+        hasStarted = false
     }
 
     func reload() {

--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -21,10 +21,13 @@ internal final class SQLFolderWatcher {
 
     @ObservationIgnored private var eventStream: FSEventStreamRef?
     @ObservationIgnored private var debounceTask: Task<Void, Never>?
+    @ObservationIgnored private var hasStarted = false
 
     private init() {}
 
     func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
         let folders = LinkedSQLFolderStorage.shared.loadFolders().filter(\.isEnabled)
         scheduleFullRescan(folders: folders)
         setupEventStream(for: folders)
@@ -34,6 +37,7 @@ internal final class SQLFolderWatcher {
         cancelEventStream()
         debounceTask?.cancel()
         debounceTask = nil
+        hasStarted = false
     }
 
     func reload() {

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -28,6 +28,7 @@ final class SyncCoordinator {
     @ObservationIgnored private var changeObserver: NSObjectProtocol?
     @ObservationIgnored private var licenseObserver: NSObjectProtocol?
     @ObservationIgnored private var syncTask: Task<Void, Never>?
+    @ObservationIgnored private var hasStarted = false
 
     private init() {
         lastSyncDate = metadataStorage.lastSyncDate
@@ -44,6 +45,9 @@ final class SyncCoordinator {
 
     /// Call from AppDelegate at launch
     func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
+
         observeAccountChanges()
         observeLocalChanges()
         observeLicenseChanges()

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -51,6 +51,9 @@ internal struct FavoritesTabView: View {
                 bottomToolbar
             }
         }
+        .onAppear {
+            SQLFolderWatcher.shared.start()
+        }
         .sheet(item: $viewModel.editDialogItem) { item in
             FavoriteEditDialog(
                 connectionId: connectionId,


### PR DESCRIPTION
## Summary

- Welcome window memory footprint at launch: **60.7 MB → 47.9 MB (-12.8 MB, -21%)**, peak 65.6 → 54.0 MB
- Source: WWDC 2019 *Optimizing App Launch* — *"Defer anything unrelated to generating the first frame"*. Apple's Mac App Programming Guide says the same: *"Any objects that are not needed at launch time should be loaded later."*
- This PR moves non-critical services out of `applicationDidFinishLaunching` to either the first `applicationDidBecomeActive` (one-shot) or the view's first `.onAppear`, with idempotency guards on each service so re-entry is a no-op

## Changes

- `AppDelegate.swift` — adds `hasRunPostLaunchActivation` guard, splits services across two phases
  - Stays in `applicationDidFinishLaunching`: theme, sync-settings keychain flag, `DatabaseManager.startObservingSystemEvents`, `MemoryPressureAdvisor`, `PluginManager.loadPlugins` (lazy `bundle.load()` is a separate PR), MCP server (already conditional), `QueryHistoryStorage` warm (already detached), launch coordinator, notification observers
  - Deferred to first `applicationDidBecomeActive`: `ConnectionStorage.migratePluginSecureFieldsIfNeeded`, `AnalyticsService.startPeriodicHeartbeat`, `SyncCoordinator.start`, `LinkedFolderWatcher.start`, `LicenseManager.startPeriodicValidation`
- `FavoritesTabView.swift` — `SQLFolderWatcher.start()` moved to `.onAppear` of the Favorites tab; users who never open Favorites never spin up the FSEvents stream
- `SyncCoordinator.swift` — `hasStarted` guard so `start()` is idempotent even if called repeatedly
- `LinkedFolderWatcher.swift` / `SQLFolderWatcher.swift` — `hasStarted` guard cleared on `stop()` so `reload()` still works correctly

## Test plan

- [x] Cold launch: Welcome appears, Settings does not (regression check vs #1022)
- [x] After ~1s, sync runs (`Pull starting`, `Sync completed successfully` in logs)
- [x] Open Favorites sidebar tab: SQL folder watcher starts, linked SQL files appear
- [x] Add/remove a linked SQL folder: `SQLFolderWatcher.shared.reload()` still works (stop clears `hasStarted`, start re-runs)
- [x] License validation runs in background (no UI block)
- [x] swiftlint --strict on changed files: 0 violations
- [x] xcodebuild Release arm64: BUILD SUCCEEDED
- [x] vmmap before/after: Physical footprint 60.7 MB → 47.9 MB