### PR TITLE
fix: throw accountUnavailable from CloudKitSyncEngine.currentAccountId for consistency

### DIFF
--- a/TablePro/Core/Sync/CloudKitSyncEngine.swift
+++ b/TablePro/Core/Sync/CloudKitSyncEngine.swift
@@ -55,7 +55,7 @@ actor CloudKitSyncEngine {
     }
 
     func currentAccountId() async throws -> String? {
-        guard let container else { return nil }
+        guard let container else { throw SyncError.accountUnavailable }
         return try await container.userRecordID().recordName
     }
 

--- a/TableProTests/Core/Sync/CloudKitSyncEngineTests.swift
+++ b/TableProTests/Core/Sync/CloudKitSyncEngineTests.swift
@@ -64,11 +64,12 @@ struct CloudKitSyncEngineTests {
         }
     }
 
-    @Test("currentAccountId returns nil without iCloud entitlement")
-    func currentAccountIdReturnsNil() async throws {
+    @Test("currentAccountId throws accountUnavailable without iCloud entitlement")
+    func currentAccountIdThrows() async throws {
         try skipIfEntitled()
         let engine = CloudKitSyncEngine()
-        let accountId = try await engine.currentAccountId()
-        #expect(accountId == nil)
+        await #expect(throws: SyncError.accountUnavailable) {
+            _ = try await engine.currentAccountId()
+        }
     }
 }


### PR DESCRIPTION
Fixes #1034.

## Summary

`CloudKitSyncEngine` has six methods that touch the optional `container`/`database`. Five throw `SyncError.accountUnavailable` when the entitlement is absent; the sixth, `currentAccountId`, returned `nil` instead. This PR makes it throw, matching its peers.

The single caller (`SyncCoordinator.checkAccountStatus` at `TablePro/Core/Sync/SyncCoordinator.swift:632`) already wraps the call in `try?`, so the observable behavior is unchanged. The fix is a contract-tightening only.

The matching test in `TableProTests/Core/Sync/CloudKitSyncEngineTests.swift` flips from `currentAccountIdReturnsNil` to `currentAccountIdThrows`, mirroring the other five test cases.

## CHANGELOG

No entry: this tightens an internal contract on a feature still in `[Unreleased]` (added by #1028, not yet released).

## Test plan

- [x] `swiftlint lint --strict` clean (no Swift body changes touch lint rules)
- [ ] `xcodebuild ... test -only-testing:TableProTests/CloudKitSyncEngineTests` passes (skips when host is iCloud-entitled)