### PR TITLE
fix(tabs): non-active restored tabs no longer require manual refresh

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -25,25 +25,28 @@ extension MainContentView {
             let hasPendingEdits =
                 changeManager.hasChanges
                 || (tabManager.selectedTab?.pendingChanges.hasChanges ?? false)
-            guard !hasPendingEdits else { return }
-            coordinator.needsLazyLoad = false
-            if let selectedTab = tabManager.selectedTab,
-                !selectedTab.tableContext.databaseName.isEmpty,
-                selectedTab.tableContext.databaseName != session.activeDatabase
-            {
-                Task { await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName) }
-            } else if let selectedTab = tabManager.selectedTab,
-                let tabSchema = selectedTab.tableContext.schemaName,
-                !tabSchema.isEmpty,
-                tabSchema != session.currentSchema
-            {
-                // Restore schema on the driver without clearing tabs (unlike switchSchema which resets UI)
-                Task {
-                    await coordinator.restoreSchemaAndRunQuery(tabSchema)
+            if !hasPendingEdits {
+                coordinator.needsLazyLoad = false
+                if let selectedTab = tabManager.selectedTab,
+                    !selectedTab.tableContext.databaseName.isEmpty,
+                    selectedTab.tableContext.databaseName != session.activeDatabase
+                {
+                    Task { await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName) }
+                } else if let selectedTab = tabManager.selectedTab,
+                    let tabSchema = selectedTab.tableContext.schemaName,
+                    !tabSchema.isEmpty,
+                    tabSchema != session.currentSchema
+                {
+                    Task {
+                        await coordinator.restoreSchemaAndRunQuery(tabSchema)
+                    }
+                } else {
+                    coordinator.runQuery()
                 }
-            } else {
-                coordinator.runQuery()
             }
+        }
+        if session.isConnected {
+            coordinator.lazyLoadCurrentTabIfNeeded()
         }
         let mappedState = mapSessionStatus(session.status)
         if mappedState != toolbarState.connectionState {


### PR DESCRIPTION
## Summary

- After reopening the app and reconnecting, only the last-active tab loaded data; other tabs (in additional native window-tabs) showed an empty grid until the user pressed Refresh
- Affects: any connection with multiple persisted tabs spread across native window tabs

## Root cause

`handleConnectionStatusChange` only triggers a query when `coordinator.needsLazyLoad == true`. The flag is set in two places:
- `handleRestoreOrDefault` for the first restored tab when the session is not yet connected
- `lazyLoadCurrentTabIfNeeded` when a `.task(id: TabLoadKey)` fires before the session is ready

For non-first restored tabs, the new window opens with `intent=.openContent skipAutoExecute=true` and `MainContentView+Setup` returns early without setting `needsLazyLoad`. There's also a race: `connectionStatusDidChange` can fire before `handleRestoreOrDefault` sets the flag, after which the lazy-load path is wedged because no further notifications fire. Either way, the only path that runs the query is the user pressing Refresh.

## Fix

`handleConnectionStatusChange` now also calls `coordinator.lazyLoadCurrentTabIfNeeded()` when the session is connected, in addition to its existing `needsLazyLoad` branch. `lazyLoadCurrentTabIfNeeded` already guards against double-execution:

- skips if `tab.execution.isExecuting`
- skips if rows are already present and not evicted
- skips if `tab.execution.lastExecutedAt != nil`
- skips if there are pending edits

So the extra call is idempotent — it triggers the query when needed and is a no-op otherwise. The `needsLazyLoad` flag becomes a fast-path hint rather than a hard gate, and the bug class around timing races / non-first-tab restoration goes away.

## Test plan

- [x] Open a connection, open 2-3 table tabs, quit
- [x] Reopen app: all tabs reappear, all show data without needing Refresh
- [x] Open a connection, switch to a different tab via native window tab: grid populates without Refresh (already worked, regression check)
- [x] Disconnect and reconnect a connection: current tab re-loads automatically
- [x] swiftlint --strict on changed file: 0 violations
- [x] xcodebuild Debug arm64: BUILD SUCCEEDED