### PR TITLE
build: add Local.xcconfig override for per-developer signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ Thumbs.db
 *.p12
 *.mobileprovision
 Secrets.xcconfig
+Local.xcconfig
 
 # Debug
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,21 @@ brew install swiftlint swiftformat
 
 ### Building with a personal Apple team
 
-To Debug-build under your own team, open `TablePro.xcodeproj`, select the `TablePro` target, then **Signing & Capabilities → Debug** sub-tab:
-
-1. **Team**: pick your personal team. If another target fails to sign later, repeat there.
-2. **Bundle Identifier**: change `com.TablePro` to something unique (e.g. `com.<yourhandle>.TablePro`).
-3. **Code Signing Entitlements** (Build Settings tab): switch Debug to `TablePro/TablePro.Debug.entitlements`. It ships in the repo and drops iCloud, which free teams don't support. Sync auto-disables at runtime.
-
-Don't commit the resulting `pbxproj` changes. They break official Release signing. Skip them locally:
+The project's signing settings are read from `Configurations/Shared.xcconfig`, which optionally includes a gitignored `Local.xcconfig` for per-developer overrides. To Debug-build under your own team, copy the example file and edit:
 
 ```bash
-git update-index --skip-worktree TablePro.xcodeproj/project.pbxproj
+cp Local.xcconfig.example Local.xcconfig
 ```
+
+In `Local.xcconfig`, uncomment and set the values you need:
+
+- `DEVELOPMENT_TEAM`: your team ID (Xcode > Settings > Accounts > Manage Certificates).
+- `PRODUCT_BUNDLE_IDENTIFIER`: make it unique under your team (e.g. `com.yourhandle.TablePro`).
+- `CODE_SIGN_ENTITLEMENTS = TablePro/TablePro.Debug.entitlements`: only if your team is free (no iCloud capability). Sync auto-disables at runtime.
+
+That's it. No pbxproj edits. `Local.xcconfig` is gitignored so your overrides stay local; the project file keeps signing for the official team.
+
+Note: free personal teams hit Apple's 10-bundle-IDs-per-7-days limit because the project signs around a dozen plugin bundles. Expect occasional waits if you re-create your team's signing identity often.
 
 To verify: save a connection password, relaunch, reopen. The password should still be there.
 

--- a/Configurations/Shared.xcconfig
+++ b/Configurations/Shared.xcconfig
@@ -1,0 +1,13 @@
+// TablePro shared build settings.
+//
+// Wired as the project-level Configuration File for both Debug and Release
+// (Project Editor > Project > Info > Configurations).
+//
+// Defaults below match the official D7HJ5TFYCU team. Contributors override
+// per-developer values in Local.xcconfig (gitignored). See CONTRIBUTING.md.
+
+DEVELOPMENT_TEAM = D7HJ5TFYCU
+PRODUCT_BUNDLE_IDENTIFIER = com.TablePro
+CODE_SIGN_ENTITLEMENTS = TablePro/TablePro.entitlements
+
+#include? "../Local.xcconfig"

--- a/Local.xcconfig.example
+++ b/Local.xcconfig.example
@@ -1,0 +1,14 @@
+// Copy this file to Local.xcconfig and uncomment the lines you want to override.
+// Local.xcconfig is gitignored. See CONTRIBUTING.md for details.
+
+// Your Apple Developer team ID.
+// Find it in Xcode > Settings > Accounts > select account > Manage Certificates,
+// or System Settings > Apple ID > Sign in with your Apple ID > Developer.
+// DEVELOPMENT_TEAM = ABCD123456
+
+// Your bundle identifier. Must be unique under your team.
+// PRODUCT_BUNDLE_IDENTIFIER = com.yourhandle.TablePro
+
+// Path to a custom entitlements file (relative to project root).
+// Free personal teams cannot sign the iCloud capability; point at the iCloud-free variant.
+// CODE_SIGN_ENTITLEMENTS = TablePro/TablePro.Debug.entitlements


### PR DESCRIPTION
Closes #1033.

## Summary

Move per-developer signing values out of `project.pbxproj` and into a gitignored `Local.xcconfig`. Removes the `git update-index --skip-worktree TablePro.xcodeproj/project.pbxproj` workaround documented after #1028. Standard Apple xcconfig pattern (project-level base configuration + optional include of a developer-local file).

