### PR TITLE
refactor: rebuild Welcome as Xcode-style launcher with HIG-correct primitives

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -636,7 +636,7 @@ struct TableProApp: App {
     var body: some Scene {
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
-                .frame(width: 840, height: 500)
+                .frame(width: 800, height: 480)
                 .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -646,6 +646,7 @@ struct TableProApp: App {
                 ))
         }
         .windowResizability(.contentSize)
+        .windowStyle(.hiddenTitleBar)
         .commandsRemoved()
 
         WindowGroup("New Connection", id: SceneId.connectionForm, for: UUID?.self) { $editingId in

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -636,7 +636,7 @@ struct TableProApp: App {
     var body: some Scene {
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
-                .frame(width: 760, height: 460)
+                .frame(width: 800, height: 480)
                 .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -636,7 +636,7 @@ struct TableProApp: App {
     var body: some Scene {
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
-                .frame(width: 820, height: 500)
+                .frame(width: 760, height: 460)
                 .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -636,7 +636,7 @@ struct TableProApp: App {
     var body: some Scene {
         Window("Welcome to TablePro", id: SceneId.welcome) {
             WelcomeWindowView()
-                .frame(width: 800, height: 480)
+                .frame(width: 840, height: 500)
                 .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(
                     restorable: false,

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -37,7 +37,7 @@ final class WelcomeViewModel {
     // MARK: - State
 
     var connections: [DatabaseConnection] = []
-    var searchText = "" { didSet { rebuildTree() } }
+    var searchText = "" { didSet { scheduleRebuildTree(oldValue: oldValue) } }
     var selectedConnectionIds: Set<UUID> = []
     var groups: [ConnectionGroup] = []
     var linkedConnections: [LinkedConnection] = []
@@ -83,6 +83,8 @@ final class WelcomeViewModel {
     @ObservationIgnored private var linkedFoldersObserver: NSObjectProtocol?
     @ObservationIgnored private var importFromAppObserver: NSObjectProtocol?
     @ObservationIgnored private var welcomeRouterTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    private static let searchDebounceNanoseconds: UInt64 = 150_000_000
 
     // MARK: - Computed Properties
 
@@ -112,15 +114,16 @@ final class WelcomeViewModel {
         maxDescendantDepthByGroup = descendantDepths
     }
 
-    var filteredConnections: [DatabaseConnection] {
-        if searchText.isEmpty {
-            return connections
+    private func scheduleRebuildTree(oldValue: String) {
+        searchDebounceTask?.cancel()
+        if searchText.isEmpty || oldValue.isEmpty {
+            rebuildTree()
+            return
         }
-        return connections.filter { connection in
-            connection.name.localizedCaseInsensitiveContains(searchText)
-                || connection.host.localizedCaseInsensitiveContains(searchText)
-                || connection.database.localizedCaseInsensitiveContains(searchText)
-                || groupName(for: connection.groupId)?.localizedCaseInsensitiveContains(searchText) == true
+        searchDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.searchDebounceNanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.rebuildTree()
         }
     }
 
@@ -152,9 +155,6 @@ final class WelcomeViewModel {
                 expandedGroupIds = allGroupIds
             }
         }
-
-        // ⌘N now shows the Welcome window (handled by ContentView and AppDelegate).
-        // The Welcome window is already open in this context, so no action needed here.
 
         connectionUpdatedObserver = NotificationCenter.default.addObserver(
             forName: .connectionUpdated, object: nil, queue: .main

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -135,10 +135,6 @@ final class WelcomeViewModel {
         connections.filter { selectedConnectionIds.contains($0.id) }
     }
 
-    var isMultipleSelection: Bool {
-        selectedConnectionIds.count > 1
-    }
-
     func groupName(for groupId: UUID?) -> String? {
         guard let groupId else { return nil }
         return groups.first { $0.id == groupId }?.name
@@ -263,6 +259,7 @@ final class WelcomeViewModel {
 
     deinit {
         welcomeRouterTask?.cancel()
+        searchDebounceTask?.cancel()
         [connectionUpdatedObserver, exportObserver, importObserver,
          importFromAppObserver, linkedFoldersObserver].forEach {
             if let observer = $0 {
@@ -319,12 +316,6 @@ final class WelcomeViewModel {
                     "Failed to connect after plugin install: \(error.localizedDescription, privacy: .public)")
                 handleConnectionFailure(error: error, connectionId: connection.id)
             }
-        }
-    }
-
-    func connectSelectedConnections() {
-        for connection in selectedConnections {
-            connectToDatabase(connection)
         }
     }
 

--- a/TablePro/Views/Components/SyncStatusIndicator.swift
+++ b/TablePro/Views/Components/SyncStatusIndicator.swift
@@ -2,14 +2,13 @@
 //  SyncStatusIndicator.swift
 //  TablePro
 //
-//  Small cloud icon showing sync status in the welcome window footer
-//
 
 import SwiftUI
 
 struct SyncStatusIndicator: View {
+    var onActivateLicense: (() -> Void)?
+
     private let syncCoordinator = SyncCoordinator.shared
-    @State private var showActivationSheet = false
 
     var body: some View {
         if shouldShow {
@@ -29,13 +28,8 @@ struct SyncStatusIndicator: View {
             }
             .buttonStyle(.plain)
             .help(helpText)
-            .sheet(isPresented: $showActivationSheet) {
-                LicenseActivationSheet()
-            }
         }
     }
-
-    // MARK: - State Mapping
 
     private var shouldShow: Bool {
         if case .disabled(.userDisabled) = syncCoordinator.syncStatus {
@@ -110,18 +104,16 @@ struct SyncStatusIndicator: View {
         case .disabled(.licenseRequired):
             return String(localized: "Pro license required for iCloud Sync")
         case .disabled(.licenseExpired):
-            return String(localized: "License expired — sync paused")
+            return String(localized: "License expired, sync paused")
         case .disabled(.userDisabled):
             return ""
         }
     }
 
-    // MARK: - Actions
-
     private func handleTap() {
         switch syncCoordinator.syncStatus {
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
-            showActivationSheet = true
+            onActivateLicense?()
         default:
             WindowOpener.shared.openSettings(tab: .account)
         }

--- a/TablePro/Views/Components/SyncStatusIndicator.swift
+++ b/TablePro/Views/Components/SyncStatusIndicator.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 struct SyncStatusIndicator: View {
-    var onActivateLicense: (() -> Void)?
+    let onActivateLicense: () -> Void
 
     private let syncCoordinator = SyncCoordinator.shared
 
@@ -113,7 +113,7 @@ struct SyncStatusIndicator: View {
     private func handleTap() {
         switch syncCoordinator.syncStatus {
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
-            onActivateLicense?()
+            onActivateLicense()
         default:
             WindowOpener.shared.openSettings(tab: .account)
         }
@@ -122,7 +122,7 @@ struct SyncStatusIndicator: View {
 
 #Preview {
     HStack(spacing: 16) {
-        SyncStatusIndicator()
+        SyncStatusIndicator(onActivateLicense: {})
     }
     .padding()
 }

--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -1,5 +1,5 @@
 //
-//  WelcomeLeftPanel.swift
+//  WelcomeActionsPanel.swift
 //  TablePro
 //
 

--- a/TablePro/Views/Connection/WelcomeConnectionRow.swift
+++ b/TablePro/Views/Connection/WelcomeConnectionRow.swift
@@ -89,6 +89,9 @@ struct WelcomeConnectionRow: View {
         if connection.host.isEmpty {
             return connection.database.isEmpty ? connection.type.rawValue : connection.database
         }
+        if connection.host.hasPrefix("/") {
+            return (connection.host as NSString).abbreviatingWithTildeInPath
+        }
         if let mongoHosts = connection.additionalFields["mongoHosts"], mongoHosts.contains(",") {
             let count = mongoHosts.split(separator: ",").count
             return String(format: String(localized: "%@ (+%d more)"), hostWithOptionalPort, count - 1)

--- a/TablePro/Views/Connection/WelcomeConnectionRow.swift
+++ b/TablePro/Views/Connection/WelcomeConnectionRow.swift
@@ -8,7 +8,6 @@ import SwiftUI
 struct WelcomeConnectionRow: View {
     let connection: DatabaseConnection
     let sshProfile: SSHProfile?
-    var onConnect: (() -> Void)?
 
     private var displayTag: ConnectionTag? {
         guard let tagId = connection.tagId else { return nil }
@@ -45,7 +44,6 @@ struct WelcomeConnectionRow: View {
             trailingAccessories
         }
         .contentShape(Rectangle())
-        .overlay(DoubleClickDetector { onConnect?() })
         .accessibilityElement(children: .combine)
     }
 
@@ -105,9 +103,6 @@ struct WelcomeConnectionRow: View {
         return "\(connection.host):\(connection.port)"
     }
 
-    /// Apple's semantic convention for routed/relayed connections is the
-    /// "via X" suffix (AirDrop, Mail forwarded threads, Network preferences).
-    /// Returns nil when SSH is not enabled or the bastion host is empty.
     private var sshViaText: String? {
         let ssh = connection.resolvedSSHConfig
         guard ssh.enabled, !ssh.host.isEmpty else { return nil }

--- a/TablePro/Views/Connection/WelcomeContextMenus.swift
+++ b/TablePro/Views/Connection/WelcomeContextMenus.swift
@@ -7,19 +7,24 @@ import SwiftUI
 
 extension WelcomeWindowView {
     @ViewBuilder
-    func contextMenuContent(for connection: DatabaseConnection) -> some View {
-        if vm.isMultipleSelection, vm.selectedConnectionIds.contains(connection.id) {
-            multiSelectionContextMenu(for: connection)
+    func contextMenuContent(for ids: Set<UUID>) -> some View {
+        if ids.isEmpty {
+            newConnectionContextMenu
         } else {
-            singleConnectionContextMenu(for: connection)
+            let connections = vm.connections.filter { ids.contains($0.id) }
+            if connections.count > 1 {
+                multiSelectionContextMenu(for: connections)
+            } else if let single = connections.first {
+                singleConnectionContextMenu(for: single)
+            }
         }
     }
 
     @ViewBuilder
-    private func multiSelectionContextMenu(for connection: DatabaseConnection) -> some View {
-        Button { vm.connectSelectedConnections() } label: {
+    private func multiSelectionContextMenu(for connections: [DatabaseConnection]) -> some View {
+        Button { primaryAction(for: Set(connections.map(\.id))) } label: {
             Label(
-                String(format: String(localized: "Connect %d Connections"), vm.selectedConnectionIds.count),
+                String(format: String(localized: "Connect %d Connections"), connections.count),
                 systemImage: "play.fill"
             )
         }
@@ -28,10 +33,10 @@ extension WelcomeWindowView {
 
         Menu(String(localized: "Share")) {
             Button {
-                vm.exportConnections(Array(vm.selectedConnections))
+                vm.exportConnections(connections)
             } label: {
                 Label(
-                    String(format: String(localized: "Export %d Connections to File..."), vm.selectedConnectionIds.count),
+                    String(format: String(localized: "Export %d Connections to File..."), connections.count),
                     systemImage: "square.and.arrow.up"
                 )
             }
@@ -39,11 +44,11 @@ extension WelcomeWindowView {
 
         Divider()
 
-        moveToGroupMenu(for: vm.selectedConnections)
+        moveToGroupMenu(for: connections)
 
         let validGroupIds = Set(vm.groups.map(\.id))
-        if vm.selectedConnections.contains(where: { $0.groupId.map { validGroupIds.contains($0) } ?? false }) {
-            Button { vm.removeFromGroup(vm.selectedConnections) } label: {
+        if connections.contains(where: { $0.groupId.map { validGroupIds.contains($0) } ?? false }) {
+            Button { vm.removeFromGroup(connections) } label: {
                 Label(String(localized: "Remove from Group"), systemImage: "folder.badge.minus")
             }
         }
@@ -51,9 +56,9 @@ extension WelcomeWindowView {
         if AppSettingsManager.shared.sync.enabled {
             Divider()
 
-            let allLocalOnly = vm.selectedConnections.allSatisfy(\.localOnly)
+            let allLocalOnly = connections.allSatisfy(\.localOnly)
             Button {
-                for conn in vm.selectedConnections {
+                for conn in connections {
                     var updated = conn
                     updated.localOnly = !allLocalOnly
                     ConnectionStorage.shared.updateConnection(updated)
@@ -72,11 +77,11 @@ extension WelcomeWindowView {
         Divider()
 
         Button(role: .destructive) {
-            vm.connectionsToDelete = vm.selectedConnections
+            vm.connectionsToDelete = connections
             vm.showDeleteConfirmation = true
         } label: {
             Label(
-                String(format: String(localized: "Delete %d Connections"), vm.selectedConnectionIds.count),
+                String(format: String(localized: "Delete %d Connections"), connections.count),
                 systemImage: "trash"
             )
         }

--- a/TablePro/Views/Connection/WelcomeLeftPanel.swift
+++ b/TablePro/Views/Connection/WelcomeLeftPanel.swift
@@ -5,9 +5,11 @@
 
 import SwiftUI
 
-struct WelcomeLeftPanel: View {
+struct WelcomeActionsPanel: View {
     let onActivateLicense: () -> Void
     let onCreateConnection: () -> Void
+    let onTrySample: () -> Void
+    let onImportFromFile: () -> Void
 
     private let updaterBridge = UpdaterBridge.shared
 
@@ -15,14 +17,14 @@ struct WelcomeLeftPanel: View {
         VStack(spacing: 0) {
             Spacer()
 
-            VStack(spacing: 16) {
+            VStack(spacing: 14) {
                 Image(nsImage: NSApp.applicationIconImage)
                     .resizable()
                     .frame(width: 96, height: 96)
                     .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
 
                 VStack(spacing: 6) {
-                    Text("TablePro")
+                    Text(verbatim: "TablePro")
                         .font(.title2.weight(.semibold))
 
                     versionLine
@@ -32,27 +34,43 @@ struct WelcomeLeftPanel: View {
             }
 
             Spacer()
-                .frame(height: 32)
+                .frame(height: 28)
 
-            Button(action: onCreateConnection) {
-                Label("Create connection...", systemImage: "plus.circle")
-                    .frame(maxWidth: .infinity, alignment: .center)
+            VStack(spacing: 8) {
+                Button(action: onCreateConnection) {
+                    Label(String(localized: "Create Connection..."), systemImage: "plus.circle")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button(action: onTrySample) {
+                    Label(String(localized: "Try Sample Database"), systemImage: "cylinder.split.1x2")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+
+                Button(action: onImportFromFile) {
+                    Label(String(localized: "Import Connections..."), systemImage: "square.and.arrow.down")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             }
-            .buttonStyle(.bordered)
-            .controlSize(.large)
-            .padding(.horizontal, 32)
+            .padding(.horizontal, 24)
 
             Spacer()
 
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 12) {
-                    SyncStatusIndicator()
-                    KeyboardHint(keys: "⌘N", label: "New")
-                    KeyboardHint(keys: "⌘,", label: "Settings")
+                    SyncStatusIndicator(onActivateLicense: onActivateLicense)
+                    KeyboardHint(keys: "⌘N", label: String(localized: "New"))
+                    KeyboardHint(keys: "⌘,", label: String(localized: "Settings"))
                 }
                 HStack(spacing: 8) {
-                    SyncStatusIndicator()
-                    KeyboardHint(keys: "⌘N", label: "New")
+                    SyncStatusIndicator(onActivateLicense: onActivateLicense)
+                    KeyboardHint(keys: "⌘N", label: String(localized: "New"))
                     KeyboardHint(keys: "⌘,", label: nil)
                 }
             }
@@ -66,14 +84,14 @@ struct WelcomeLeftPanel: View {
 
     private var versionLine: some View {
         HStack(spacing: 6) {
-            Text("Version \(Bundle.main.appVersion)")
+            Text(String(format: String(localized: "Version %@"), Bundle.main.appVersion))
                 .foregroundStyle(.secondary)
             Text(verbatim: "·")
                 .foregroundStyle(.tertiary)
             Button {
                 updaterBridge.checkForUpdates()
             } label: {
-                Text("Check for Updates...")
+                Text(String(localized: "Check for Updates..."))
             }
             .buttonStyle(.link)
             .disabled(!updaterBridge.canCheckForUpdates)
@@ -84,40 +102,15 @@ struct WelcomeLeftPanel: View {
     @ViewBuilder
     private var licenseLine: some View {
         if LicenseManager.shared.status.isValid {
-            Label("Pro", systemImage: "checkmark.seal.fill")
+            Label(String(localized: "Pro"), systemImage: "checkmark.seal.fill")
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(Color(nsColor: .systemGreen))
         } else {
-            HoverAccentButton(action: onActivateLicense) {
-                Text("Activate License")
+            Button(action: onActivateLicense) {
+                Text(String(localized: "Activate License"))
                     .font(.subheadline)
             }
-        }
-    }
-}
-
-private struct HoverAccentButton<Label: View>: View {
-    let action: () -> Void
-    @ViewBuilder let label: () -> Label
-
-    @State private var isHovering = false
-
-    var body: some View {
-        Button(action: action) {
-            label()
-                .foregroundStyle(isHovering
-                    ? AnyShapeStyle(Color.accentColor)
-                    : AnyShapeStyle(HierarchicalShapeStyle.secondary))
-                .underline(isHovering, color: .accentColor)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovering = hovering
-            if hovering {
-                NSCursor.pointingHand.push()
-            } else {
-                NSCursor.pop()
-            }
+            .buttonStyle(.link)
         }
     }
 }

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -34,6 +34,7 @@ struct WelcomeWindowView: View {
                     .transition(.move(edge: .trailing))
             }
         }
+        .ignoresSafeArea()
         .onAppear {
             vm.setUp()
             focus = .connectionList

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -204,7 +204,7 @@ struct WelcomeWindowView: View {
                 onTrySample: { vm.openSampleDatabase() },
                 onImportFromFile: { vm.importConnectionsFromFile() }
             )
-            .frame(width: 240)
+            .frame(width: 220)
             .background(.regularMaterial)
 
             Divider()

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -233,15 +233,17 @@ struct WelcomeWindowView: View {
         .background(Color(nsColor: .controlBackgroundColor))
         .contentShape(Rectangle())
         .contextMenu { newConnectionContextMenu }
-        .background {
-            Button {
-                searchFocusTrigger += 1
-            } label: {
-                EmptyView()
-            }
-            .keyboardShortcut("f", modifiers: .command)
-            .accessibilityHidden(true)
+        .background(findShortcut)
+    }
+
+    private var findShortcut: some View {
+        Button {
+            searchFocusTrigger += 1
+        } label: {
+            EmptyView()
         }
+        .keyboardShortcut("f", modifiers: .command)
+        .accessibilityHidden(true)
     }
 
     private var connectionsHeader: some View {
@@ -275,10 +277,11 @@ struct WelcomeWindowView: View {
                 text: $vm.searchText,
                 placeholder: String(localized: "Search for connection..."),
                 controlSize: .regular,
-                focusTrigger: searchFocusTrigger
+                focusTrigger: searchFocusTrigger,
+                maxWidth: 240
             )
             .focused($focus, equals: .search)
-            .frame(maxWidth: 240)
+            .layoutPriority(0)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -402,12 +405,11 @@ struct WelcomeWindowView: View {
 
     func primaryAction(for ids: Set<UUID>) {
         guard !ids.isEmpty else { return }
-        for id in ids {
-            if let conn = vm.connections.first(where: { $0.id == id }) {
-                vm.connectToDatabase(conn)
-            } else if let linked = vm.linkedConnections.first(where: { $0.id == id }) {
-                vm.connectToLinkedConnection(linked)
-            }
+        for connection in vm.connections where ids.contains(connection.id) {
+            vm.connectToDatabase(connection)
+        }
+        for linked in vm.linkedConnections where ids.contains(linked.id) {
+            vm.connectToLinkedConnection(linked)
         }
     }
 

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -9,6 +9,7 @@ import UniformTypeIdentifiers
 
 struct WelcomeWindowView: View {
     private enum FocusField {
+        case search
         case connectionList
     }
 
@@ -195,60 +196,85 @@ struct WelcomeWindowView: View {
     // MARK: - Layout
 
     private var welcomeContent: some View {
-        NavigationSplitView(columnVisibility: .constant(.all)) {
-            WelcomeLeftPanel(
+        HStack(spacing: 0) {
+            WelcomeActionsPanel(
                 onActivateLicense: { vm.activeSheet = .activation },
-                onCreateConnection: { WindowOpener.shared.openConnectionForm() }
+                onCreateConnection: { WindowOpener.shared.openConnectionForm() },
+                onTrySample: { vm.openSampleDatabase() },
+                onImportFromFile: { vm.importConnectionsFromFile() }
             )
-            .navigationSplitViewColumnWidth(240)
-            .toolbar(removing: .sidebarToggle)
-        } detail: {
-            connectionsDetail
+            .frame(width: 240)
+            .background(.regularMaterial)
+
+            Divider()
+
+            connectionsPanel
         }
-        .navigationSplitViewStyle(.balanced)
         .transition(.opacity)
     }
 
-    // MARK: - Detail (Connections)
+    // MARK: - Connections panel
 
-    private var connectionsDetail: some View {
-        Group {
-            if vm.treeItems.isEmpty && vm.filteredConnections.isEmpty {
-                emptyState
-            } else {
-                connectionList
+    private var connectionsPanel: some View {
+        VStack(spacing: 0) {
+            connectionsHeader
+            Divider()
+            ZStack {
+                if vm.treeItems.isEmpty && vm.linkedConnections.isEmpty {
+                    emptyState
+                } else {
+                    connectionList
+                }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .controlBackgroundColor))
         .contentShape(Rectangle())
         .contextMenu { newConnectionContextMenu }
-        .searchable(
-            text: $vm.searchText,
-            placement: .toolbar,
-            prompt: Text("Search for connection...")
-        )
-        .onSubmit(of: .search) {
-            vm.connectSelectedConnections()
+        .onKeyPress(characters: .init(charactersIn: "f"), phases: .down) { keyPress in
+            guard keyPress.modifiers.contains(.command) else { return .ignored }
+            focus = .search
+            return .handled
         }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    WindowOpener.shared.openConnectionForm()
-                } label: {
-                    Label(String(localized: "New Connection"), systemImage: "plus")
-                }
-                .help(String(localized: "New Connection (⌘N)"))
-            }
+    }
 
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    vm.pendingMoveToNewGroup = []
-                    vm.activeSheet = .newGroup(parentId: nil)
-                } label: {
-                    Label(String(localized: "New Group"), systemImage: "folder.badge.plus")
-                }
-                .help(String(localized: "New Group"))
+    private var connectionsHeader: some View {
+        HStack(spacing: 8) {
+            Button {
+                WindowOpener.shared.openConnectionForm()
+            } label: {
+                Image(systemName: "plus")
+                    .frame(width: 14, height: 14)
             }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .help(String(localized: "New Connection (⌘N)"))
+            .accessibilityLabel(String(localized: "New Connection"))
+
+            Button {
+                vm.pendingMoveToNewGroup = []
+                vm.activeSheet = .newGroup(parentId: nil)
+            } label: {
+                Image(systemName: "folder.badge.plus")
+                    .frame(width: 14, height: 14)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .help(String(localized: "New Group"))
+            .accessibilityLabel(String(localized: "New Group"))
+
+            Spacer()
+
+            NativeSearchField(
+                text: $vm.searchText,
+                placeholder: String(localized: "Search for connection..."),
+                controlSize: .regular
+            )
+            .focused($focus, equals: .search)
+            .frame(maxWidth: 240)
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
     }
 
     // MARK: - Connection List
@@ -279,9 +305,10 @@ struct WelcomeWindowView: View {
             .listStyle(.inset)
             .scrollContentBackground(.hidden)
             .focused($focus, equals: .connectionList)
-            .onKeyPress(.return) {
-                vm.connectSelectedConnections()
-                return .handled
+            .contextMenu(forSelectionType: UUID.self) { ids in
+                contextMenuContent(for: ids)
+            } primaryAction: { ids in
+                primaryAction(for: ids)
             }
             .onKeyPress(characters: .init(charactersIn: "\u{7F}\u{08}"), phases: .down) { keyPress in
                 guard keyPress.modifiers.contains(.command) else { return .ignored }
@@ -333,13 +360,11 @@ struct WelcomeWindowView: View {
         let sshProfile = connection.sshProfileId.flatMap { SSHProfileStorage.shared.profile(for: $0) }
         return WelcomeConnectionRow(
             connection: connection,
-            sshProfile: sshProfile,
-            onConnect: { vm.connectToDatabase(connection) }
+            sshProfile: sshProfile
         )
         .tag(connection.id)
         .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
         .listRowSeparator(.hidden)
-        .contextMenu { contextMenuContent(for: connection) }
     }
 
     private func linkedConnectionRow(for linked: LinkedConnection) -> some View {
@@ -365,13 +390,16 @@ struct WelcomeWindowView: View {
         .padding(.vertical, 4)
         .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
         .contentShape(Rectangle())
-        .background { DoubleClickDetector { vm.connectToLinkedConnection(linked) } }
         .listRowSeparator(.hidden)
-        .contextMenu {
-            Button {
+    }
+
+    private func primaryAction(for ids: Set<UUID>) {
+        guard !ids.isEmpty else { return }
+        for id in ids {
+            if let conn = vm.connections.first(where: { $0.id == id }) {
+                vm.connectToDatabase(conn)
+            } else if let linked = vm.linkedConnections.first(where: { $0.id == id }) {
                 vm.connectToLinkedConnection(linked)
-            } label: {
-                Label(String(localized: "Connect"), systemImage: "play.fill")
             }
         }
     }
@@ -416,8 +444,15 @@ private struct TreeRowsView<ConnectionContent: View>: View {
     var vm: WelcomeViewModel
     let connectionRowBuilder: (DatabaseConnection) -> ConnectionContent
 
+    private var hasGroups: Bool {
+        items.contains { node in
+            if case .group = node { return true }
+            return false
+        }
+    }
+
     var body: some View {
-        let allConnections = !items.contains { if case .group = $0 { return true } else { return false } }
+        let allConnections = !hasGroups
         ForEach(items) { item in
             switch item {
             case .connection(let conn):

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -18,6 +18,7 @@ struct WelcomeWindowView: View {
     @State private var pendingInstallType: DatabaseType?
     @State private var pendingInstallPayload: DatabaseTypeChooserPayload?
     @State private var urlImportPresented: Bool = false
+    @State private var searchFocusTrigger: Int = 0
     @FocusState private var focus: FocusField?
 
     var body: some View {
@@ -232,10 +233,14 @@ struct WelcomeWindowView: View {
         .background(Color(nsColor: .controlBackgroundColor))
         .contentShape(Rectangle())
         .contextMenu { newConnectionContextMenu }
-        .onKeyPress(characters: .init(charactersIn: "f"), phases: .down) { keyPress in
-            guard keyPress.modifiers.contains(.command) else { return .ignored }
-            focus = .search
-            return .handled
+        .background {
+            Button {
+                searchFocusTrigger += 1
+            } label: {
+                EmptyView()
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .accessibilityHidden(true)
         }
     }
 
@@ -269,7 +274,8 @@ struct WelcomeWindowView: View {
             NativeSearchField(
                 text: $vm.searchText,
                 placeholder: String(localized: "Search for connection..."),
-                controlSize: .regular
+                controlSize: .regular,
+                focusTrigger: searchFocusTrigger
             )
             .focused($focus, equals: .search)
             .frame(maxWidth: 240)

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -393,7 +393,7 @@ struct WelcomeWindowView: View {
         .listRowSeparator(.hidden)
     }
 
-    private func primaryAction(for ids: Set<UUID>) {
+    func primaryAction(for ids: Set<UUID>) {
         guard !ids.isEmpty else { return }
         for id in ids {
             if let conn = vm.connections.first(where: { $0.id == id }) {

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -205,7 +205,7 @@ struct WelcomeWindowView: View {
                 onTrySample: { vm.openSampleDatabase() },
                 onImportFromFile: { vm.importConnectionsFromFile() }
             )
-            .frame(width: 220)
+            .frame(width: 240)
             .background(.regularMaterial)
 
             Divider()

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -17,6 +17,7 @@ struct NativeSearchField: NSViewRepresentable {
     var onSubmit: (() -> Void)?
     var focusOnAppear: Bool = false
     var focusTrigger: Int = 0
+    var maxWidth: CGFloat?
 
     func makeNSView(context: Context) -> NSSearchField {
         let field = NSSearchField()
@@ -25,6 +26,11 @@ struct NativeSearchField: NSViewRepresentable {
         field.controlSize = controlSize
         field.sendsSearchStringImmediately = true
         field.setAccessibilityIdentifier("sidebar-filter")
+        field.cell?.usesSingleLineMode = true
+        if let maxWidth {
+            field.preferredMaxLayoutWidth = maxWidth
+            field.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth).isActive = true
+        }
         context.coordinator.lastFocusTrigger = focusTrigger
         if focusOnAppear {
             DispatchQueue.main.async {

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -16,6 +16,7 @@ struct NativeSearchField: NSViewRepresentable {
     var onMoveDown: (() -> Void)?
     var onSubmit: (() -> Void)?
     var focusOnAppear: Bool = false
+    var focusTrigger: Int = 0
 
     func makeNSView(context: Context) -> NSSearchField {
         let field = NSSearchField()
@@ -24,6 +25,7 @@ struct NativeSearchField: NSViewRepresentable {
         field.controlSize = controlSize
         field.sendsSearchStringImmediately = true
         field.setAccessibilityIdentifier("sidebar-filter")
+        context.coordinator.lastFocusTrigger = focusTrigger
         if focusOnAppear {
             DispatchQueue.main.async {
                 field.window?.makeFirstResponder(field)
@@ -40,6 +42,13 @@ struct NativeSearchField: NSViewRepresentable {
         context.coordinator.onMoveUp = onMoveUp
         context.coordinator.onMoveDown = onMoveDown
         context.coordinator.onSubmit = onSubmit
+
+        if focusTrigger != context.coordinator.lastFocusTrigger {
+            context.coordinator.lastFocusTrigger = focusTrigger
+            DispatchQueue.main.async {
+                field.window?.makeFirstResponder(field)
+            }
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -51,6 +60,7 @@ struct NativeSearchField: NSViewRepresentable {
         var onMoveUp: (() -> Void)?
         var onMoveDown: (() -> Void)?
         var onSubmit: (() -> Void)?
+        var lastFocusTrigger: Int = 0
 
         init(text: Binding<String>) {
             self.text = text
@@ -66,6 +76,14 @@ struct NativeSearchField: NSViewRepresentable {
         }
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                if let field = control as? NSSearchField {
+                    field.stringValue = ""
+                }
+                text.wrappedValue = ""
+                control.window?.makeFirstResponder(nil)
+                return true
+            }
             if commandSelector == #selector(NSResponder.moveUp(_:)), let onMoveUp {
                 onMoveUp()
                 return true


### PR DESCRIPTION
## Why this exists

The Welcome window's runtime behavior is launcher-shaped: open the window, pick a connection, the connection opens in its own window, the launcher is dismissed/backgrounded. Apple's documented analogue is Xcode's Welcome window. PR #1052 picked the Mail/Notes-style `NavigationSplitView` + toolbar-search frame, which fixed the white-search-on-vibrancy bug correctly using documented APIs but forced a "sidebar isn't really a sidebar" mismatch (Apple HIG: sidebar = navigation; the Welcome left column is branding + a primary CTA).

This PR reverses the structural choice while keeping the API hygiene from #1052 and folds in audit findings (drop `DoubleClickDetector`, drop per-row `.contextMenu`, single sheet path for license activation, search debounce, single filter source, localization gaps, comments).

## Architecture

- `HStack { WelcomeActionsPanel, Divider, ConnectionsPanel }`. No `NavigationSplitView`. No structural sidebar.
- Window: `820x500`, `.windowResizability(.contentSize)`, `.windowStyle(.hiddenTitleBar)`. Launcher exception per HIG `Launching` page.
- Actions panel (left, 240pt, `.regularMaterial`): app icon + version + license + three action buttons (Create Connection prominent, Try Sample, Import Connections) + sync indicator + keyboard hints. Localized version line and Check-for-Updates link.
- Connections panel (right, opaque `controlBackgroundColor`): inline header with `+` / "New Group" buttons + `NativeSearchField` + connection list. Search field renders correctly because the panel background is opaque, not vibrancy.

## HIG-correct primitives

| Concern | API |
|---|---|
| Single-purpose launcher window | `Window` scene + `.windowResizability(.contentSize)` |
| Search field | `NSSearchField` via `NativeSearchField` wrapper, on opaque background |
| Cmd-F focus | `.onKeyPress(characters: .init(charactersIn: "f"))` on connections panel sets `focus = .search` |
| Double-click + context menu | `contextMenu(forSelectionType: UUID.self, menu:, primaryAction:)` on the List, identical pattern to `FavoritesTabView.swift:145` |
| Multi-select context menu | Selection set is passed to the menu closure, which dispatches to single/multi/empty branches |
| License activation | One sheet path through `vm.activeSheet = .activation`; `SyncStatusIndicator` accepts a callback |
| Search debounce | 150ms `Task` cancellation; immediate rebuild on entering/leaving search |
| Hover affordance for "Activate License" | `.buttonStyle(.link)` (system link cursor) instead of custom `NSCursor.push/pop` |

## Audit cleanups

- Drop `DoubleClickDetector` from welcome surfaces (`WelcomeConnectionRow.swift`, linked-folder row).
- Drop per-row `.contextMenu` in `TreeRowsView`. Replaced by container-level `contextMenu(forSelectionType:)`.
- Drop `vm.filteredConnections` (dual filter source); empty-state checks `vm.treeItems.isEmpty && vm.linkedConnections.isEmpty`.
- Drop `searchText.didSet { rebuildTree() }` synchronous path; replaced with debounced `scheduleRebuildTree`.
- Drop `SyncStatusIndicator`'s local `.sheet`. Routes through callback.
- Drop three commented blocks: `SyncStatusIndicator.swift:5-6` header, `WelcomeConnectionRow.swift:108-113` doc, `WelcomeViewModel.swift:156-157` planning note.
- Wrap unlocalized strings: `Version %@`, `Check for Updates...`, `Pro`, `Activate License`, `New`, `Settings`.
- Replace `License expired — sync paused` with `License expired, sync paused` (em-dash removed per CLAUDE.md style).
- Extract `hasGroups` computed in `TreeRowsView` to replace inline `if case .group = $0` predicate.

## Out of scope

- Other `DoubleClickDetector` callers (`SidebarView.swift:196`, `DatabaseSwitcherSheet.swift:254`, `DatabaseTypeChooserSheet.swift:78`, `QuickSwitcherView.swift:171`). Each warrants its own selection-type-driven refactor in a follow-up.
- "Recents" section. `DatabaseConnection` has no `lastUsedAt`; data-model change first.
- `WindowChromeConfigurator` / `WindowOpenerBridge` `NSViewRepresentable` bridges. SwiftUI has no first-class API for hiding individual standard window buttons; these are unavoidable.

## CHANGELOG

No entry. The Welcome SwiftUI scene rework is already in `[Unreleased]` Changed; this PR refines that unreleased work, which CLAUDE.md says not to double-log. Same logic as #1052.

## Source material

- Audit and HIG research notes saved in `docs/refactor/welcome-hig-research.md` and `docs/refactor/welcome-hig-synthesis.md` (already on a separate branch / not staged).
- Apple HIG: [Sidebars](https://developer.apple.com/design/human-interface-guidelines/sidebars), [Search fields](https://developer.apple.com/design/human-interface-guidelines/search-fields), [Toolbars](https://developer.apple.com/design/human-interface-guidelines/toolbars), [Launching](https://developer.apple.com/design/human-interface-guidelines/patterns/launching).
- Apple API: [`contextMenu(forSelectionType:menu:primaryAction:)`](https://developer.apple.com/documentation/swiftui/view/contextmenu(forselectiontype:menu:primaryaction:)).

## Test plan

- [ ] Welcome opens at 820x500, non-resizable, no title bar, no sidebar toggle button.
- [ ] Left (actions) panel shows three buttons; Create is prominent, Sample and Import are bordered.
- [ ] Right (connections) panel: `+` and "New Group" inline buttons, search field renders without white box bezel.
- [ ] Cmd-F focuses the search field. Esc clears.
- [ ] Type to filter; debounced (~150ms).
- [ ] Single-click selects, double-click connects (via `primaryAction`).
- [ ] Right-click on selected row in a multi-selection shows the multi-selection menu.
- [ ] Right-click on an unselected row shows the single-row menu (collapsed selection).
- [ ] Right-click on empty space in the list shows the new-connection menu.
- [ ] Empty state shows "Try Sample Database" CTA.
- [ ] License activation works from both the version-line link and the sync indicator.
- [ ] Linked folder rows still connect via the same `primaryAction`.