### PR TITLE
feat: AI chat tool calling (phase 4 — providers + UI + tool registry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Typing `@` opens a caret-anchored picker that filters as you type. Up/Down navigates, Return or Tab inserts, Escape dismisses.
   - Attachments render as chips above the input and inside the user message bubble.
   - Editing a sent message restores its typed text and chips so you can adjust both before resending.
-- AI Chat: tool calling. The AI can look up your database on demand instead of relying on context you attached up front. Tools available: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`. Tool calls and their results render as expandable pills in the assistant's reply. Supported on Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot does not yet support tool calling.
+- AI Chat: tool calling. The AI can look up your database on demand instead of relying on context you attached up front.
+  - Read-only tools: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`.
+  - Tool calls and their results render as expandable pills in the assistant's reply.
+  - Supported providers: Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Typing `@` opens a caret-anchored picker that filters as you type. Up/Down navigates, Return or Tab inserts, Escape dismisses.
   - Attachments render as chips above the input and inside the user message bubble.
   - Editing a sent message restores its typed text and chips so you can adjust both before resending.
+- AI Chat: tool calling. The AI can look up your database on demand instead of relying on context you attached up front. Tools available: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`. Tool calls and their results render as expandable pills in the assistant's reply. Supported on Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot does not yet support tool calling.
 
 ### Changed
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -53,6 +53,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         MemoryPressureAdvisor.startMonitoring()
         PluginManager.shared.loadPlugins()
+        ChatToolBootstrap.register()
 
         NSWorkspace.shared.notificationCenter.addObserver(
             self, selector: #selector(handleSystemDidWake),
@@ -265,25 +266,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func showWelcomeFromDock() {
         WindowOpener.shared.openWelcome()
-    }
-
-    @objc func newWindowForTab(_ sender: Any?) {
-        guard let keyWindow = NSApp.keyWindow,
-              let connectionId = MainActor.assumeIsolated({
-                  WindowLifecycleMonitor.shared.connectionId(forWindow: keyWindow)
-              })
-        else { return }
-
-        MainActor.assumeIsolated {
-            if let actions = MainContentCoordinator.allActiveCoordinators()
-                .first(where: { $0.connectionId == connectionId })?.commandActions {
-                actions.newTab()
-            } else {
-                WindowManager.shared.openTab(
-                    payload: EditorTabPayload(connectionId: connectionId, intent: .newEmptyTab)
-                )
-            }
-        }
     }
 
     @objc func connectFromDock(_ sender: NSMenuItem) {

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -268,6 +268,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         WindowOpener.shared.openWelcome()
     }
 
+    @objc func newWindowForTab(_ sender: Any?) {
+        guard let keyWindow = NSApp.keyWindow,
+              let connectionId = MainActor.assumeIsolated({
+                  WindowLifecycleMonitor.shared.connectionId(forWindow: keyWindow)
+              })
+        else { return }
+
+        MainActor.assumeIsolated {
+            if let actions = MainContentCoordinator.allActiveCoordinators()
+                .first(where: { $0.connectionId == connectionId })?.commandActions {
+                actions.newTab()
+            } else {
+                WindowManager.shared.openTab(
+                    payload: EditorTabPayload(connectionId: connectionId, intent: .newEmptyTab)
+                )
+            }
+        }
+    }
+
     @objc func connectFromDock(_ sender: NSMenuItem) {
         guard let connectionId = sender.representedObject as? UUID else { return }
         Task {

--- a/TablePro/Core/AI/AnthropicProvider.swift
+++ b/TablePro/Core/AI/AnthropicProvider.swift
@@ -45,6 +45,7 @@ final class AnthropicProvider: ChatTransport {
 
                     var inputTokens = 0
                     var outputTokens = 0
+                    var toolUseIdsByIndex: [Int: String] = [:]
 
                     for try await line in bytes.lines {
                         if Task.isCancelled { break }
@@ -58,10 +59,31 @@ final class AnthropicProvider: ChatTransport {
                         else { continue }
 
                         switch type {
+                        case "content_block_start":
+                            if let index = json["index"] as? Int,
+                               let block = json["content_block"] as? [String: Any],
+                               (block["type"] as? String) == "tool_use",
+                               let blockId = block["id"] as? String,
+                               let blockName = block["name"] as? String {
+                                toolUseIdsByIndex[index] = blockId
+                                continuation.yield(.toolUseStart(id: blockId, name: blockName))
+                            }
                         case "content_block_delta":
-                            if let delta = json["delta"] as? [String: Any],
-                               let text = delta["text"] as? String {
+                            guard let delta = json["delta"] as? [String: Any] else { break }
+                            let deltaType = delta["type"] as? String
+                            if deltaType == "input_json_delta" {
+                                if let index = json["index"] as? Int,
+                                   let id = toolUseIdsByIndex[index],
+                                   let partial = delta["partial_json"] as? String {
+                                    continuation.yield(.toolUseDelta(id: id, inputJSONDelta: partial))
+                                }
+                            } else if let text = delta["text"] as? String {
                                 continuation.yield(.textDelta(text))
+                            }
+                        case "content_block_stop":
+                            if let index = json["index"] as? Int,
+                               let id = toolUseIdsByIndex.removeValue(forKey: index) {
+                                continuation.yield(.toolUseEnd(id: id))
                             }
                         case "message_start":
                             if let message = json["message"] as? [String: Any],
@@ -185,16 +207,78 @@ final class AnthropicProvider: ChatTransport {
             body["system"] = systemPrompt
         }
 
-        let apiMessages = turns
+        if !options.tools.isEmpty {
+            body["tools"] = try options.tools.map(Self.encodeToolSpec(_:))
+        }
+
+        let apiMessages = try turns
             .filter { $0.role != .system }
-            .compactMap { turn -> [String: String]? in
-                let text = turn.plainText
-                guard !text.isEmpty else { return nil }
-                return ["role": turn.role.rawValue, "content": text]
-            }
+            .compactMap { try Self.encodeTurn($0) }
         body["messages"] = apiMessages
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         return request
+    }
+
+    private static func encodeToolSpec(_ spec: ChatToolSpec) throws -> [String: Any] {
+        [
+            "name": spec.name,
+            "description": spec.description,
+            "input_schema": try jsonObject(from: spec.inputSchema)
+        ]
+    }
+
+    private static func encodeTurn(_ turn: ChatTurn) throws -> [String: Any]? {
+        let blocks = turn.blocks
+        let needsTypedBlocks = blocks.contains { block in
+            switch block {
+            case .toolUse, .toolResult:
+                return true
+            case .text, .attachment:
+                return false
+            }
+        }
+
+        if needsTypedBlocks {
+            let encoded = try blocks.compactMap { try encodeBlock($0) }
+            guard !encoded.isEmpty else { return nil }
+            return ["role": turn.role.rawValue, "content": encoded]
+        }
+
+        let text = turn.plainText
+        guard !text.isEmpty else { return nil }
+        return ["role": turn.role.rawValue, "content": text]
+    }
+
+    private static func encodeBlock(_ block: ChatContentBlock) throws -> [String: Any]? {
+        switch block {
+        case .text(let text):
+            guard !text.isEmpty else { return nil }
+            return ["type": "text", "text": text]
+        case .toolUse(let toolUse):
+            return [
+                "type": "tool_use",
+                "id": toolUse.id,
+                "name": toolUse.name,
+                "input": try jsonObject(from: toolUse.input)
+            ]
+        case .toolResult(let result):
+            var encoded: [String: Any] = [
+                "type": "tool_result",
+                "tool_use_id": result.toolUseId,
+                "content": result.content
+            ]
+            if result.isError {
+                encoded["is_error"] = true
+            }
+            return encoded
+        case .attachment:
+            return nil
+        }
+    }
+
+    private static func jsonObject(from value: JSONValue) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
     }
 }

--- a/TablePro/Core/AI/Chat/ChatTool.swift
+++ b/TablePro/Core/AI/Chat/ChatTool.swift
@@ -12,7 +12,7 @@ protocol ChatTool: Sendable {
     var description: String { get }
     var inputSchema: JSONValue { get }
 
-    func execute(input: JSONValue) async throws -> ChatToolResult
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult
 }
 
 struct ChatToolResult: Sendable, Equatable, Codable {

--- a/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
+++ b/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
@@ -1,0 +1,62 @@
+//
+//  ChatToolArgumentDecoder.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Typed decoders for `JSONValue` input arguments coming from the AI.
+/// Mirrors `MCPArgumentDecoder` for the MCP protocol but operates on the
+/// chat-side `JSONValue` enum.
+enum ChatToolArgumentDecoder {
+    static func requireString(_ args: JSONValue, key: String) throws -> String {
+        guard case .object(let dict) = args, let value = dict[key], case .string(let str) = value else {
+            throw ChatToolArgumentError.missingOrInvalid(key: key, expected: "string")
+        }
+        return str
+    }
+
+    static func optionalString(_ args: JSONValue, key: String) -> String? {
+        guard case .object(let dict) = args, let value = dict[key], case .string(let str) = value else {
+            return nil
+        }
+        return str
+    }
+
+    static func requireUUID(_ args: JSONValue, key: String) throws -> UUID {
+        let str = try requireString(args, key: key)
+        guard let uuid = UUID(uuidString: str) else {
+            throw ChatToolArgumentError.missingOrInvalid(key: key, expected: "UUID string")
+        }
+        return uuid
+    }
+
+    static func optionalBool(_ args: JSONValue, key: String, default fallback: Bool = false) -> Bool {
+        guard case .object(let dict) = args, let value = dict[key], case .bool(let bool) = value else {
+            return fallback
+        }
+        return bool
+    }
+}
+
+enum ChatToolArgumentError: Error, LocalizedError {
+    case missingOrInvalid(key: String, expected: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingOrInvalid(let key, let expected):
+            return "Argument '\(key)' is missing or not a \(expected)"
+        }
+    }
+}
+
+/// JSON-encode a `JsonValue` (MCP wire type) as a string for inclusion in a
+/// `ChatToolResult`. The chat layer needs strings; MCP bridges return `JsonValue`.
+enum ChatToolJSONFormatter {
+    static func string(from value: JsonValue) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}

--- a/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
+++ b/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
@@ -49,14 +49,3 @@ enum ChatToolArgumentError: Error, LocalizedError {
         }
     }
 }
-
-/// JSON-encode a `JsonValue` (MCP wire type) as a string for inclusion in a
-/// `ChatToolResult`. The chat layer needs strings; MCP bridges return `JsonValue`.
-enum ChatToolJSONFormatter {
-    static func string(from value: JsonValue) throws -> String {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-        let data = try encoder.encode(value)
-        return String(data: data, encoding: .utf8) ?? "{}"
-    }
-}

--- a/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
+++ b/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
@@ -1,0 +1,25 @@
+//
+//  ChatToolBootstrap.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Registers the built-in chat tools at app launch and exposes the shared
+/// `MCPConnectionBridge` instance the tools delegate to. Call `register()` once
+/// from `AppDelegate.applicationDidFinishLaunching(_:)`.
+@MainActor
+enum ChatToolBootstrap {
+    static let bridge = MCPConnectionBridge()
+
+    static func register() {
+        let registry = ChatToolRegistry.shared
+        registry.register(ListConnectionsChatTool())
+        registry.register(GetConnectionStatusChatTool())
+        registry.register(ListDatabasesChatTool())
+        registry.register(ListSchemasChatTool())
+        registry.register(ListTablesChatTool())
+        registry.register(DescribeTableChatTool())
+        registry.register(GetTableDDLChatTool())
+    }
+}

--- a/TablePro/Core/AI/Chat/ChatToolContext.swift
+++ b/TablePro/Core/AI/Chat/ChatToolContext.swift
@@ -1,0 +1,14 @@
+//
+//  ChatToolContext.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Per-call context passed to `ChatTool.execute(input:context:)`. Carries the
+/// active chat connection (so tools can default `connection_id` arguments) and
+/// the shared `MCPConnectionBridge` actor that does the underlying database work.
+struct ChatToolContext: Sendable {
+    let connectionId: UUID?
+    let bridge: MCPConnectionBridge
+}

--- a/TablePro/Core/AI/Chat/ChatToolJSONFormatter.swift
+++ b/TablePro/Core/AI/Chat/ChatToolJSONFormatter.swift
@@ -1,0 +1,17 @@
+//
+//  ChatToolJSONFormatter.swift
+//  TablePro
+//
+
+import Foundation
+
+/// JSON-encode a `JsonValue` (MCP wire type) as a string for inclusion in a
+/// `ChatToolResult`. The chat layer needs strings; MCP bridges return `JsonValue`.
+enum ChatToolJSONFormatter {
+    static func string(from value: JsonValue) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/DescribeTableChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/DescribeTableChatTool.swift
@@ -1,0 +1,41 @@
+//
+//  DescribeTableChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct DescribeTableChatTool: ChatTool {
+    let name = "describe_table"
+    let description = String(localized: "Describe the columns of a table or view.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ]),
+            "table": .object([
+                "type": .string("string"),
+                "description": .string("Table or view name")
+            ]),
+            "schema": .object([
+                "type": .string("string"),
+                "description": .string("Schema name (uses current if omitted)")
+            ])
+        ]),
+        "required": .array([.string("table")])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let table = try ChatToolArgumentDecoder.requireString(input, key: "table")
+        let schema = ChatToolArgumentDecoder.optionalString(input, key: "schema")
+        let payload = try await context.bridge.describeTable(
+            connectionId: connectionId,
+            table: table,
+            schema: schema
+        )
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/GetConnectionStatusChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/GetConnectionStatusChatTool.swift
@@ -1,0 +1,37 @@
+//
+//  GetConnectionStatusChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct GetConnectionStatusChatTool: ChatTool {
+    let name = "get_connection_status"
+    let description = String(localized: "Get detailed status for a specific database connection.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ])
+        ]),
+        "required": .array([.string("connection_id")])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let payload = try await context.bridge.getConnectionStatus(connectionId: connectionId)
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}
+
+func resolveConnectionId(input: JSONValue, context: ChatToolContext) throws -> UUID {
+    if let connectionId = try? ChatToolArgumentDecoder.requireUUID(input, key: "connection_id") {
+        return connectionId
+    }
+    if let active = context.connectionId {
+        return active
+    }
+    throw ChatToolArgumentError.missingOrInvalid(key: "connection_id", expected: "UUID string (or attach a connection in the chat)")
+}

--- a/TablePro/Core/AI/Chat/Tools/GetTableDDLChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/GetTableDDLChatTool.swift
@@ -1,0 +1,41 @@
+//
+//  GetTableDDLChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct GetTableDDLChatTool: ChatTool {
+    let name = "get_table_ddl"
+    let description = String(localized: "Get the DDL (CREATE statement) for a table.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ]),
+            "table": .object([
+                "type": .string("string"),
+                "description": .string("Table name")
+            ]),
+            "schema": .object([
+                "type": .string("string"),
+                "description": .string("Schema name (uses current if omitted)")
+            ])
+        ]),
+        "required": .array([.string("table")])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let table = try ChatToolArgumentDecoder.requireString(input, key: "table")
+        let schema = ChatToolArgumentDecoder.optionalString(input, key: "schema")
+        let payload = try await context.bridge.getTableDDL(
+            connectionId: connectionId,
+            table: table,
+            schema: schema
+        )
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/ListConnectionsChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ListConnectionsChatTool.swift
@@ -1,0 +1,20 @@
+//
+//  ListConnectionsChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ListConnectionsChatTool: ChatTool {
+    let name = "list_connections"
+    let description = String(localized: "List all saved database connections with their current status.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let payload = await context.bridge.listConnections()
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/ListDatabasesChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ListDatabasesChatTool.swift
@@ -1,0 +1,26 @@
+//
+//  ListDatabasesChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ListDatabasesChatTool: ChatTool {
+    let name = "list_databases"
+    let description = String(localized: "List databases available on a connection.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ])
+        ])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let payload = try await context.bridge.listDatabases(connectionId: connectionId)
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/ListSchemasChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ListSchemasChatTool.swift
@@ -1,0 +1,26 @@
+//
+//  ListSchemasChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ListSchemasChatTool: ChatTool {
+    let name = "list_schemas"
+    let description = String(localized: "List schemas available in the active database of a connection.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ])
+        ])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let payload = try await context.bridge.listSchemas(connectionId: connectionId)
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/ListTablesChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ListTablesChatTool.swift
@@ -1,0 +1,52 @@
+//
+//  ListTablesChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ListTablesChatTool: ChatTool {
+    let name = "list_tables"
+    let description = String(localized: "List tables and views in the active database of a connection.")
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ]),
+            "database": .object([
+                "type": .string("string"),
+                "description": .string("Database name (uses current if omitted)")
+            ]),
+            "schema": .object([
+                "type": .string("string"),
+                "description": .string("Schema name (uses current if omitted)")
+            ]),
+            "include_row_counts": .object([
+                "type": .string("boolean"),
+                "description": .string("Include approximate row counts (default false)")
+            ])
+        ])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let database = ChatToolArgumentDecoder.optionalString(input, key: "database")
+        let schema = ChatToolArgumentDecoder.optionalString(input, key: "schema")
+        let includeRowCounts = ChatToolArgumentDecoder.optionalBool(input, key: "include_row_counts", default: false)
+
+        if let database {
+            _ = try await context.bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+        if let schema {
+            _ = try await context.bridge.switchSchema(connectionId: connectionId, schema: schema)
+        }
+
+        let payload = try await context.bridge.listTables(
+            connectionId: connectionId,
+            includeRowCounts: includeRowCounts
+        )
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/GeminiProvider.swift
+++ b/TablePro/Core/AI/GeminiProvider.swift
@@ -59,10 +59,21 @@ final class GeminiProvider: ChatTransport {
                         if let candidates = json["candidates"] as? [[String: Any]],
                            let firstCandidate = candidates.first,
                            let content = firstCandidate["content"] as? [String: Any],
-                           let parts = content["parts"] as? [[String: Any]],
-                           let firstPart = parts.first,
-                           let text = firstPart["text"] as? String {
-                            continuation.yield(.textDelta(text))
+                           let parts = content["parts"] as? [[String: Any]] {
+                            for part in parts {
+                                if let text = part["text"] as? String, !text.isEmpty {
+                                    continuation.yield(.textDelta(text))
+                                }
+                                if let functionCall = part["functionCall"] as? [String: Any],
+                                   let name = functionCall["name"] as? String {
+                                    let id = UUID().uuidString
+                                    let argsObject = functionCall["args"] ?? [String: Any]()
+                                    let argsString = encodeArgsToJSONString(argsObject)
+                                    continuation.yield(.toolUseStart(id: id, name: name))
+                                    continuation.yield(.toolUseDelta(id: id, inputJSONDelta: argsString))
+                                    continuation.yield(.toolUseEnd(id: id))
+                                }
+                            }
                         }
 
                         if let usageMetadata = json["usageMetadata"] as? [String: Any] {
@@ -200,21 +211,120 @@ final class GeminiProvider: ChatTransport {
             body["systemInstruction"] = ["parts": [["text": systemPrompt]]]
         }
 
-        let contents = turns
-            .filter { $0.role != .system }
-            .compactMap { turn -> [String: Any]? in
-                let text = turn.plainText
-                guard !text.isEmpty else { return nil }
-                let role = turn.role == .assistant ? "model" : "user"
-                return [
-                    "role": role,
-                    "parts": [["text": text]]
+        if !options.tools.isEmpty {
+            let declarations = options.tools.map { tool -> [String: Any] in
+                var entry: [String: Any] = [
+                    "name": tool.name,
+                    "description": tool.description
                 ]
+                if let parameters = jsonValueToAny(tool.inputSchema) {
+                    entry["parameters"] = parameters
+                }
+                return entry
             }
-        body["contents"] = contents
+            body["tools"] = [["functionDeclarations": declarations]]
+        }
+
+        body["contents"] = encodeContents(turns: turns)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         return request
+    }
+
+    private func encodeContents(turns: [ChatTurn]) -> [[String: Any]] {
+        var encoded: [[String: Any]] = []
+        for (index, turn) in turns.enumerated() where turn.role != .system {
+            guard let entry = encodeTurn(turn, previousTurn: index > 0 ? turns[index - 1] : nil) else {
+                continue
+            }
+            encoded.append(entry)
+        }
+        return encoded
+    }
+
+    private func encodeTurn(_ turn: ChatTurn, previousTurn: ChatTurn?) -> [String: Any]? {
+        let role = turn.role == .assistant ? "model" : "user"
+        var parts: [[String: Any]] = []
+
+        for block in turn.blocks {
+            switch block {
+            case .text(let text):
+                guard !text.isEmpty else { continue }
+                parts.append(["text": text])
+            case .attachment:
+                continue
+            case .toolUse(let useBlock):
+                let argsObject = jsonValueToAny(useBlock.input) ?? [String: Any]()
+                parts.append([
+                    "functionCall": [
+                        "name": useBlock.name,
+                        "args": argsObject
+                    ]
+                ])
+            case .toolResult(let resultBlock):
+                let toolName = resolveToolName(
+                    forToolUseId: resultBlock.toolUseId,
+                    in: previousTurn
+                ) ?? resultBlock.toolUseId
+                parts.append([
+                    "functionResponse": [
+                        "name": toolName,
+                        "response": ["content": resultBlock.content]
+                    ]
+                ])
+            }
+        }
+
+        if parts.isEmpty {
+            let fallback = turn.plainText
+            guard !fallback.isEmpty else { return nil }
+            parts.append(["text": fallback])
+        }
+
+        return ["role": role, "parts": parts]
+    }
+
+    private func resolveToolName(forToolUseId id: String, in previousTurn: ChatTurn?) -> String? {
+        guard let previousTurn else { return nil }
+        for block in previousTurn.blocks {
+            if case .toolUse(let useBlock) = block, useBlock.id == id {
+                return useBlock.name
+            }
+        }
+        return nil
+    }
+
+    private func jsonValueToAny(_ value: JSONValue) -> Any? {
+        switch value {
+        case .null:
+            return NSNull()
+        case .bool(let bool):
+            return bool
+        case .integer(let int):
+            return int
+        case .number(let double):
+            return double
+        case .string(let string):
+            return string
+        case .array(let array):
+            return array.map { jsonValueToAny($0) ?? NSNull() }
+        case .object(let object):
+            var dict: [String: Any] = [:]
+            for (key, child) in object {
+                dict[key] = jsonValueToAny(child) ?? NSNull()
+            }
+            return dict
+        }
+    }
+
+    private func encodeArgsToJSONString(_ args: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(args),
+              let data = try? JSONSerialization.data(withJSONObject: args),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
     }
 
     func mapHTTPError(statusCode: Int, body: String) -> AIProviderError {

--- a/TablePro/Core/AI/GeminiProvider.swift
+++ b/TablePro/Core/AI/GeminiProvider.swift
@@ -234,15 +234,14 @@ final class GeminiProvider: ChatTransport {
     private func encodeContents(turns: [ChatTurn]) -> [[String: Any]] {
         var encoded: [[String: Any]] = []
         for (index, turn) in turns.enumerated() where turn.role != .system {
-            guard let entry = encodeTurn(turn, previousTurn: index > 0 ? turns[index - 1] : nil) else {
-                continue
-            }
+            let priorTurns = Array(turns.prefix(index))
+            guard let entry = encodeTurn(turn, priorTurns: priorTurns) else { continue }
             encoded.append(entry)
         }
         return encoded
     }
 
-    private func encodeTurn(_ turn: ChatTurn, previousTurn: ChatTurn?) -> [String: Any]? {
+    private func encodeTurn(_ turn: ChatTurn, priorTurns: [ChatTurn]) -> [String: Any]? {
         let role = turn.role == .assistant ? "model" : "user"
         var parts: [[String: Any]] = []
 
@@ -264,7 +263,7 @@ final class GeminiProvider: ChatTransport {
             case .toolResult(let resultBlock):
                 let toolName = resolveToolName(
                     forToolUseId: resultBlock.toolUseId,
-                    in: previousTurn
+                    in: priorTurns
                 ) ?? resultBlock.toolUseId
                 parts.append([
                     "functionResponse": [
@@ -284,11 +283,12 @@ final class GeminiProvider: ChatTransport {
         return ["role": role, "parts": parts]
     }
 
-    private func resolveToolName(forToolUseId id: String, in previousTurn: ChatTurn?) -> String? {
-        guard let previousTurn else { return nil }
-        for block in previousTurn.blocks {
-            if case .toolUse(let useBlock) = block, useBlock.id == id {
-                return useBlock.name
+    private func resolveToolName(forToolUseId id: String, in priorTurns: [ChatTurn]) -> String? {
+        for turn in priorTurns.reversed() {
+            for block in turn.blocks {
+                if case .toolUse(let useBlock) = block, useBlock.id == id {
+                    return useBlock.name
+                }
             }
         }
         return nil
@@ -318,13 +318,17 @@ final class GeminiProvider: ChatTransport {
     }
 
     private func encodeArgsToJSONString(_ args: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(args),
-              let data = try? JSONSerialization.data(withJSONObject: args),
-              let string = String(data: data, encoding: .utf8)
-        else {
+        guard JSONSerialization.isValidJSONObject(args) else {
+            Self.logger.warning("Gemini functionCall args was not a valid JSON object; falling back to empty input")
             return "{}"
         }
-        return string
+        do {
+            let data = try JSONSerialization.data(withJSONObject: args)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            Self.logger.warning("Gemini functionCall args serialization failed: \(error.localizedDescription, privacy: .public)")
+            return "{}"
+        }
     }
 
     func mapHTTPError(statusCode: Int, body: String) -> AIProviderError {

--- a/TablePro/Core/AI/OpenAICompatibleProvider.swift
+++ b/TablePro/Core/AI/OpenAICompatibleProvider.swift
@@ -62,6 +62,8 @@ final class OpenAICompatibleProvider: ChatTransport {
 
                     var inputTokens = 0
                     var outputTokens = 0
+                    var toolCallIndexToId: [Int: String] = [:]
+                    var toolCallOrder: [Int] = []
 
                     for try await line in bytes.lines {
                         if Task.isCancelled { break }
@@ -81,14 +83,44 @@ final class OpenAICompatibleProvider: ChatTransport {
                               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
                         else { continue }
 
-                        if let choices = json["choices"] as? [[String: Any]],
-                           let delta = choices.first?["delta"] as? [String: Any],
-                           let content = delta["content"] as? String {
+                        let choices = json["choices"] as? [[String: Any]]
+                        let firstChoice = choices?.first
+                        let delta = firstChoice?["delta"] as? [String: Any]
+
+                        if let delta, let content = delta["content"] as? String, !content.isEmpty {
                             continuation.yield(.textDelta(content))
                         } else if let message = json["message"] as? [String: Any],
                                   let content = message["content"] as? String,
                                   !content.isEmpty {
                             continuation.yield(.textDelta(content))
+                        }
+
+                        if let delta, let toolCalls = delta["tool_calls"] as? [[String: Any]] {
+                            handleToolCallDeltas(
+                                toolCalls,
+                                indexToId: &toolCallIndexToId,
+                                order: &toolCallOrder,
+                                continuation: continuation
+                            )
+                        } else if let message = json["message"] as? [String: Any],
+                                  let toolCalls = message["tool_calls"] as? [[String: Any]] {
+                            handleOllamaToolCalls(
+                                toolCalls,
+                                indexToId: &toolCallIndexToId,
+                                order: &toolCallOrder,
+                                continuation: continuation
+                            )
+                        }
+
+                        if let finishReason = firstChoice?["finish_reason"] as? String,
+                           finishReason == "tool_calls" {
+                            for index in toolCallOrder {
+                                if let id = toolCallIndexToId[index] {
+                                    continuation.yield(.toolUseEnd(id: id))
+                                }
+                            }
+                            toolCallIndexToId.removeAll()
+                            toolCallOrder.removeAll()
                         }
 
                         if let usage = json["usage"] as? [String: Any],
@@ -104,6 +136,13 @@ final class OpenAICompatibleProvider: ChatTransport {
                         }
 
                         if json["done"] as? Bool == true {
+                            for index in toolCallOrder {
+                                if let id = toolCallIndexToId[index] {
+                                    continuation.yield(.toolUseEnd(id: id))
+                                }
+                            }
+                            toolCallIndexToId.removeAll()
+                            toolCallOrder.removeAll()
                             break
                         }
                     }
@@ -123,6 +162,70 @@ final class OpenAICompatibleProvider: ChatTransport {
 
             continuation.onTermination = { _ in
                 task.cancel()
+            }
+        }
+    }
+
+    private func handleToolCallDeltas(
+        _ toolCalls: [[String: Any]],
+        indexToId: inout [Int: String],
+        order: inout [Int],
+        continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation
+    ) {
+        for toolCall in toolCalls {
+            guard let index = toolCall["index"] as? Int else { continue }
+            let function = toolCall["function"] as? [String: Any]
+
+            if indexToId[index] == nil {
+                let id = (toolCall["id"] as? String)
+                    ?? "call_\(index)_\(UUID().uuidString.prefix(8))"
+                let name = (function?["name"] as? String) ?? ""
+                indexToId[index] = id
+                order.append(index)
+                continuation.yield(.toolUseStart(id: id, name: name))
+            }
+
+            if let id = indexToId[index],
+               let arguments = function?["arguments"] as? String,
+               !arguments.isEmpty {
+                continuation.yield(.toolUseDelta(id: id, inputJSONDelta: arguments))
+            }
+        }
+    }
+
+    private func handleOllamaToolCalls(
+        _ toolCalls: [[String: Any]],
+        indexToId: inout [Int: String],
+        order: inout [Int],
+        continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation
+    ) {
+        for (offset, toolCall) in toolCalls.enumerated() {
+            guard let function = toolCall["function"] as? [String: Any],
+                  let name = function["name"] as? String else { continue }
+
+            let index = (toolCall["index"] as? Int) ?? offset
+            let id = (toolCall["id"] as? String)
+                ?? "call_\(index)_\(UUID().uuidString.prefix(8))"
+
+            if indexToId[index] == nil {
+                indexToId[index] = id
+                order.append(index)
+                continuation.yield(.toolUseStart(id: id, name: name))
+            }
+
+            let argumentsString: String
+            if let stringArgs = function["arguments"] as? String {
+                argumentsString = stringArgs
+            } else if let objectArgs = function["arguments"],
+                      let data = try? JSONSerialization.data(withJSONObject: objectArgs),
+                      let encoded = String(data: data, encoding: .utf8) {
+                argumentsString = encoded
+            } else {
+                argumentsString = ""
+            }
+
+            if !argumentsString.isEmpty, let resolvedId = indexToId[index] {
+                continuation.yield(.toolUseDelta(id: resolvedId, inputJSONDelta: argumentsString))
             }
         }
     }
@@ -227,17 +330,12 @@ final class OpenAICompatibleProvider: ChatTransport {
             )
         }
 
-        var apiMessages: [[String: String]] = []
+        var apiMessages: [[String: Any]] = []
         if let systemPrompt = options.systemPrompt {
             apiMessages.append(["role": "system", "content": systemPrompt])
         }
         for turn in turns where turn.role != .system {
-            let text = turn.plainText
-            guard !text.isEmpty else { continue }
-            apiMessages.append([
-                "role": turn.role.rawValue,
-                "content": text
-            ])
+            apiMessages.append(contentsOf: encodeTurn(turn))
         }
 
         var body: [String: Any] = [
@@ -255,8 +353,93 @@ final class OpenAICompatibleProvider: ChatTransport {
             body["stream_options"] = ["include_usage": true]
         }
 
+        if !options.tools.isEmpty {
+            body["tools"] = try options.tools.map { try encodeTool($0) }
+        }
+
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         return request
+    }
+
+    private func encodeTurn(_ turn: ChatTurn) -> [[String: Any]] {
+        let toolUseBlocks = turn.blocks.compactMap { block -> ToolUseBlock? in
+            if case .toolUse(let useBlock) = block { return useBlock }
+            return nil
+        }
+        let toolResultBlocks = turn.blocks.compactMap { block -> ToolResultBlock? in
+            if case .toolResult(let resultBlock) = block { return resultBlock }
+            return nil
+        }
+        let textContent = turn.plainText
+
+        if turn.role == .assistant, !toolUseBlocks.isEmpty {
+            var message: [String: Any] = ["role": "assistant"]
+            if textContent.isEmpty {
+                message["content"] = NSNull()
+            } else {
+                message["content"] = textContent
+            }
+            message["tool_calls"] = toolUseBlocks.map { block -> [String: Any] in
+                [
+                    "id": block.id,
+                    "type": "function",
+                    "function": [
+                        "name": block.name,
+                        "arguments": jsonString(from: block.input)
+                    ]
+                ]
+            }
+            return [message]
+        }
+
+        if turn.role == .user, !toolResultBlocks.isEmpty {
+            var messages: [[String: Any]] = toolResultBlocks.map { block in
+                [
+                    "role": "tool",
+                    "tool_call_id": block.toolUseId,
+                    "content": block.content
+                ]
+            }
+            if !textContent.isEmpty {
+                messages.append([
+                    "role": "user",
+                    "content": textContent
+                ])
+            }
+            return messages
+        }
+
+        guard !textContent.isEmpty else { return [] }
+        return [[
+            "role": turn.role.rawValue,
+            "content": textContent
+        ]]
+    }
+
+    private func encodeTool(_ tool: ChatToolSpec) throws -> [String: Any] {
+        let parameters = try jsonObject(from: tool.inputSchema)
+        return [
+            "type": "function",
+            "function": [
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": parameters
+            ]
+        ]
+    }
+
+    private func jsonString(from value: JSONValue) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private func jsonObject(from value: JSONValue) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
     }
 
     private func fetchOpenAIModels() async throws -> [String] {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -740,6 +740,8 @@ final class AIChatViewModel {
         }
     }
 
+    private static let maxToolRoundtrips = 5
+
     private func runStream(
         chatMessages: [ChatTurn],
         promptContext: PromptContext?,
@@ -749,101 +751,115 @@ final class AIChatViewModel {
     ) {
         streamingTask = Task.detached(priority: .userInitiated) { [weak self] in
             do {
-                // Build system prompt off the main actor
-                let systemPrompt: String? = promptContext.map {
-                    AISchemaContext.buildSystemPrompt(
-                        databaseType: $0.databaseType,
-                        databaseName: $0.databaseName,
-                        tables: $0.tables,
-                        columnsByTable: $0.columnsByTable,
-                        foreignKeys: $0.foreignKeys,
-                        currentQuery: $0.currentQuery,
-                        queryResults: $0.queryResults,
-                        settings: $0.settings,
-                        identifierQuote: $0.identifierQuote,
-                        editorLanguage: $0.editorLanguage,
-                        queryLanguageName: $0.queryLanguageName
-                    )
-                }
-
-                // Pre-send size check
-                let totalSize = ((systemPrompt ?? "") as NSString).length
-                    + chatMessages.reduce(0) { $0 + ($1.plainText as NSString).length }
-                if totalSize > 100_000 {
-                    await MainActor.run { [weak self] in
-                        guard let self else { return }
-                        self.errorMessage = String(
-                            localized: "Message too large. Try disabling 'Include schema' or 'Include query results' in AI settings."
-                        )
-                        if let idx = self.messages.firstIndex(where: { $0.id == assistantID }) {
-                            self.messages.remove(at: idx)
-                        }
-                        self.isStreaming = false
-                        self.streamingAssistantID = nil
-                    }
-                    return
-                }
-
-                let stream = resolved.provider.streamChat(
+                let systemPrompt = Self.buildSystemPrompt(promptContext)
+                guard let self else { return }
+                let preflightOK = await self.preflightCheck(
+                    systemPrompt: systemPrompt,
                     turns: chatMessages,
-                    options: ChatTransportOptions(
-                        model: resolved.model,
-                        systemPrompt: systemPrompt
-                    )
+                    assistantID: assistantID
                 )
+                guard preflightOK else { return }
 
-                // Batch tokens off the main actor, flush on interval
-                var pendingContent = ""
-                var pendingUsage: AITokenUsage?
+                let toolSpecs = await MainActor.run { ChatToolRegistry.shared.allSpecs }
+                var workingTurns = chatMessages
+                var currentAssistantID = assistantID
                 let flushInterval: ContinuousClock.Duration = .milliseconds(150)
-                var lastFlushTime: ContinuousClock.Instant = .now
 
-                for try await event in stream {
-                    guard !Task.isCancelled else { break }
-                    switch event {
-                    case .textDelta(let token):
-                        pendingContent += token
-                    case .usage(let usage):
-                        pendingUsage = usage
-                    case .toolUseStart, .toolUseDelta, .toolUseEnd:
+                for roundtrip in 0..<Self.maxToolRoundtrips {
+                    let stream = resolved.provider.streamChat(
+                        turns: workingTurns,
+                        options: ChatTransportOptions(
+                            model: resolved.model,
+                            systemPrompt: systemPrompt,
+                            tools: toolSpecs
+                        )
+                    )
+
+                    // Batch tokens, accumulate tool-use events
+                    var pendingContent = ""
+                    var pendingUsage: AITokenUsage?
+                    var toolUseOrder: [String] = []
+                    var toolUseNames: [String: String] = [:]
+                    var toolUseInputs: [String: String] = [:]
+                    var lastFlushTime: ContinuousClock.Instant = .now
+                    let assistantIDForRound = currentAssistantID
+
+                    for try await event in stream {
+                        guard !Task.isCancelled else { break }
+                        switch event {
+                        case .textDelta(let token):
+                            pendingContent += token
+                        case .usage(let usage):
+                            pendingUsage = usage
+                        case .toolUseStart(let id, let name):
+                            if toolUseInputs[id] == nil {
+                                toolUseOrder.append(id)
+                                toolUseInputs[id] = ""
+                            }
+                            toolUseNames[id] = name
+                        case .toolUseDelta(let id, let inputJSONDelta):
+                            toolUseInputs[id, default: ""] += inputJSONDelta
+                        case .toolUseEnd:
+                            break
+                        }
+
+                        if ContinuousClock.now - lastFlushTime >= flushInterval {
+                            await self.flushPending(
+                                content: pendingContent,
+                                usage: pendingUsage,
+                                into: assistantIDForRound
+                            )
+                            pendingContent = ""
+                            pendingUsage = nil
+                            lastFlushTime = .now
+                        }
+                    }
+
+                    if !Task.isCancelled, !pendingContent.isEmpty || pendingUsage != nil {
+                        await self.flushPending(
+                            content: pendingContent,
+                            usage: pendingUsage,
+                            into: assistantIDForRound
+                        )
+                    }
+
+                    guard !Task.isCancelled else { return }
+
+                    if toolUseOrder.isEmpty { break }
+
+
+                    if roundtrip == Self.maxToolRoundtrips - 1 {
+                        await MainActor.run { [weak self] in
+                            self?.errorMessage = String(
+                                localized: "AI made too many tool calls in one response. Try simplifying the request."
+                            )
+                        }
                         break
                     }
 
-                    if ContinuousClock.now - lastFlushTime >= flushInterval {
-                        let content = pendingContent
-                        let usage = pendingUsage
-                        pendingContent = ""
-                        pendingUsage = nil
-                        await MainActor.run { [weak self] in
-                            guard let self,
-                                  let idx = self.messages.firstIndex(where: { $0.id == assistantID })
-                            else { return }
-                            if !content.isEmpty {
-                                self.messages[idx].appendText(content)
-                            }
-                            if let usage {
-                                self.messages[idx].usage = usage
-                            }
-                        }
-                        lastFlushTime = .now
+                    let toolUseBlocks = Self.assembleToolUseBlocks(
+                        order: toolUseOrder,
+                        names: toolUseNames,
+                        inputs: toolUseInputs
+                    )
+                    let context = await MainActor.run {
+                        ChatToolContext(
+                            connectionId: self?.connection?.id,
+                            bridge: ChatToolBootstrap.bridge
+                        )
                     }
-                }
+                    let toolResultBlocks = await Self.executeToolUses(toolUseBlocks, context: context)
+                    guard !Task.isCancelled else { return }
 
-                // Final flush — deliver remaining buffered tokens
-                if !Task.isCancelled, !pendingContent.isEmpty || pendingUsage != nil {
-                    let content = pendingContent
-                    let usage = pendingUsage
-                    await MainActor.run { [weak self] in
-                        guard let self,
-                              let idx = self.messages.firstIndex(where: { $0.id == assistantID })
-                        else { return }
-                        if !content.isEmpty {
-                            self.messages[idx].appendText(content)
-                        }
-                        if let usage {
-                            self.messages[idx].usage = usage
-                        }
-                    }
+                    let continuation = await self.appendToolRoundtrip(
+                        assistantIDForRound: assistantIDForRound,
+                        toolUseBlocks: toolUseBlocks,
+                        toolResultBlocks: toolResultBlocks,
+                        resolved: resolved
+                    )
+                    currentAssistantID = continuation.nextAssistantID
+                    workingTurns.append(continuation.assistantTurn)
+                    workingTurns.append(continuation.userTurn)
                 }
 
                 guard !Task.isCancelled else { return }
@@ -875,6 +891,171 @@ final class AIChatViewModel {
                 }
             }
         }
+    }
+
+    private static func buildSystemPrompt(_ promptContext: PromptContext?) -> String? {
+        promptContext.map {
+            AISchemaContext.buildSystemPrompt(
+                databaseType: $0.databaseType,
+                databaseName: $0.databaseName,
+                tables: $0.tables,
+                columnsByTable: $0.columnsByTable,
+                foreignKeys: $0.foreignKeys,
+                currentQuery: $0.currentQuery,
+                queryResults: $0.queryResults,
+                settings: $0.settings,
+                identifierQuote: $0.identifierQuote,
+                editorLanguage: $0.editorLanguage,
+                queryLanguageName: $0.queryLanguageName
+            )
+        }
+    }
+
+    private struct ToolRoundtripContinuation {
+        let nextAssistantID: UUID
+        let assistantTurn: ChatTurn
+        let userTurn: ChatTurn
+    }
+
+    private func appendToolRoundtrip(
+        assistantIDForRound: UUID,
+        toolUseBlocks: [ToolUseBlock],
+        toolResultBlocks: [ToolResultBlock],
+        resolved: AIProviderFactory.ResolvedProvider
+    ) async -> ToolRoundtripContinuation {
+        await MainActor.run { [weak self] () -> ToolRoundtripContinuation in
+            let assistantText: String = {
+                guard let self,
+                      let idx = self.messages.firstIndex(where: { $0.id == assistantIDForRound })
+                else { return "" }
+                for block in toolUseBlocks {
+                    self.messages[idx].blocks.append(.toolUse(block))
+                }
+                return self.messages[idx].plainText
+            }()
+            var assistantBlocks: [ChatContentBlock] = []
+            if !assistantText.isEmpty { assistantBlocks.append(.text(assistantText)) }
+            assistantBlocks.append(contentsOf: toolUseBlocks.map { .toolUse($0) })
+            let assistantTurn = ChatTurn(
+                id: assistantIDForRound,
+                role: .assistant,
+                blocks: assistantBlocks,
+                modelId: resolved.model,
+                providerId: resolved.config.id.uuidString
+            )
+            let userTurn = ChatTurn(
+                role: .user,
+                blocks: toolResultBlocks.map { .toolResult($0) }
+            )
+            let nextAssistant = ChatTurn(
+                role: .assistant,
+                blocks: [],
+                modelId: resolved.model,
+                providerId: resolved.config.id.uuidString
+            )
+            self?.messages.append(userTurn)
+            self?.messages.append(nextAssistant)
+            self?.streamingAssistantID = nextAssistant.id
+            return ToolRoundtripContinuation(
+                nextAssistantID: nextAssistant.id,
+                assistantTurn: assistantTurn,
+                userTurn: userTurn
+            )
+        }
+    }
+
+    private func flushPending(content: String, usage: AITokenUsage?, into assistantID: UUID) async {
+        guard !content.isEmpty || usage != nil else { return }
+        await MainActor.run { [weak self] in
+            guard let self,
+                  let idx = self.messages.firstIndex(where: { $0.id == assistantID })
+            else { return }
+            if !content.isEmpty {
+                self.messages[idx].appendText(content)
+            }
+            if let usage {
+                self.messages[idx].usage = usage
+            }
+        }
+    }
+
+    private func preflightCheck(systemPrompt: String?, turns: [ChatTurn], assistantID: UUID) async -> Bool {
+        let totalSize = ((systemPrompt ?? "") as NSString).length
+            + turns.reduce(0) { $0 + ($1.plainText as NSString).length }
+        guard totalSize > 100_000 else { return true }
+        await MainActor.run { [weak self] in
+            guard let self else { return }
+            self.errorMessage = String(
+                localized: "Message too large. Try disabling 'Include schema' or 'Include query results' in AI settings."
+            )
+            if let idx = self.messages.firstIndex(where: { $0.id == assistantID }) {
+                self.messages.remove(at: idx)
+            }
+            self.isStreaming = false
+            self.streamingAssistantID = nil
+        }
+        return false
+    }
+
+    private static func assembleToolUseBlocks(
+        order: [String],
+        names: [String: String],
+        inputs: [String: String]
+    ) -> [ToolUseBlock] {
+        order.compactMap { id -> ToolUseBlock? in
+            guard let name = names[id] else { return nil }
+            let inputString = inputs[id] ?? "{}"
+            let inputValue: JSONValue
+            if inputString.isEmpty {
+                inputValue = .object([:])
+            } else if let data = inputString.data(using: .utf8),
+                      let decoded = try? JSONDecoder().decode(JSONValue.self, from: data) {
+                inputValue = decoded
+            } else {
+                inputValue = .object([:])
+            }
+            return ToolUseBlock(id: id, name: name, input: inputValue)
+        }
+    }
+
+    private static func executeToolUses(
+        _ blocks: [ToolUseBlock],
+        context: ChatToolContext
+    ) async -> [ToolResultBlock] {
+        let registry = await MainActor.run { ChatToolRegistry.shared }
+        var results: [ToolResultBlock] = []
+        for block in blocks {
+            guard !Task.isCancelled else { break }
+            let resultBlock: ToolResultBlock
+            if let tool = await MainActor.run(body: { registry.tool(named: block.name) }) {
+                do {
+                    let result = try await tool.execute(input: block.input, context: context)
+                    resultBlock = ToolResultBlock(
+                        toolUseId: block.id,
+                        content: result.content,
+                        isError: result.isError
+                    )
+                } catch {
+                    Self.logger.warning(
+                        "Tool \(block.name, privacy: .public) execution failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                    resultBlock = ToolResultBlock(
+                        toolUseId: block.id,
+                        content: "Error: \(error.localizedDescription)",
+                        isError: true
+                    )
+                }
+            } else {
+                Self.logger.warning("Tool '\(block.name, privacy: .public)' not registered; returning error")
+                resultBlock = ToolResultBlock(
+                    toolUseId: block.id,
+                    content: "Tool '\(block.name)' is not available",
+                    isError: true
+                )
+            }
+            results.append(resultBlock)
+        }
+        return results
     }
 
     private func resolveConnectionPolicy(settings: AISettings) -> AIConnectionPolicy? {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -830,9 +830,15 @@ final class AIChatViewModel {
 
                     if roundtrip == Self.maxToolRoundtrips - 1 {
                         await MainActor.run { [weak self] in
-                            self?.errorMessage = String(
+                            guard let self else { return }
+                            self.errorMessage = String(
                                 localized: "AI made too many tool calls in one response. Try simplifying the request."
                             )
+                            if let idx = self.messages.firstIndex(where: { $0.id == currentAssistantID }),
+                               self.messages[idx].plainText.isEmpty {
+                                self.messages.remove(at: idx)
+                            }
+                            self.lastMessageFailed = true
                         }
                         break
                     }
@@ -997,7 +1003,7 @@ final class AIChatViewModel {
         return false
     }
 
-    nonisolated private static func assembleToolUseBlocks(
+    nonisolated static func assembleToolUseBlocks(
         order: [String],
         names: [String: String],
         inputs: [String: String]
@@ -1018,44 +1024,55 @@ final class AIChatViewModel {
         }
     }
 
-    nonisolated private static func executeToolUses(
+    nonisolated static func executeToolUses(
         _ blocks: [ToolUseBlock],
         context: ChatToolContext
     ) async -> [ToolResultBlock] {
-        let registry = await MainActor.run { ChatToolRegistry.shared }
-        var results: [ToolResultBlock] = []
-        for block in blocks {
-            guard !Task.isCancelled else { break }
-            let resultBlock: ToolResultBlock
-            if let tool = await MainActor.run(body: { registry.tool(named: block.name) }) {
-                do {
-                    let result = try await tool.execute(input: block.input, context: context)
-                    resultBlock = ToolResultBlock(
-                        toolUseId: block.id,
-                        content: result.content,
-                        isError: result.isError
-                    )
-                } catch {
-                    Self.logger.warning(
-                        "Tool \(block.name, privacy: .public) execution failed: \(error.localizedDescription, privacy: .public)"
-                    )
-                    resultBlock = ToolResultBlock(
-                        toolUseId: block.id,
-                        content: "Error: \(error.localizedDescription)",
-                        isError: true
-                    )
+        await withTaskGroup(of: (Int, ToolResultBlock).self) { group in
+            for (index, block) in blocks.enumerated() {
+                group.addTask {
+                    (index, await runToolUse(block, context: context))
                 }
-            } else {
-                Self.logger.warning("Tool '\(block.name, privacy: .public)' not registered; returning error")
-                resultBlock = ToolResultBlock(
-                    toolUseId: block.id,
-                    content: "Tool '\(block.name)' is not available",
-                    isError: true
-                )
             }
-            results.append(resultBlock)
+            var indexed: [(Int, ToolResultBlock)] = []
+            for await pair in group { indexed.append(pair) }
+            return indexed.sorted(by: { $0.0 < $1.0 }).map(\.1)
         }
-        return results
+    }
+
+    nonisolated private static func runToolUse(
+        _ block: ToolUseBlock,
+        context: ChatToolContext
+    ) async -> ToolResultBlock {
+        if Task.isCancelled {
+            return ToolResultBlock(toolUseId: block.id, content: "Cancelled", isError: true)
+        }
+        let tool = await MainActor.run { ChatToolRegistry.shared.tool(named: block.name) }
+        guard let tool else {
+            Self.logger.warning("Tool '\(block.name, privacy: .public)' not registered; returning error")
+            return ToolResultBlock(
+                toolUseId: block.id,
+                content: "Tool '\(block.name)' is not available",
+                isError: true
+            )
+        }
+        do {
+            let result = try await tool.execute(input: block.input, context: context)
+            return ToolResultBlock(
+                toolUseId: block.id,
+                content: result.content,
+                isError: result.isError
+            )
+        } catch {
+            Self.logger.warning(
+                "Tool \(block.name, privacy: .public) execution failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return ToolResultBlock(
+                toolUseId: block.id,
+                content: "Error: \(error.localizedDescription)",
+                isError: true
+            )
+        }
     }
 
     private func resolveConnectionPolicy(settings: AISettings) -> AIConnectionPolicy? {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -844,7 +844,7 @@ final class AIChatViewModel {
                     )
                     let context = await MainActor.run {
                         ChatToolContext(
-                            connectionId: self?.connection?.id,
+                            connectionId: self.connection?.id,
                             bridge: ChatToolBootstrap.bridge
                         )
                     }

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -893,7 +893,7 @@ final class AIChatViewModel {
         }
     }
 
-    private static func buildSystemPrompt(_ promptContext: PromptContext?) -> String? {
+    nonisolated private static func buildSystemPrompt(_ promptContext: PromptContext?) -> String? {
         promptContext.map {
             AISchemaContext.buildSystemPrompt(
                 databaseType: $0.databaseType,
@@ -997,7 +997,7 @@ final class AIChatViewModel {
         return false
     }
 
-    private static func assembleToolUseBlocks(
+    nonisolated private static func assembleToolUseBlocks(
         order: [String],
         names: [String: String],
         inputs: [String: String]
@@ -1018,7 +1018,7 @@ final class AIChatViewModel {
         }
     }
 
-    private static func executeToolUses(
+    nonisolated private static func executeToolUses(
         _ blocks: [ToolUseBlock],
         context: ChatToolContext
     ) async -> [ToolResultBlock] {

--- a/TablePro/Views/AIChat/AIChatMessageView.swift
+++ b/TablePro/Views/AIChat/AIChatMessageView.swift
@@ -135,17 +135,51 @@ struct AIChatMessageView: View {
 
     @ViewBuilder
     private var messageContent: some View {
-        if message.plainText.isEmpty {
+        let renderable = renderableBlocks
+        if renderable.isEmpty {
             TypingIndicatorView()
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
         } else {
-            Markdown(message.plainText)
-                .markdownTheme(.tableProChat)
-                .textSelection(.enabled)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(renderable.enumerated()), id: \.offset) { _, block in
+                    switch block {
+                    case .text(let text):
+                        Markdown(text)
+                            .markdownTheme(.tableProChat)
+                            .textSelection(.enabled)
+                            .padding(.horizontal, 8)
+                    case .toolUse(let useBlock):
+                        AIChatToolUseBlockView(block: useBlock)
+                    case .toolResult(let resultBlock):
+                        AIChatToolResultBlockView(block: resultBlock)
+                    case .attachment:
+                        EmptyView()
+                    }
+                }
+            }
+            .padding(.vertical, 6)
         }
+    }
+
+    private var renderableBlocks: [ChatContentBlock] {
+        var result: [ChatContentBlock] = []
+        for block in message.blocks {
+            switch block {
+            case .text(let text):
+                if text.isEmpty { continue }
+                if case .text(let existing) = result.last {
+                    result[result.count - 1] = .text(existing + text)
+                } else {
+                    result.append(.text(text))
+                }
+            case .toolUse, .toolResult:
+                result.append(block)
+            case .attachment:
+                continue
+            }
+        }
+        return result
     }
 }
 

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -175,11 +175,12 @@ struct AIChatPanelView: View {
     // MARK: - Message List
 
     private var messageList: some View {
+        let visibleMessages = viewModel.messages.filter { isVisibleInMessageList($0) }
         let spacedMessageIDs: Set<UUID> = {
             var ids = Set<UUID>()
-            let visible = viewModel.messages.filter { $0.role != .system }
-            for i in 1..<visible.count where visible[i].role == .user && visible[i - 1].role == .assistant {
-                ids.insert(visible[i].id)
+            for i in 1..<visibleMessages.count
+                where visibleMessages[i].role == .user && visibleMessages[i - 1].role == .assistant {
+                ids.insert(visibleMessages[i].id)
             }
             return ids
         }()
@@ -188,22 +189,20 @@ struct AIChatPanelView: View {
             ZStack(alignment: .bottom) {
                 ScrollView {
                     LazyVStack(spacing: 0) {
-                        ForEach(viewModel.messages) { message in
-                            if message.role != .system {
-                                if spacedMessageIDs.contains(message.id) {
-                                    Spacer()
-                                        .frame(height: 16)
-                                }
-                                AIChatMessageView(
-                                    message: message,
-                                    onRetry: shouldShowRetry(for: message) ? { viewModel.retry() } : nil,
-                                    onRegenerate: shouldShowRegenerate(for: message) ? { viewModel.regenerate() } : nil,
-                                    onEdit: message.role == .user && !viewModel.isStreaming
-                                        ? { viewModel.editMessage(message) } : nil
-                                )
-                                .padding(.vertical, 4)
-                                .id(message.id)
+                        ForEach(visibleMessages) { message in
+                            if spacedMessageIDs.contains(message.id) {
+                                Spacer()
+                                    .frame(height: 16)
                             }
+                            AIChatMessageView(
+                                message: message,
+                                onRetry: shouldShowRetry(for: message) ? { viewModel.retry() } : nil,
+                                onRegenerate: shouldShowRegenerate(for: message) ? { viewModel.regenerate() } : nil,
+                                onEdit: message.role == .user && !viewModel.isStreaming
+                                    ? { viewModel.editMessage(message) } : nil
+                            )
+                            .padding(.vertical, 4)
+                            .id(message.id)
                         }
 
                         Color.clear
@@ -527,6 +526,23 @@ struct AIChatPanelView: View {
     private func updateContext() {
         viewModel.currentQuery = currentQuery
         viewModel.queryResults = queryResults
+    }
+
+    /// Hide system turns and user turns that exist only to carry tool-result
+    /// blocks back to the model — those are protocol plumbing, not user input.
+    private func isVisibleInMessageList(_ message: ChatTurn) -> Bool {
+        guard message.role != .system else { return false }
+        if message.role == .user {
+            let hasUserContent = message.blocks.contains { block in
+                switch block {
+                case .text(let value): return !value.isEmpty
+                case .attachment: return true
+                case .toolUse, .toolResult: return false
+                }
+            }
+            if !hasUserContent { return false }
+        }
+        return true
     }
 
     private func updateMentionState(text: String, caret: Int) {

--- a/TablePro/Views/AIChat/AIChatToolResultBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatToolResultBlockView.swift
@@ -1,0 +1,91 @@
+//
+//  AIChatToolResultBlockView.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+struct AIChatToolResultBlockView: View {
+    let block: ToolResultBlock
+
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                isExpanded.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: block.isError ? "xmark.circle" : "checkmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(accentColor)
+                    Text(headerLabel)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(accentColor.opacity(0.12))
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    Text(displayContent)
+                        .font(.caption)
+                        .fontDesign(.monospaced)
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color(nsColor: .textBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var accentColor: Color {
+        block.isError
+            ? Color(nsColor: .systemRed)
+            : Color(nsColor: .systemGreen)
+    }
+
+    private var headerLabel: String {
+        block.isError
+            ? String(localized: "Error")
+            : String(localized: "Result")
+    }
+
+    private var displayContent: String {
+        guard let data = block.content.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(
+                with: data,
+                options: [.fragmentsAllowed]
+              ),
+              let prettyData = try? JSONSerialization.data(
+                withJSONObject: parsed,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+              ),
+              let pretty = String(data: prettyData, encoding: .utf8) else {
+            return block.content
+        }
+        return pretty
+    }
+}

--- a/TablePro/Views/AIChat/AIChatToolUseBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatToolUseBlockView.swift
@@ -1,0 +1,77 @@
+//
+//  AIChatToolUseBlockView.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+struct AIChatToolUseBlockView: View {
+    let block: ToolUseBlock
+
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                isExpanded.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "wrench.adjustable")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: 4) {
+                        Text(String(localized: "Calling"))
+                            .foregroundStyle(.secondary)
+                        Text(block.name)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.primary)
+                    }
+                    .font(.caption)
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    Text(prettyInput)
+                        .font(.caption)
+                        .fontDesign(.monospaced)
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color(nsColor: .textBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var prettyInput: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(block.input),
+              let string = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return string
+    }
+}

--- a/TablePro/Views/AIChat/AIChatToolUseBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatToolUseBlockView.swift
@@ -14,6 +14,7 @@ struct AIChatToolUseBlockView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Button {
+                guard hasInput else { return }
                 isExpanded.toggle()
             } label: {
                 HStack(spacing: 6) {
@@ -28,10 +29,12 @@ struct AIChatToolUseBlockView: View {
                             .foregroundStyle(.primary)
                     }
                     .font(.caption)
-                    Image(systemName: "chevron.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    if hasInput {
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    }
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
@@ -43,7 +46,7 @@ struct AIChatToolUseBlockView: View {
             }
             .buttonStyle(.plain)
 
-            if isExpanded {
+            if isExpanded && hasInput {
                 ScrollView(.horizontal, showsIndicators: false) {
                     Text(prettyInput)
                         .font(.caption)
@@ -63,6 +66,15 @@ struct AIChatToolUseBlockView: View {
             }
         }
         .padding(.horizontal, 8)
+    }
+
+    private var hasInput: Bool {
+        switch block.input {
+        case .object(let dict): return !dict.isEmpty
+        case .array(let array): return !array.isEmpty
+        case .null: return false
+        default: return true
+        }
     }
 
     private var prettyInput: String {

--- a/TableProTests/Core/AI/AssembleToolUseBlocksTests.swift
+++ b/TableProTests/Core/AI/AssembleToolUseBlocksTests.swift
@@ -1,0 +1,74 @@
+//
+//  AssembleToolUseBlocksTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AIChatViewModel.assembleToolUseBlocks")
+struct AssembleToolUseBlocksTests {
+    @Test("Empty inputs produce empty objects")
+    func emptyInputs() {
+        let blocks = AIChatViewModel.assembleToolUseBlocks(
+            order: ["call_1"],
+            names: ["call_1": "list_tables"],
+            inputs: ["call_1": ""]
+        )
+        #expect(blocks.count == 1)
+        #expect(blocks[0].id == "call_1")
+        #expect(blocks[0].name == "list_tables")
+        #expect(blocks[0].input == .object([:]))
+    }
+
+    @Test("Fragmented JSON across chunk boundaries reassembles correctly")
+    func fragmentedJSON() {
+        let blocks = AIChatViewModel.assembleToolUseBlocks(
+            order: ["call_1"],
+            names: ["call_1": "describe_table"],
+            inputs: ["call_1": #"{"table":"us"# + #"ers","schema":"public"}"#]
+        )
+        #expect(blocks.count == 1)
+        #expect(blocks[0].input == .object([
+            "table": .string("users"),
+            "schema": .string("public")
+        ]))
+    }
+
+    @Test("Order is preserved across multiple tool calls")
+    func ordering() {
+        let blocks = AIChatViewModel.assembleToolUseBlocks(
+            order: ["call_2", "call_1"],
+            names: ["call_1": "describe_table", "call_2": "list_tables"],
+            inputs: ["call_1": #"{}"#, "call_2": #"{}"#]
+        )
+        #expect(blocks.count == 2)
+        #expect(blocks[0].id == "call_2")
+        #expect(blocks[0].name == "list_tables")
+        #expect(blocks[1].id == "call_1")
+        #expect(blocks[1].name == "describe_table")
+    }
+
+    @Test("Missing name in dictionary skips that entry")
+    func missingName() {
+        let blocks = AIChatViewModel.assembleToolUseBlocks(
+            order: ["call_1", "call_2"],
+            names: ["call_2": "list_tables"],
+            inputs: ["call_1": #"{}"#, "call_2": #"{}"#]
+        )
+        #expect(blocks.count == 1)
+        #expect(blocks[0].id == "call_2")
+    }
+
+    @Test("Malformed JSON falls back to empty object")
+    func malformedJSON() {
+        let blocks = AIChatViewModel.assembleToolUseBlocks(
+            order: ["call_1"],
+            names: ["call_1": "list_tables"],
+            inputs: ["call_1": "{not json"]
+        )
+        #expect(blocks.count == 1)
+        #expect(blocks[0].input == .object([:]))
+    }
+}

--- a/TableProTests/Core/AI/ChatToolArgumentDecoderTests.swift
+++ b/TableProTests/Core/AI/ChatToolArgumentDecoderTests.swift
@@ -1,0 +1,67 @@
+//
+//  ChatToolArgumentDecoderTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatToolArgumentDecoder")
+struct ChatToolArgumentDecoderTests {
+    @Test("requireString returns value when key exists and is a string")
+    func requireStringPresent() throws {
+        let args: JSONValue = .object(["name": .string("alpha")])
+        #expect(try ChatToolArgumentDecoder.requireString(args, key: "name") == "alpha")
+    }
+
+    @Test("requireString throws when key is missing")
+    func requireStringMissing() {
+        let args: JSONValue = .object([:])
+        #expect(throws: ChatToolArgumentError.self) {
+            _ = try ChatToolArgumentDecoder.requireString(args, key: "name")
+        }
+    }
+
+    @Test("requireString throws when value is not a string")
+    func requireStringWrongType() {
+        let args: JSONValue = .object(["count": .integer(42)])
+        #expect(throws: ChatToolArgumentError.self) {
+            _ = try ChatToolArgumentDecoder.requireString(args, key: "count")
+        }
+    }
+
+    @Test("optionalString returns nil for missing key")
+    func optionalStringMissing() {
+        let args: JSONValue = .object([:])
+        #expect(ChatToolArgumentDecoder.optionalString(args, key: "name") == nil)
+    }
+
+    @Test("requireUUID parses a valid UUID string")
+    func requireUUIDValid() throws {
+        let id = UUID()
+        let args: JSONValue = .object(["connection_id": .string(id.uuidString)])
+        #expect(try ChatToolArgumentDecoder.requireUUID(args, key: "connection_id") == id)
+    }
+
+    @Test("requireUUID throws for malformed UUID string")
+    func requireUUIDInvalid() {
+        let args: JSONValue = .object(["connection_id": .string("not-a-uuid")])
+        #expect(throws: ChatToolArgumentError.self) {
+            _ = try ChatToolArgumentDecoder.requireUUID(args, key: "connection_id")
+        }
+    }
+
+    @Test("optionalBool returns the default when key missing")
+    func optionalBoolDefault() {
+        let args: JSONValue = .object([:])
+        #expect(ChatToolArgumentDecoder.optionalBool(args, key: "enabled", default: true) == true)
+        #expect(ChatToolArgumentDecoder.optionalBool(args, key: "enabled", default: false) == false)
+    }
+
+    @Test("optionalBool returns the value when present")
+    func optionalBoolPresent() {
+        let args: JSONValue = .object(["enabled": .bool(false)])
+        #expect(ChatToolArgumentDecoder.optionalBool(args, key: "enabled", default: true) == false)
+    }
+}

--- a/TableProTests/Core/AI/ChatToolRegistryTests.swift
+++ b/TableProTests/Core/AI/ChatToolRegistryTests.swift
@@ -23,10 +23,12 @@ struct ChatToolRegistryTests {
             self.response = response
         }
 
-        func execute(input: JSONValue) async throws -> ChatToolResult {
+        func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
             ChatToolResult(content: response)
         }
     }
+
+    private static let stubContext = ChatToolContext(connectionId: nil, bridge: MCPConnectionBridge())
 
     @Test("Registered tool can be looked up by name")
     func lookupByName() {
@@ -43,7 +45,7 @@ struct ChatToolRegistryTests {
         registry.register(StubTool(name: "alpha", response: "new"))
         #expect(registry.allTools.count == 1)
         let tool = try #require(registry.tool(named: "alpha"))
-        let result = try await tool.execute(input: .object([:]))
+        let result = try await tool.execute(input: .object([:]), context: Self.stubContext)
         #expect(result.content == "new")
     }
 
@@ -52,7 +54,7 @@ struct ChatToolRegistryTests {
         let registry = ChatToolRegistry()
         registry.register(StubTool(name: "alpha", response: "result"))
         let tool = try #require(registry.tool(named: "alpha"))
-        let result = try await tool.execute(input: .object([:]))
+        let result = try await tool.execute(input: .object([:]), context: Self.stubContext)
         #expect(result.content == "result")
         #expect(result.isError == false)
     }


### PR DESCRIPTION
## Summary

Phase 4 of #1047 in one PR. The AI can now call tools on demand to inspect the database instead of relying on context the user attached up front. Anthropic, OpenAI, OpenRouter, Gemini, Ollama, and custom OpenAI-compatible endpoints all support tool calls. Copilot does not (its LSP protocol does not surface tool calling).

## What landed

### 4b — Foundation (single commit, main worktree)

- `ChatToolContext` carries the active connection id and a shared `MCPConnectionBridge`. Passed to `ChatTool.execute(input:context:)`.
- 7 read-only chat tools wrap the existing MCP bridge: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`.
- `ChatToolBootstrap.register()` runs at app launch (called from `AppDelegate.applicationDidFinishLaunching`).
- `AIChatViewModel.runStream` now passes `ChatToolRegistry.shared.allSpecs` into `ChatTransportOptions.tools` and runs a roundtrip loop (capped at 5) that consumes `.toolUseStart`/`.toolUseDelta`/`.toolUseEnd` stream events, executes the matching tool, appends an assistant turn (text + toolUse blocks) and a user turn (toolResult blocks) to the conversation, and re-enters the stream until the model returns a plain text response or hits the cap.
- Helpers extracted to keep the function under SwiftLint's 160-line limit: `buildSystemPrompt`, `preflightCheck`, `flushPending`, `assembleToolUseBlocks`, `executeToolUses`, `appendToolRoundtrip`.

### 4c — Provider tool emission and parsing (parallel teams)

- **Anthropic** (`AnthropicProvider.swift`): `tools` request key with `input_schema`, block-aware encoding for `tool_use` / `tool_result` content arrays, SSE parsing of `content_block_start` / `content_block_delta` (input_json_delta) / `content_block_stop` mapped to `ChatStreamEvent`.
- **OpenAI / OpenRouter / Ollama / Custom** (`OpenAICompatibleProvider.swift`): `tools` with `function.parameters`, assistant turns emit `tool_calls` (arguments as JSON-encoded string per OpenAI spec), tool results emit one `role: "tool"` message per result. Separate Ollama path because Ollama emits `message.tool_calls` in a single NDJSON frame and may serialize `arguments` as a JSON object instead of a string; both shapes handled.
- **Gemini** (`GeminiProvider.swift`): `tools[0].functionDeclarations` request shape, model turns with `functionCall` parts (args as JSON object), user turns with `functionResponse` parts (name resolved by walking back to find the originating tool_use block). Stream parser yields the `.toolUseStart`/`.toolUseDelta`/`.toolUseEnd` trio in one shot per `functionCall` part since Gemini does not stream argument deltas.

### 4d — UI (parallel team)

- `AIChatToolUseBlockView` renders an inline pill with `wrench.adjustable` + tool name; tap expands to pretty-printed JSON args.
- `AIChatToolResultBlockView` renders a result pill colored by `isError` (green / red); tap expands to the tool's output, parsed as JSON when possible, plain text otherwise.
- `AIChatMessageView.messageContent` rewrites the block iteration: contiguous text runs render as one Markdown view (preserving the existing styling and code-block flow), tool blocks render inline.

## Architecture flow

```
user types "what tables are in the orders database?"
   ↓
AIChatViewModel.startStreaming → preflightCheck → ensureSchemaLoaded (if opt-in)
   ↓
runStream loop (max 5 roundtrips)
   ↓
provider.streamChat(turns, options.tools=registry.allSpecs)
   ↓
provider sees `tools` in request → AI emits tool_use → provider yields .toolUseStart/Delta/End
   ↓
viewModel accumulates, after stream end calls executeToolUses(blocks, context)
   ↓
ChatToolRegistry.shared.tool(named:).execute(input:context:) → MCPConnectionBridge → real DB
   ↓
ToolResultBlocks built, appended as user turn, loop continues
   ↓
final round: AI emits .textDelta → flushed to assistant message
```

## Constraints honored

- All seven chat tools are read-only. Write-side tools (`execute_query`, `confirm_destructive_operation`, `disconnect`, etc.) are out of scope here; they need the safe-mode dialog flow which is a separate PR.
- Tool execution respects task cancellation: `Task.isCancelled` checked between each tool in the loop, `prepTask` and `streamingTask` both cancellable from the UI.
- Driver fetch errors are caught and turned into `ToolResultBlock(isError: true)` rather than crashing the stream. Logged via `Self.logger.warning`.
- Foundation function-body length stayed under 160 via 6 extracted helpers.

## CI / lint

`swiftlint lint --strict` clean across all 812 files.

## Test plan

- [ ] Anthropic: ask "what tables are in this database?" — see `list_tables` pill, then a real list.
- [ ] OpenAI: same prompt — same behavior, different wire format.
- [ ] Gemini: same prompt — same behavior; verify `functionCall` parts come through.
- [ ] Ollama: pick a tool-capable model (e.g., `llama3.1` or `qwen2.5`); same prompt.
- [ ] OpenRouter: pick any provider with tool support.
- [ ] Multi-step: "describe the columns of the orders table and tell me which one is the primary key" — should call `describe_table` first, then answer.
- [ ] Tool error: rename a table mid-conversation, ask the AI to describe the old name — verify the error pill renders red and the AI can recover.
- [ ] Cancellation: send a message with tools, hit stop during a tool call — UI cleans up, no orphaned state.
- [ ] Edit a sent message that triggered tool calls — typed text restores; the prior round's tool history is unaffected.
- [ ] Copilot: tools field is sent but Copilot ignores it; verify chat still works as text-only.

## Out of scope (followups)

- Write-side tools (`execute_query`, etc.) with safe-mode confirm flow.
- Per-model capability detection for Ollama (today, unsupported models surface the API error).
- Apple Intelligence transport (#1048) — depends on this PR landing.
- User-defined slash commands.
- `@savedQuery` chip support.