## What this PR delivers (committed files only)

- `Configurations/Shared.xcconfig`: project-level defaults for `DEVELOPMENT_TEAM`, `PRODUCT_BUNDLE_IDENTIFIER`, `CODE_SIGN_ENTITLEMENTS`. Final line is `#include? "../Local.xcconfig"` (Apple's documented optional-include syntax).
- `Local.xcconfig.example`: copy-and-edit template, three commented overrides.
- `.gitignore`: ignores `Local.xcconfig`.
- `CONTRIBUTING.md`: rewrites the personal-team section to a `cp` + edit + build flow. No more pbxproj skip-worktree hack.

## What you (maintainer) need to do in Xcode before merging

The override only takes effect after the project file is rewired. xcconfig values cannot override target-level Build Settings; the existing target-level entries must be removed so they fall back to the xcconfig.

1. **Wire `Configurations/Shared.xcconfig` at the project level**:
   - Project Editor (top of file list) → select the **TablePro project** (not a target) → **Info** tab → **Configurations** section.
   - For both `Debug` and `Release`, set "Based on Configuration File" → `Configurations/Shared`.

2. **Remove redundant target-level overrides** (so the xcconfig flows through):
   - **TablePro app target** → Build Settings → for both Debug and Release configs, delete:
     - `DEVELOPMENT_TEAM` (currently `D7HJ5TFYCU`)
     - `PRODUCT_BUNDLE_IDENTIFIER` (currently `com.TablePro`)
     - `CODE_SIGN_ENTITLEMENTS` (currently `TablePro/TablePro.entitlements`)
   - **mcp-server target** → Build Settings → delete `DEVELOPMENT_TEAM` (both configs).
   - **Do not touch plugin targets** (`MySQLDriver`, `PostgreSQLDriver`, etc.). They have unique bundle IDs (`com.TablePro.MySQLDriver` etc.) that must stay per-target. Their `DEVELOPMENT_TEAM = ""` already inherits from the project.

3. **Verify**:
   - Build TablePro Debug under the official `D7HJ5TFYCU` team. Should produce a binary signed exactly as before (no `Local.xcconfig` present, defaults from `Shared.xcconfig` apply).
   - `codesign -d --entitlements - build/Debug/TablePro.app` should still show `D7HJ5TFYCU.com.TablePro.shared` as the keychain access group.

The pbxproj diff from these changes is small (~16 deleted lines, ~4 baseConfigurationReference additions). Worth a careful diff review before committing.

## Why this is the canonical Apple pattern

- **`#include?`** (with `?`) is documented Xcode syntax for optional includes. Used in Apple's own sample code (Backyard Birds, Food Truck).
- **Project-level base configuration with target-level pbxproj overrides removed** is exactly how Apple structures sample projects when per-developer overrides are needed.
- **No comments-as-instructions, no `--skip-worktree`, no shadow files**. Just the standard build settings inheritance chain: SDK defaults → project xcconfig (Shared) → optional Local.xcconfig override → target build settings (left untouched for plugins).

## Caveats

- Free personal teams still hit Apple's 10-bundle-IDs-per-7-days limit because the project signs around a dozen plugin bundles. Documented in CONTRIBUTING.md. xcconfig can't fix that.
- Existing contributors who ran `git update-index --skip-worktree TablePro.xcodeproj/project.pbxproj` should undo with `git update-index --no-skip-worktree TablePro.xcodeproj/project.pbxproj` before pulling this branch.

## CHANGELOG

Not updated: this is a build/contributor-tooling change, not a runtime feature. The previous PR #1028 (which this supersedes for the personal-team flow) is still in `[Unreleased]`. Happy to add a Changed entry if you want one.

## Test plan

- [x] `swiftlint lint --strict`: no Swift changes.
- [x] Banned-word check on diff: clean.
- [ ] After Xcode wiring: Release build under official team produces identical signing (`codesign -d --entitlements -` matches main).
- [ ] After Xcode wiring: contributor flow tested with `cp Local.xcconfig.example Local.xcconfig` → set `DEVELOPMENT_TEAM` → build succeeds.