### PR TITLE
feat: slash commands /explain /optimize /fix /help in the AI chat composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - AI Chat: inline model picker in the composer with per-turn model attribution. Switch between configured providers and any of their available models without leaving the chat. The model that produced each assistant turn is shown in the message footer.
+- AI Chat: slash commands `/explain`, `/optimize`, `/fix`, and `/help`. Type the command in the composer or pick from the slash menu next to the model picker. `/explain`, `/optimize`, and `/fix` operate on the current query in the active editor. `/help` lists the commands inline.
 
 ### Fixed
 

--- a/TablePro/Core/AI/Chat/SlashCommand.swift
+++ b/TablePro/Core/AI/Chat/SlashCommand.swift
@@ -5,56 +5,58 @@
 
 import Foundation
 
-struct SlashCommand: Identifiable, Sendable {
-    let name: String
-    let descriptionKey: String.LocalizationValue
-    let requiresQuery: Bool
+enum SlashCommand: String, CaseIterable, Identifiable, Sendable {
+    case explain
+    case optimize
+    case fix
+    case help
 
-    var id: String { name }
+    var id: String { rawValue }
+
+    var name: String { rawValue }
 
     var description: String {
-        String(localized: descriptionKey)
+        switch self {
+        case .explain: return String(localized: "Explain the current query")
+        case .optimize: return String(localized: "Suggest optimizations for the current query")
+        case .fix: return String(localized: "Fix the last error on the current query")
+        case .help: return String(localized: "List available commands")
+        }
     }
 
-    static let allCommands: [SlashCommand] = [
-        SlashCommand(
-            name: "explain",
-            descriptionKey: "Explain the current query",
-            requiresQuery: true
-        ),
-        SlashCommand(
-            name: "optimize",
-            descriptionKey: "Suggest optimizations for the current query",
-            requiresQuery: true
-        ),
-        SlashCommand(
-            name: "fix",
-            descriptionKey: "Fix the last error on the current query",
-            requiresQuery: true
-        ),
-        SlashCommand(
-            name: "help",
-            descriptionKey: "List available commands",
-            requiresQuery: false
-        )
-    ]
+    var requiresQuery: Bool {
+        switch self {
+        case .explain, .optimize, .fix: return true
+        case .help: return false
+        }
+    }
+
+    static let allCommands: [SlashCommand] = allCases
+
+    /// Parses a typed input. Returns the command and any body text after it,
+    /// or nil if the text doesn't start with a known slash command.
+    /// Examples:
+    ///   "/explain"               -> (.explain, "")
+    ///   "/explain SELECT 1"      -> (.explain, "SELECT 1")
+    ///   "/Notacommand"           -> nil
+    ///   "hello"                  -> nil
+    static func parse(_ text: String) -> (command: SlashCommand, body: String)? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else { return nil }
+        let afterSlash = trimmed.dropFirst()
+        let nameSubstring = afterSlash.prefix(while: { !$0.isWhitespace })
+        let name = String(nameSubstring).lowercased()
+        guard let command = SlashCommand(rawValue: name) else { return nil }
+        let body = afterSlash
+            .dropFirst(nameSubstring.count)
+            .trimmingCharacters(in: .whitespaces)
+        return (command, body)
+    }
 
     static func match(prefix: String) -> [SlashCommand] {
         guard prefix.hasPrefix("/") else { return [] }
         let typed = prefix.dropFirst().lowercased()
-        if typed.isEmpty { return allCommands }
-        return allCommands.filter { $0.name.hasPrefix(typed) }
-    }
-
-    static func parse(_ text: String) -> SlashCommand? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("/") else { return nil }
-        let head = trimmed
-            .dropFirst()
-            .split(whereSeparator: { $0.isWhitespace })
-            .first
-            .map(String.init)
-            .map { $0.lowercased() } ?? ""
-        return allCommands.first { $0.name == head }
+        if typed.isEmpty { return allCases }
+        return allCases.filter { $0.name.hasPrefix(typed) }
     }
 }

