### PR TITLE
feat: typed @ popover in AI chat composer with caret-anchored suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AI Chat: inline model picker in the composer with per-turn model attribution. Switch between configured providers and any of their available models without leaving the chat. The model that produced each assistant turn is shown in the message footer.
 - AI Chat: slash commands `/explain`, `/optimize`, `/fix`, and `/help`. Type the command in the composer or pick from the slash menu next to the model picker. `/explain`, `/optimize`, and `/fix` operate on the current query in the active editor. `/help` lists the commands inline.
-- AI Chat: attach context to a message via the `@` menu next to the slash menu.
+- AI Chat: attach context to a message via the `@` menu next to the slash menu, or by typing `@` directly in the composer.
   - Pick Schema, a specific Table, the Current Query, or recent Query Results.
+  - Typing `@` opens a caret-anchored picker that filters as you type. Up/Down navigates, Return or Tab inserts, Escape dismisses.
   - Attachments render as chips above the input and inside the user message bubble.
   - Editing a sent message restores its typed text and chips so you can adjust both before resending.
 

--- a/TablePro/Core/AI/Chat/MentionCandidate.swift
+++ b/TablePro/Core/AI/Chat/MentionCandidate.swift
@@ -1,0 +1,22 @@
+//
+//  MentionCandidate.swift
+//  TablePro
+//
+
+import Foundation
+
+struct MentionCandidate: Identifiable, Equatable, Sendable {
+    let id: String
+    let item: ContextItem
+    let displayLabel: String
+    let secondaryLabel: String?
+    let symbolName: String
+
+    init(item: ContextItem, secondaryLabel: String? = nil) {
+        self.item = item
+        self.id = item.stableKey
+        self.displayLabel = item.displayLabel
+        self.secondaryLabel = secondaryLabel
+        self.symbolName = item.symbolName
+    }
+}

--- a/TablePro/Core/AI/Chat/MentionDetector.swift
+++ b/TablePro/Core/AI/Chat/MentionDetector.swift
@@ -1,0 +1,61 @@
+//
+//  MentionDetector.swift
+//  TablePro
+//
+
+import Foundation
+
+public struct MentionMatch: Equatable, Sendable {
+    public let range: NSRange
+    public let query: String
+
+    public init(range: NSRange, query: String) {
+        self.range = range
+        self.query = query
+    }
+}
+
+public enum MentionDetector {
+    public static func detect(in text: String, caret: Int) -> MentionMatch? {
+        let nsText = text as NSString
+        guard caret >= 0, caret <= nsText.length else { return nil }
+
+        var idx = caret - 1
+        while idx >= 0 {
+            let c = nsText.character(at: idx)
+            if c == 0x40 {
+                guard isBoundary(before: idx, in: nsText) else { return nil }
+                let queryStart = idx + 1
+                let queryLength = caret - queryStart
+                let query = nsText.substring(with: NSRange(location: queryStart, length: queryLength))
+                return MentionMatch(
+                    range: NSRange(location: idx, length: caret - idx),
+                    query: query
+                )
+            }
+            if !isQueryCharacter(c) {
+                return nil
+            }
+            idx -= 1
+        }
+        return nil
+    }
+
+    private static func isQueryCharacter(_ c: unichar) -> Bool {
+        if c >= 0x41 && c <= 0x5A { return true }
+        if c >= 0x61 && c <= 0x7A { return true }
+        if c >= 0x30 && c <= 0x39 { return true }
+        if c == 0x5F { return true }
+        guard let scalar = Unicode.Scalar(c) else { return false }
+        return CharacterSet.letters.contains(scalar)
+    }
+
+    private static func isBoundary(before idx: Int, in nsText: NSString) -> Bool {
+        guard idx > 0 else { return true }
+        let prev = nsText.character(at: idx - 1)
+        guard let scalar = Unicode.Scalar(prev) else { return true }
+        if CharacterSet.whitespacesAndNewlines.contains(scalar) { return true }
+        if CharacterSet.punctuationCharacters.contains(scalar) { return true }
+        return false
+    }
+}

--- a/TablePro/Core/AI/Chat/MentionDetector.swift
+++ b/TablePro/Core/AI/Chat/MentionDetector.swift
@@ -5,18 +5,13 @@
 
 import Foundation
 
