### PR TITLE
feat: ChatTool protocol + ChatToolRegistry foundation for AI tool calling

### DIFF
--- a/TablePro/Core/AI/Chat/ChatTool.swift
+++ b/TablePro/Core/AI/Chat/ChatTool.swift
@@ -1,0 +1,33 @@
+//
+//  ChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+/// A tool the AI can call from a chat turn. Implementations are registered
+/// with `ChatToolRegistry` and exposed to providers via `ChatToolSpec`.
+public protocol ChatTool: Sendable {
+    var name: String { get }
+    var description: String { get }
+    var inputSchema: JSONValue { get }
+
+    func execute(input: JSONValue) async throws -> ChatToolResult
+}
+
+public struct ChatToolResult: Sendable, Equatable {
+    public let content: String
+    public let isError: Bool
+
+    public init(content: String, isError: Bool = false) {
+        self.content = content
+        self.isError = isError
+    }
+}
+
+public extension ChatTool {
+    /// Wire-format spec for `ChatTransportOptions.tools`.
+    var spec: ChatToolSpec {
+        ChatToolSpec(name: name, description: description, inputSchema: inputSchema)
+    }
+}

--- a/TablePro/Core/AI/Chat/ChatTool.swift
+++ b/TablePro/Core/AI/Chat/ChatTool.swift
@@ -15,7 +15,10 @@ public protocol ChatTool: Sendable {
     func execute(input: JSONValue) async throws -> ChatToolResult
 }
 