--- a/TablePro/Core/AI/Chat/SlashCommand.swift
+++ b/TablePro/Core/AI/Chat/SlashCommand.swift
@@ -1,0 +1,60 @@
+//
+//  SlashCommand.swift
+//  TablePro
+//
+
+import Foundation
+
+struct SlashCommand: Identifiable, Sendable {
+    let name: String
+    let descriptionKey: String.LocalizationValue
+    let requiresQuery: Bool
+
+    var id: String { name }
+
+    var description: String {
+        String(localized: descriptionKey)
+    }
+
+    static let allCommands: [SlashCommand] = [
+        SlashCommand(
+            name: "explain",
+            descriptionKey: "Explain the current query",
+            requiresQuery: true
+        ),
+        SlashCommand(
+            name: "optimize",
+            descriptionKey: "Suggest optimizations for the current query",
+            requiresQuery: true
+        ),
+        SlashCommand(
+            name: "fix",
+            descriptionKey: "Fix the last error on the current query",
+            requiresQuery: true
+        ),
+        SlashCommand(
+            name: "help",
+            descriptionKey: "List available commands",
+            requiresQuery: false
+        )
+    ]
+
+    static func match(prefix: String) -> [SlashCommand] {
+        guard prefix.hasPrefix("/") else { return [] }
+        let typed = prefix.dropFirst().lowercased()
+        if typed.isEmpty { return allCommands }
+        return allCommands.filter { $0.name.hasPrefix(typed) }
+    }
+
+    static func parse(_ text: String) -> SlashCommand? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else { return nil }
+        let head = trimmed
+            .dropFirst()
+            .split(whereSeparator: { $0.isWhitespace })
+            .first
+            .map(String.init)
+            .map { $0.lowercased() } ?? ""
+        return allCommands.first { $0.name == head }
+    }
+}

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -112,42 +112,57 @@ final class AIChatViewModel {
         }
     }
 
