### PR TITLE
refactor: derive chat view-model schema state from SchemaService

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -398,8 +398,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         if let currentSession, let rightPanelState {
             UnifiedRightPanelView(
                 state: rightPanelState,
-                connection: currentSession.connection,
-                tables: currentSession.tables
+                connection: currentSession.connection
             )
         } else {
             Color.clear

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -216,6 +216,7 @@ final class AIChatViewModel {
     /// nonisolated(unsafe) is required because deinit is not @MainActor-isolated,
     /// so accessing a @MainActor property from deinit requires opting out of isolation.
     @ObservationIgnored nonisolated(unsafe) private var streamingTask: Task<Void, Never>?
+    @ObservationIgnored private var prepTask: Task<Void, Never>?
     private var streamingAssistantID: UUID?
     private let chatStorage = AIChatStorage.shared
     private var sessionApprovedConnections: Set<UUID> = []
@@ -283,17 +284,27 @@ final class AIChatViewModel {
         }
         guard let connection,
               let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
-        let task = Task { [weak self] in
-            let columns = (try? await driver.fetchColumns(table: tableName)) ?? []
-            let fkMap = (try? await driver.fetchForeignKeys(forTables: [tableName])) ?? [:]
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.columnsByTable[tableName] = columns
-                if let fks = fkMap[tableName] {
-                    self.foreignKeysByTable[tableName] = fks
-                }
-                self.inFlightColumnFetches[tableName] = nil
+        let task: Task<Void, Never> = Task { [weak self] in
+            let columns: [ColumnInfo]
+            do {
+                columns = try await driver.fetchColumns(table: tableName)
+            } catch {
+                Self.logger.warning("Column fetch failed for \(tableName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                columns = []
             }
+            let fkMap: [String: [ForeignKeyInfo]]
+            do {
+                fkMap = try await driver.fetchForeignKeys(forTables: [tableName])
+            } catch {
+                Self.logger.warning("Foreign key fetch failed for \(tableName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                fkMap = [:]
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.columnsByTable[tableName] = columns
+            if let fks = fkMap[tableName] {
+                self.foreignKeysByTable[tableName] = fks
+            }
+            self.inFlightColumnFetches[tableName] = nil
         }
         inFlightColumnFetches[tableName] = task
         await task.value
@@ -327,8 +338,13 @@ final class AIChatViewModel {
             for table in tablesToFetch where (columnsByTable[table.name] ?? []).isEmpty {
                 let name = table.name
                 group.addTask {
-                    let cols = (try? await driver.fetchColumns(table: name)) ?? []
-                    return (name, cols)
+                    do {
+                        let cols = try await driver.fetchColumns(table: name)
+                        return (name, cols)
+                    } catch {
+                        Self.logger.warning("Schema column fetch failed for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return (name, [])
+                    }
                 }
             }
             for await (name, cols) in group {
@@ -336,9 +352,17 @@ final class AIChatViewModel {
             }
         }
 
-        let fkMap = (try? await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))) ?? [:]
-        for (name, fks) in fkMap {
-            foreignKeysByTable[name] = fks
+        guard !Task.isCancelled else { return }
+
+        let needsFKFetch = tablesToFetch.contains { foreignKeysByTable[$0.name] == nil }
+        guard needsFKFetch else { return }
+        do {
+            let fkMap = try await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))
+            for (name, fks) in fkMap {
+                foreignKeysByTable[name] = fks
+            }
+        } catch {
+            Self.logger.warning("Foreign key bulk fetch failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -449,6 +473,8 @@ final class AIChatViewModel {
 
     /// Cancel the current streaming response
     func cancelStream() {
+        prepTask?.cancel()
+        prepTask = nil
         streamingTask?.cancel()
         streamingTask = nil
         isStreaming = false
@@ -561,6 +587,8 @@ final class AIChatViewModel {
     /// Unlike `clearConversation()`, this does not delete persisted history.
     func clearSessionData() {
         AIProviderFactory.resetCopilotConversation()
+        prepTask?.cancel()
+        prepTask = nil
         streamingTask?.cancel()
         streamingTask = nil
         AIProviderFactory.invalidateCache()
@@ -639,6 +667,8 @@ final class AIChatViewModel {
     }
 
     private func startStreaming() {
+        prepTask?.cancel()
+        prepTask = nil
         if streamingTask != nil {
             streamingTask?.cancel()
             streamingTask = nil
@@ -686,16 +716,19 @@ final class AIChatViewModel {
 
         isStreaming = true
 
-        Task { @MainActor [weak self] in
+        prepTask?.cancel()
+        prepTask = Task { [weak self] in
             guard let self else { return }
             if settings.includeSchema {
                 await self.ensureSchemaLoaded()
             }
+            guard !Task.isCancelled else { return }
             let promptContext = self.capturePromptContext(settings: settings)
             var chatMessages: [ChatTurn] = []
             for turn in self.messages.dropLast() {
                 chatMessages.append(await self.resolveTurnForWire(turn))
             }
+            guard !Task.isCancelled else { return }
             self.runStream(
                 chatMessages: chatMessages,
                 promptContext: promptContext,
@@ -703,6 +736,7 @@ final class AIChatViewModel {
                 assistantID: assistantID,
                 settings: settings
             )
+            self.prepTask = nil
         }
     }
 

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -307,8 +307,9 @@ final class AIChatViewModel {
             await inFlight.value
             return
         }
-        let task = Task { [weak self] in
-            await self?.runSchemaLoad()
+        let task: Task<Void, Never> = Task { [weak self] in
+            guard let self else { return }
+            await self.runSchemaLoad()
         }
         inFlightSchemaLoad = task
         await task.value

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -46,17 +46,22 @@ final class AIChatViewModel {
     /// Current database connection (set by parent view)
     var connection: DatabaseConnection?
 
-    /// Available tables in the current database
-    var tables: [TableInfo] = []
+    /// Tables for the current connection. Always derived live from `SchemaService`,
+    /// so reads stay in sync with schema reloads without any push-from-upstream plumbing.
+    var tables: [TableInfo] {
+        guard let id = connection?.id else { return [] }
+        return SchemaService.shared.tables(for: id)
+    }
 
-    /// Column info by table name (for schema context)
+    /// Column info cache populated on-demand when chips are attached or
+    /// schema is auto-included. Keyed by table name within the active connection.
     var columnsByTable: [String: [ColumnInfo]] = [:]
 
-    /// Foreign keys by table name
+    /// Foreign keys cache populated alongside columns.
     var foreignKeysByTable: [String: [ForeignKeyInfo]] = [:]
 
-    /// Schema provider for reusing cached column data (set by parent coordinator)
-    var schemaProvider: SQLSchemaProvider?
+    @ObservationIgnored private var inFlightColumnFetches: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored private var inFlightSchemaLoad: Task<Void, Never>?
 
     /// Current query text from the active editor tab
     var currentQuery: String?
@@ -211,7 +216,6 @@ final class AIChatViewModel {
     /// nonisolated(unsafe) is required because deinit is not @MainActor-isolated,
     /// so accessing a @MainActor property from deinit requires opting out of isolation.
     @ObservationIgnored nonisolated(unsafe) private var streamingTask: Task<Void, Never>?
-    @ObservationIgnored nonisolated(unsafe) private var schemaFetchTask: Task<Void, Never>?
     private var streamingAssistantID: UUID?
     private let chatStorage = AIChatStorage.shared
     private var sessionApprovedConnections: Set<UUID> = []
@@ -225,7 +229,6 @@ final class AIChatViewModel {
 
     deinit {
         streamingTask?.cancel()
-        schemaFetchTask?.cancel()
     }
 
     // MARK: - Actions
@@ -255,40 +258,86 @@ final class AIChatViewModel {
     func attach(_ item: ContextItem) {
         guard !attachedContext.contains(where: { $0.stableKey == item.stableKey }) else { return }
         attachedContext.append(item)
-        primeAttachmentData(for: item)
+        Task { await primeAttachmentData(for: item) }
     }
 
-    private var liveTables: [TableInfo] {
-        if !tables.isEmpty { return tables }
-        guard let id = connection?.id else { return [] }
-        return SchemaService.shared.tables(for: id)
-    }
-
-    private func primeAttachmentData(for item: ContextItem) {
+    private func primeAttachmentData(for item: ContextItem) async {
         switch item {
         case .schema:
-            fetchSchemaContext(forceLoad: true)
+            await ensureSchemaLoaded()
         case .table(_, let name):
-            fetchTableColumns(name: name)
+            await ensureColumnsLoaded(forTable: name)
         case .currentQuery, .queryResult, .savedQuery, .file:
             break
         }
     }
 
-    private func fetchTableColumns(name: String) {
-        if let existing = columnsByTable[name], !existing.isEmpty { return }
+    /// Ensure column + foreign-key data for `tableName` is in `columnsByTable`.
+    /// Idempotent and dedups concurrent calls so chip attach + send-time resolve
+    /// share a single fetch.
+    func ensureColumnsLoaded(forTable tableName: String) async {
+        if let existing = columnsByTable[tableName], !existing.isEmpty { return }
+        if let inFlight = inFlightColumnFetches[tableName] {
+            await inFlight.value
+            return
+        }
         guard let connection,
               let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let columns = (try? await driver.fetchColumns(table: name)) ?? []
-            let fkMap = (try? await driver.fetchForeignKeys(forTables: [name])) ?? [:]
+        let task = Task { [weak self] in
+            let columns = (try? await driver.fetchColumns(table: tableName)) ?? []
+            let fkMap = (try? await driver.fetchForeignKeys(forTables: [tableName])) ?? [:]
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                self.columnsByTable[name] = columns
-                if let fks = fkMap[name] {
-                    self.foreignKeysByTable[name] = fks
+                self.columnsByTable[tableName] = columns
+                if let fks = fkMap[tableName] {
+                    self.foreignKeysByTable[tableName] = fks
+                }
+                self.inFlightColumnFetches[tableName] = nil
+            }
+        }
+        inFlightColumnFetches[tableName] = task
+        await task.value
+    }
+
+    /// Ensure column data is loaded for all tables in the live schema (capped by
+    /// `maxSchemaTables`). Used by `@Schema` chip resolution and the
+    /// auto-include-schema system-prompt path.
+    func ensureSchemaLoaded() async {
+        if let inFlight = inFlightSchemaLoad {
+            await inFlight.value
+            return
+        }
+        let task = Task { [weak self] in
+            await self?.runSchemaLoad()
+        }
+        inFlightSchemaLoad = task
+        await task.value
+        inFlightSchemaLoad = nil
+    }
+
+    private func runSchemaLoad() async {
+        guard let connection,
+              let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
+        let settings = AppSettingsManager.shared.ai
+        let tablesToFetch = Array(tables.prefix(settings.maxSchemaTables))
+        guard !tablesToFetch.isEmpty else { return }
+
+        await withTaskGroup(of: (String, [ColumnInfo]).self) { group in
+            for table in tablesToFetch where (columnsByTable[table.name] ?? []).isEmpty {
+                let name = table.name
+                group.addTask {
+                    let cols = (try? await driver.fetchColumns(table: name)) ?? []
+                    return (name, cols)
                 }
             }
+            for await (name, cols) in group {
+                columnsByTable[name] = cols
+            }
+        }
+
+        let fkMap = (try? await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))) ?? [:]
+        for (name, fks) in fkMap {
+            foreignKeysByTable[name] = fks
         }
     }
 
@@ -297,14 +346,20 @@ final class AIChatViewModel {
     }
 
     /// Produce a wire-ready copy of a turn with `.attachment` blocks expanded
-    /// into appended text. The stored `messages` array keeps the raw form so
-    /// `editMessage` can recover the typed text and attachments cleanly.
-    func resolveTurnForWire(_ turn: ChatTurn) -> ChatTurn {
+    /// into appended text. Awaits any uncached column/foreign-key data so the
+    /// AI receives real schema instead of a "(columns not loaded)" placeholder.
+    /// The stored `messages` array keeps the raw form so `editMessage` can
+    /// recover the typed text and attachments cleanly.
+    func resolveTurnForWire(_ turn: ChatTurn) async -> ChatTurn {
         let attachments = turn.blocks.compactMap { block -> ContextItem? in
             if case .attachment(let item) = block { return item }
             return nil
         }
         guard !attachments.isEmpty else { return turn }
+
+        for item in attachments {
+            await primeAttachmentData(for: item)
+        }
 
         let typed = turn.blocks.compactMap { block -> String? in
             if case .text(let value) = block { return value }
@@ -348,14 +403,13 @@ final class AIChatViewModel {
     }
 
     private func resolveSchemaAttachment() -> String? {
-        let activeTables = liveTables
-        guard !activeTables.isEmpty else { return nil }
+        guard !tables.isEmpty else { return nil }
         let settings = AppSettingsManager.shared.ai
         let identifierQuote = connection.flatMap {
             PluginManager.shared.sqlDialect(for: $0.type)?.identifierQuote
         } ?? "\""
         let section = AISchemaContext.buildSchemaSection(
-            tables: activeTables,
+            tables: tables,
             columnsByTable: columnsByTable,
             foreignKeys: foreignKeysByTable,
             maxTables: settings.maxSchemaTables,
@@ -367,14 +421,11 @@ final class AIChatViewModel {
 
     private func resolveTableAttachment(name: String) -> String? {
         let columns = columnsByTable[name] ?? []
+        guard !columns.isEmpty else { return nil }
         let foreignKeys = foreignKeysByTable[name] ?? []
         var lines: [String] = ["## Table \(name)"]
-        if columns.isEmpty {
-            lines.append("(columns not loaded)")
-        } else {
-            for column in columns {
-                lines.append("- \(column.name): \(column.dataType)")
-            }
+        for column in columns {
+            lines.append("- \(column.name): \(column.dataType)")
         }
         if !foreignKeys.isEmpty {
             lines.append("Foreign keys:")
@@ -511,14 +562,14 @@ final class AIChatViewModel {
         AIProviderFactory.resetCopilotConversation()
         streamingTask?.cancel()
         streamingTask = nil
-        schemaFetchTask?.cancel()
-        schemaFetchTask = nil
         AIProviderFactory.invalidateCache()
-        schemaProvider = nil
         connection = nil
-        tables = []
         columnsByTable = [:]
         foreignKeysByTable = [:]
+        inFlightColumnFetches.values.forEach { $0.cancel() }
+        inFlightColumnFetches.removeAll()
+        inFlightSchemaLoad?.cancel()
+        inFlightSchemaLoad = nil
         currentQuery = nil
         queryResults = nil
         messages = []
@@ -626,8 +677,6 @@ final class AIChatViewModel {
             }
         }
 
-        let promptContext = capturePromptContext(settings: settings)
-
         let assistantMessage = ChatTurn(role: .assistant, blocks: [], modelId: resolved.model, providerId: resolved.config.id.uuidString)
         messages.append(assistantMessage)
         trimMessagesIfNeeded()
@@ -636,9 +685,33 @@ final class AIChatViewModel {
 
         isStreaming = true
 
-        // Capture value types on main actor before detaching
-        let chatMessages = messages.dropLast().map { resolveTurnForWire($0) }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if settings.includeSchema {
+                await self.ensureSchemaLoaded()
+            }
+            let promptContext = self.capturePromptContext(settings: settings)
+            var chatMessages: [ChatTurn] = []
+            for turn in self.messages.dropLast() {
+                chatMessages.append(await self.resolveTurnForWire(turn))
+            }
+            self.runStream(
+                chatMessages: chatMessages,
+                promptContext: promptContext,
+                resolved: resolved,
+                assistantID: assistantID,
+                settings: settings
+            )
+        }
+    }
 
+    private func runStream(
+        chatMessages: [ChatTurn],
+        promptContext: PromptContext?,
+        resolved: AIProviderFactory.ResolvedProvider,
+        assistantID: UUID,
+        settings: AISettings
+    ) {
         streamingTask = Task.detached(priority: .userInitiated) { [weak self] in
             do {
                 // Build system prompt off the main actor
@@ -812,78 +885,5 @@ final class AIChatViewModel {
             editorLanguage: PluginManager.shared.editorLanguage(for: connection.type),
             queryLanguageName: PluginManager.shared.queryLanguageName(for: connection.type)
         )
-    }
-
-    // MARK: - Schema Context
-
-    func fetchSchemaContext(forceLoad: Bool = false) {
-        let settings = AppSettingsManager.shared.ai
-        guard forceLoad || settings.includeSchema,
-              let connection,
-              let driver = DatabaseManager.shared.driver(for: connection.id)
-        else { return }
-
-        schemaFetchTask?.cancel()
-
-        let tablesToFetch = Array(liveTables.prefix(settings.maxSchemaTables))
-        guard !tablesToFetch.isEmpty else { return }
-        let capturedProvider = schemaProvider
-
-        schemaFetchTask = Task.detached(priority: .userInitiated) { [weak self] in
-            var columns: [String: [ColumnInfo]] = [:]
-            var foreignKeys: [String: [ForeignKeyInfo]] = [:]
-
-            let fetchColumns: @Sendable (TableInfo) async -> (String, [ColumnInfo]) = { table in
-                if let provider = capturedProvider {
-                    let cached = await provider.getColumns(for: table.name)
-                    if !cached.isEmpty {
-                        return (table.name, cached)
-                    }
-                }
-                do {
-                    let cols = try await driver.fetchColumns(table: table.name)
-                    return (table.name, cols)
-                } catch {
-                    return (table.name, [])
-                }
-            }
-
-            let concurrencyLimit = 4
-            await withTaskGroup(of: (String, [ColumnInfo]).self) { group in
-                var pending = tablesToFetch.makeIterator()
-
-                // Seed initial batch
-                for _ in 0..<concurrencyLimit {
-                    guard let table = pending.next() else { break }
-                    group.addTask { await fetchColumns(table) }
-                }
-
-                // Drip-feed remaining tables as each completes
-                for await (tableName, cols) in group {
-                    if !cols.isEmpty {
-                        columns[tableName] = cols
-                    }
-                    if let next = pending.next() {
-                        group.addTask { await fetchColumns(next) }
-                    }
-                }
-            }
-
-            do {
-                let fkResult = try await driver.fetchForeignKeys(forTables: tablesToFetch.map(\.name))
-                for (table, fks) in fkResult {
-                    foreignKeys[table] = fks
-                }
-            } catch {
-                // Foreign key fetch is best-effort for AI context
-            }
-
-            guard !Task.isCancelled else { return }
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.columnsByTable = columns
-                self.foreignKeysByTable = foreignKeys
-            }
-        }
     }
 }

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// AI chat panel displayed alongside the main editor content
 struct AIChatPanelView: View {
     let connection: DatabaseConnection
-    let tables: [TableInfo]
     var currentQuery: String?
     var queryResults: String?
 
@@ -50,10 +49,6 @@ struct AIChatPanelView: View {
         }
         .onChange(of: connection.id) {
             viewModel.connection = connection
-        }
-        .task(id: tables) {
-            viewModel.tables = tables
-            viewModel.fetchSchemaContext()
         }
         .task(id: settingsManager.ai.providers.map(\.id)) {
             await viewModel.loadAvailableModels()
@@ -574,8 +569,7 @@ struct AIChatPanelView: View {
             }
         }
 
-        let liveTables = SchemaService.shared.tables(for: connectionId)
-        let matchingTables = liveTables
+        let matchingTables = viewModel.tables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
             .prefix(10)

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -261,7 +261,6 @@ struct MainContentView: View {
                 setupCommandActions()
                 updateToolbarPendingState()
                 updateInspectorContext()
-                rightPanelState.aiViewModel.schemaProvider = SchemaProviderRegistry.shared.getOrCreate(for: connection.id)
                 coordinator.aiViewModel = rightPanelState.aiViewModel
                 coordinator.rightPanelState = rightPanelState
 

--- a/TablePro/Views/RightSidebar/UnifiedRightPanelView.swift
+++ b/TablePro/Views/RightSidebar/UnifiedRightPanelView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct UnifiedRightPanelView: View {
     @Bindable var state: RightPanelState
     let connection: DatabaseConnection
-    let tables: [TableInfo]
 
     private var ctx: InspectorContext { state.inspectorContext }
 
@@ -49,7 +48,6 @@ struct UnifiedRightPanelView: View {
                 case .aiChat:
                     AIChatPanelView(
                         connection: connection,
-                        tables: tables,
                         currentQuery: ctx.currentQuery,
                         queryResults: ctx.queryResults,
                         viewModel: state.aiViewModel


### PR DESCRIPTION
## Summary

Eliminates the snapshot pipeline that fed schema state into `AIChatViewModel` and replaces it with live reads from `SchemaService.shared`. Fixes the root cause of every "I can't see the tables" / "(columns not loaded)" report we've been chasing.

Builds on #1063 (typed `@` popover) which fixed the symptoms at the popover and chip-resolve sites. This PR removes the workarounds that #1063 introduced by fixing the underlying staleness.

## Why this matters

`MainSplitViewController.rebuildPanes()` set `inspectorHosting.rootView` once at session-init and never re-rendered when `SchemaService` populated tables async after. The chat panel inherited a snapshot of `tables: []` for the rest of its life. Every consumer (popover candidates, button-menu submenu, chip resolver, schema attachment) read from that frozen snapshot. The button-menu tables submenu has had this bug since 3b.1 and just hasn't been noticed.

## Changes

**`AIChatViewModel`**

- `var tables: [TableInfo]` → computed property reading `SchemaService.shared.tables(for: connection?.id)`. Because both `SchemaService.states` and `viewModel.connection` are `@Observable` storage, SwiftUI tracks the dependency through the function call and re-renders consumers when schema reloads.
- New `ensureColumnsLoaded(forTable:)` and `ensureSchemaLoaded()` — async, idempotent, dedup concurrent calls via in-flight task tracking. Used by chip attach (eager) and `resolveTurnForWire` (await on send).
- `resolveTurnForWire` is now `async` and awaits any uncached column data before resolving. The AI gets real schema instead of `(columns not loaded)`.
- Dropped the `(columns not loaded)` fallback in `resolveTableAttachment` — if columns are still missing after the await, the chip drops out of the wire payload entirely. We don't lie to the AI.
- Removed `fetchSchemaContext`, `schemaFetchTask`, `schemaProvider`, `liveTables`, and `primeAttachmentData` (#1063 workarounds — superseded by the new model).
- `startStreaming` split into a sync setup phase + async data-priming phase + `runStream` for the actual detached stream task. Prevents the prior race where columns weren't loaded by the time `capturePromptContext` ran.

**Views**

- `AIChatPanelView`: dropped `let tables: [TableInfo]` prop. Removed the `.task(id: tables) { viewModel.tables = tables; viewModel.fetchSchemaContext() }` push. Mention candidates now read `viewModel.tables` directly (which is the live `SchemaService` source).
- `UnifiedRightPanelView`: dropped `let tables: [TableInfo]` prop and pass-through.
- `MainSplitViewController`: dropped `tables: currentSession.tables` argument.
- `MainContentView`: removed the now-unused `aiViewModel.schemaProvider = ...` external assignment.

## What this fixes

| Bug | Before | After |
|---|---|---|
| Typed `@` popover shows no tables | Empty list (snapshot stale) | Live tables every time |
| Button menu Tables submenu disabled on fresh open | Disabled (snapshot stale) | Enabled when schema loads |
| `@InvoiceLine` chip → AI says "I can't see your DB" | `(columns not loaded)` placeholder | Real columns after async fetch |
| Schema reload doesn't propagate to chat | Frozen on pre-reload data | Live re-render via `@Observable` tracking |

## CHANGELOG

No entry. The mention-attachment feature is itself in `[Unreleased]` (see line 14, "AI Chat: attach context to a message via the `@` menu..."), and the bugs being fixed are in unreleased work, so per CLAUDE.md a Fixed entry is wrong.

## Trade-off

For users who have `Settings > AI > Include schema` ON, schema fetch now happens at first send rather than at panel mount. Adds ~500ms one-time latency on the first message of each connection. Subsequent messages are fast (cached). Net: simpler model, no observable UX regression except the first-send blip.

## Test plan

- [ ] Open chat panel with a fresh connection. Type `@` immediately. Tables show in popover.
- [ ] Pick `@SomeTable`. Type "what columns does this have?" and send. AI responds with actual columns.
- [ ] Attach `@Schema` chip. Send. AI sees the full schema.
- [ ] Reload schema while chat is open. Type `@` again. Popover reflects new tables.
- [ ] Switch connections. Schema state resets cleanly.
- [ ] Existing button-menu `@` works with the same source.

## Base branch

Stacked on `feat/chat-typed-mention-popover` (#1063). Either merge in order, or rebase this onto main once #1063 lands.