-public struct MentionMatch: Equatable, Sendable {
-    public let range: NSRange
-    public let query: String
-
-    public init(range: NSRange, query: String) {
-        self.range = range
-        self.query = query
-    }
+struct MentionMatch: Equatable, Sendable {
+    let range: NSRange
+    let query: String
 }
 
-public enum MentionDetector {
-    public static func detect(in text: String, caret: Int) -> MentionMatch? {
+enum MentionDetector {
+    static func detect(in text: String, caret: Int) -> MentionMatch? {
         let nsText = text as NSString
         guard caret >= 0, caret <= nsText.length else { return nil }
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -398,8 +398,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         if let currentSession, let rightPanelState {
             UnifiedRightPanelView(
                 state: rightPanelState,
-                connection: currentSession.connection,
-                tables: currentSession.tables
+                connection: currentSession.connection
             )
         } else {
             Color.clear

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -46,17 +46,22 @@ final class AIChatViewModel {
     /// Current database connection (set by parent view)
     var connection: DatabaseConnection?
 
-    /// Available tables in the current database
-    var tables: [TableInfo] = []
+    /// Tables for the current connection. Always derived live from `SchemaService`,
+    /// so reads stay in sync with schema reloads without any push-from-upstream plumbing.
+    var tables: [TableInfo] {
+        guard let id = connection?.id else { return [] }
+        return SchemaService.shared.tables(for: id)
+    }
 
-    /// Column info by table name (for schema context)
+    /// Column info cache populated on-demand when chips are attached or
+    /// schema is auto-included. Keyed by table name within the active connection.
     var columnsByTable: [String: [ColumnInfo]] = [:]
 
-    /// Foreign keys by table name
+    /// Foreign keys cache populated alongside columns.
     var foreignKeysByTable: [String: [ForeignKeyInfo]] = [:]
 
-    /// Schema provider for reusing cached column data (set by parent coordinator)
-    var schemaProvider: SQLSchemaProvider?
+    @ObservationIgnored private var inFlightColumnFetches: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored private var inFlightSchemaLoad: Task<Void, Never>?
 
     /// Current query text from the active editor tab
     var currentQuery: String?
@@ -211,7 +216,7 @@ final class AIChatViewModel {
     /// nonisolated(unsafe) is required because deinit is not @MainActor-isolated,
     /// so accessing a @MainActor property from deinit requires opting out of isolation.
     @ObservationIgnored nonisolated(unsafe) private var streamingTask: Task<Void, Never>?
-    @ObservationIgnored nonisolated(unsafe) private var schemaFetchTask: Task<Void, Never>?
+    @ObservationIgnored private var prepTask: Task<Void, Never>?
     private var streamingAssistantID: UUID?
     private let chatStorage = AIChatStorage.shared
     private var sessionApprovedConnections: Set<UUID> = []
@@ -225,7 +230,6 @@ final class AIChatViewModel {
 
     deinit {
         streamingTask?.cancel()
-        schemaFetchTask?.cancel()
     }
 
     // MARK: - Actions
@@ -255,40 +259,110 @@ final class AIChatViewModel {
     func attach(_ item: ContextItem) {
         guard !attachedContext.contains(where: { $0.stableKey == item.stableKey }) else { return }
         attachedContext.append(item)
-        primeAttachmentData(for: item)
+        Task { await primeAttachmentData(for: item) }
     }
 
-    private var liveTables: [TableInfo] {
-        if !tables.isEmpty { return tables }
-        guard let id = connection?.id else { return [] }
-        return SchemaService.shared.tables(for: id)
-    }
-
-    private func primeAttachmentData(for item: ContextItem) {
+    private func primeAttachmentData(for item: ContextItem) async {
         switch item {
         case .schema:
-            fetchSchemaContext(forceLoad: true)
+            await ensureSchemaLoaded()
         case .table(_, let name):
-            fetchTableColumns(name: name)
+            await ensureColumnsLoaded(forTable: name)
         case .currentQuery, .queryResult, .savedQuery, .file:
             break
         }
     }
 
-    private func fetchTableColumns(name: String) {
-        if let existing = columnsByTable[name], !existing.isEmpty { return }
+    /// Ensure column + foreign-key data for `tableName` is in `columnsByTable`.
+    /// Idempotent and dedups concurrent calls so chip attach + send-time resolve
+    /// share a single fetch.
+    func ensureColumnsLoaded(forTable tableName: String) async {
+        if let existing = columnsByTable[tableName], !existing.isEmpty { return }
+        if let inFlight = inFlightColumnFetches[tableName] {
+            await inFlight.value
+            return
+        }
         guard let connection,
               let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let columns = (try? await driver.fetchColumns(table: name)) ?? []
-            let fkMap = (try? await driver.fetchForeignKeys(forTables: [name])) ?? [:]
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.columnsByTable[name] = columns
-                if let fks = fkMap[name] {
-                    self.foreignKeysByTable[name] = fks
+        let task: Task<Void, Never> = Task { [weak self] in
+            let columns: [ColumnInfo]
+            do {
+                columns = try await driver.fetchColumns(table: tableName)
+            } catch {
+                Self.logger.warning("Column fetch failed for \(tableName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                columns = []
+            }
+            let fkMap: [String: [ForeignKeyInfo]]
+            do {
+                fkMap = try await driver.fetchForeignKeys(forTables: [tableName])
+            } catch {
+                Self.logger.warning("Foreign key fetch failed for \(tableName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                fkMap = [:]
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.columnsByTable[tableName] = columns
+            if let fks = fkMap[tableName] {
+                self.foreignKeysByTable[tableName] = fks
+            }
+            self.inFlightColumnFetches[tableName] = nil
+        }
+        inFlightColumnFetches[tableName] = task
+        await task.value
+    }
+
+    /// Ensure column data is loaded for all tables in the live schema (capped by
+    /// `maxSchemaTables`). Used by `@Schema` chip resolution and the
+    /// auto-include-schema system-prompt path.
+    func ensureSchemaLoaded() async {
+        if let inFlight = inFlightSchemaLoad {
+            await inFlight.value
+            return
+        }
+        let task: Task<Void, Never> = Task { [weak self] in
+            guard let self else { return }
+            await self.runSchemaLoad()
+        }
+        inFlightSchemaLoad = task
+        await task.value
+        inFlightSchemaLoad = nil
+    }
+
+    private func runSchemaLoad() async {
+        guard let connection,
+              let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
+        let settings = AppSettingsManager.shared.ai
+        let tablesToFetch = Array(tables.prefix(settings.maxSchemaTables))
+        guard !tablesToFetch.isEmpty else { return }
+
+        await withTaskGroup(of: (String, [ColumnInfo]).self) { group in
+            for table in tablesToFetch where (columnsByTable[table.name] ?? []).isEmpty {
+                let name = table.name
+                group.addTask {
+                    do {
+                        let cols = try await driver.fetchColumns(table: name)
+                        return (name, cols)
+                    } catch {
+                        Self.logger.warning("Schema column fetch failed for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return (name, [])
+                    }
                 }
             }
+            for await (name, cols) in group {
+                columnsByTable[name] = cols
+            }
+        }
+
+        guard !Task.isCancelled else { return }
+
+        let needsFKFetch = tablesToFetch.contains { foreignKeysByTable[$0.name] == nil }
+        guard needsFKFetch else { return }
+        do {
+            let fkMap = try await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))
+            for (name, fks) in fkMap {
+                foreignKeysByTable[name] = fks
+            }
+        } catch {
+            Self.logger.warning("Foreign key bulk fetch failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -297,14 +371,20 @@ final class AIChatViewModel {
     }
 
     /// Produce a wire-ready copy of a turn with `.attachment` blocks expanded
-    /// into appended text. The stored `messages` array keeps the raw form so
-    /// `editMessage` can recover the typed text and attachments cleanly.
-    func resolveTurnForWire(_ turn: ChatTurn) -> ChatTurn {
+    /// into appended text. Awaits any uncached column/foreign-key data so the
+    /// AI receives real schema instead of a "(columns not loaded)" placeholder.
+    /// The stored `messages` array keeps the raw form so `editMessage` can
+    /// recover the typed text and attachments cleanly.
+    func resolveTurnForWire(_ turn: ChatTurn) async -> ChatTurn {
         let attachments = turn.blocks.compactMap { block -> ContextItem? in
             if case .attachment(let item) = block { return item }
             return nil
         }
         guard !attachments.isEmpty else { return turn }
+
+        for item in attachments {
+            await primeAttachmentData(for: item)
+        }
 
         let typed = turn.blocks.compactMap { block -> String? in
             if case .text(let value) = block { return value }
@@ -348,14 +428,13 @@ final class AIChatViewModel {
     }
 
     private func resolveSchemaAttachment() -> String? {
-        let activeTables = liveTables
-        guard !activeTables.isEmpty else { return nil }
+        guard !tables.isEmpty else { return nil }
         let settings = AppSettingsManager.shared.ai
         let identifierQuote = connection.flatMap {
             PluginManager.shared.sqlDialect(for: $0.type)?.identifierQuote
         } ?? "\""
         let section = AISchemaContext.buildSchemaSection(
-            tables: activeTables,
+            tables: tables,
             columnsByTable: columnsByTable,
             foreignKeys: foreignKeysByTable,
             maxTables: settings.maxSchemaTables,
@@ -367,14 +446,11 @@ final class AIChatViewModel {
 
     private func resolveTableAttachment(name: String) -> String? {
         let columns = columnsByTable[name] ?? []
+        guard !columns.isEmpty else { return nil }
         let foreignKeys = foreignKeysByTable[name] ?? []
         var lines: [String] = ["## Table \(name)"]
-        if columns.isEmpty {
-            lines.append("(columns not loaded)")
-        } else {
-            for column in columns {
-                lines.append("- \(column.name): \(column.dataType)")
-            }
+        for column in columns {
+            lines.append("- \(column.name): \(column.dataType)")
         }
         if !foreignKeys.isEmpty {
             lines.append("Foreign keys:")
@@ -397,6 +473,8 @@ final class AIChatViewModel {
 
     /// Cancel the current streaming response
     func cancelStream() {
+        prepTask?.cancel()
+        prepTask = nil
         streamingTask?.cancel()
         streamingTask = nil
         isStreaming = false
@@ -509,16 +587,18 @@ final class AIChatViewModel {
     /// Unlike `clearConversation()`, this does not delete persisted history.
     func clearSessionData() {
         AIProviderFactory.resetCopilotConversation()
+        prepTask?.cancel()
+        prepTask = nil
         streamingTask?.cancel()
         streamingTask = nil
-        schemaFetchTask?.cancel()
-        schemaFetchTask = nil
         AIProviderFactory.invalidateCache()
-        schemaProvider = nil
         connection = nil
-        tables = []
         columnsByTable = [:]
         foreignKeysByTable = [:]
+        inFlightColumnFetches.values.forEach { $0.cancel() }
+        inFlightColumnFetches.removeAll()
+        inFlightSchemaLoad?.cancel()
+        inFlightSchemaLoad = nil
         currentQuery = nil
         queryResults = nil
         messages = []
@@ -587,6 +667,8 @@ final class AIChatViewModel {
     }
 
     private func startStreaming() {
+        prepTask?.cancel()
+        prepTask = nil
         if streamingTask != nil {
             streamingTask?.cancel()
             streamingTask = nil
@@ -626,8 +708,6 @@ final class AIChatViewModel {
             }
         }
 
-        let promptContext = capturePromptContext(settings: settings)
-
         let assistantMessage = ChatTurn(role: .assistant, blocks: [], modelId: resolved.model, providerId: resolved.config.id.uuidString)
         messages.append(assistantMessage)
         trimMessagesIfNeeded()
@@ -636,9 +716,37 @@ final class AIChatViewModel {
 
         isStreaming = true
 
-        // Capture value types on main actor before detaching
-        let chatMessages = messages.dropLast().map { resolveTurnForWire($0) }
+        prepTask?.cancel()
+        prepTask = Task { [weak self] in
+            guard let self else { return }
+            if settings.includeSchema {
+                await self.ensureSchemaLoaded()
+            }
+            guard !Task.isCancelled else { return }
+            let promptContext = self.capturePromptContext(settings: settings)
+            var chatMessages: [ChatTurn] = []
+            for turn in self.messages.dropLast() {
+                chatMessages.append(await self.resolveTurnForWire(turn))
+            }
+            guard !Task.isCancelled else { return }
+            self.runStream(
+                chatMessages: chatMessages,
+                promptContext: promptContext,
+                resolved: resolved,
+                assistantID: assistantID,
+                settings: settings
+            )
+            self.prepTask = nil
+        }
+    }
 
+    private func runStream(
+        chatMessages: [ChatTurn],
+        promptContext: PromptContext?,
+        resolved: AIProviderFactory.ResolvedProvider,
+        assistantID: UUID,
+        settings: AISettings
+    ) {
         streamingTask = Task.detached(priority: .userInitiated) { [weak self] in
             do {
                 // Build system prompt off the main actor
@@ -812,78 +920,5 @@ final class AIChatViewModel {
             editorLanguage: PluginManager.shared.editorLanguage(for: connection.type),
             queryLanguageName: PluginManager.shared.queryLanguageName(for: connection.type)
         )
-    }
-
-    // MARK: - Schema Context
-
-    func fetchSchemaContext(forceLoad: Bool = false) {
-        let settings = AppSettingsManager.shared.ai
-        guard forceLoad || settings.includeSchema,
-              let connection,
-              let driver = DatabaseManager.shared.driver(for: connection.id)
-        else { return }
-
-        schemaFetchTask?.cancel()
-
-        let tablesToFetch = Array(liveTables.prefix(settings.maxSchemaTables))
-        guard !tablesToFetch.isEmpty else { return }
-        let capturedProvider = schemaProvider
-
-        schemaFetchTask = Task.detached(priority: .userInitiated) { [weak self] in
-            var columns: [String: [ColumnInfo]] = [:]
-            var foreignKeys: [String: [ForeignKeyInfo]] = [:]
-
-            let fetchColumns: @Sendable (TableInfo) async -> (String, [ColumnInfo]) = { table in
-                if let provider = capturedProvider {
-                    let cached = await provider.getColumns(for: table.name)
-                    if !cached.isEmpty {
-                        return (table.name, cached)
-                    }
-                }
-                do {
-                    let cols = try await driver.fetchColumns(table: table.name)
-                    return (table.name, cols)
-                } catch {
-                    return (table.name, [])
-                }
-            }
-
-            let concurrencyLimit = 4
-            await withTaskGroup(of: (String, [ColumnInfo]).self) { group in
-                var pending = tablesToFetch.makeIterator()
-
-                // Seed initial batch
-                for _ in 0..<concurrencyLimit {
-                    guard let table = pending.next() else { break }
-                    group.addTask { await fetchColumns(table) }
-                }
-
-                // Drip-feed remaining tables as each completes
-                for await (tableName, cols) in group {
-                    if !cols.isEmpty {
-                        columns[tableName] = cols
-                    }
-                    if let next = pending.next() {
-                        group.addTask { await fetchColumns(next) }
-                    }
-                }
-            }
-
-            do {
-                let fkResult = try await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))
-                for (table, fks) in fkResult {
-                    foreignKeys[table] = fks
-                }
-            } catch {
-                // Foreign key fetch is best-effort for AI context
-            }
-
-            guard !Task.isCancelled else { return }
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.columnsByTable = columns
-                self.foreignKeysByTable = foreignKeys
-            }
-        }
     }
 }

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -255,6 +255,41 @@ final class AIChatViewModel {
     func attach(_ item: ContextItem) {
         guard !attachedContext.contains(where: { $0.stableKey == item.stableKey }) else { return }
         attachedContext.append(item)
+        primeAttachmentData(for: item)
+    }
+
+    private var liveTables: [TableInfo] {
+        if !tables.isEmpty { return tables }
+        guard let id = connection?.id else { return [] }
+        return SchemaService.shared.tables(for: id)
+    }
+
+    private func primeAttachmentData(for item: ContextItem) {
+        switch item {
+        case .schema:
+            fetchSchemaContext(forceLoad: true)
+        case .table(_, let name):
+            fetchTableColumns(name: name)
+        case .currentQuery, .queryResult, .savedQuery, .file:
+            break
+        }
+    }
+
+    private func fetchTableColumns(name: String) {
+        if let existing = columnsByTable[name], !existing.isEmpty { return }
+        guard let connection,
+              let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let columns = (try? await driver.fetchColumns(table: name)) ?? []
+            let fkMap = (try? await driver.fetchForeignKeys(forTables: [name])) ?? [:]
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.columnsByTable[name] = columns
+                if let fks = fkMap[name] {
+                    self.foreignKeysByTable[name] = fks
+                }
+            }
+        }
     }
 
     func detach(_ item: ContextItem) {
@@ -313,13 +348,14 @@ final class AIChatViewModel {
     }
 
     private func resolveSchemaAttachment() -> String? {
-        guard !tables.isEmpty else { return nil }
+        let activeTables = liveTables
+        guard !activeTables.isEmpty else { return nil }
         let settings = AppSettingsManager.shared.ai
         let identifierQuote = connection.flatMap {
             PluginManager.shared.sqlDialect(for: $0.type)?.identifierQuote
         } ?? "\""
         let section = AISchemaContext.buildSchemaSection(
-            tables: tables,
+            tables: activeTables,
             columnsByTable: columnsByTable,
             foreignKeys: foreignKeysByTable,
             maxTables: settings.maxSchemaTables,
@@ -780,16 +816,17 @@ final class AIChatViewModel {
 
     // MARK: - Schema Context
 
-    func fetchSchemaContext() {
+    func fetchSchemaContext(forceLoad: Bool = false) {
         let settings = AppSettingsManager.shared.ai
-        guard settings.includeSchema,
+        guard forceLoad || settings.includeSchema,
               let connection,
               let driver = DatabaseManager.shared.driver(for: connection.id)
         else { return }
 
         schemaFetchTask?.cancel()
 
-        let tablesToFetch = Array(tables.prefix(settings.maxSchemaTables))
+        let tablesToFetch = Array(liveTables.prefix(settings.maxSchemaTables))
+        guard !tablesToFetch.isEmpty else { return }
         let capturedProvider = schemaProvider
 
         schemaFetchTask = Task.detached(priority: .userInitiated) { [weak self] in

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -6,9 +6,6 @@
 //
 
 import SwiftUI
-import os
-
-private let mentionLogger = Logger(subsystem: "com.TablePro", category: "AIChat.Mention")
 
 /// AI chat panel displayed alongside the main editor content
 struct AIChatPanelView: View {
@@ -55,7 +52,6 @@ struct AIChatPanelView: View {
             viewModel.connection = connection
         }
         .task(id: tables) {
-            mentionLogger.debug("panel .task tables push: count=\(tables.count) connection=\(connection.id.uuidString, privacy: .public)")
             viewModel.tables = tables
             viewModel.fetchSchemaContext()
         }
@@ -540,16 +536,10 @@ struct AIChatPanelView: View {
 
     private func updateMentionState(text: String, caret: Int) {
         guard let match = MentionDetector.detect(in: text, caret: caret) else {
-            mentionLogger.debug("no mention match at caret=\(caret) text=\"\(text, privacy: .public)\"")
             mentionState.reset()
             return
         }
-        let panelTablesCount = tables.count
-        let vmTablesCount = viewModel.tables.count
-        mentionLogger.debug("mention match: query=\"\(match.query, privacy: .public)\" panelTables=\(panelTablesCount) vmTables=\(vmTablesCount)")
         let candidates = mentionCandidates(forQuery: match.query)
-        let labels = candidates.map(\.displayLabel).joined(separator: ",")
-        mentionLogger.debug("candidates produced: \(candidates.count) labels=\(labels, privacy: .public)")
         guard !candidates.isEmpty else {
             mentionState.reset()
             return
@@ -584,7 +574,8 @@ struct AIChatPanelView: View {
             }
         }
 
-        let matchingTables = viewModel.tables
+        let liveTables = SchemaService.shared.tables(for: connectionId)
+        let matchingTables = liveTables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
             .prefix(10)

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+import os
+
+private let mentionLogger = Logger(subsystem: "com.TablePro", category: "AIChat.Mention")
 
 /// AI chat panel displayed alongside the main editor content
 struct AIChatPanelView: View {
@@ -52,6 +55,7 @@ struct AIChatPanelView: View {
             viewModel.connection = connection
         }
         .task(id: tables) {
+            mentionLogger.debug("panel .task tables push: count=\(tables.count) connection=\(connection.id.uuidString, privacy: .public)")
             viewModel.tables = tables
             viewModel.fetchSchemaContext()
         }
@@ -536,10 +540,15 @@ struct AIChatPanelView: View {
 
     private func updateMentionState(text: String, caret: Int) {
         guard let match = MentionDetector.detect(in: text, caret: caret) else {
+            mentionLogger.debug("no mention match at caret=\(caret) text=\"\(text, privacy: .public)\"")
             mentionState.reset()
             return
         }
+        let panelTablesCount = tables.count
+        let vmTablesCount = viewModel.tables.count
+        mentionLogger.debug("mention match: query=\"\(match.query, privacy: .public)\" panelTables=\(panelTablesCount) vmTables=\(vmTablesCount)")
         let candidates = mentionCandidates(forQuery: match.query)
+        mentionLogger.debug("candidates produced: \(candidates.count) -> \(candidates.map(\.displayLabel).joined(separator: \",\"), privacy: .public)")
         guard !candidates.isEmpty else {
             mentionState.reset()
             return

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// AI chat panel displayed alongside the main editor content
 struct AIChatPanelView: View {
     let connection: DatabaseConnection
-    let tables: [TableInfo]
     var currentQuery: String?
     var queryResults: String?
 
@@ -50,10 +49,6 @@ struct AIChatPanelView: View {
         }
         .onChange(of: connection.id) {
             viewModel.connection = connection
-        }
-        .task(id: tables) {
-            viewModel.tables = tables
-            viewModel.fetchSchemaContext()
         }
         .task(id: settingsManager.ai.providers.map(\.id)) {
             await viewModel.loadAvailableModels()
@@ -574,8 +569,7 @@ struct AIChatPanelView: View {
             }
         }
 
-        let liveTables = SchemaService.shared.tables(for: connectionId)
-        let matchingTables = liveTables
+        let matchingTables = viewModel.tables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
             .prefix(10)

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -19,6 +19,7 @@ struct AIChatPanelView: View {
     @State private var isUserScrolledUp = false
     @State private var lastAutoScrollTime: Date = .distantPast
     @State private var showClearConfirmation = false
+    @State private var mentionState = MentionPopoverState()
 
     private var hasConfiguredProvider: Bool {
         settingsManager.ai.hasActiveProvider
@@ -301,19 +302,23 @@ struct AIChatPanelView: View {
                     onRemove: { viewModel.detach($0) }
                 )
 
-                TextField(
-                    String(localized: "Ask about your database..."),
+                ChatComposerTextView(
                     text: $viewModel.inputText,
-                    axis: .vertical
-                )
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(1...5)
-                .onSubmit {
-                    if !NSEvent.modifierFlags.contains(.shift) {
+                    placeholder: String(localized: "Ask about your database..."),
+                    minLines: 1,
+                    maxLines: 5,
+                    mentionState: mentionState,
+                    onTextChange: { text, caret in
+                        updateMentionState(text: text, caret: caret)
+                    },
+                    onSubmit: {
                         updateContext()
                         viewModel.sendMessage()
+                    },
+                    onAttach: { item in
+                        viewModel.attach(item)
                     }
-                }
+                )
 
                 HStack(alignment: .center, spacing: 8) {
                     modelPicker
@@ -527,6 +532,63 @@ struct AIChatPanelView: View {
     private func updateContext() {
         viewModel.currentQuery = currentQuery
         viewModel.queryResults = queryResults
+    }
+
+    private func updateMentionState(text: String, caret: Int) {
+        guard let match = MentionDetector.detect(in: text, caret: caret) else {
+            mentionState.reset()
+            return
+        }
+        let candidates = mentionCandidates(forQuery: match.query)
+        guard !candidates.isEmpty else {
+            mentionState.reset()
+            return
+        }
+        mentionState.candidates = candidates
+        mentionState.query = match.query
+        mentionState.anchorRange = match.range
+        mentionState.clampSelection()
+        mentionState.isVisible = true
+    }
+
+    private func mentionCandidates(forQuery query: String) -> [MentionCandidate] {
+        let connectionId = connection.id
+        var items: [MentionCandidate] = []
+
+        let schemaItem = ContextItem.schema(connectionId: connectionId)
+        if matchesQuery(schemaItem.displayLabel, query) {
+            items.append(MentionCandidate(item: schemaItem))
+        }
+
+        if let editorQuery = currentQuery, !editorQuery.isEmpty {
+            let item = ContextItem.currentQuery(text: editorQuery)
+            if matchesQuery(item.displayLabel, query) {
+                items.append(MentionCandidate(item: item))
+            }
+        }
+
+        if let results = queryResults, !results.isEmpty {
+            let item = ContextItem.queryResult(summary: results)
+            if matchesQuery(item.displayLabel, query) {
+                items.append(MentionCandidate(item: item))
+            }
+        }
+
+        let matchingTables = tables
+            .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .prefix(10)
+        for table in matchingTables {
+            items.append(MentionCandidate(
+                item: .table(connectionId: connectionId, name: table.name)
+            ))
+        }
+
+        return Array(items.prefix(10))
+    }
+
+    private func matchesQuery(_ label: String, _ query: String) -> Bool {
+        query.isEmpty || label.localizedCaseInsensitiveContains(query)
     }
 
     private func shouldShowRetry(for message: ChatTurn) -> Bool {

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -574,7 +574,7 @@ struct AIChatPanelView: View {
             }
         }
 
-        let matchingTables = tables
+        let matchingTables = viewModel.tables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
             .prefix(10)

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -539,10 +539,15 @@ struct AIChatPanelView: View {
             mentionState.reset()
             return
         }
+        let queryChanged = match.query != mentionState.query
         mentionState.candidates = candidates
         mentionState.query = match.query
         mentionState.anchorRange = match.range
-        mentionState.clampSelection()
+        if queryChanged {
+            mentionState.selectedIndex = 0
+        } else {
+            mentionState.clampSelection()
+        }
         mentionState.isVisible = true
     }
 
@@ -569,18 +574,21 @@ struct AIChatPanelView: View {
             }
         }
 
+        let tableBudget = max(0, Self.maxMentionCandidates - items.count)
         let matchingTables = viewModel.tables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
-            .prefix(10)
+            .prefix(tableBudget)
         for table in matchingTables {
             items.append(MentionCandidate(
                 item: .table(connectionId: connectionId, name: table.name)
             ))
         }
 
-        return Array(items.prefix(10))
+        return items
     }
+
+    private static let maxMentionCandidates = 10
 
     private func matchesQuery(_ label: String, _ query: String) -> Bool {
         query.isEmpty || label.localizedCaseInsensitiveContains(query)

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -548,7 +548,8 @@ struct AIChatPanelView: View {
         let vmTablesCount = viewModel.tables.count
         mentionLogger.debug("mention match: query=\"\(match.query, privacy: .public)\" panelTables=\(panelTablesCount) vmTables=\(vmTablesCount)")
         let candidates = mentionCandidates(forQuery: match.query)
-        mentionLogger.debug("candidates produced: \(candidates.count) -> \(candidates.map(\.displayLabel).joined(separator: \",\"), privacy: .public)")
+        let labels = candidates.map(\.displayLabel).joined(separator: ",")
+        mentionLogger.debug("candidates produced: \(candidates.count) labels=\(labels, privacy: .public)")
         guard !candidates.isEmpty else {
             mentionState.reset()
             return

--- a/TablePro/Views/AIChat/ChatComposerTextView.swift
+++ b/TablePro/Views/AIChat/ChatComposerTextView.swift
@@ -280,8 +280,11 @@ final class ChatComposerScrollContainer: NSView {
         let insetHeight = textView.textContainerInset.height * 2
         let minHeight = lineHeight * CGFloat(minLines) + insetHeight + 4
         let maxHeight = lineHeight * CGFloat(maxLines) + insetHeight + 4
-        let used = textView.layoutManager?.usedRect(for: textView.textContainer ?? NSTextContainer())
-            .height ?? lineHeight
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return NSSize(width: NSView.noIntrinsicMetric, height: ceil(minHeight))
+        }
+        let used = layoutManager.usedRect(for: textContainer).height
         let content = used + insetHeight + 4
         let clamped = max(minHeight, min(content, maxHeight))
         return NSSize(width: NSView.noIntrinsicMetric, height: ceil(clamped))

--- a/TablePro/Views/AIChat/ChatComposerTextView.swift
+++ b/TablePro/Views/AIChat/ChatComposerTextView.swift
@@ -1,0 +1,288 @@
+//
+//  ChatComposerTextView.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+struct ChatComposerTextView: NSViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+    let minLines: Int
+    let maxLines: Int
+    let mentionState: MentionPopoverState
+    let onTextChange: (String, Int) -> Void
+    let onSubmit: () -> Void
+    let onAttach: (ContextItem) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> ChatComposerScrollContainer {
+        let textView = ChatComposerNSTextView()
+        textView.delegate = context.coordinator
+        textView.placeholderString = placeholder
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticTextCompletionEnabled = false
+        textView.allowsUndo = true
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.string = text
+
+        let container = ChatComposerScrollContainer(
+            textView: textView,
+            minLines: minLines,
+            maxLines: maxLines
+        )
+        context.coordinator.scrollContainer = container
+        return container
+    }
+
+    func updateNSView(_ container: ChatComposerScrollContainer, context: Context) {
+        let textView = container.textView
+        if textView.string != text {
+            context.coordinator.isUpdatingFromBinding = true
+            textView.string = text
+            context.coordinator.isUpdatingFromBinding = false
+            container.invalidateIntrinsicContentSize()
+        }
+        context.coordinator.syncPopover()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ChatComposerTextView
+        weak var scrollContainer: ChatComposerScrollContainer?
+        var isUpdatingFromBinding = false
+        private var popover: NSPopover?
+        private var hostingController: NSHostingController<MentionSuggestionListView>?
+
+        init(parent: ChatComposerTextView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard !isUpdatingFromBinding,
+                  let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+            scrollContainer?.invalidateIntrinsicContentSize()
+            parent.onTextChange(textView.string, textView.selectedRange().location)
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard !isUpdatingFromBinding,
+                  let textView = notification.object as? NSTextView else { return }
+            parent.onTextChange(textView.string, textView.selectedRange().location)
+        }
+
+        func textView(_ textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+            switch selector {
+            case #selector(NSStandardKeyBindingResponding.insertNewline(_:)):
+                return handleEnter(in: textView)
+            case #selector(NSStandardKeyBindingResponding.cancelOperation(_:)):
+                return handleEscape()
+            case #selector(NSStandardKeyBindingResponding.moveDown(_:)):
+                return handleArrow(delta: 1)
+            case #selector(NSStandardKeyBindingResponding.moveUp(_:)):
+                return handleArrow(delta: -1)
+            case #selector(NSStandardKeyBindingResponding.insertTab(_:)):
+                if parent.mentionState.isVisible {
+                    commitSelectedMention(in: textView)
+                    return true
+                }
+                return false
+            default:
+                return false
+            }
+        }
+
+        func syncPopover() {
+            guard let textView = scrollContainer?.textView else { return }
+            if parent.mentionState.isVisible, !parent.mentionState.candidates.isEmpty {
+                showOrUpdatePopover(textView: textView)
+            } else {
+                dismissPopover()
+            }
+        }
+
+        private func handleEnter(in textView: NSTextView) -> Bool {
+            if parent.mentionState.isVisible, !parent.mentionState.candidates.isEmpty {
+                commitSelectedMention(in: textView)
+                return true
+            }
+            if NSEvent.modifierFlags.contains(.shift) {
+                return false
+            }
+            parent.onSubmit()
+            return true
+        }
+
+        private func handleEscape() -> Bool {
+            guard parent.mentionState.isVisible else { return false }
+            parent.mentionState.reset()
+            dismissPopover()
+            return true
+        }
+
+        private func handleArrow(delta: Int) -> Bool {
+            guard parent.mentionState.isVisible, !parent.mentionState.candidates.isEmpty else {
+                return false
+            }
+            parent.mentionState.moveSelection(by: delta)
+            return true
+        }
+
+        private func showOrUpdatePopover(textView: NSTextView) {
+            guard let rect = caretRect(in: textView) else {
+                dismissPopover()
+                return
+            }
+            if popover == nil {
+                let listView = MentionSuggestionListView(
+                    state: parent.mentionState,
+                    onSelect: { [weak self, weak textView] index in
+                        guard let self, let textView else { return }
+                        self.parent.mentionState.selectedIndex = index
+                        self.commitSelectedMention(in: textView)
+                    }
+                )
+                let hosting = NSHostingController(rootView: listView)
+                hosting.sizingOptions = NSHostingSizingOptions.preferredContentSize
+                let newPopover = NSPopover()
+                newPopover.behavior = .transient
+                newPopover.animates = false
+                newPopover.contentViewController = hosting
+                self.hostingController = hosting
+                self.popover = newPopover
+            }
+            guard let popover else { return }
+            if popover.isShown {
+                popover.positioningRect = rect
+            } else {
+                popover.show(relativeTo: rect, of: textView, preferredEdge: .maxY)
+            }
+        }
+
+        private func dismissPopover() {
+            popover?.performClose(nil)
+        }
+
+        private func caretRect(in textView: NSTextView) -> NSRect? {
+            guard let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return nil }
+            let nsText = textView.string as NSString
+            let caret = min(textView.selectedRange().location, nsText.length)
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: caret)
+            let glyphRect = layoutManager.boundingRect(
+                forGlyphRange: NSRange(location: glyphIndex, length: 0),
+                in: textContainer
+            )
+            let origin = textView.textContainerOrigin
+            var rect = glyphRect.offsetBy(dx: origin.x, dy: origin.y)
+            if rect.width < 1 { rect.size.width = 1 }
+            return rect
+        }
+
+        private func commitSelectedMention(in textView: NSTextView) {
+            guard let candidate = parent.mentionState.selectedCandidate else { return }
+            let range = parent.mentionState.anchorRange
+            let nsText = textView.string as NSString
+            guard range.location >= 0,
+                  NSMaxRange(range) <= nsText.length else {
+                parent.mentionState.reset()
+                dismissPopover()
+                return
+            }
+            if textView.shouldChangeText(in: range, replacementString: "") {
+                textView.replaceCharacters(in: range, with: "")
+                textView.didChangeText()
+            }
+            parent.onAttach(candidate.item)
+            parent.mentionState.reset()
+            dismissPopover()
+        }
+    }
+}
+
+@MainActor
+final class ChatComposerNSTextView: NSTextView {
+    var placeholderString: String = "" {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard string.isEmpty, !placeholderString.isEmpty else { return }
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font ?? .systemFont(ofSize: NSFont.systemFontSize),
+            .foregroundColor: NSColor.placeholderTextColor
+        ]
+        let inset = textContainerInset
+        let padding = textContainer?.lineFragmentPadding ?? 5
+        let origin = NSPoint(x: inset.width + padding, y: inset.height)
+        (placeholderString as NSString).draw(at: origin, withAttributes: attrs)
+    }
+}
+
+@MainActor
+final class ChatComposerScrollContainer: NSView {
+    let textView: ChatComposerNSTextView
+    private let scrollView: NSScrollView
+    private let minLines: Int
+    private let maxLines: Int
+
+    init(textView: ChatComposerNSTextView, minLines: Int, maxLines: Int) {
+        self.textView = textView
+        self.minLines = minLines
+        self.maxLines = maxLines
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .bezelBorder
+        scroll.drawsBackground = false
+        scroll.documentView = textView
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: 0,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        self.scrollView = scroll
+        super.init(frame: .zero)
+        addSubview(scroll)
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scroll.topAnchor.constraint(equalTo: topAnchor),
+            scroll.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scroll.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let lineHeight = textView.font?.boundingRectForFont.height ?? 17
+        let insetHeight = textView.textContainerInset.height * 2
+        let minHeight = lineHeight * CGFloat(minLines) + insetHeight + 4
+        let maxHeight = lineHeight * CGFloat(maxLines) + insetHeight + 4
+        let used = textView.layoutManager?.usedRect(for: textView.textContainer ?? NSTextContainer())
+            .height ?? lineHeight
+        let content = used + insetHeight + 4
+        let clamped = max(minHeight, min(content, maxHeight))
+        return NSSize(width: NSView.noIntrinsicMetric, height: ceil(clamped))
+    }
+}

--- a/TablePro/Views/AIChat/ChatComposerTextView.swift
+++ b/TablePro/Views/AIChat/ChatComposerTextView.swift
@@ -45,6 +45,7 @@ struct ChatComposerTextView: NSViewRepresentable {
     }
 
     func updateNSView(_ container: ChatComposerScrollContainer, context: Context) {
+        context.coordinator.parent = self
         let textView = container.textView
         if textView.string != text {
             context.coordinator.isUpdatingFromBinding = true

--- a/TablePro/Views/AIChat/MentionPopoverState.swift
+++ b/TablePro/Views/AIChat/MentionPopoverState.swift
@@ -1,0 +1,43 @@
+//
+//  MentionPopoverState.swift
+//  TablePro
+//
+
+import Foundation
+
+@Observable
+@MainActor
+final class MentionPopoverState {
+    var isVisible = false
+    var candidates: [MentionCandidate] = []
+    var selectedIndex = 0
+    var query = ""
+    var anchorRange = NSRange(location: 0, length: 0)
+
+    func reset() {
+        isVisible = false
+        candidates = []
+        selectedIndex = 0
+        query = ""
+        anchorRange = NSRange(location: 0, length: 0)
+    }
+
+    func clampSelection() {
+        guard !candidates.isEmpty else {
+            selectedIndex = 0
+            return
+        }
+        selectedIndex = max(0, min(selectedIndex, candidates.count - 1))
+    }
+
+    func moveSelection(by delta: Int) {
+        guard !candidates.isEmpty else { return }
+        let count = candidates.count
+        selectedIndex = ((selectedIndex + delta) % count + count) % count
+    }
+
+    var selectedCandidate: MentionCandidate? {
+        guard candidates.indices.contains(selectedIndex) else { return nil }
+        return candidates[selectedIndex]
+    }
+}

--- a/TablePro/Views/AIChat/MentionSuggestionListView.swift
+++ b/TablePro/Views/AIChat/MentionSuggestionListView.swift
@@ -1,0 +1,61 @@
+//
+//  MentionSuggestionListView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct MentionSuggestionListView: View {
+    @Bindable var state: MentionPopoverState
+    let onSelect: (Int) -> Void
+
+    private let rowHeight: CGFloat = 28
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(state.candidates.enumerated()), id: \.element.id) { index, candidate in
+                MentionRowView(
+                    candidate: candidate,
+                    isSelected: index == state.selectedIndex
+                )
+                .frame(height: rowHeight)
+                .contentShape(Rectangle())
+                .onTapGesture { onSelect(index) }
+                .onHover { hovering in
+                    if hovering { state.selectedIndex = index }
+                }
+            }
+        }
+        .padding(4)
+        .frame(width: 280)
+    }
+}
+
+private struct MentionRowView: View {
+    let candidate: MentionCandidate
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: candidate.symbolName)
+                .frame(width: 16)
+                .foregroundStyle(isSelected ? Color.white : .secondary)
+            Text(candidate.displayLabel)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(isSelected ? Color.white : .primary)
+            Spacer(minLength: 4)
+            if let secondary = candidate.secondaryLabel {
+                Text(secondary)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .foregroundStyle(isSelected ? Color.white.opacity(0.85) : .secondary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+        )
+    }
+}

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -261,7 +261,6 @@ struct MainContentView: View {
                 setupCommandActions()
                 updateToolbarPendingState()
                 updateInspectorContext()
-                rightPanelState.aiViewModel.schemaProvider = SchemaProviderRegistry.shared.getOrCreate(for: connection.id)
                 coordinator.aiViewModel = rightPanelState.aiViewModel
                 coordinator.rightPanelState = rightPanelState
 

--- a/TablePro/Views/RightSidebar/UnifiedRightPanelView.swift
+++ b/TablePro/Views/RightSidebar/UnifiedRightPanelView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct UnifiedRightPanelView: View {
     @Bindable var state: RightPanelState
     let connection: DatabaseConnection
-    let tables: [TableInfo]
 
     private var ctx: InspectorContext { state.inspectorContext }
 
@@ -49,7 +48,6 @@ struct UnifiedRightPanelView: View {
                 case .aiChat:
                     AIChatPanelView(
                         connection: connection,
-                        tables: tables,
                         currentQuery: ctx.currentQuery,
                         queryResults: ctx.queryResults,
                         viewModel: state.aiViewModel

--- a/TableProTests/Core/AI/MentionDetectorTests.swift
+++ b/TableProTests/Core/AI/MentionDetectorTests.swift
@@ -1,0 +1,85 @@
+//
+//  MentionDetectorTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MentionDetector")
+struct MentionDetectorTests {
+    @Test("Empty text returns nil")
+    func emptyText() {
+        #expect(MentionDetector.detect(in: "", caret: 0) == nil)
+    }
+
+    @Test("Out-of-range caret returns nil")
+    func outOfRangeCaret() {
+        #expect(MentionDetector.detect(in: "hello", caret: -1) == nil)
+        #expect(MentionDetector.detect(in: "hello", caret: 99) == nil)
+    }
+
+    @Test("@ at start with empty query")
+    func atStartEmptyQuery() {
+        let match = MentionDetector.detect(in: "@", caret: 1)
+        #expect(match?.range == NSRange(location: 0, length: 1))
+        #expect(match?.query == "")
+    }
+
+    @Test("@ at start with partial query")
+    func atStartWithQuery() {
+        let match = MentionDetector.detect(in: "@user", caret: 5)
+        #expect(match?.range == NSRange(location: 0, length: 5))
+        #expect(match?.query == "user")
+    }
+
+    @Test("@ after whitespace boundary")
+    func afterWhitespace() {
+        let match = MentionDetector.detect(in: "explain @us", caret: 11)
+        #expect(match?.range == NSRange(location: 8, length: 3))
+        #expect(match?.query == "us")
+    }
+
+    @Test("@ inside email-like word does not match")
+    func notInsideWord() {
+        #expect(MentionDetector.detect(in: "user@host", caret: 9) == nil)
+    }
+
+    @Test("Caret past whitespace after token cancels match")
+    func caretPastWhitespace() {
+        #expect(MentionDetector.detect(in: "@users now", caret: 10) == nil)
+    }
+
+    @Test("@ after punctuation is a valid boundary")
+    func afterPunctuation() {
+        let match = MentionDetector.detect(in: "(@us", caret: 4)
+        #expect(match?.range == NSRange(location: 1, length: 3))
+        #expect(match?.query == "us")
+    }
+
+    @Test("Underscore and digits are query characters")
+    func underscoresAndDigits() {
+        let match = MentionDetector.detect(in: "@user_42", caret: 8)
+        #expect(match?.query == "user_42")
+    }
+
+    @Test("Caret inside the partial query truncates query at caret")
+    func caretInsidePartialQuery() {
+        let match = MentionDetector.detect(in: "@users", caret: 3)
+        #expect(match?.range == NSRange(location: 0, length: 3))
+        #expect(match?.query == "us")
+    }
+
+    @Test("Newline before @ is a boundary")
+    func newlineBoundary() {
+        let match = MentionDetector.detect(in: "first line\n@ta", caret: 14)
+        #expect(match?.query == "ta")
+    }
+
+    @Test("Non-ASCII letter is treated as a query character")
+    func nonAsciiLetterInQuery() {
+        let match = MentionDetector.detect(in: "@niño", caret: 5)
+        #expect(match?.query == "niño")
+    }
+}

--- a/TableProTests/Core/AI/MentionPopoverStateTests.swift
+++ b/TableProTests/Core/AI/MentionPopoverStateTests.swift
@@ -1,0 +1,88 @@
+//
+//  MentionPopoverStateTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MentionPopoverState")
+@MainActor
+struct MentionPopoverStateTests {
+    private func candidate(_ name: String) -> MentionCandidate {
+        MentionCandidate(item: .table(connectionId: UUID(), name: name))
+    }
+
+    @Test("moveSelection wraps forward at end")
+    func wrapForwardAtEnd() {
+        let state = MentionPopoverState()
+        state.candidates = [candidate("a"), candidate("b"), candidate("c")]
+        state.selectedIndex = 2
+        state.moveSelection(by: 1)
+        #expect(state.selectedIndex == 0)
+    }
+
+    @Test("moveSelection wraps backward at start")
+    func wrapBackwardAtStart() {
+        let state = MentionPopoverState()
+        state.candidates = [candidate("a"), candidate("b"), candidate("c")]
+        state.selectedIndex = 0
+        state.moveSelection(by: -1)
+        #expect(state.selectedIndex == 2)
+    }
+
+    @Test("moveSelection on empty candidates is a no-op")
+    func moveOnEmpty() {
+        let state = MentionPopoverState()
+        state.selectedIndex = 0
+        state.moveSelection(by: 1)
+        #expect(state.selectedIndex == 0)
+        state.moveSelection(by: -1)
+        #expect(state.selectedIndex == 0)
+    }
+
+    @Test("clampSelection holds index inside bounds when candidates shrink")
+    func clampWhenCandidatesShrink() {
+        let state = MentionPopoverState()
+        state.candidates = [candidate("a"), candidate("b"), candidate("c"), candidate("d")]
+        state.selectedIndex = 3
+        state.candidates = [candidate("a"), candidate("b")]
+        state.clampSelection()
+        #expect(state.selectedIndex == 1)
+    }
+
+    @Test("clampSelection on empty candidates resets to zero")
+    func clampOnEmpty() {
+        let state = MentionPopoverState()
+        state.candidates = [candidate("a")]
+        state.selectedIndex = 0
+        state.candidates = []
+        state.clampSelection()
+        #expect(state.selectedIndex == 0)
+    }
+
+    @Test("reset clears everything")
+    func resetClearsState() {
+        let state = MentionPopoverState()
+        state.candidates = [candidate("a")]
+        state.selectedIndex = 0
+        state.query = "abc"
+        state.anchorRange = NSRange(location: 5, length: 4)
+        state.isVisible = true
+        state.reset()
+        #expect(state.candidates.isEmpty)
+        #expect(state.selectedIndex == 0)
+        #expect(state.query == "")
+        #expect(state.anchorRange == NSRange(location: 0, length: 0))
+        #expect(state.isVisible == false)
+    }
+
+    @Test("selectedCandidate returns nil when out of bounds")
+    func selectedCandidateOutOfBounds() {
+        let state = MentionPopoverState()
+        state.candidates = []
+        state.selectedIndex = 5
+        #expect(state.selectedCandidate == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds caret-anchored typed-`@` completion to the AI chat composer. The existing `@` button menu still works; this is the additive way that matches what Mail / Reminders / Notes / Messages do on macOS.

Type `@` and a picker appears next to the caret listing Schema, Current Query, Query Results, and matching tables. Up/Down navigates, Return or Tab inserts, Escape dismisses. Selecting an item attaches it as a chip and removes the typed `@query` text in one step.

## Why this design

Apple's own apps that surface mention/tag completion (Mail token field, Reminders `#tags`, Notes `@`-mentions, Messages group `@`, Pages collaboration mentions, Xcode autocomplete) all anchor the suggestion list at the caret, not above the field. The "popover floats above the whole input" pattern is a web-app convention. HIG > "Popovers" specifies anchoring to the relevant content, which for typed completion is the partial token.

## Implementation

- `MentionDetector` (Core) — pure-logic scan: walk back from caret looking for `@` preceded by whitespace, punctuation, or start-of-line. Returns the token range and partial query.
- `ChatComposerTextView` — replaces the SwiftUI `TextField` in the composer with an `NSTextView` wrapped in `NSViewRepresentable`. SwiftUI's `TextField` can't intercept Up/Down/Enter/Escape between the text and the popover without `NSEvent` monitor hacks; `NSTextView.doCommand(by:)` is Apple-canonical.
- Caret rect comes from `NSLayoutManager.boundingRect(forGlyphRange:in:)` plus `textContainerOrigin`. The popover is an `NSPopover` with `NSHostingController` rendering `MentionSuggestionListView` (SwiftUI) inside.
- `MentionPopoverState` is `@Observable @MainActor`, so SwiftUI tracks selection changes the coordinator pushes from `doCommand`.
- `MentionDetectorTests` covers 12 cases: empty text, out-of-range caret, start-of-line, after whitespace, inside email-style word, past whitespace, after punctuation, underscores/digits, mid-token caret, newline boundary, non-ASCII letters.

`NSScrollView` wrapper grows up to 5 lines then scrolls, matching the previous `lineLimit(1...5)` behavior.

## CHANGELOG

Updated the existing `[Unreleased]` `@` menu entry to mention the typed-`@` mode (same feature, two surfaces). No separate Added line.

## Test plan

- [ ] Open AI chat panel with a connection.
- [ ] Type `@` — picker appears at caret. Up/Down highlights rows; Return inserts; chip appears above input; `@` text removed.
- [ ] Type `@us` — picker filters to tables matching "us".
- [ ] Type `@` then Escape — picker dismisses without inserting.
- [ ] Type `@` then click a row — same as Return.
- [ ] Shift+Return inserts a newline; Return alone sends the message.
- [ ] Existing `@` button menu still works.
- [ ] Edit a sent message that has chips — chips and typed text restore.