### PR TITLE
feat: AI Chat defaults to opt-in context (auto-include off for new installs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Attachments render as chips above the input and inside the user message bubble.
   - Editing a sent message restores its typed text and chips so you can adjust both before resending.
 
+### Changed
+
+- AI Chat: new installations default to opt-in context. Schema, current query, and query results no longer auto-include in every prompt; attach them via the `@` menu when you want them. Existing users keep their current Settings -> AI -> "Include schema/current query/query results" choices unchanged.
+
 ### Fixed
 
 - New tab via Cmd+T no longer flashes focus back to the previous tab in the same window group

--- a/TablePro/Models/AI/AIModels.swift
+++ b/TablePro/Models/AI/AIModels.swift
@@ -149,8 +149,8 @@ struct AISettings: Codable, Equatable, Sendable {
         providers: [],
         activeProviderID: nil,
         inlineSuggestionsEnabled: false,
-        includeSchema: true,
-        includeCurrentQuery: true,
+        includeSchema: false,
+        includeCurrentQuery: false,
         includeQueryResults: false,
         maxSchemaTables: 20,
         defaultConnectionPolicy: .askEachTime
@@ -161,8 +161,8 @@ struct AISettings: Codable, Equatable, Sendable {
         providers: [AIProviderConfig] = [],
         activeProviderID: UUID? = nil,
         inlineSuggestionsEnabled: Bool = false,
-        includeSchema: Bool = true,
-        includeCurrentQuery: Bool = true,
+        includeSchema: Bool = false,
+        includeCurrentQuery: Bool = false,
         includeQueryResults: Bool = false,
         maxSchemaTables: Int = 20,
         defaultConnectionPolicy: AIConnectionPolicy = .askEachTime

--- a/TableProTests/Models/AISettingsTests.swift
+++ b/TableProTests/Models/AISettingsTests.swift
@@ -17,7 +17,7 @@ struct AISettingsTests {
     @Test("decoding without enabled key defaults to true")
     func decodingWithoutEnabledDefaultsToTrue() throws {
         let json = "{}"
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let settings = try JSONDecoder().decode(AISettings.self, from: data)
         #expect(settings.enabled == true)
     }
@@ -25,9 +25,36 @@ struct AISettingsTests {
     @Test("decoding with enabled false sets it correctly")
     func decodingWithEnabledFalse() throws {
         let json = "{\"enabled\": false}"
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let settings = try JSONDecoder().decode(AISettings.self, from: data)
         #expect(settings.enabled == false)
+    }
+
+    @Test("New installs default to opt-in context (no auto schema/query/results)")
+    func newInstallsAreOptIn() {
+        let settings = AISettings.default
+        #expect(settings.includeSchema == false)
+        #expect(settings.includeCurrentQuery == false)
+        #expect(settings.includeQueryResults == false)
+    }
+
+    @Test("Existing users with stored true values keep their auto-context behavior")
+    func upgradedUsersKeepAutoContext() throws {
+        let json = #"{"includeSchema": true, "includeCurrentQuery": true, "includeQueryResults": true}"#
+        let data = Data(json.utf8)
+        let settings = try JSONDecoder().decode(AISettings.self, from: data)
+        #expect(settings.includeSchema == true)
+        #expect(settings.includeCurrentQuery == true)
+        #expect(settings.includeQueryResults == true)
+    }
+
+    @Test("Decoding without context keys preserves backward-compat true defaults")
+    func decoderFallbacksAreBackwardCompatible() throws {
+        let json = "{}"
+        let data = Data(json.utf8)
+        let settings = try JSONDecoder().decode(AISettings.self, from: data)
+        #expect(settings.includeSchema == true)
+        #expect(settings.includeCurrentQuery == true)
     }
 }
 
@@ -88,7 +115,7 @@ struct AISettingsActiveProviderTests {
     @Test("Decoding without activeProviderID defaults to nil")
     func decodingWithoutActiveProviderDefaultsToNil() throws {
         let json = #"{"enabled": true, "providers": []}"#
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let settings = try JSONDecoder().decode(AISettings.self, from: data)
         #expect(settings.activeProviderID == nil)
         #expect(settings.activeProvider == nil)


### PR DESCRIPTION
Phase 3c of #1047. Flips the *new install* defaults for `includeSchema`, `includeCurrentQuery`, `includeQueryResults` from `true` to `false`. The umbrella's stated goal: "Opt-in context only, no auto-shoveling schema into every prompt."

## What changes for whom

| Population | Before | After |
|---|---|---|
| Brand new install (no stored AISettings yet) | Schema + current query auto-included; query results were already off | All three off; users opt in via `@`-mention or via Settings -> AI |
| Existing user (already used the app once, settings written to disk) | Whatever they had | Unchanged — `init(from: Decoder)` decoder fallbacks still default to `true` for missing keys, but their *stored* values take priority |
| Existing user with explicitly toggled values | Whatever they had | Unchanged |

The decoder backward-compat is the load-bearing detail: existing users' AISettings JSON has these keys explicitly written, so the decoder reads their preference and ignores the new struct defaults. Only callers who construct `AISettings()` from scratch (new install, tests not specifying these fields) get the new defaults.

## Why this is the right shape

- The **only** code path that creates an unconfigured `AISettings` is first-launch initialization. Existing users round-trip through `init(from:)` which reads stored values.
- Decoder fallbacks (the `?? true` for missing-key cases) are intentionally left at `true` so a user upgrading from an even older TablePro version that didn't have these keys keeps their auto-context behavior. The `?? true` only fires when the key is genuinely absent from disk.

## Tests

`AISettingsTests` — 3 new:
- `newInstallsAreOptIn` — `AISettings.default` has all three off
- `upgradedUsersKeepAutoContext` — explicit `true` in JSON round-trips
- `decoderFallbacksAreBackwardCompatible` — empty JSON `{}` still decodes to `true` for the two well-known auto-context keys

Plus `Data(json.utf8)` instead of `json.data(using: .utf8)!` (cleans up force-unwrap warnings in the new tests).

## CHANGELOG

Entry under `[Unreleased]` -> `Changed` describing the new-installs default + how existing users keep their behavior.

## Test plan

- [ ] On a fresh install (delete preferences), open AI Chat. Send a message without attaching anything. The system prompt sent to the AI should NOT contain `## Database Schema`.
- [ ] On an existing install with auto-context enabled (Settings -> AI -> Include schema is checked), open AI Chat. Send a message. The system prompt should still contain `## Database Schema`.
- [ ] Settings -> AI shows the toggles as before. New install: unchecked. Existing install: whatever was checked previously.