### PR TITLE
feat: @-mention attachments in AI chat composer (Schema / Table / Current Query / Query Results)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AI Chat: inline model picker in the composer with per-turn model attribution. Switch between configured providers and any of their available models without leaving the chat. The model that produced each assistant turn is shown in the message footer.
 - AI Chat: slash commands `/explain`, `/optimize`, `/fix`, and `/help`. Type the command in the composer or pick from the slash menu next to the model picker. `/explain`, `/optimize`, and `/fix` operate on the current query in the active editor. `/help` lists the commands inline.
-- AI Chat: attach context to a message via the `@` menu next to the slash menu. Pick Schema, a specific Table, the Current Query, or recent Query Results to include alongside the typed prompt. Attached items render as chips above the input and inside the user message bubble.
+- AI Chat: attach context to a message via the `@` menu next to the slash menu.
+  - Pick Schema, a specific Table, the Current Query, or recent Query Results.
+  - Attachments render as chips above the input and inside the user message bubble.
+  - Editing a sent message restores its typed text and chips so you can adjust both before resending.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AI Chat: inline model picker in the composer with per-turn model attribution. Switch between configured providers and any of their available models without leaving the chat. The model that produced each assistant turn is shown in the message footer.
 - AI Chat: slash commands `/explain`, `/optimize`, `/fix`, and `/help`. Type the command in the composer or pick from the slash menu next to the model picker. `/explain`, `/optimize`, and `/fix` operate on the current query in the active editor. `/help` lists the commands inline.
+- AI Chat: attach context to a message via the `@` menu next to the slash menu. Pick Schema, a specific Table, the Current Query, or recent Query Results to include alongside the typed prompt. Attached items render as chips above the input and inside the user message bubble.
 
 ### Fixed
 

