### PR TITLE
fix: demote ChatTool foundation to internal access level

### DIFF
--- a/TablePro/Core/AI/Chat/ChatTool.swift
+++ b/TablePro/Core/AI/Chat/ChatTool.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A tool the AI can call from a chat turn. Implementations are registered
 /// with `ChatToolRegistry` and exposed to providers via `ChatToolSpec`.
-public protocol ChatTool: Sendable {
+protocol ChatTool: Sendable {
     var name: String { get }
     var description: String { get }
     var inputSchema: JSONValue { get }
@@ -15,20 +15,20 @@ public protocol ChatTool: Sendable {
     func execute(input: JSONValue) async throws -> ChatToolResult
 }
 
-public struct ChatToolResult: Sendable, Equatable, Codable {
+struct ChatToolResult: Sendable, Equatable, Codable {
     /// Tool results are UTF-8 text in this version. A future expansion may
     /// widen `content` to accept multiple typed blocks (text, image,
     /// structured data); treat the current shape as a forward-compat floor.
-    public let content: String
-    public let isError: Bool
+    let content: String
+    let isError: Bool
 
-    public init(content: String, isError: Bool = false) {
+    init(content: String, isError: Bool = false) {
         self.content = content
         self.isError = isError
     }
 }
 
-public extension ChatTool {
+extension ChatTool {
     /// Wire-format spec for `ChatTransportOptions.tools`.
     var spec: ChatToolSpec {
         ChatToolSpec(name: name, description: description, inputSchema: inputSchema)

--- a/TablePro/Core/AI/Chat/ChatToolRegistry.swift
+++ b/TablePro/Core/AI/Chat/ChatToolRegistry.swift
@@ -8,16 +8,16 @@ import os
 
 /// Process-wide registry of `ChatTool` implementations available to AI chat.
 @MainActor
-public final class ChatToolRegistry {
-    public static let shared = ChatToolRegistry()
+final class ChatToolRegistry {
+    static let shared = ChatToolRegistry()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ChatToolRegistry")
 
     private var tools: [String: any ChatTool] = [:]
 
-    public init() {}
+    init() {}
 
-    public func register(_ tool: any ChatTool) {
+    func register(_ tool: any ChatTool) {
         let existing = tools[tool.name]
         tools[tool.name] = tool
         if existing != nil {
@@ -25,20 +25,20 @@ public final class ChatToolRegistry {
         }
     }
 
-    public func unregister(name: String) {
+    func unregister(name: String) {
         tools.removeValue(forKey: name)
     }
 
-    public func tool(named name: String) -> (any ChatTool)? {
+    func tool(named name: String) -> (any ChatTool)? {
         tools[name]
     }
 
-    public var allTools: [any ChatTool] {
+    var allTools: [any ChatTool] {
         tools.values
             .sorted { $0.name < $1.name }
     }
 
-    public var allSpecs: [ChatToolSpec] {
+    var allSpecs: [ChatToolSpec] {
         allTools.map(\.spec)
     }
 }


### PR DESCRIPTION
## Summary

Build fails on `ChatToolRegistry.swift:41`:

```
Property cannot be declared public because its type uses an internal type
```

Foundation PR #1062 marked `ChatTool`, `ChatToolResult`, `ChatToolRegistry`, and the `spec` extension `public`. But `ChatToolSpec` and `JSONValue` (both used in protocol requirements and the `allSpecs` return type) are internal. The compiler correctly rejects a public API surface that exposes internal types.

## Why demote (not promote)

Two ways to fix it: make `ChatToolSpec` + `JSONValue` public to match, or drop `public` from the foundation. There is no external module consuming `ChatTool` yet — the umbrella's plugin SDK story is not in scope. Demoting matches actual usage (in-app only) and keeps the surface area honest. If Phase 4 ends up exposing tools via `TableProPluginKit`, promote then with a deliberate API design pass instead of dragging `JSONValue` into the public API by accident.

## Changes

- `ChatTool.swift`: drop `public` from `protocol ChatTool`, `struct ChatToolResult`, members, and the `spec` extension.
- `ChatToolRegistry.swift`: drop `public` from class, `shared`, `init`, `register`, `unregister`, `tool(named:)`, `allTools`, `allSpecs`.

Tests already use `@testable import TablePro` so they keep working with internal types.

## CHANGELOG

No entry. The foundation is itself in `[Unreleased]` infrastructure (no user-facing surface), so per CLAUDE.md a Fixed entry for unreleased work is wrong.

## Test plan

- [ ] App builds.
- [ ] `xcodebuild test -only-testing:TableProTests/ChatToolRegistryTests` passes.