### PR TITLE
docs: simplify personal-team setup section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,21 @@ touch Secrets.xcconfig
 brew install swiftlint swiftformat
 ```
 
-If you're signing the Debug build with a non-official Apple Developer team (e.g. a free personal team), three things in the project file are tied to the official team and need a one-time local override in Xcode. Open `TablePro.xcodeproj`, select the `TablePro` target, then:
+### Building with a personal Apple team
 
-1. **Team**: Signing & Capabilities tab → click the **Debug** sub-tab at the top (so the change scopes to Debug only) → set Team to your personal team. If the build fails with a signing error on a different target (driver plugin, framework, mcp-server, tests), repeat for that target — codesign signs each target independently.
-2. **Bundle Identifier**: same Debug sub-tab → change `com.TablePro` to something unique under your team (e.g. `com.<yourhandle>.TablePro`). The default `com.TablePro` is reserved for the official team in Apple's developer portal. Plugin sub-IDs (`com.TablePro.MySQLDriver` etc.) are auto-registered under your team and don't need renaming.
-3. **Entitlements**: Build Settings tab → search "Code Signing Entitlements" → in the **Debug** row, change `TablePro/TablePro.entitlements` to `TablePro/TablePro.Debug.entitlements`. This second file already ships with the repo (you don't need to create it); it is identical to the default minus the iCloud keys, which free personal teams don't support. iCloud sync is automatically disabled at runtime when the entitlement is absent.
+To Debug-build under your own team, open `TablePro.xcodeproj`, select the `TablePro` target, then **Signing & Capabilities → Debug** sub-tab:
 
-These changes will appear in `TablePro.xcodeproj/project.pbxproj`. **Don't commit them**, or you'll break the official Release signing. Either revert with `git checkout TablePro.xcodeproj/project.pbxproj` before every commit, or run `git update-index --skip-worktree TablePro.xcodeproj/project.pbxproj` once to make git ignore your local changes to that file. Release builds and official-team Debug builds keep using `com.TablePro` and `TablePro/TablePro.entitlements` unchanged.
+1. **Team**: pick your personal team. If another target fails to sign later, repeat there.
+2. **Bundle Identifier**: change `com.TablePro` to something unique (e.g. `com.<yourhandle>.TablePro`).
+3. **Code Signing Entitlements** (Build Settings tab): switch Debug to `TablePro/TablePro.Debug.entitlements`. It ships in the repo and drops iCloud, which free teams don't support. Sync auto-disables at runtime.
 
-Verify the setup by saving a database connection with a password, quitting and relaunching the app, then re-opening the connection: the password should still be there.
+Don't commit the resulting `pbxproj` changes. They break official Release signing. Skip them locally:
+
+```bash
+git update-index --skip-worktree TablePro.xcodeproj/project.pbxproj
+```
+
+To verify: save a connection password, relaunch, reopen. The password should still be there.
 
 Build:
 


### PR DESCRIPTION
## Summary

Tighten the personal-team Debug-build section added in #1028. Same instructions, ~40% fewer words, easier to scan.

## Changes

- Drop the prose intro and fold context into the step list.
- Drop trivia that doesn't affect what a contributor types: the "developer portal reservation" note and the plugin-sub-ID note.
- Drop the "either revert or skip-worktree" alternative; just give the one that works (`skip-worktree`).
- Promote the section to `### Building with a personal Apple team` so the heading shows up in nav.
- Remove em dashes (CLAUDE.md writing-style rule).

## Test plan

- [x] `git diff --cached -U0 | grep -nE '—|seamless|robust|...'` clean on added lines
- [x] Markdown renders correctly (numbered list, code block, heading)