--- a/TablePro/Core/AI/AISchemaContext.swift
+++ b/TablePro/Core/AI/AISchemaContext.swift
@@ -93,7 +93,7 @@ struct AISchemaContext {
 
     // MARK: - Private
 
-    private static func buildSchemaSection(
+    static func buildSchemaSection(
         tables: [TableInfo],
         columnsByTable: [String: [ColumnInfo]],
         foreignKeys: [String: [ForeignKeyInfo]],

--- a/TablePro/Core/AI/Chat/ContextItem+Display.swift
+++ b/TablePro/Core/AI/Chat/ContextItem+Display.swift
@@ -1,0 +1,59 @@
+//
+//  ContextItem+Display.swift
+//  TablePro
+//
+
+import Foundation
+
+extension ContextItem {
+    var displayLabel: String {
+        switch self {
+        case .schema:
+            return String(localized: "Schema")
+        case .table(_, let name):
+            return name
+        case .currentQuery:
+            return String(localized: "Current Query")
+        case .queryResult:
+            return String(localized: "Query Results")
+        case .savedQuery:
+            return String(localized: "Saved Query")
+        case .file(let url):
+            return url.lastPathComponent
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .schema:
+            return "tablecells"
+        case .table:
+            return "tablecells.badge.ellipsis"
+        case .currentQuery:
+            return "doc.text"
+        case .queryResult:
+            return "list.bullet.rectangle"
+        case .savedQuery:
+            return "star"
+        case .file:
+            return "doc"
+        }
+    }
+
+    var stableKey: String {
+        switch self {
+        case .schema(let connectionId):
+            return "schema:\(connectionId.uuidString)"
+        case .table(let connectionId, let name):
+            return "table:\(connectionId.uuidString):\(name)"
+        case .currentQuery:
+            return "currentQuery"
+        case .queryResult:
+            return "queryResult"
+        case .savedQuery(let id):
+            return "savedQuery:\(id.uuidString)"
+        case .file(let url):
+            return "file:\(url.absoluteString)"
+        }
+    }
+}

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -193,6 +193,10 @@ final class AIChatViewModel {
         guard let idx = messages.firstIndex(where: { $0.id == message.id }) else { return }
 
         inputText = message.plainText
+        attachedContext = message.blocks.compactMap { block in
+            if case .attachment(let item) = block { return item }
+            return nil
+        }
         messages.removeSubrange(idx...)
         persistCurrentConversation()
     }
@@ -236,10 +240,8 @@ final class AIChatViewModel {
             return
         }
 
-        let attachments = attachedContext
-        let prompt = composePrompt(text: text, attachments: attachments)
-        var blocks: [ChatContentBlock] = [.text(prompt)]
-        blocks.append(contentsOf: attachments.map { .attachment($0) })
+        var blocks: [ChatContentBlock] = [.text(text)]
+        blocks.append(contentsOf: attachedContext.map { .attachment($0) })
 
         messages.append(ChatTurn(role: .user, blocks: blocks))
         trimMessagesIfNeeded()
@@ -259,13 +261,36 @@ final class AIChatViewModel {
         attachedContext.removeAll { $0.stableKey == item.stableKey }
     }
 
-    private func composePrompt(text: String, attachments: [ContextItem]) -> String {
-        guard !attachments.isEmpty else { return text }
+    /// Produce a wire-ready copy of a turn with `.attachment` blocks expanded
+    /// into appended text. The stored `messages` array keeps the raw form so
+    /// `editMessage` can recover the typed text and attachments cleanly.
+    func resolveTurnForWire(_ turn: ChatTurn) -> ChatTurn {
+        let attachments = turn.blocks.compactMap { block -> ContextItem? in
+            if case .attachment(let item) = block { return item }
+            return nil
+        }
+        guard !attachments.isEmpty else { return turn }
+
+        let typed = turn.blocks.compactMap { block -> String? in
+            if case .text(let value) = block { return value }
+            return nil
+        }.joined()
+
         let resolved = attachments
             .compactMap { resolveAttachment($0) }
             .joined(separator: "\n\n")
-        if resolved.isEmpty { return text }
-        return text + "\n\n---\n\n" + resolved
+        if resolved.isEmpty { return turn }
+
+        let combined = typed.isEmpty ? resolved : typed + "\n\n---\n\n" + resolved
+        return ChatTurn(
+            id: turn.id,
+            role: turn.role,
+            blocks: [.text(combined)],
+            timestamp: turn.timestamp,
+            usage: turn.usage,
+            modelId: turn.modelId,
+            providerId: turn.providerId
+        )
     }
 
     private func resolveAttachment(_ item: ContextItem) -> String? {
@@ -289,19 +314,39 @@ final class AIChatViewModel {
 
     private func resolveSchemaAttachment() -> String? {
         guard !tables.isEmpty else { return nil }
-        let lines = tables.prefix(50).map { table -> String in
-            let columns = columnsByTable[table.name] ?? []
-            let columnList = columns.map { "  - \($0.name): \($0.dataType)" }.joined(separator: "\n")
-            return "### \(table.name)\n\(columnList.isEmpty ? "  (columns not loaded)" : columnList)"
-        }
-        return "## Schema\n" + lines.joined(separator: "\n")
+        let settings = AppSettingsManager.shared.ai
+        let identifierQuote = connection.flatMap {
+            PluginManager.shared.sqlDialect(for: $0.type)?.identifierQuote
+        } ?? "\""
+        let section = AISchemaContext.buildSchemaSection(
+            tables: tables,
+            columnsByTable: columnsByTable,
+            foreignKeys: foreignKeysByTable,
+            maxTables: settings.maxSchemaTables,
+            identifierQuote: identifierQuote
+        )
+        guard !section.isEmpty else { return nil }
+        return "## Schema\n\(section)"
     }
 
     private func resolveTableAttachment(name: String) -> String? {
         let columns = columnsByTable[name] ?? []
-        guard !columns.isEmpty else { return "## Table \(name)\n(columns not loaded)" }
-        let columnList = columns.map { "- \($0.name): \($0.dataType)" }.joined(separator: "\n")
-        return "## Table \(name)\n\(columnList)"
+        let foreignKeys = foreignKeysByTable[name] ?? []
+        var lines: [String] = ["## Table \(name)"]
+        if columns.isEmpty {
+            lines.append("(columns not loaded)")
+        } else {
+            for column in columns {
+                lines.append("- \(column.name): \(column.dataType)")
+            }
+        }
+        if !foreignKeys.isEmpty {
+            lines.append("Foreign keys:")
+            for foreign in foreignKeys {
+                lines.append("- \(foreign.column) -> \(foreign.referencedTable).\(foreign.referencedColumn)")
+            }
+        }
+        return lines.joined(separator: "\n")
     }
 
     /// Send a pre-filled prompt
@@ -556,7 +601,7 @@ final class AIChatViewModel {
         isStreaming = true
 
         // Capture value types on main actor before detaching
-        let chatMessages = Array(messages.dropLast())
+        let chatMessages = messages.dropLast().map { resolveTurnForWire($0) }
 
         streamingTask = Task.detached(priority: .userInitiated) { [weak self] in
             do {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -39,6 +39,7 @@ final class AIChatViewModel {
     var selectedProviderId: UUID?
     var selectedModel: String?
     var availableModels: [UUID: [String]] = [:]
+    var attachedContext: [ContextItem] = []
 
     // MARK: - Context Properties
 
@@ -235,13 +236,72 @@ final class AIChatViewModel {
             return
         }
 
-        let userMessage = ChatTurn(role: .user, blocks: [.text(text)])
-        messages.append(userMessage)
+        let attachments = attachedContext
+        let prompt = composePrompt(text: text, attachments: attachments)
+        var blocks: [ChatContentBlock] = [.text(prompt)]
+        blocks.append(contentsOf: attachments.map { .attachment($0) })
+
+        messages.append(ChatTurn(role: .user, blocks: blocks))
         trimMessagesIfNeeded()
         inputText = ""
+        attachedContext = []
         errorMessage = nil
 
         startStreaming()
+    }
+
+    func attach(_ item: ContextItem) {
+        guard !attachedContext.contains(where: { $0.stableKey == item.stableKey }) else { return }
+        attachedContext.append(item)
+    }
+
+    func detach(_ item: ContextItem) {
+        attachedContext.removeAll { $0.stableKey == item.stableKey }
+    }
+
+    private func composePrompt(text: String, attachments: [ContextItem]) -> String {
+        guard !attachments.isEmpty else { return text }
+        let resolved = attachments
+            .compactMap { resolveAttachment($0) }
+            .joined(separator: "\n\n")
+        if resolved.isEmpty { return text }
+        return text + "\n\n---\n\n" + resolved
+    }
+
+    private func resolveAttachment(_ item: ContextItem) -> String? {
+        switch item {
+        case .schema:
+            return resolveSchemaAttachment()
+        case .table(_, let name):
+            return resolveTableAttachment(name: name)
+        case .currentQuery(let text):
+            let snapshot = text.isEmpty ? (currentQuery ?? "") : text
+            guard !snapshot.isEmpty else { return nil }
+            return "## Current Query\n```\n\(snapshot)\n```"
+        case .queryResult(let summary):
+            let snapshot = summary.isEmpty ? (queryResults ?? "") : summary
+            guard !snapshot.isEmpty else { return nil }
+            return "## Query Results\n\(snapshot)"
+        case .savedQuery, .file:
+            return nil
+        }
+    }
+
+    private func resolveSchemaAttachment() -> String? {
+        guard !tables.isEmpty else { return nil }
+        let lines = tables.prefix(50).map { table -> String in
+            let columns = columnsByTable[table.name] ?? []
+            let columnList = columns.map { "  - \($0.name): \($0.type)" }.joined(separator: "\n")
+            return "### \(table.name)\n\(columnList.isEmpty ? "  (columns not loaded)" : columnList)"
+        }
+        return "## Schema\n" + lines.joined(separator: "\n")
+    }
+
+    private func resolveTableAttachment(name: String) -> String? {
+        let columns = columnsByTable[name] ?? []
+        guard !columns.isEmpty else { return "## Table \(name)\n(columns not loaded)" }
+        let columnList = columns.map { "- \($0.name): \($0.type)" }.joined(separator: "\n")
+        return "## Table \(name)\n\(columnList)"
     }
 
     /// Send a pre-filled prompt

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -291,7 +291,7 @@ final class AIChatViewModel {
         guard !tables.isEmpty else { return nil }
         let lines = tables.prefix(50).map { table -> String in
             let columns = columnsByTable[table.name] ?? []
-            let columnList = columns.map { "  - \($0.name): \($0.type)" }.joined(separator: "\n")
+            let columnList = columns.map { "  - \($0.name): \($0.dataType)" }.joined(separator: "\n")
             return "### \(table.name)\n\(columnList.isEmpty ? "  (columns not loaded)" : columnList)"
         }
         return "## Schema\n" + lines.joined(separator: "\n")
@@ -300,7 +300,7 @@ final class AIChatViewModel {
     private func resolveTableAttachment(name: String) -> String? {
         let columns = columnsByTable[name] ?? []
         guard !columns.isEmpty else { return "## Table \(name)\n(columns not loaded)" }
-        let columnList = columns.map { "- \($0.name): \($0.type)" }.joined(separator: "\n")
+        let columnList = columns.map { "- \($0.name): \($0.dataType)" }.joined(separator: "\n")
         return "## Table \(name)\n\(columnList)"
     }
 

--- a/TablePro/Views/AIChat/AIChatContextChipView.swift
+++ b/TablePro/Views/AIChat/AIChatContextChipView.swift
@@ -1,0 +1,61 @@
+//
+//  AIChatContextChipView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct AIChatContextChipView: View {
+    let item: ContextItem
+    var onRemove: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: item.symbolName)
+                .font(.caption2)
+            Text(item.displayLabel)
+                .font(.caption)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if let onRemove {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(String(localized: "Remove attachment"))
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Color.accentColor.opacity(0.12), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
+        )
+    }
+}
+
+struct AIChatContextChipStrip: View {
+    let items: [ContextItem]
+    var onRemove: ((ContextItem) -> Void)?
+
+    var body: some View {
+        if !items.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(items, id: \.stableKey) { item in
+                        AIChatContextChipView(
+                            item: item,
+                            onRemove: onRemove.map { handler in { handler(item) } }
+                        )
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+            }
+        }
+    }
+}

--- a/TablePro/Views/AIChat/AIChatContextChipView.swift
+++ b/TablePro/Views/AIChat/AIChatContextChipView.swift
@@ -47,10 +47,8 @@ struct AIChatContextChipStrip: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
                     ForEach(items, id: \.stableKey) { item in
-                        AIChatContextChipView(
-                            item: item,
-                            onRemove: onRemove.map { handler in { handler(item) } }
-                        )
+                        let removeAction: (() -> Void)? = onRemove.map { handler in { handler(item) } }
+                        AIChatContextChipView(item: item, onRemove: removeAction)
                     }
                 }
                 .padding(.horizontal, 8)

--- a/TablePro/Views/AIChat/AIChatMessageView.swift
+++ b/TablePro/Views/AIChat/AIChatMessageView.swift
@@ -16,6 +16,13 @@ struct AIChatMessageView: View {
     var onRegenerate: (() -> Void)?
     var onEdit: (() -> Void)?
 
+    private var attachedContextItems: [ContextItem] {
+        message.blocks.compactMap { block in
+            if case .attachment(let item) = block { return item }
+            return nil
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             if message.role == .user {
@@ -30,6 +37,11 @@ struct AIChatMessageView: View {
                     }
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+
+                    if !attachedContextItems.isEmpty {
+                        AIChatContextChipStrip(items: attachedContextItems)
+                            .padding(.bottom, 2)
+                    }
 
                     Markdown(message.plainText)
                         .markdownTheme(.tableProChat)

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -390,48 +390,57 @@ struct AIChatPanelView: View {
         }
     }
 
+    @ViewBuilder
     private var mentionMenu: some View {
-        Menu {
-            if let connectionId = viewModel.connection?.id {
+        if let connectionId = viewModel.connection?.id {
+            Menu {
                 Button {
                     viewModel.attach(.schema(connectionId: connectionId))
                 } label: {
                     Label(String(localized: "Schema"), systemImage: "tablecells")
                 }
-                if !viewModel.tables.isEmpty {
-                    Menu(String(localized: "Tables")) {
-                        ForEach(viewModel.tables, id: \.name) { table in
-                            Button {
-                                viewModel.attach(.table(connectionId: connectionId, name: table.name))
-                            } label: {
-                                Text(table.name)
-                            }
+                .disabled(viewModel.tables.isEmpty)
+
+                Menu(String(localized: "Tables")) {
+                    let sortedTables = viewModel.tables.sorted {
+                        $0.name.localizedStandardCompare($1.name) == .orderedAscending
+                    }
+                    ForEach(sortedTables, id: \.name) { table in
+                        Button {
+                            viewModel.attach(.table(connectionId: connectionId, name: table.name))
+                        } label: {
+                            Text(table.name)
                         }
                     }
                 }
-            }
-            if let query = currentQuery, !query.isEmpty {
+                .disabled(viewModel.tables.isEmpty)
+
                 Button {
-                    viewModel.attach(.currentQuery(text: query))
+                    if let query = currentQuery, !query.isEmpty {
+                        viewModel.attach(.currentQuery(text: query))
+                    }
                 } label: {
                     Label(String(localized: "Current Query"), systemImage: "doc.text")
                 }
-            }
-            if let results = queryResults, !results.isEmpty {
+                .disabled((currentQuery ?? "").isEmpty)
+
                 Button {
-                    viewModel.attach(.queryResult(summary: results))
+                    if let results = queryResults, !results.isEmpty {
+                        viewModel.attach(.queryResult(summary: results))
+                    }
                 } label: {
                     Label(String(localized: "Query Results"), systemImage: "list.bullet.rectangle")
                 }
+                .disabled((queryResults ?? "").isEmpty)
+            } label: {
+                Image(systemName: "at")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-        } label: {
-            Image(systemName: "at")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help(String(localized: "Attach context"))
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
-        .help(String(localized: "Attach context"))
     }
 
     private var slashCommandMenu: some View {

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -296,6 +296,11 @@ struct AIChatPanelView: View {
         VStack(spacing: 0) {
             Divider()
             VStack(alignment: .leading, spacing: 6) {
+                AIChatContextChipStrip(
+                    items: viewModel.attachedContext,
+                    onRemove: { viewModel.detach($0) }
+                )
+
                 TextField(
                     String(localized: "Ask about your database..."),
                     text: $viewModel.inputText,
@@ -313,6 +318,7 @@ struct AIChatPanelView: View {
                 HStack(alignment: .center, spacing: 8) {
                     modelPicker
                     slashCommandMenu
+                    mentionMenu
                     Spacer()
                     if viewModel.isStreaming {
                         Button {
@@ -382,6 +388,50 @@ struct AIChatPanelView: View {
             .fixedSize()
             .help(String(localized: "Choose AI provider and model"))
         }
+    }
+
+    private var mentionMenu: some View {
+        Menu {
+            if let connectionId = viewModel.connection?.id {
+                Button {
+                    viewModel.attach(.schema(connectionId: connectionId))
+                } label: {
+                    Label(String(localized: "Schema"), systemImage: "tablecells")
+                }
+                if !viewModel.tables.isEmpty {
+                    Menu(String(localized: "Tables")) {
+                        ForEach(viewModel.tables, id: \.name) { table in
+                            Button {
+                                viewModel.attach(.table(connectionId: connectionId, name: table.name))
+                            } label: {
+                                Text(table.name)
+                            }
+                        }
+                    }
+                }
+            }
+            if let query = currentQuery, !query.isEmpty {
+                Button {
+                    viewModel.attach(.currentQuery(text: query))
+                } label: {
+                    Label(String(localized: "Current Query"), systemImage: "doc.text")
+                }
+            }
+            if let results = queryResults, !results.isEmpty {
+                Button {
+                    viewModel.attach(.queryResult(summary: results))
+                } label: {
+                    Label(String(localized: "Query Results"), systemImage: "list.bullet.rectangle")
+                }
+            }
+        } label: {
+            Image(systemName: "at")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(String(localized: "Attach context"))
     }
 
     private var slashCommandMenu: some View {

--- a/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
@@ -1,0 +1,89 @@
+//
+//  AIChatViewModelMentionsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AIChatViewModel @-mentions")
+@MainActor
+struct AIChatViewModelMentionsTests {
+    @Test("attach adds item to attachedContext")
+    func attachAdds() {
+        let vm = AIChatViewModel()
+        let id = UUID()
+        vm.attach(.table(connectionId: id, name: "Customer"))
+        #expect(vm.attachedContext.count == 1)
+    }
+
+    @Test("attach is idempotent on stableKey")
+    func attachDeduplicates() {
+        let vm = AIChatViewModel()
+        let id = UUID()
+        vm.attach(.table(connectionId: id, name: "Customer"))
+        vm.attach(.table(connectionId: id, name: "Customer"))
+        #expect(vm.attachedContext.count == 1)
+    }
+
+    @Test("detach removes the matching item")
+    func detachRemoves() {
+        let vm = AIChatViewModel()
+        let id = UUID()
+        let item = ContextItem.table(connectionId: id, name: "Customer")
+        vm.attach(item)
+        vm.attach(.schema(connectionId: id))
+        vm.detach(item)
+        #expect(vm.attachedContext.count == 1)
+        #expect(vm.attachedContext.first?.stableKey == "schema:\(id.uuidString)")
+    }
+
+    @Test("Sending with attachments embeds them as attachment blocks on the user turn")
+    func sendMessageEmbedsAttachments() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.inputText = "What is this?"
+        vm.attach(.currentQuery(text: "SELECT 1"))
+
+        vm.sendMessage()
+
+        let userTurn = vm.messages.first(where: { $0.role == .user })
+        #expect(userTurn != nil)
+        let attachmentBlocks = userTurn?.blocks.compactMap { block -> ContextItem? in
+            if case .attachment(let item) = block { return item }
+            return nil
+        }
+        #expect(attachmentBlocks?.count == 1)
+        #expect(vm.attachedContext.isEmpty)
+    }
+
+    @Test("Sending with currentQuery attachment embeds the query text in the prompt")
+    func currentQueryResolved() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.inputText = "Explain"
+        vm.attach(.currentQuery(text: "SELECT * FROM Customer"))
+
+        vm.sendMessage()
+
+        let userTurn = vm.messages.first(where: { $0.role == .user })
+        let prompt = userTurn?.plainText ?? ""
+        #expect(prompt.contains("Explain"))
+        #expect(prompt.contains("SELECT * FROM Customer"))
+        #expect(prompt.contains("## Current Query"))
+    }
+
+    @Test("Sending with empty input is a no-op even when attachments are present")
+    func emptyInputDoesNotSend() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.attach(.currentQuery(text: "SELECT 1"))
+        vm.inputText = ""
+
+        vm.sendMessage()
+
+        #expect(vm.messages.isEmpty)
+        #expect(vm.attachedContext.count == 1)
+    }
+}

--- a/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
@@ -86,4 +86,57 @@ struct AIChatViewModelMentionsTests {
         #expect(vm.messages.isEmpty)
         #expect(vm.attachedContext.count == 1)
     }
+
+    @Test("Stored user turn keeps typed text raw (not pre-resolved)")
+    func storedTurnIsRaw() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.inputText = "Explain"
+        vm.attach(.currentQuery(text: "SELECT * FROM Customer"))
+
+        vm.sendMessage()
+
+        let userTurn = vm.messages.first(where: { $0.role == .user })
+        #expect(userTurn?.plainText == "Explain")
+        #expect(userTurn?.blocks.contains(where: {
+            if case .attachment = $0 { return true } else { return false }
+        }) == true)
+    }
+
+    @Test("resolveTurnForWire expands attachments into the text block")
+    func resolveTurnForWireExpands() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        let raw = ChatTurn(role: .user, blocks: [
+            .text("Explain"),
+            .attachment(.currentQuery(text: "SELECT * FROM Customer"))
+        ])
+
+        let wire = vm.resolveTurnForWire(raw)
+
+        #expect(wire.id == raw.id)
+        #expect(wire.plainText.contains("Explain"))
+        #expect(wire.plainText.contains("SELECT * FROM Customer"))
+        #expect(wire.plainText.contains("## Current Query"))
+    }
+
+    @Test("editMessage restores typed text and attachments")
+    func editMessageRecoversAttachments() {
+        let vm = AIChatViewModel()
+        vm.connection = TestFixtures.makeConnection(type: .mysql)
+        vm.inputText = "What is this?"
+        let connectionId = vm.connection?.id ?? UUID()
+        vm.attach(.table(connectionId: connectionId, name: "Customer"))
+        vm.sendMessage()
+
+        let userTurn = vm.messages.first(where: { $0.role == .user })
+        #expect(userTurn != nil)
+
+        guard let userTurn else { return }
+        vm.editMessage(userTurn)
+
+        #expect(vm.inputText == "What is this?")
+        #expect(vm.attachedContext.count == 1)
+        #expect(vm.attachedContext.first?.stableKey.hasPrefix("table:") == true)
+    }
 }


### PR DESCRIPTION
Phase 3b.1 of #1047. Attach context to a chat message via an `@` menu next to the slash menu. Items render as chips above the input and inside the user message bubble. Outgoing user turns carry the items as `.attachment(ContextItem)` blocks plus an expanded text section appended to the prompt.

## What you can attach

| | |
|---|---|
| Schema | Full schema as a markdown section (table list with column types) |
| Table | Single table's column list |
| Current Query | The text of the active editor query |
| Query Results | The recent query-results summary already cached for the auto-prompt |

Saved Queries and File items exist in `ContextItem` (defined in #1057) but are not exposed in the picker yet — those need async fetches and are deferred.

## Implementation

- `ContextItem+Display.swift` — `displayLabel`, `symbolName`, `stableKey`. The chip view, picker, and the dedupe in `attach(_:)` all key off `stableKey`, so two `.table(id, "Customer")` references collapse to one attachment.
- `AIChatViewModel`:
  - `attachedContext: [ContextItem]` (observable) holds the currently-staged attachments.
  - `attach(_:)` / `detach(_:)` mutate the list with stable-key dedupe.
  - `composePrompt(text:attachments:)` joins typed text with `resolveAttachment(_:)` output, separated by `---`.
  - `sendMessage()` builds a `ChatTurn` with `[.text(prompt)] + attachments.map { .attachment($0) }`. The text block is what the AI sees via `plainText`; the attachment blocks are UI markers for chip rendering.
  - After send, `attachedContext` is cleared.
- `AIChatContextChipView` / `AIChatContextChipStrip` — small reusable chip (icon + label + optional `xmark`).
- `AIChatPanelView`:
  - Chip strip rendered above the TextField.
  - `mentionMenu` button between `slashCommandMenu` and the Send button. Categories show only when their data is available (Schema needs `connection.id`, Tables needs `viewModel.tables`, etc.).
- `AIChatMessageView`:
  - User bubbles render `attachedContextItems` (extracted from `.attachment` blocks) as a chip strip above the message text. So scrolling history shows what was attached.

## Why this design

- **The text block carries the full prompt.** Providers extract text via `turn.plainText`. They don't need to know about attachment blocks — they see the resolved text inline. No provider migration required.
- **Attachment blocks are persistent UI markers.** They serialize through `ChatTurn`'s Codable and survive across app restarts via `AIChatStorage`. The chip rendering in user bubbles works on stored conversations.
- **Stable-key dedupe** prevents the obvious "click Schema 5 times → 5 chips" footgun.

## What's NOT in this PR

- Typed `@`-detection popover (filter as you type `@cus...` for the Customer table). Tracked as 3b.2 follow-up.
- Saved-query and file attachments (need async fetch hooks).
- Removing the auto-context prompt (`AISchemaContext.buildSystemPrompt`) — that's Phase 3c. Currently auto-context AND `@`-mention attachments both reach the AI; users can rely on the auto-shovel and just use mentions for emphasis. 3c will flip the default.

## Tests

`AIChatViewModelMentionsTests`: 6 tests covering attach idempotency, detach, attachment-block embedding on send, currentQuery resolution into the prompt, and the empty-input no-op.

## Test plan

- [ ] Open AI Chat. The `@` button is to the right of the slash menu and the model picker.
- [ ] Click `@`. Pick Schema. A "Schema" chip appears above the input.
- [ ] Click `@` again. Pick a Tables sub-item. Second chip appears.
- [ ] Click the X on a chip to remove it.
- [ ] Type "What is this?" and send. The chips disappear from the input. The user message bubble shows the chips above the text. The AI receives the prompt with expanded schema/table sections.
- [ ] Restart the app and reopen the conversation. Chips still render in the user bubble (persisted via Codable on `ChatTurn.blocks`).