### PR TITLE
refactor: make SortableHeaderCell.titleRect AX-correct and share data grid horizontal inset

### DIFF
--- a/TablePro/Views/Results/Cells/DataGridBaseCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridBaseCellView.swift
@@ -96,10 +96,13 @@ class DataGridBaseCellView: NSTableCellView {
         textField = cellTextField
         addSubview(cellTextField)
 
-        textFieldTrailingConstraint = cellTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4)
+        textFieldTrailingConstraint = cellTextField.trailingAnchor.constraint(
+            equalTo: trailingAnchor,
+            constant: -DataGridMetrics.cellHorizontalInset
+        )
 
         NSLayoutConstraint.activate([
-            cellTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            cellTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: DataGridMetrics.cellHorizontalInset),
             textFieldTrailingConstraint,
             cellTextField.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])

--- a/TablePro/Views/Results/Cells/DataGridCellRegistry.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellRegistry.swift
@@ -122,8 +122,14 @@ final class DataGridCellRegistry {
             cellView.addSubview(cell)
 
             NSLayoutConstraint.activate([
-                cell.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 4),
-                cell.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -4),
+                cell.leadingAnchor.constraint(
+                    equalTo: cellView.leadingAnchor,
+                    constant: DataGridMetrics.cellHorizontalInset
+                ),
+                cell.trailingAnchor.constraint(
+                    equalTo: cellView.trailingAnchor,
+                    constant: -DataGridMetrics.cellHorizontalInset
+                ),
                 cell.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
             ])
         }