-public struct ChatToolResult: Sendable, Equatable {
+public struct ChatToolResult: Sendable, Equatable, Codable {
+    /// Tool results are UTF-8 text in this version. A future expansion may
+    /// widen `content` to accept multiple typed blocks (text, image,
+    /// structured data); treat the current shape as a forward-compat floor.
     public let content: String
     public let isError: Bool
 

--- a/TablePro/Core/AI/Chat/ChatToolRegistry.swift
+++ b/TablePro/Core/AI/Chat/ChatToolRegistry.swift
@@ -1,0 +1,44 @@
+//
+//  ChatToolRegistry.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// Process-wide registry of `ChatTool` implementations available to AI chat.
+@MainActor
+public final class ChatToolRegistry {
+    public static let shared = ChatToolRegistry()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatToolRegistry")
+
+    private var tools: [String: any ChatTool] = [:]
+
+    private init() {}
+
+    public func register(_ tool: any ChatTool) {
+        let existing = tools[tool.name]
+        tools[tool.name] = tool
+        if existing != nil {
+            Self.logger.debug("Replaced ChatTool '\(tool.name, privacy: .public)' in registry")
+        }
+    }
+
+    public func unregister(name: String) {
+        tools.removeValue(forKey: name)
+    }
+
+    public func tool(named name: String) -> (any ChatTool)? {
+        tools[name]
+    }
+
+    public var allTools: [any ChatTool] {
+        tools.values
+            .sorted { $0.name < $1.name }
+    }
+
+    public var allSpecs: [ChatToolSpec] {
+        allTools.map(\.spec)
+    }
+}

--- a/TablePro/Core/AI/Chat/ChatToolRegistry.swift
+++ b/TablePro/Core/AI/Chat/ChatToolRegistry.swift
@@ -15,13 +15,13 @@ public final class ChatToolRegistry {
 
     private var tools: [String: any ChatTool] = [:]
 
-    private init() {}
+    public init() {}
 
     public func register(_ tool: any ChatTool) {
         let existing = tools[tool.name]
         tools[tool.name] = tool
         if existing != nil {
-            Self.logger.debug("Replaced ChatTool '\(tool.name, privacy: .public)' in registry")
+            Self.logger.warning("Replaced ChatTool '\(tool.name, privacy: .public)' in registry; second registration won")
         }
     }
 

--- a/TableProTests/Core/AI/ChatToolRegistryTests.swift
+++ b/TableProTests/Core/AI/ChatToolRegistryTests.swift
@@ -1,0 +1,88 @@
+//
+//  ChatToolRegistryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatToolRegistry")
+@MainActor
+struct ChatToolRegistryTests {
+    private struct StubTool: ChatTool {
+        let name: String
+        let description: String
+        let inputSchema: JSONValue
+        let response: String
+
+        init(name: String, description: String = "", response: String = "ok") {
+            self.name = name
+            self.description = description
+            self.inputSchema = .object(["type": .string("object"), "properties": .object([:])])
+            self.response = response
+        }
+
+        func execute(input: JSONValue) async throws -> ChatToolResult {
+            ChatToolResult(content: response)
+        }
+    }
+
+    private func makeRegistry() -> ChatToolRegistry {
+        let registry = ChatToolRegistry.shared
+        for spec in registry.allSpecs {
+            registry.unregister(name: spec.name)
+        }
+        return registry
+    }
+
+    @Test("Registered tool can be looked up by name")
+    func lookupByName() {
+        let registry = makeRegistry()
+        registry.register(StubTool(name: "alpha"))
+        #expect(registry.tool(named: "alpha")?.name == "alpha")
+        #expect(registry.tool(named: "missing") == nil)
+    }
+
+    @Test("Re-registering a tool with the same name replaces the previous one")
+    func reregisterReplaces() async throws {
+        let registry = makeRegistry()
+        registry.register(StubTool(name: "alpha", response: "old"))
+        registry.register(StubTool(name: "alpha", response: "new"))
+        #expect(registry.allTools.count == 1)
+        let result = try await runStub(registry.tool(named: "alpha"))
+        #expect(result?.content == "new")
+    }
+
+    @Test("allTools is sorted alphabetically by name")
+    func allToolsSorted() {
+        let registry = makeRegistry()
+        registry.register(StubTool(name: "charlie"))
+        registry.register(StubTool(name: "alpha"))
+        registry.register(StubTool(name: "bravo"))
+        #expect(registry.allTools.map(\.name) == ["alpha", "bravo", "charlie"])
+    }
+
+    @Test("allSpecs mirrors allTools and exposes wire-format ChatToolSpec")
+    func specsMirrorTools() {
+        let registry = makeRegistry()
+        registry.register(StubTool(name: "list_tables", description: "List tables"))
+        let specs = registry.allSpecs
+        #expect(specs.count == 1)
+        #expect(specs.first?.name == "list_tables")
+        #expect(specs.first?.description == "List tables")
+    }
+
+    @Test("unregister removes the entry")
+    func unregisterRemoves() {
+        let registry = makeRegistry()
+        registry.register(StubTool(name: "alpha"))
+        registry.unregister(name: "alpha")
+        #expect(registry.tool(named: "alpha") == nil)
+    }
+
+    private func runStub(_ tool: (any ChatTool)?) async throws -> ChatToolResult? {
+        guard let tool else { return nil }
+        return try await tool.execute(input: .object([:]))
+    }
+}

--- a/TableProTests/Core/AI/ChatToolRegistryTests.swift
+++ b/TableProTests/Core/AI/ChatToolRegistryTests.swift
@@ -28,17 +28,9 @@ struct ChatToolRegistryTests {
         }
     }
 
-    private func makeRegistry() -> ChatToolRegistry {
-        let registry = ChatToolRegistry.shared
-        for spec in registry.allSpecs {
-            registry.unregister(name: spec.name)
-        }
-        return registry
-    }
-
     @Test("Registered tool can be looked up by name")
     func lookupByName() {
-        let registry = makeRegistry()
+        let registry = ChatToolRegistry()
         registry.register(StubTool(name: "alpha"))
         #expect(registry.tool(named: "alpha")?.name == "alpha")
         #expect(registry.tool(named: "missing") == nil)
@@ -46,17 +38,28 @@ struct ChatToolRegistryTests {
 
     @Test("Re-registering a tool with the same name replaces the previous one")
     func reregisterReplaces() async throws {
-        let registry = makeRegistry()
+        let registry = ChatToolRegistry()
         registry.register(StubTool(name: "alpha", response: "old"))
         registry.register(StubTool(name: "alpha", response: "new"))
         #expect(registry.allTools.count == 1)
-        let result = try await runStub(registry.tool(named: "alpha"))
-        #expect(result?.content == "new")
+        let tool = try #require(registry.tool(named: "alpha"))
+        let result = try await tool.execute(input: .object([:]))
+        #expect(result.content == "new")
+    }
+
+    @Test("execute returns the configured ChatToolResult")
+    func executeReturnsResult() async throws {
+        let registry = ChatToolRegistry()
+        registry.register(StubTool(name: "alpha", response: "result"))
+        let tool = try #require(registry.tool(named: "alpha"))
+        let result = try await tool.execute(input: .object([:]))
+        #expect(result.content == "result")
+        #expect(result.isError == false)
     }
 
     @Test("allTools is sorted alphabetically by name")
     func allToolsSorted() {
-        let registry = makeRegistry()
+        let registry = ChatToolRegistry()
         registry.register(StubTool(name: "charlie"))
         registry.register(StubTool(name: "alpha"))
         registry.register(StubTool(name: "bravo"))
@@ -65,7 +68,7 @@ struct ChatToolRegistryTests {
 
     @Test("allSpecs mirrors allTools and exposes wire-format ChatToolSpec")
     func specsMirrorTools() {
-        let registry = makeRegistry()
+        let registry = ChatToolRegistry()
         registry.register(StubTool(name: "list_tables", description: "List tables"))
         let specs = registry.allSpecs
         #expect(specs.count == 1)
@@ -75,14 +78,17 @@ struct ChatToolRegistryTests {
 
     @Test("unregister removes the entry")
     func unregisterRemoves() {
-        let registry = makeRegistry()
+        let registry = ChatToolRegistry()
         registry.register(StubTool(name: "alpha"))
         registry.unregister(name: "alpha")
         #expect(registry.tool(named: "alpha") == nil)
     }
 
-    private func runStub(_ tool: (any ChatTool)?) async throws -> ChatToolResult? {
-        guard let tool else { return nil }
-        return try await tool.execute(input: .object([:]))
+    @Test("ChatToolResult is Codable for round-trip with ToolResultBlock")
+    func chatToolResultRoundTripsThroughCodable() throws {
+        let result = ChatToolResult(content: "hello", isError: true)
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ChatToolResult.self, from: data)
+        #expect(decoded == result)
     }
 }


### PR DESCRIPTION
Phase 4a of #1047. Foundation for tool calling: defines the `ChatTool` protocol and a process-wide registry. Sets up the abstraction so subsequent PRs can bridge MCP tools, wire provider tool emission, and add tool-use UI without rebuilding the API surface.

## What's in this PR

- `ChatTool` (protocol): `name`, `description`, `inputSchema: JSONValue`, `execute(input:) async throws -> ChatToolResult`. Sendable. Each implementation declares its JSON Schema for the wire and an async execute that runs the actual side effect.
- `ChatToolResult`: `(content: String, isError: Bool)`. The format providers will inline as `.toolResult` blocks when the multi-turn execution loop lands.
- `ChatTool.spec`: produces a `ChatToolSpec` (already defined in `ChatTransportOptions.tools` from #1057). The spec is what gets serialized into provider requests.
- `ChatToolRegistry`: `@MainActor` singleton with `register / unregister / tool(named:) / allTools / allSpecs`. Sorts `allTools` alphabetically so wire payloads are stable across runs.

## What's NOT in this PR

| Phase | What |
|---|---|
| 4b | Bridge: wrap each `MCPToolImplementation` (in `Core/MCP/Protocol/Tools/`) as a `ChatTool` so chat and external MCP clients share the same execution code. Includes `JsonValue` ↔ `JSONValue` converter (different JSON-discriminated-union types in MCP Wire vs Chat). |
| 4c | Provider tool emission: send `options.tools` in Anthropic / OpenAI request bodies; parse `tool_use` events from streams; loop the conversation when a tool call is requested. |
| 4d | UI: render tool-use cards in `AIChatMessageView` (expandable "Calling list_tables" blocks with status, input, output). |

Each phase ships independently against this foundation.

## Why MainActor

`ChatToolRegistry` registration happens at app launch alongside `AIProviderRegistration.registerAll()` (also `@MainActor`). Tools that close over UI-side state (e.g., a future "show this in the editor" tool) need MainActor access. Easier to start MainActor and relax later than the reverse.

## Tests

`ChatToolRegistryTests`: 5 tests with a `StubTool`:
- Register + lookup by name
- Re-registering replaces (last write wins)
- `allTools` is alphabetically sorted
- `allSpecs` mirrors `allTools` and produces correct `ChatToolSpec`
- `unregister` removes the entry

The tests defensively reset the registry's contents at the start of each test so the singleton doesn't leak state between cases.

## CHANGELOG

No entry. The protocol + registry are unused infrastructure; nothing user-visible changes. CHANGELOG entries land with phase 4b/4c/4d as those expose user-facing behavior.

## Test plan

- [ ] Build the app. No behavior change; the registry is empty until phase 4b populates it.
- [ ] `xcodebuild test` runs `ChatToolRegistryTests` green.