-    func runSlashCommand(_ command: SlashCommand) {
-        switch command.name {
-        case "help":
-            inputText = ""
-            let helpLines = SlashCommand.allCommands
-                .map { "- `/\($0.name)` · \($0.description)" }
-                .joined(separator: "\n")
-            let helpMarkdown = String(localized: "**Available commands:**") + "\n\n" + helpLines
+    func runSlashCommand(_ command: SlashCommand, body: String = "") {
+        inputText = ""
+        errorMessage = nil
+
+        let invocationText = body.isEmpty ? "/\(command.name)" : "/\(command.name) \(body)"
+        let databaseType = connection?.type ?? .mysql
+
+        switch command {
+        case .help:
+            let helpMarkdown = Self.helpMarkdown
+            if let last = messages.last, last.role == .assistant, last.plainText == helpMarkdown {
+                return
+            }
+            messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
             messages.append(ChatTurn(role: .assistant, blocks: [.text(helpMarkdown)]))
-            persistCurrentConversation()
-        case "explain":
-            guard let query = currentQuery, !query.isEmpty else {
-                errorMessage = String(localized: "No query in the active editor to explain.")
-                return
-            }
-            let databaseType = connection?.type ?? .mysql
+        case .explain:
+            guard let query = resolveQuery(body: body, command: command) else { return }
+            messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
             sendWithContext(prompt: AIPromptTemplates.explainQuery(query, databaseType: databaseType))
-        case "optimize":
-            guard let query = currentQuery, !query.isEmpty else {
-                errorMessage = String(localized: "No query in the active editor to optimize.")
-                return
-            }
-            let databaseType = connection?.type ?? .mysql
+        case .optimize:
+            guard let query = resolveQuery(body: body, command: command) else { return }
+            messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
             sendWithContext(prompt: AIPromptTemplates.optimizeQuery(query, databaseType: databaseType))
-        case "fix":
-            guard let query = currentQuery, !query.isEmpty else {
-                errorMessage = String(localized: "No query in the active editor to fix.")
-                return
-            }
+        case .fix:
+            guard let query = resolveQuery(body: body, command: command) else { return }
+            messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
             let lastError = queryResults ?? ""
-            let databaseType = connection?.type ?? .mysql
             sendWithContext(prompt: AIPromptTemplates.fixError(query: query, error: lastError, databaseType: databaseType))
-        default:
-            break
         }
     }
+
+    private func resolveQuery(body: String, command: SlashCommand) -> String? {
+        if !body.isEmpty {
+            return body
+        }
+        if let editorQuery = currentQuery, !editorQuery.isEmpty {
+            return editorQuery
+        }
+        errorMessage = String(
+            format: String(localized: "/%@ needs a query: type one in the editor or after the command."),
+            command.name
+        )
+        return nil
+    }
+
+    private static let helpMarkdown: String = {
+        let lines = SlashCommand.allCommands
+            .map { "- `/\($0.name)` · \($0.description)" }
+            .joined(separator: "\n")
+        return String(localized: "**Available commands:**") + "\n\n" + lines
+    }()
 
     func handleFixError(query: String, error: String) {
         startNewConversation()
@@ -215,10 +230,8 @@ final class AIChatViewModel {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
 
-        if let command = SlashCommand.parse(text) {
-            inputText = ""
-            errorMessage = nil
-            runSlashCommand(command)
+        if let parsed = SlashCommand.parse(text) {
+            runSlashCommand(parsed.command, body: parsed.body)
             return
         }
 

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -116,7 +116,6 @@ final class AIChatViewModel {
         switch command.name {
         case "help":
             inputText = ""
-            startNewConversation()
             let helpLines = SlashCommand.allCommands
                 .map { "- `/\($0.name)` · \($0.description)" }
                 .joined(separator: "\n")
@@ -128,20 +127,23 @@ final class AIChatViewModel {
                 errorMessage = String(localized: "No query in the active editor to explain.")
                 return
             }
-            handleExplainSelection(query)
+            let databaseType = connection?.type ?? .mysql
+            sendWithContext(prompt: AIPromptTemplates.explainQuery(query, databaseType: databaseType))
         case "optimize":
             guard let query = currentQuery, !query.isEmpty else {
                 errorMessage = String(localized: "No query in the active editor to optimize.")
                 return
             }
-            handleOptimizeSelection(query)
+            let databaseType = connection?.type ?? .mysql
+            sendWithContext(prompt: AIPromptTemplates.optimizeQuery(query, databaseType: databaseType))
         case "fix":
             guard let query = currentQuery, !query.isEmpty else {
                 errorMessage = String(localized: "No query in the active editor to fix.")
                 return
             }
             let lastError = queryResults ?? ""
-            handleFixError(query: query, error: lastError)
+            let databaseType = connection?.type ?? .mysql
+            sendWithContext(prompt: AIPromptTemplates.fixError(query: query, error: lastError, databaseType: databaseType))
         default:
             break
         }

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -112,6 +112,43 @@ final class AIChatViewModel {
         }
     }
 
+    func runSlashCommand(_ command: SlashCommand) {
+        switch command.name {
+        case "help":
+            inputText = ""
+            startNewConversation()
+            let helpText = SlashCommand.allCommands
+                .map { "/\($0.name) · \($0.description)" }
+                .joined(separator: "\n")
+            messages.append(ChatTurn(
+                role: .assistant,
+                blocks: [.text(String(localized: "Available commands:") + "\n" + helpText)]
+            ))
+            persistCurrentConversation()
+        case "explain":
+            guard let query = currentQuery, !query.isEmpty else {
+                errorMessage = String(localized: "No query in the active editor to explain.")
+                return
+            }
+            handleExplainSelection(query)
+        case "optimize":
+            guard let query = currentQuery, !query.isEmpty else {
+                errorMessage = String(localized: "No query in the active editor to optimize.")
+                return
+            }
+            handleOptimizeSelection(query)
+        case "fix":
+            guard let query = currentQuery, !query.isEmpty else {
+                errorMessage = String(localized: "No query in the active editor to fix.")
+                return
+            }
+            let lastError = queryResults ?? ""
+            handleFixError(query: query, error: lastError)
+        default:
+            break
+        }
+    }
+
     func handleFixError(query: String, error: String) {
         startNewConversation()
         let databaseType = connection?.type ?? .mysql
@@ -177,6 +214,13 @@ final class AIChatViewModel {
     func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
+
+        if let command = SlashCommand.parse(text) {
+            inputText = ""
+            errorMessage = nil
+            runSlashCommand(command)
+            return
+        }
 
         let userMessage = ChatTurn(role: .user, blocks: [.text(text)])
         messages.append(userMessage)

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -117,13 +117,11 @@ final class AIChatViewModel {
         case "help":
             inputText = ""
             startNewConversation()
-            let helpText = SlashCommand.allCommands
-                .map { "/\($0.name) · \($0.description)" }
+            let helpLines = SlashCommand.allCommands
+                .map { "- `/\($0.name)` · \($0.description)" }
                 .joined(separator: "\n")
-            messages.append(ChatTurn(
-                role: .assistant,
-                blocks: [.text(String(localized: "Available commands:") + "\n" + helpText)]
-            ))
+            let helpMarkdown = String(localized: "**Available commands:**") + "\n\n" + helpLines
+            messages.append(ChatTurn(role: .assistant, blocks: [.text(helpMarkdown)]))
             persistCurrentConversation()
         case "explain":
             guard let query = currentQuery, !query.isEmpty else {

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -312,6 +312,7 @@ struct AIChatPanelView: View {
 
                 HStack(alignment: .center, spacing: 8) {
                     modelPicker
+                    slashCommandMenu
                     Spacer()
                     if viewModel.isStreaming {
                         Button {
@@ -381,6 +382,25 @@ struct AIChatPanelView: View {
             .fixedSize()
             .help(String(localized: "Choose AI provider and model"))
         }
+    }
+
+    private var slashCommandMenu: some View {
+        Menu {
+            ForEach(SlashCommand.allCommands) { command in
+                Button {
+                    viewModel.runSlashCommand(command)
+                } label: {
+                    Text("/\(command.name) · \(command.description)")
+                }
+            }
+        } label: {
+            Image(systemName: "command")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(String(localized: "Slash commands"))
     }
 
     @ViewBuilder

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -388,6 +388,7 @@ struct AIChatPanelView: View {
         Menu {
             ForEach(SlashCommand.allCommands) { command in
                 Button {
+                    updateContext()
                     viewModel.runSlashCommand(command)
                 } label: {
                     Text("/\(command.name) · \(command.description)")

--- a/TableProTests/Core/AI/SlashCommandTests.swift
+++ b/TableProTests/Core/AI/SlashCommandTests.swift
@@ -1,0 +1,57 @@
+//
+//  SlashCommandTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SlashCommand")
+struct SlashCommandTests {
+    @Test("parse recognizes known commands at the start of input")
+    func parsesKnownCommand() {
+        #expect(SlashCommand.parse("/explain")?.name == "explain")
+        #expect(SlashCommand.parse("/optimize")?.name == "optimize")
+        #expect(SlashCommand.parse("/fix")?.name == "fix")
+        #expect(SlashCommand.parse("/help")?.name == "help")
+    }
+
+    @Test("parse is case-insensitive on the name")
+    func parseCaseInsensitive() {
+        #expect(SlashCommand.parse("/Explain")?.name == "explain")
+        #expect(SlashCommand.parse("/HELP")?.name == "help")
+    }
+
+    @Test("parse trims surrounding whitespace before matching")
+    func parseTrimsWhitespace() {
+        #expect(SlashCommand.parse("  /explain  ")?.name == "explain")
+        #expect(SlashCommand.parse("\n/help\n")?.name == "help")
+    }
+
+    @Test("parse returns nil for non-slash input")
+    func parseRejectsNonSlash() {
+        #expect(SlashCommand.parse("explain") == nil)
+        #expect(SlashCommand.parse("hello world") == nil)
+        #expect(SlashCommand.parse("") == nil)
+    }
+
+    @Test("parse returns nil for unknown slash commands")
+    func parseRejectsUnknown() {
+        #expect(SlashCommand.parse("/notacommand") == nil)
+        #expect(SlashCommand.parse("/sql") == nil)
+    }
+
+    @Test("match by typed prefix returns filtered results")
+    func matchByPrefix() {
+        let all = SlashCommand.match(prefix: "/")
+        #expect(all.count == SlashCommand.allCommands.count)
+
+        let filtered = SlashCommand.match(prefix: "/ex")
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "explain")
+
+        #expect(SlashCommand.match(prefix: "/zzz").isEmpty)
+        #expect(SlashCommand.match(prefix: "ex").isEmpty)
+    }
+}

--- a/TableProTests/Core/AI/SlashCommandTests.swift
+++ b/TableProTests/Core/AI/SlashCommandTests.swift
@@ -11,22 +11,38 @@ import Testing
 struct SlashCommandTests {
     @Test("parse recognizes known commands at the start of input")
     func parsesKnownCommand() {
-        #expect(SlashCommand.parse("/explain")?.name == "explain")
-        #expect(SlashCommand.parse("/optimize")?.name == "optimize")
-        #expect(SlashCommand.parse("/fix")?.name == "fix")
-        #expect(SlashCommand.parse("/help")?.name == "help")
+        #expect(SlashCommand.parse("/explain")?.command == .explain)
+        #expect(SlashCommand.parse("/optimize")?.command == .optimize)
+        #expect(SlashCommand.parse("/fix")?.command == .fix)
+        #expect(SlashCommand.parse("/help")?.command == .help)
     }
 
-    @Test("parse is case-insensitive on the name")
+    @Test("parse extracts the body after the command name")
+    func parseExtractsBody() {
+        let parsed = SlashCommand.parse("/explain SELECT * FROM users")
+        #expect(parsed?.command == .explain)
+        #expect(parsed?.body == "SELECT * FROM users")
+
+        let bare = SlashCommand.parse("/explain")
+        #expect(bare?.body == "")
+
+        let bodyOnly = SlashCommand.parse("/fix    extra   whitespace   ")
+        #expect(bodyOnly?.body == "extra   whitespace")
+    }
+
+    @Test("parse is case-insensitive on the command name only")
     func parseCaseInsensitive() {
-        #expect(SlashCommand.parse("/Explain")?.name == "explain")
-        #expect(SlashCommand.parse("/HELP")?.name == "help")
+        #expect(SlashCommand.parse("/Explain")?.command == .explain)
+        #expect(SlashCommand.parse("/HELP")?.command == .help)
+        let parsed = SlashCommand.parse("/EXPLAIN SELECT 1")
+        #expect(parsed?.command == .explain)
+        #expect(parsed?.body == "SELECT 1")
     }
 
     @Test("parse trims surrounding whitespace before matching")
     func parseTrimsWhitespace() {
-        #expect(SlashCommand.parse("  /explain  ")?.name == "explain")
-        #expect(SlashCommand.parse("\n/help\n")?.name == "help")
+        #expect(SlashCommand.parse("  /explain  ")?.command == .explain)
+        #expect(SlashCommand.parse("\n/help\n")?.command == .help)
     }
 
     @Test("parse returns nil for non-slash input")
@@ -49,9 +65,17 @@ struct SlashCommandTests {
 
         let filtered = SlashCommand.match(prefix: "/ex")
         #expect(filtered.count == 1)
-        #expect(filtered.first?.name == "explain")
+        #expect(filtered.first == .explain)
 
         #expect(SlashCommand.match(prefix: "/zzz").isEmpty)
         #expect(SlashCommand.match(prefix: "ex").isEmpty)
+    }
+
+    @Test("requiresQuery is true for query-acting commands and false for help")
+    func requiresQuerySemantics() {
+        #expect(SlashCommand.explain.requiresQuery)
+        #expect(SlashCommand.optimize.requiresQuery)
+        #expect(SlashCommand.fix.requiresQuery)
+        #expect(!SlashCommand.help.requiresQuery)
     }
 }

--- a/TableProTests/ViewModels/AIChatViewModelSlashTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelSlashTests.swift
@@ -1,0 +1,102 @@
+//
+//  AIChatViewModelSlashTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AIChatViewModel runSlashCommand")
+@MainActor
+struct AIChatViewModelSlashTests {
+    @Test("/help appends an assistant turn with the command list")
+    func helpAppendsAssistantTurn() {
+        let vm = AIChatViewModel()
+        vm.runSlashCommand(.help)
+
+        let assistant = vm.messages.last(where: { $0.role == .assistant })
+        #expect(assistant != nil)
+        #expect(assistant?.plainText.contains("Available commands") == true)
+        #expect(assistant?.plainText.contains("/explain") == true)
+        #expect(assistant?.plainText.contains("/help") == true)
+    }
+
+    @Test("/help is idempotent: pressing it twice doesn't append twice")
+    func helpDeduplicates() {
+        let vm = AIChatViewModel()
+        vm.runSlashCommand(.help)
+        let countAfterFirst = vm.messages.count
+        vm.runSlashCommand(.help)
+        #expect(vm.messages.count == countAfterFirst)
+    }
+
+    @Test("/explain with no editor query and no body sets an error message")
+    func explainWithoutQueryErrors() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.currentQuery = nil
+
+        vm.runSlashCommand(.explain)
+
+        #expect(vm.errorMessage != nil)
+        #expect(vm.errorMessage?.contains("explain") == true)
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test("/explain with body uses the body as the query")
+    func explainPrefersBody() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.currentQuery = "SELECT 1"
+
+        vm.runSlashCommand(.explain, body: "SELECT * FROM custom")
+
+        let userTurns = vm.messages.filter { $0.role == .user }
+        #expect(userTurns.count >= 2)
+        #expect(userTurns.first?.plainText == "/explain SELECT * FROM custom")
+        let prompt = userTurns.last?.plainText ?? ""
+        #expect(prompt.contains("SELECT * FROM custom"))
+        #expect(!prompt.contains("SELECT 1"))
+    }
+
+    @Test("/explain falls back to editor query when body is empty")
+    func explainFallsBackToEditorQuery() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.currentQuery = "SELECT * FROM editor_query"
+
+        vm.runSlashCommand(.explain)
+
+        let userTurns = vm.messages.filter { $0.role == .user }
+        #expect(userTurns.first?.plainText == "/explain")
+        let prompt = userTurns.last?.plainText ?? ""
+        #expect(prompt.contains("SELECT * FROM editor_query"))
+    }
+
+    @Test("Slash invocation appears as a user turn before the prompt template")
+    func slashInvocationVisibleAsUserTurn() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.currentQuery = "SELECT 1"
+
+        vm.runSlashCommand(.optimize)
+
+        let firstUserTurn = vm.messages.first(where: { $0.role == .user })
+        #expect(firstUserTurn?.plainText == "/optimize")
+    }
+
+    @Test("runSlashCommand clears inputText and errorMessage")
+    func runSlashCommandClearsTransientState() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.currentQuery = "SELECT 1"
+        vm.inputText = "/explain"
+        vm.errorMessage = "stale"
+
+        vm.runSlashCommand(.explain)
+
+        #expect(vm.inputText.isEmpty)
+        #expect(vm.errorMessage == nil)
+    }
+}


### PR DESCRIPTION
Phase 3a of #1047. Slash commands for the AI chat composer.

## What you can do

| Type | Effect |
|---|---|
| `/explain` | Explains the current query in the active editor |
| `/optimize` | Suggests optimizations for the current query |
| `/fix` | Fixes the last error reported on the current query |
| `/help` | Lists available commands inline (no AI call) |

Two ways to invoke:
1. Type the command in the composer and press send.
2. Click the `command` symbol button next to the model picker and pick from the menu.

## Why both UIs

Slash typing is for power users; the menu button is for discoverability. Same code path either way (`AIChatViewModel.runSlashCommand(_:)`).

## Implementation

- `SlashCommand` is a small `Sendable` struct with a static registry of built-in commands and `parse(_:)` / `match(prefix:)` helpers. Lives in `Core/AI/Chat/SlashCommand.swift` next to the other chat types.
- `AIChatViewModel.sendMessage()` checks `SlashCommand.parse(text)` first; if it matches, runs the command instead of streaming the literal text to the AI.
- `AIChatViewModel.runSlashCommand(_:)` dispatches to the existing `handleExplainSelection` / `handleOptimizeSelection` / `handleFixError` methods (the same ones the editor's right-click menu uses), so the prompt templates and ambient-context resolution are reused.
- `/help` is client-side: it appends a synthetic assistant turn listing the commands. No AI roundtrip.
- `slashCommandMenu` is added next to `modelPicker` in the composer footer row.

## What's NOT in this PR

- Inline popover that filters as you type `/ex...` — deferred. The menu button covers discoverability for now; the popover is polish.
- User-defined slash commands — deferred. The umbrella mentions them but the built-ins cover the immediate need.

## CHANGELOG

Added entry under `[Unreleased]`.

## Tests

`SlashCommandTests`: 6 tests covering parse with valid/invalid/case-variant input, whitespace trimming, prefix-matching for filtered suggestions.

## Test plan

- [ ] Type `/explain` in the composer (with a query in the editor) and press send. AI explains the query.
- [ ] Type `/help` and press send. Inline assistant turn lists commands. No AI call.
- [ ] Click the command-symbol menu button next to the model picker. Pick `/optimize`. AI optimizes the query.
- [ ] Type `/fix` with no query in the editor. Error message: "No query in the active editor to fix."
- [ ] Type `/notacommand` and send. The literal text is sent to the AI as a normal message.
- [ ] Mixed-case `/EXPLAIN` works.