--- a/TablePro/Views/Results/Cells/DataGridChevronCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridChevronCellView.swift
@@ -11,7 +11,10 @@ class DataGridChevronCellView: DataGridBaseCellView {
     override func installAccessory() {
         addSubview(chevronButton)
         NSLayoutConstraint.activate([
-            chevronButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            chevronButton.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -DataGridMetrics.cellHorizontalInset
+            ),
             chevronButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             chevronButton.widthAnchor.constraint(equalToConstant: 10),
             chevronButton.heightAnchor.constraint(equalToConstant: 12),
@@ -34,7 +37,7 @@ class DataGridChevronCellView: DataGridBaseCellView {
 
     override func textFieldTrailingInset(for content: DataGridCellContent, state: DataGridCellState) -> CGFloat {
         let show = state.isEditable && !state.visualState.isDeleted
-        return show ? -18 : -4
+        return show ? -18 : -DataGridMetrics.cellHorizontalInset
     }
 
     @objc

--- a/TablePro/Views/Results/Cells/DataGridForeignKeyCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridForeignKeyCellView.swift
@@ -15,7 +15,10 @@ final class DataGridForeignKeyCellView: DataGridBaseCellView {
     override func installAccessory() {
         addSubview(fkButton)
         NSLayoutConstraint.activate([
-            fkButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            fkButton.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -DataGridMetrics.cellHorizontalInset
+            ),
             fkButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             fkButton.widthAnchor.constraint(equalToConstant: 16),
             fkButton.heightAnchor.constraint(equalToConstant: 16),

--- a/TablePro/Views/Results/Cells/DataGridMetrics.swift
+++ b/TablePro/Views/Results/Cells/DataGridMetrics.swift
@@ -1,0 +1,10 @@
+//
+//  DataGridMetrics.swift
+//  TablePro
+//
+
+import CoreGraphics
+
+enum DataGridMetrics {
+    static let cellHorizontalInset: CGFloat = 4
+}

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -67,18 +67,7 @@ struct DataGridView: NSViewRepresentable {
         tableView.action = #selector(TableViewCoordinator.handleClick(_:))
         tableView.doubleAction = #selector(TableViewCoordinator.handleDoubleClick(_:))
 
-        let rowNumberColumn = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
-        rowNumberColumn.title = "#"
-        rowNumberColumn.width = 40
-        rowNumberColumn.minWidth = 40
-        rowNumberColumn.maxWidth = 60
-        rowNumberColumn.isEditable = false
-        rowNumberColumn.resizingMask = []
-        let rowNumberHeaderCell = SortableHeaderCell(textCell: "#")
-        rowNumberHeaderCell.font = rowNumberColumn.headerCell.font
-        rowNumberHeaderCell.alignment = .right
-        rowNumberColumn.headerCell = rowNumberHeaderCell
-        rowNumberColumn.headerCell.setAccessibilityLabel(String(localized: "Row number"))
+        let rowNumberColumn = Self.makeRowNumberColumn()
         tableView.addTableColumn(rowNumberColumn)
         rowNumberColumn.isHidden = !configuration.showRowNumbers
 
@@ -322,6 +311,24 @@ struct DataGridView: NSViewRepresentable {
     }
 
     // MARK: - Column Layout Helpers
+
+    @MainActor
+    static func makeRowNumberColumn() -> NSTableColumn {
+        let column = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        column.title = "#"
+        column.width = 40
+        column.minWidth = 40
+        column.maxWidth = 60
+        column.isEditable = false
+        column.resizingMask = []
+        let defaultHeaderFont = column.headerCell.font
+        let headerCell = SortableHeaderCell(textCell: "#")
+        headerCell.font = defaultHeaderFont
+        headerCell.alignment = .right
+        headerCell.setAccessibilityLabel(String(localized: "Row number"))
+        column.headerCell = headerCell
+        return column
+    }
 
     static let firstDataTableColumnIndex: Int = 1
 

--- a/TablePro/Views/Results/SortableHeaderCell.swift
+++ b/TablePro/Views/Results/SortableHeaderCell.swift
@@ -13,7 +13,7 @@ final class SortableHeaderCell: NSTableHeaderCell {
     private static let indicatorPadding: CGFloat = 4
     private static let indicatorSpacing: CGFloat = 2
     private static let priorityFontSize: CGFloat = 9
-    private static let titleHorizontalPadding: CGFloat = 4
+    private static let defaultIndicatorSize = NSSize(width: 9, height: 6)
 
     override init(textCell string: String) {
         super.init(textCell: string)
@@ -30,27 +30,12 @@ final class SortableHeaderCell: NSTableHeaderCell {
     }
 
     override func drawInterior(withFrame cellFrame: NSRect, in controlView: NSView) {
-        guard let direction = sortDirection else {
-            drawTitle(in: titleRect(forBounds: cellFrame), font: titleFont(isSorted: false))
-            return
-        }
+        drawTitle(in: titleRect(forBounds: cellFrame), font: titleFont(isSorted: sortDirection != nil))
+
+        guard let direction = sortDirection else { return }
 
         let indicatorImage = Self.indicatorImage(for: direction)
-        let indicatorSize = indicatorImage?.size ?? NSSize(width: 9, height: 6)
-        let priorityText = priorityNumberString()
-        let priorityWidth = priorityText.map { Self.measureWidth(of: $0) } ?? 0
-        let reservedWidth = indicatorSize.width
-            + Self.indicatorPadding * 2
-            + (priorityText == nil ? 0 : priorityWidth + Self.indicatorSpacing)
-
-        let titleFrame = NSRect(
-            x: cellFrame.minX,
-            y: cellFrame.minY,
-            width: max(0, cellFrame.width - reservedWidth),
-            height: cellFrame.height
-        )
-        drawTitle(in: titleRect(forBounds: titleFrame), font: titleFont(isSorted: true))
-
+        let indicatorSize = indicatorImage?.size ?? Self.defaultIndicatorSize
         let indicatorOriginX = cellFrame.maxX - Self.indicatorPadding - indicatorSize.width
         let indicatorOriginY = cellFrame.midY - indicatorSize.height / 2
         let indicatorRect = NSRect(
@@ -61,7 +46,8 @@ final class SortableHeaderCell: NSTableHeaderCell {
         )
         Self.drawIndicator(image: indicatorImage, in: indicatorRect)
 
-        if let priorityText {
+        if let priorityText = priorityNumberString() {
+            let priorityWidth = Self.measureWidth(of: priorityText)
             let textOriginX = indicatorOriginX - Self.indicatorSpacing - priorityWidth
             let textRect = NSRect(
                 x: textOriginX,
@@ -74,13 +60,23 @@ final class SortableHeaderCell: NSTableHeaderCell {
     }
 
     override func titleRect(forBounds rect: NSRect) -> NSRect {
-        let inset = min(Self.titleHorizontalPadding, rect.width / 2)
+        let inset = min(DataGridMetrics.cellHorizontalInset, rect.width / 2)
+        let availableWidth = max(0, rect.width - inset * 2 - reservedTrailingWidth())
         return NSRect(
             x: rect.minX + inset,
             y: rect.minY,
-            width: max(0, rect.width - inset * 2),
+            width: availableWidth,
             height: rect.height
         )
+    }
+
+    private func reservedTrailingWidth() -> CGFloat {
+        guard let direction = sortDirection else { return 0 }
+        let indicatorWidth = Self.indicatorImage(for: direction)?.size.width
+            ?? Self.defaultIndicatorSize.width
+        let priorityText = priorityNumberString()
+        let priorityComponent = priorityText.map { Self.measureWidth(of: $0) + Self.indicatorSpacing } ?? 0
+        return indicatorWidth + Self.indicatorPadding * 2 + priorityComponent
     }
 
     private func titleFont(isSorted: Bool) -> NSFont {

--- a/TableProTests/Views/Results/SortableHeaderCellTests.swift
+++ b/TableProTests/Views/Results/SortableHeaderCellTests.swift
@@ -22,4 +22,51 @@ struct SortableHeaderCellTests {
         #expect(titleRect.minX == 3)
         #expect(titleRect.width == 0)
     }
+
+    @Test("Sorted title rect reserves trailing space for the indicator")
+    func sortedTitleRectReservesTrailingSpaceForIndicator() {
+        let bounds = NSRect(x: 0, y: 0, width: 100, height: 24)
+
+        let unsorted = SortableHeaderCell(textCell: "id")
+        let sorted = SortableHeaderCell(textCell: "id")
+        sorted.sortDirection = .ascending
+
+        let unsortedRect = unsorted.titleRect(forBounds: bounds)
+        let sortedRect = sorted.titleRect(forBounds: bounds)
+
+        #expect(sortedRect.minX == unsortedRect.minX)
+        #expect(sortedRect.width < unsortedRect.width)
+        #expect(sortedRect.maxX <= bounds.maxX - DataGridMetrics.cellHorizontalInset)
+    }
+
+    @Test("Priority badge shrinks the sorted title rect further")
+    func priorityBadgeShrinksSortedTitleRectFurther() {
+        let bounds = NSRect(x: 0, y: 0, width: 100, height: 24)
+
+        let sorted = SortableHeaderCell(textCell: "id")
+        sorted.sortDirection = .ascending
+
+        let prioritized = SortableHeaderCell(textCell: "id")
+        prioritized.sortDirection = .ascending
+        prioritized.sortPriority = 2
+
+        let sortedWidth = sorted.titleRect(forBounds: bounds).width
+        let prioritizedWidth = prioritized.titleRect(forBounds: bounds).width
+
+        #expect(prioritizedWidth < sortedWidth)
+    }
+}
+
+@MainActor
+@Suite("DataGridView.makeRowNumberColumn")
+struct DataGridRowNumberColumnTests {
+    @Test("Row-number column header uses a right-aligned SortableHeaderCell")
+    func rowNumberHeaderIsRightAlignedSortableCell() throws {
+        let column = DataGridView.makeRowNumberColumn()
+
+        let headerCell = try #require(column.headerCell as? SortableHeaderCell)
+        #expect(headerCell.alignment == .right)
+        #expect(column.identifier == ColumnIdentitySchema.rowNumberIdentifier)
+        #expect(column.title == "#")
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up refactor to #1040. Two correctness wins and one cleanup.

### 1. `titleRect(forBounds:)` now returns the same rect AppKit and AX see

After #1040, `drawInterior` was passing an indicator-subtracted sub-rect into `titleRect(forBounds:)`. AppKit and AX call `cell.titleRect(forBounds: cellFrame)` with full cell bounds, so external callers were getting back a frame that overlapped the sort indicator and priority badge.

Moved the indicator/priority width math into a private `reservedTrailingWidth()` helper that `titleRect(forBounds:)` consults. `drawInterior` now calls `titleRect(forBounds: cellFrame)` exactly once on the full bounds, and AX hit-testing lines up with what is actually drawn.

### 2. Row-number column header right-alignment is now testable

Extracted `DataGridView.makeRowNumberColumn()` as a static `@MainActor` factory so the row-number column setup can be exercised from tests. Added `DataGridRowNumberColumnTests.rowNumberHeaderIsRightAlignedSortableCell` so a future drive-by edit cannot silently drop `.alignment = .right` on the `#` header.

### 3. Shared `DataGridMetrics.cellHorizontalInset`

The 4pt inset that ties data cells and column headers together was duplicated as literals across 5 files. Pulled into a single `DataGridMetrics.cellHorizontalInset` constant (new `Cells/DataGridMetrics.swift`). `SortableHeaderCell`, `DataGridBaseCellView`, `DataGridCellRegistry`, `DataGridChevronCellView`, `DataGridForeignKeyCellView` all read from it. The two values can no longer drift.

## Tests

- `SortableHeaderCellTests.sortedTitleRectReservesTrailingSpaceForIndicator` — sorted rect is narrower than unsorted at the same bounds, and its `maxX` does not run past the trailing inset.
- `SortableHeaderCellTests.priorityBadgeShrinksSortedTitleRectFurther` — priority >= 2 shrinks the rect further, matching what is reserved for the badge.
- `DataGridRowNumberColumnTests.rowNumberHeaderIsRightAlignedSortableCell` — `#` header is a `SortableHeaderCell` with `.right` alignment.
- Existing `titleRectUsesDataCellHorizontalPadding` and `narrowTitleRectDoesNotProduceNegativeWidth` still pass against the new `titleRect`.

## Validation

- `swiftlint lint --strict --config .swiftlint.yml` clean across all eight changed files.
- `xcodebuild ... test -only-testing:TableProTests/SortableHeaderCellTests` and `-only-testing:TableProTests/DataGridRowNumberColumnTests` to verify (run locally).

## CHANGELOG

No entry. The AX semantic issue this fixes was introduced in #1040, which has not shipped, and project rules say not to add a Fixed entry for fixing something that is itself still unreleased.

## Related

- #1040 — header padding alignment (merged)