### PR TITLE
refactor: rebuild Welcome window as NavigationSplitView with toolbar-hosted search

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -636,7 +636,7 @@ struct TableProApp: App {
     var body: some Scene {
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
-                .frame(width: 700, height: 450)
+                .frame(width: 820, height: 500)
                 .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,
@@ -646,7 +646,6 @@ struct TableProApp: App {
                 ))
         }
         .windowResizability(.contentSize)
-        .windowStyle(.hiddenTitleBar)
         .commandsRemoved()
 
         WindowGroup("New Connection", id: SceneId.connectionForm, for: UUID?.self) { $editingId in

--- a/TablePro/Views/Connection/WelcomeLeftPanel.swift
+++ b/TablePro/Views/Connection/WelcomeLeftPanel.swift
@@ -61,7 +61,7 @@ struct WelcomeLeftPanel: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 20)
         }
-        .frame(width: 260)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var versionLine: some View {

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -123,7 +123,7 @@ struct WelcomeWindowView: View {
             welcomeChooserState = WelcomeChooserState(
                 initialType: payload.initialType,
                 onSelected: { type in
-                    if PluginManager.shared.isDriverInstalled(for: type) {
+                    if PluginManager.shared.isDriverLoaded(for: type) {
                         PendingNewConnectionType.shared.set(type)
                         payload.onSelected(type)
                     } else {
@@ -219,7 +219,6 @@ struct WelcomeWindowView: View {
                 connectionList
             }
         }
-        .frame(minWidth: 350)
         .contentShape(Rectangle())
         .contextMenu { newConnectionContextMenu }
         .searchable(

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -3,14 +3,12 @@
 //  TablePro
 //
 
-import AppKit
 import os
 import SwiftUI
 import UniformTypeIdentifiers
 
 struct WelcomeWindowView: View {
     private enum FocusField {
-        case search
         case connectionList
     }
 
@@ -35,11 +33,9 @@ struct WelcomeWindowView: View {
                     .transition(.move(edge: .trailing))
             }
         }
-        .background(VisualEffectBackground(material: .underWindowBackground, blendingMode: .behindWindow))
-        .ignoresSafeArea()
         .onAppear {
             vm.setUp()
-            focus = .search
+            focus = .connectionList
         }
         .alert(
             vm.connectionsToDelete.count == 1
@@ -127,7 +123,7 @@ struct WelcomeWindowView: View {
             welcomeChooserState = WelcomeChooserState(
                 initialType: payload.initialType,
                 onSelected: { type in
-                    if PluginManager.shared.isDriverLoaded(for: type) {
+                    if PluginManager.shared.isDriverInstalled(for: type) {
                         PendingNewConnectionType.shared.set(type)
                         payload.onSelected(type)
                     } else {
@@ -199,95 +195,24 @@ struct WelcomeWindowView: View {
     // MARK: - Layout
 
     private var welcomeContent: some View {
-        HStack(spacing: 0) {
+        NavigationSplitView(columnVisibility: .constant(.all)) {
             WelcomeLeftPanel(
                 onActivateLicense: { vm.activeSheet = .activation },
                 onCreateConnection: { WindowOpener.shared.openConnectionForm() }
             )
-            Divider()
-            rightPanel
+            .navigationSplitViewColumnWidth(240)
+            .toolbar(removing: .sidebarToggle)
+        } detail: {
+            connectionsDetail
         }
+        .navigationSplitViewStyle(.balanced)
         .transition(.opacity)
     }
 
-    // MARK: - Right Panel
+    // MARK: - Detail (Connections)
 
-    private var rightPanel: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                HStack(spacing: 4) {
-                    WelcomeToolbarButton(
-                        systemImage: "plus",
-                        help: String(localized: "New Connection (⌘N)"),
-                        accessibilityLabel: String(localized: "New Connection")
-                    ) {
-                        WindowOpener.shared.openConnectionForm()
-                    }
-
-                    WelcomeToolbarButton(
-                        systemImage: "folder.badge.plus",
-                        help: String(localized: "New Group"),
-                        accessibilityLabel: String(localized: "New Group")
-                    ) {
-                        vm.pendingMoveToNewGroup = []
-                        vm.activeSheet = .newGroup(parentId: nil)
-                    }
-                }
-                .padding(.trailing, 12)
-
-                NativeSearchField(
-                    text: $vm.searchText,
-                    placeholder: String(localized: "Search for connection..."),
-                    controlSize: .regular
-                )
-                .focused($focus, equals: .search)
-                .onKeyPress(.return) {
-                    vm.connectSelectedConnections()
-                    return .handled
-                }
-                .onKeyPress(.escape) {
-                    if !vm.searchText.isEmpty {
-                        vm.searchText = ""
-                    }
-                    focus = .connectionList
-                    return .handled
-                }
-                .onKeyPress(characters: .init(charactersIn: "\u{7F}\u{08}"), phases: .down) { keyPress in
-                    guard keyPress.modifiers.contains(.command) else { return .ignored }
-                    let toDelete = vm.selectedConnections
-                    guard !toDelete.isEmpty else { return .ignored }
-                    vm.connectionsToDelete = toDelete
-                    vm.showDeleteConfirmation = true
-                    return .handled
-                }
-                .onKeyPress(characters: .init(charactersIn: "jn"), phases: [.down, .repeat]) { keyPress in
-                    guard keyPress.modifiers.contains(.control) else { return .ignored }
-                    vm.moveToNextConnection()
-                    focus = .connectionList
-                    return .handled
-                }
-                .onKeyPress(characters: .init(charactersIn: "kp"), phases: [.down, .repeat]) { keyPress in
-                    guard keyPress.modifiers.contains(.control) else { return .ignored }
-                    vm.moveToPreviousConnection()
-                    focus = .connectionList
-                    return .handled
-                }
-                .onKeyPress(.downArrow) {
-                    vm.moveToNextConnection()
-                    focus = .connectionList
-                    return .handled
-                }
-                .onKeyPress(.upArrow) {
-                    vm.moveToPreviousConnection()
-                    focus = .connectionList
-                    return .handled
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-
-            Divider()
-
+    private var connectionsDetail: some View {
+        Group {
             if vm.treeItems.isEmpty && vm.filteredConnections.isEmpty {
                 emptyState
             } else {
@@ -297,6 +222,34 @@ struct WelcomeWindowView: View {
         .frame(minWidth: 350)
         .contentShape(Rectangle())
         .contextMenu { newConnectionContextMenu }
+        .searchable(
+            text: $vm.searchText,
+            placement: .toolbar,
+            prompt: Text("Search for connection...")
+        )
+        .onSubmit(of: .search) {
+            vm.connectSelectedConnections()
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    WindowOpener.shared.openConnectionForm()
+                } label: {
+                    Label(String(localized: "New Connection"), systemImage: "plus")
+                }
+                .help(String(localized: "New Connection (⌘N)"))
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    vm.pendingMoveToNewGroup = []
+                    vm.activeSheet = .newGroup(parentId: nil)
+                } label: {
+                    Label(String(localized: "New Group"), systemImage: "folder.badge.plus")
+                }
+                .help(String(localized: "New Group"))
+            }
+        }
     }
 
     // MARK: - Connection List
@@ -664,47 +617,6 @@ private struct ConnectionCreationOverlays: ViewModifier {
                     }
                 )
             }
-    }
-}
-
-// MARK: - Visual Effect Background
-
-private struct VisualEffectBackground: NSViewRepresentable {
-    let material: NSVisualEffectView.Material
-    let blendingMode: NSVisualEffectView.BlendingMode
-
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = material
-        view.blendingMode = blendingMode
-        view.state = .followsWindowActiveState
-        view.isEmphasized = true
-        return view
-    }
-
-    func updateNSView(_ view: NSVisualEffectView, context: Context) {
-        view.material = material
-        view.blendingMode = blendingMode
-    }
-}
-
-// MARK: - Toolbar Button
-
-private struct WelcomeToolbarButton: View {
-    let systemImage: String
-    let help: String
-    let accessibilityLabel: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .frame(width: 16, height: 16)
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.large)
-        .help(help)
-        .accessibilityLabel(accessibilityLabel)
     }
 }
 


### PR DESCRIPTION
## Summary

The Welcome window's search field rendered as an opaque white rounded rect over the window's vibrancy material. Per Apple's documented vibrancy model, controls overlaid on an `NSVisualEffectView` (instead of added inside it) do not inherit vibrant appearance. The custom `HStack` + `NSSearchField` + `VisualEffectBackground` layout was the source.

Replaces it with Apple's documented APIs:

- `NavigationSplitView(columnVisibility: .constant(.all))` for the layout.
- `.navigationSplitViewColumnWidth(240)` for the fixed sidebar.
- `.toolbar(removing: .sidebarToggle)` inside the sidebar closure (Apple's documented placement) to drop the system toggle button.
- `.searchable(text:, placement: .toolbar, prompt:)` so the system renders the search field in the window toolbar with correct vibrancy compositing.
- `.toolbar { ToolbarItem(placement: .primaryAction) { ... } }` for the `+` and "New Group" actions.

Window scene: 820x500 fixed (`.frame` + `.windowResizability(.contentSize)`). Old 700x450 with a 260pt sidebar gave only 440pt for the connection list, which truncated typical SQLite paths. New 820x500 with 240pt sidebar follows Mail/Notes/Music proportions (~29% sidebar).

Removed the private `VisualEffectBackground` and `WelcomeToolbarButton` helper structs (now dead) and the unused `import AppKit`.

## Visible UX changes

- Window title bar now visible (was chromeless via `.windowStyle(.hiddenTitleBar)`). The toolbar items and `.searchable` field need a real toolbar, and Apple's first-party launchers with this pattern (Mail, Notes, Music, System Settings) all show a title bar.
- Keyboard navigation from search to list: previously the custom `NSSearchField` had explicit handlers that moved selection on Up/Down arrow. With `.searchable`, the user presses Tab to leave the search field, then Up/Down arrows move the list selection. This is the standard macOS responder-chain pattern. Return still triggers connect via `.onSubmit(of: .search)`.

## Why this is HIG-correct

- **Search field**: HIG, "Search fields": "On macOS, place a search field in a toolbar when its scope encompasses the entire window." `.searchable(placement: .toolbar)` does exactly that.
- **Vibrancy**: per the documented `NSVisualEffectView` model, controls placed as subviews of the visual-effect view inherit vibrant appearance. The system-rendered toolbar field is set up correctly by AppKit; no custom plumbing.
- **Sidebar lockdown**: `.toolbar(removing: .sidebarToggle)` and `columnVisibility: .constant(.all)` are the documented modifiers (macOS 14+).
- **Window resizability**: `.windowResizability(.contentSize)` is the documented modifier for fixed-size windows.

No introspection libraries, no `NSViewControllerRepresentable` for `NSSplitViewController` access, no custom `NSVisualEffectView` plumbing.

## Caveat

Apple's developer forum confirms that on macOS, even with `.toolbar(removing: .sidebarToggle)` and locked visibility, users can theoretically drag the column divider to collapse the sidebar. Fully preventing that requires `NSSplitViewItem.canCollapse = false`, which means either SwiftUI-Introspect or `NSViewControllerRepresentable` plumbing. Both fail the "no hack, no custom" rule and are out of scope here. If divider drag turns out to be a real problem in practice, the only Apple-documented escape is to drop `NavigationSplitView` for `HStack`, which would break `.searchable`'s toolbar placement.

## Review fixes

- Reverted an unrelated `isDriverInstalled` rename that got swept into the first commit (the supporting `PluginManager` change is on a different pending branch and would have broken CI compilation).
- Dropped a dead `.frame(minWidth: 350)` on the detail group (NavigationSplitView already enforces column widths).

## CHANGELOG

No entry. The Welcome window SwiftUI scene rework is already in `[Unreleased]` Changed; this PR refines that unreleased work, which CLAUDE.md says not to double-log.

## Test plan

- [ ] Build and open the Welcome window.
- [ ] Search field renders inside the window toolbar with no opaque white bezel.
- [ ] No sidebar toggle button in the toolbar.
- [ ] Window cannot be resized.
- [ ] `+` and "New Group" toolbar buttons work.
- [ ] Typing in the search field filters the connection list.
- [ ] Pressing Return in the search field connects to the selected connection.
- [ ] Pressing Tab from the search field moves focus to the connection list, then Up/Down arrows move selection.