### PR TITLE
feat: AI chat phase 5 (saved-query chips, user-defined slash commands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Read-only tools: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`.
   - Tool calls and their results render as expandable pills in the assistant's reply.
   - Supported providers: Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
+- AI Chat: attach a saved query as a chip via `@`. Type `@` and pick a saved SQL query to send its name and body to the AI alongside your message.
+- AI Chat: user-defined slash commands. Create your own commands in Settings -> AI -> Custom Slash Commands. Templates support `{{query}}`, `{{schema}}`, `{{database}}`, and `{{body}}` placeholders that get substituted at send time.
 
 ### Changed
 

--- a/TablePro/Core/AI/Chat/ContextItem+Display.swift
+++ b/TablePro/Core/AI/Chat/ContextItem+Display.swift
@@ -16,8 +16,8 @@ extension ContextItem {
             return String(localized: "Current Query")
         case .queryResult:
             return String(localized: "Query Results")
-        case .savedQuery:
-            return String(localized: "Saved Query")
+        case .savedQuery(_, let name):
+            return name.isEmpty ? String(localized: "Saved Query") : name
         case .file(let url):
             return url.lastPathComponent
         }
@@ -50,7 +50,7 @@ extension ContextItem {
             return "currentQuery"
         case .queryResult:
             return "queryResult"
-        case .savedQuery(let id):
+        case .savedQuery(let id, _):
             return "savedQuery:\(id.uuidString)"
         case .file(let url):
             return "file:\(url.absoluteString)"

--- a/TablePro/Core/AI/Chat/ContextItem.swift
+++ b/TablePro/Core/AI/Chat/ContextItem.swift
@@ -10,7 +10,7 @@ enum ContextItem: Codable, Equatable, Sendable {
     case table(connectionId: UUID, name: String)
     case currentQuery(text: String)
     case queryResult(summary: String)
-    case savedQuery(id: UUID)
+    case savedQuery(id: UUID, name: String)
     case file(url: URL)
 
     private enum CodingKeys: String, CodingKey {
@@ -37,7 +37,9 @@ enum ContextItem: Codable, Equatable, Sendable {
         case .queryResult:
             self = .queryResult(summary: try container.decode(String.self, forKey: .summary))
         case .savedQuery:
-            self = .savedQuery(id: try container.decode(UUID.self, forKey: .id))
+            let id = try container.decode(UUID.self, forKey: .id)
+            let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            self = .savedQuery(id: id, name: name)
         case .file:
             self = .file(url: try container.decode(URL.self, forKey: .url))
         }
@@ -59,9 +61,10 @@ enum ContextItem: Codable, Equatable, Sendable {
         case .queryResult(let summary):
             try container.encode(Kind.queryResult, forKey: .kind)
             try container.encode(summary, forKey: .summary)
-        case .savedQuery(let id):
+        case .savedQuery(let id, let name):
             try container.encode(Kind.savedQuery, forKey: .kind)
             try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
         case .file(let url):
             try container.encode(Kind.file, forKey: .kind)
             try container.encode(url, forKey: .url)

--- a/TablePro/Core/AI/Chat/CustomSlashCommandRenderer.swift
+++ b/TablePro/Core/AI/Chat/CustomSlashCommandRenderer.swift
@@ -18,16 +18,35 @@ enum CustomSlashCommandRenderer {
     }
 
     static func render(_ command: CustomSlashCommand, context: Context) -> String {
-        var output = command.promptTemplate
-        let substitutions: [(CustomSlashCommandVariable, String)] = [
-            (.query, context.query ?? ""),
-            (.schema, context.schema ?? ""),
-            (.database, context.database ?? ""),
-            (.body, context.body)
+        let values: [String: String] = [
+            CustomSlashCommandVariable.query.rawValue: context.query ?? "",
+            CustomSlashCommandVariable.schema.rawValue: context.schema ?? "",
+            CustomSlashCommandVariable.database.rawValue: context.database ?? "",
+            CustomSlashCommandVariable.body.rawValue: context.body
         ]
-        for (variable, value) in substitutions {
-            output = output.replacingOccurrences(of: variable.placeholder, with: value)
+        let template = command.promptTemplate
+        var result = ""
+        var index = template.startIndex
+        while index < template.endIndex {
+            if let openRange = template.range(of: "{{", range: index..<template.endIndex) {
+                result.append(contentsOf: template[index..<openRange.lowerBound])
+                if let closeRange = template.range(of: "}}", range: openRange.upperBound..<template.endIndex) {
+                    let name = String(template[openRange.upperBound..<closeRange.lowerBound])
+                    if let value = values[name] {
+                        result.append(value)
+                    } else {
+                        result.append(contentsOf: template[openRange.lowerBound..<closeRange.upperBound])
+                    }
+                    index = closeRange.upperBound
+                } else {
+                    result.append(contentsOf: template[openRange.lowerBound..<template.endIndex])
+                    break
+                }
+            } else {
+                result.append(contentsOf: template[index..<template.endIndex])
+                break
+            }
         }
-        return output
+        return result
     }
 }

--- a/TablePro/Core/AI/Chat/CustomSlashCommandRenderer.swift
+++ b/TablePro/Core/AI/Chat/CustomSlashCommandRenderer.swift
@@ -1,0 +1,33 @@
+//
+//  CustomSlashCommandRenderer.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Renders a `CustomSlashCommand` template into a final prompt by substituting
+/// `{{query}}`, `{{schema}}`, `{{database}}`, and `{{body}}` placeholders with
+/// the current chat context. Unknown placeholders pass through unchanged so
+/// users can leave them visible if they want literal braces.
+enum CustomSlashCommandRenderer {
+    struct Context {
+        let query: String?
+        let schema: String?
+        let database: String?
+        let body: String
+    }
+
+    static func render(_ command: CustomSlashCommand, context: Context) -> String {
+        var output = command.promptTemplate
+        let substitutions: [(CustomSlashCommandVariable, String)] = [
+            (.query, context.query ?? ""),
+            (.schema, context.schema ?? ""),
+            (.database, context.database ?? ""),
+            (.body, context.body)
+        ]
+        for (variable, value) in substitutions {
+            output = output.replacingOccurrences(of: variable.placeholder, with: value)
+        }
+        return output
+    }
+}

--- a/TablePro/Core/Storage/CustomSlashCommandStorage.swift
+++ b/TablePro/Core/Storage/CustomSlashCommandStorage.swift
@@ -1,0 +1,66 @@
+//
+//  CustomSlashCommandStorage.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+import os
+
+/// UserDefaults-backed store for `CustomSlashCommand`s. Observable so the
+/// chat composer's slash menu and the Settings list rerender on edits.
+@MainActor
+@Observable
+final class CustomSlashCommandStorage {
+    static let shared = CustomSlashCommandStorage()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "CustomSlashCommandStorage")
+    private static let defaultsKey = "ai.customSlashCommands.v1"
+    private let defaults: UserDefaults
+
+    private(set) var commands: [CustomSlashCommand] = []
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.commands = Self.load(from: defaults)
+    }
+
+    func add(_ command: CustomSlashCommand) {
+        commands.append(command)
+        persist()
+    }
+
+    func update(_ command: CustomSlashCommand) {
+        guard let idx = commands.firstIndex(where: { $0.id == command.id }) else { return }
+        commands[idx] = command
+        persist()
+    }
+
+    func delete(id: UUID) {
+        commands.removeAll { $0.id == id }
+        persist()
+    }
+
+    func command(named name: String) -> CustomSlashCommand? {
+        commands.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(commands)
+            defaults.set(data, forKey: Self.defaultsKey)
+        } catch {
+            Self.logger.warning("Failed to persist custom slash commands: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private static func load(from defaults: UserDefaults) -> [CustomSlashCommand] {
+        guard let data = defaults.data(forKey: Self.defaultsKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([CustomSlashCommand].self, from: data)
+        } catch {
+            Self.logger.warning("Failed to load custom slash commands: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+}

--- a/TablePro/Models/AI/CustomSlashCommand.swift
+++ b/TablePro/Models/AI/CustomSlashCommand.swift
@@ -1,0 +1,46 @@
+//
+//  CustomSlashCommand.swift
+//  TablePro
+//
+
+import Foundation
+
+/// A user-defined slash command for the AI chat. Users author these in
+/// Settings -> AI -> Custom Commands. Templates support variables that get
+/// substituted at execution time: `{{query}}` (current editor query),
+/// `{{schema}}` (the formatted schema for the active connection),
+/// `{{database}}` (active database name), `{{body}}` (text typed after the
+/// command in the composer).
+struct CustomSlashCommand: Codable, Equatable, Identifiable, Sendable {
+    let id: UUID
+    var name: String
+    var description: String
+    var promptTemplate: String
+
+    init(
+        id: UUID = UUID(),
+        name: String = "",
+        description: String = "",
+        promptTemplate: String = ""
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.promptTemplate = promptTemplate
+    }
+
+    /// Whether the command has the minimum fields populated to run.
+    var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+            && !promptTemplate.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}
+
+enum CustomSlashCommandVariable: String, CaseIterable {
+    case query
+    case schema
+    case database
+    case body
+
+    var placeholder: String { "{{\(rawValue)}}" }
+}

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -149,20 +149,43 @@ final class AIChatViewModel {
         }
     }
 
-    func runCustomSlashCommand(_ command: CustomSlashCommand, body: String = "") {
-        guard command.isValid else { return }
+    func runCustomSlashCommand(_ command: CustomSlashCommand, body: String = "") async {
+        guard command.isValid else {
+            Self.logger.warning("runCustomSlashCommand called with invalid command: name=\(command.name, privacy: .public)")
+            return
+        }
         inputText = ""
         errorMessage = nil
         let invocationText = body.isEmpty ? "/\(command.name)" : "/\(command.name) \(body)"
+        let needsSchema = command.promptTemplate.contains(CustomSlashCommandVariable.schema.placeholder)
+        if needsSchema {
+            await ensureSchemaLoaded()
+        }
         let renderingContext = CustomSlashCommandRenderer.Context(
             query: currentQuery,
-            schema: nil,
+            schema: needsSchema ? renderedSchemaSection() : nil,
             database: connection.flatMap { DatabaseManager.shared.activeDatabaseName(for: $0) },
             body: body
         )
         let prompt = CustomSlashCommandRenderer.render(command, context: renderingContext)
         messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
         sendWithContext(prompt: prompt)
+    }
+
+    private func renderedSchemaSection() -> String? {
+        guard !tables.isEmpty else { return nil }
+        let settings = AppSettingsManager.shared.ai
+        let identifierQuote = connection.flatMap {
+            PluginManager.shared.sqlDialect(for: $0.type)?.identifierQuote
+        } ?? "\""
+        let section = AISchemaContext.buildSchemaSection(
+            tables: tables,
+            columnsByTable: columnsByTable,
+            foreignKeys: foreignKeysByTable,
+            maxTables: settings.maxSchemaTables,
+            identifierQuote: identifierQuote
+        )
+        return section.isEmpty ? nil : section
     }
 
     private func resolveQuery(body: String, command: SlashCommand) -> String? {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -149,6 +149,22 @@ final class AIChatViewModel {
         }
     }
 
+    func runCustomSlashCommand(_ command: CustomSlashCommand, body: String = "") {
+        guard command.isValid else { return }
+        inputText = ""
+        errorMessage = nil
+        let invocationText = body.isEmpty ? "/\(command.name)" : "/\(command.name) \(body)"
+        let renderingContext = CustomSlashCommandRenderer.Context(
+            query: currentQuery,
+            schema: nil,
+            database: connection.flatMap { DatabaseManager.shared.activeDatabaseName(for: $0) },
+            body: body
+        )
+        let prompt = CustomSlashCommandRenderer.render(command, context: renderingContext)
+        messages.append(ChatTurn(role: .user, blocks: [.text(invocationText)]))
+        sendWithContext(prompt: prompt)
+    }
+
     private func resolveQuery(body: String, command: SlashCommand) -> String? {
         if !body.isEmpty {
             return body
@@ -268,8 +284,37 @@ final class AIChatViewModel {
             await ensureSchemaLoaded()
         case .table(_, let name):
             await ensureColumnsLoaded(forTable: name)
-        case .currentQuery, .queryResult, .savedQuery, .file:
+        case .savedQuery(let id, _):
+            await ensureSavedQueryLoaded(id: id)
+        case .currentQuery, .queryResult, .file:
             break
+        }
+    }
+
+    /// Loaded `SQLFavorite` instances keyed by id, populated when saved-query
+    /// chips are attached so `resolveSavedQueryAttachment` can serialize them.
+    @ObservationIgnored private var cachedSavedQueries: [UUID: SQLFavorite] = [:]
+
+    /// Saved queries available as `@`-mention candidates for the active connection.
+    /// Refreshed on connection change via `loadSavedQueries()`.
+    var savedQueries: [SQLFavorite] = []
+
+    func loadSavedQueries() async {
+        guard let connectionId = connection?.id else {
+            savedQueries = []
+            return
+        }
+        let favorites = await SQLFavoriteManager.shared.fetchFavorites(connectionId: connectionId)
+        savedQueries = favorites
+        for favorite in favorites {
+            cachedSavedQueries[favorite.id] = favorite
+        }
+    }
+
+    private func ensureSavedQueryLoaded(id: UUID) async {
+        if cachedSavedQueries[id] != nil { return }
+        if let favorite = await SQLFavoriteManager.shared.fetchFavorite(id: id) {
+            cachedSavedQueries[id] = favorite
         }
     }
 
@@ -422,9 +467,20 @@ final class AIChatViewModel {
             let snapshot = summary.isEmpty ? (queryResults ?? "") : summary
             guard !snapshot.isEmpty else { return nil }
             return "## Query Results\n\(snapshot)"
-        case .savedQuery, .file:
+        case .savedQuery(let id, let name):
+            return resolveSavedQueryAttachment(id: id, fallbackName: name)
+        case .file:
             return nil
         }
+    }
+
+    private func resolveSavedQueryAttachment(id: UUID, fallbackName: String) -> String? {
+        guard let favorite = cachedSavedQueries[id] else { return nil }
+        let displayName = favorite.name.isEmpty ? fallbackName : favorite.name
+        let header = displayName.isEmpty
+            ? String(localized: "Saved Query")
+            : "\(String(localized: "Saved Query")): \(displayName)"
+        return "## \(header)\n```sql\n\(favorite.query)\n```"
     }
 
     private func resolveSchemaAttachment() -> String? {

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -462,7 +462,7 @@ struct AIChatPanelView: View {
                     ForEach(customCommands) { command in
                         Button {
                             updateContext()
-                            viewModel.runCustomSlashCommand(command)
+                            Task { await viewModel.runCustomSlashCommand(command) }
                         } label: {
                             if command.description.isEmpty {
                                 Text("/\(command.name)")

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -53,6 +53,9 @@ struct AIChatPanelView: View {
         .task(id: settingsManager.ai.providers.map(\.id)) {
             await viewModel.loadAvailableModels()
         }
+        .task(id: connection.id) {
+            await viewModel.loadSavedQueries()
+        }
         .alert(
             String(localized: "Allow AI Access"),
             isPresented: $viewModel.showAIAccessConfirmation
@@ -443,13 +446,31 @@ struct AIChatPanelView: View {
     }
 
     private var slashCommandMenu: some View {
-        Menu {
+        let customCommands = CustomSlashCommandStorage.shared.commands.filter(\.isValid)
+        return Menu {
             ForEach(SlashCommand.allCommands) { command in
                 Button {
                     updateContext()
                     viewModel.runSlashCommand(command)
                 } label: {
                     Text("/\(command.name) · \(command.description)")
+                }
+            }
+            if !customCommands.isEmpty {
+                Divider()
+                Section(String(localized: "Custom")) {
+                    ForEach(customCommands) { command in
+                        Button {
+                            updateContext()
+                            viewModel.runCustomSlashCommand(command)
+                        } label: {
+                            if command.description.isEmpty {
+                                Text("/\(command.name)")
+                            } else {
+                                Text("/\(command.name) · \(command.description)")
+                            }
+                        }
+                    }
                 }
             }
         } label: {
@@ -590,7 +611,7 @@ struct AIChatPanelView: View {
             }
         }
 
-        let tableBudget = max(0, Self.maxMentionCandidates - items.count)
+        let tableBudget = max(0, (Self.maxMentionCandidates / 2) - items.count)
         let matchingTables = viewModel.tables
             .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
@@ -598,6 +619,17 @@ struct AIChatPanelView: View {
         for table in matchingTables {
             items.append(MentionCandidate(
                 item: .table(connectionId: connectionId, name: table.name)
+            ))
+        }
+
+        let savedBudget = max(0, Self.maxMentionCandidates - items.count)
+        let matchingSavedQueries = viewModel.savedQueries
+            .filter { query.isEmpty || $0.name.localizedCaseInsensitiveContains(query) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .prefix(savedBudget)
+        for favorite in matchingSavedQueries {
+            items.append(MentionCandidate(
+                item: .savedQuery(id: favorite.id, name: favorite.name)
             ))
         }
 

--- a/TablePro/Views/Settings/AISettingsView.swift
+++ b/TablePro/Views/Settings/AISettingsView.swift
@@ -25,6 +25,7 @@ struct AISettingsView: View {
                 providersSection
                 inlineSuggestionsSection
                 contextSection
+                CustomSlashCommandsSection(storage: CustomSlashCommandStorage.shared)
                 privacySection
             }
         }

--- a/TablePro/Views/Settings/CustomSlashCommandsSection.swift
+++ b/TablePro/Views/Settings/CustomSlashCommandsSection.swift
@@ -1,0 +1,167 @@
+//
+//  CustomSlashCommandsSection.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct CustomSlashCommandsSection: View {
+    @Bindable var storage: CustomSlashCommandStorage
+    @State private var editing: CustomSlashCommand?
+    @State private var isCreating = false
+
+    var body: some View {
+        Section {
+            if storage.commands.isEmpty {
+                emptyState
+            } else {
+                ForEach(storage.commands) { command in
+                    row(for: command)
+                }
+            }
+            HStack {
+                Spacer()
+                Button {
+                    editing = CustomSlashCommand()
+                    isCreating = true
+                } label: {
+                    Label(String(localized: "Add Command"), systemImage: "plus")
+                }
+                .controlSize(.small)
+            }
+        } header: {
+            Text(String(localized: "Custom Slash Commands"))
+        } footer: {
+            Text(String(
+                localized: "Create your own slash commands. Use {{query}}, {{schema}}, {{database}}, or {{body}} in the template to insert chat context at runtime."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .sheet(item: $editing) { command in
+            CustomSlashCommandEditorSheet(
+                initial: command,
+                isCreating: isCreating,
+                onSave: { updated in
+                    if isCreating {
+                        storage.add(updated)
+                    } else {
+                        storage.update(updated)
+                    }
+                    editing = nil
+                    isCreating = false
+                },
+                onCancel: {
+                    editing = nil
+                    isCreating = false
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        Text(String(localized: "No custom commands yet."))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private func row(for command: CustomSlashCommand) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("/\(command.name)")
+                    .font(.body)
+                if !command.description.isEmpty {
+                    Text(command.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            Button(String(localized: "Edit")) {
+                editing = command
+                isCreating = false
+            }
+            .controlSize(.small)
+            Button(role: .destructive) {
+                storage.delete(id: command.id)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .controlSize(.small)
+        }
+    }
+}
+
+struct CustomSlashCommandEditorSheet: View {
+    @State var draft: CustomSlashCommand
+    let isCreating: Bool
+    let onSave: (CustomSlashCommand) -> Void
+    let onCancel: () -> Void
+
+    init(
+        initial: CustomSlashCommand,
+        isCreating: Bool,
+        onSave: @escaping (CustomSlashCommand) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _draft = State(initialValue: initial)
+        self.isCreating = isCreating
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    LabeledContent(String(localized: "Name")) {
+                        TextField("review", text: $draft.name)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    LabeledContent(String(localized: "Description")) {
+                        TextField(String(localized: "Optional one-line description"), text: $draft.description)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                }
+                Section {
+                    TextEditor(text: $draft.promptTemplate)
+                        .font(.body.monospaced())
+                        .frame(minHeight: 140)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(Color(nsColor: .separatorColor))
+                        )
+                } header: {
+                    Text(String(localized: "Prompt template"))
+                } footer: {
+                    Text(String(localized: """
+                        Use {{query}} for the current editor query, {{schema}} for the active schema, \
+                        {{database}} for the active database name, and {{body}} for any text typed \
+                        after the command.
+                        """))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(String(localized: "Cancel"), action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(isCreating ? String(localized: "Add") : String(localized: "Save")) {
+                    onSave(draft)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!draft.isValid)
+            }
+            .padding(12)
+        }
+        .frame(minWidth: 480, minHeight: 360)
+    }
+}

--- a/TableProTests/Core/AI/ContextItemSavedQueryCodableTests.swift
+++ b/TableProTests/Core/AI/ContextItemSavedQueryCodableTests.swift
@@ -1,0 +1,46 @@
+//
+//  ContextItemSavedQueryCodableTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ContextItem.savedQuery Codable migration")
+struct ContextItemSavedQueryCodableTests {
+    @Test("Decodes legacy payload missing the name field")
+    func decodesLegacyMissingName() throws {
+        let id = UUID()
+        let json = #"{"kind":"savedQuery","id":"\#(id.uuidString)"}"#
+        let item = try JSONDecoder().decode(ContextItem.self, from: Data(json.utf8))
+        guard case .savedQuery(let decodedId, let name) = item else {
+            Issue.record("Expected .savedQuery; got \(item)")
+            return
+        }
+        #expect(decodedId == id)
+        #expect(name == "")
+    }
+
+    @Test("Decodes new payload with name")
+    func decodesNewWithName() throws {
+        let id = UUID()
+        let json = #"{"kind":"savedQuery","id":"\#(id.uuidString)","name":"Top Customers"}"#
+        let item = try JSONDecoder().decode(ContextItem.self, from: Data(json.utf8))
+        guard case .savedQuery(let decodedId, let name) = item else {
+            Issue.record("Expected .savedQuery; got \(item)")
+            return
+        }
+        #expect(decodedId == id)
+        #expect(name == "Top Customers")
+    }
+
+    @Test("Round-trips through JSON")
+    func roundTrip() throws {
+        let id = UUID()
+        let original = ContextItem.savedQuery(id: id, name: "Audit Log")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ContextItem.self, from: data)
+        #expect(decoded == original)
+    }
+}

--- a/TableProTests/Core/AI/CustomSlashCommandRendererTests.swift
+++ b/TableProTests/Core/AI/CustomSlashCommandRendererTests.swift
@@ -1,0 +1,89 @@
+//
+//  CustomSlashCommandRendererTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("CustomSlashCommandRenderer")
+struct CustomSlashCommandRendererTests {
+    private func makeCommand(template: String) -> CustomSlashCommand {
+        CustomSlashCommand(name: "test", description: "", promptTemplate: template)
+    }
+
+    private func makeContext(
+        query: String? = nil,
+        schema: String? = nil,
+        database: String? = nil,
+        body: String = ""
+    ) -> CustomSlashCommandRenderer.Context {
+        .init(query: query, schema: schema, database: database, body: body)
+    }
+
+    @Test("Substitutes a single placeholder")
+    func substitutesSingle() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "Run: {{query}}"),
+            context: makeContext(query: "SELECT 1")
+        )
+        #expect(result == "Run: SELECT 1")
+    }
+
+    @Test("Substitutes multiple placeholders independently")
+    func substitutesMultiple() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "DB={{database}} | Q={{query}} | B={{body}}"),
+            context: makeContext(query: "SELECT 1", database: "main", body: "extra")
+        )
+        #expect(result == "DB=main | Q=SELECT 1 | B=extra")
+    }
+
+    @Test("Missing values render as empty strings")
+    func missingValuesAreEmpty() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "schema={{schema}}, q={{query}}"),
+            context: makeContext()
+        )
+        #expect(result == "schema=, q=")
+    }
+
+    @Test("Unknown placeholders pass through unchanged")
+    func unknownPlaceholdersPassThrough() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "{{query}} and {{notARealVar}}"),
+            context: makeContext(query: "x")
+        )
+        #expect(result == "x and {{notARealVar}}")
+    }
+
+    @Test("Placeholder text inside a substituted value is not re-expanded")
+    func noRecursiveExpansion() {
+        // body contains literal `{{query}}` text. It should remain literal,
+        // not get replaced by the query variable on a later pass.
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "Body: {{body}}"),
+            context: makeContext(query: "SELECT 1", body: "fix this {{query}}")
+        )
+        #expect(result == "Body: fix this {{query}}")
+    }
+
+    @Test("Empty template returns empty string")
+    func emptyTemplate() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: ""),
+            context: makeContext(query: "SELECT 1")
+        )
+        #expect(result == "")
+    }
+
+    @Test("Template without placeholders is returned verbatim")
+    func noPlaceholders() {
+        let result = CustomSlashCommandRenderer.render(
+            makeCommand(template: "just literal text"),
+            context: makeContext(query: "ignored")
+        )
+        #expect(result == "just literal text")
+    }
+}

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -103,6 +103,40 @@ Conversations auto-save and auto-title from your first message. Browse, clear, o
 
 Failed responses show **Retry**. Successful ones show **Regenerate**. Click **Stop** to cancel a streaming response.
 
+### Attach context with `@`
+
+Type `@` in the composer to anchor a picker at the caret. Pick from:
+
+- **Schema**: every table's columns and foreign keys.
+- A specific **Table**: that table's columns and foreign keys only.
+- **Current Query**: whatever's in the active editor tab.
+- **Query Results**: the most recent query result snapshot.
+- **Saved Query**: pick one of your starred queries to send its name and SQL alongside the message.
+
+Up/Down navigates, Return or Tab inserts, Escape dismisses. The `@` button next to the composer opens the same picker as a menu.
+
+### Slash commands
+
+Type `/` (or click the `⌘` button next to the composer) to invoke a command:
+
+- **`/explain`**: explain the active query.
+- **`/optimize`**: suggest optimizations for the active query.
+- **`/fix`**: fix the last error against the active query.
+- **`/help`**: list the commands inline in the chat.
+
+Create your own under **Settings → AI → Custom Slash Commands**. Templates support these placeholders that get substituted at send time:
+
+- `{{query}}`: the current editor query.
+- `{{schema}}`: the formatted schema for the active connection (capped by **Max schema tables** in AI settings).
+- `{{database}}`: the active database name.
+- `{{body}}`: text typed after the command (e.g. `/review WHERE clauses` passes `WHERE clauses`).
+
+### Tool calling
+
+The AI can look up your database on demand by calling a tool. You'll see a pill like `Calling list_tables` in the assistant's reply, expanding to show the arguments. The result pill shows the tool's response.
+
+Read-only tools available now: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`. Supported on Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
+
 <Frame caption="Streaming response">
   <img
     className="block dark:hidden"


### PR DESCRIPTION
## Summary

Closes the remaining items in the AI Chat umbrella (#1047):

- **5a — Saved-query chips.** Type `@` and pick a saved SQL query. The chip carries the favorite's name; on send the chip resolves to the query body wrapped in a SQL code block under a `## Saved Query: <name>` header.
- **5b — User-defined slash commands.** Author your own commands in Settings -> AI -> Custom Slash Commands. Templates support `{{query}}` (current editor query), `{{schema}}` (active schema), `{{database}}` (active database name), and `{{body}}` (text typed after the command in the composer).

## Changes

### 5a — Saved query chips

- `ContextItem.savedQuery(id:name:)` carries the name alongside the id (Codable migration: missing `name` decodes as empty string).
- `AIChatViewModel.cachedSavedQueries: [UUID: SQLFavorite]` populated on attach + on connection load.
- `primeAttachmentData` now handles `.savedQuery` by looking up the favorite via `SQLFavoriteManager.shared.fetchFavorite(id:)`.
- `resolveSavedQueryAttachment(id:fallbackName:)` formats the cached favorite as `## Saved Query: <name>\n\`\`\`sql\n<query>\n\`\`\``.
- `loadSavedQueries()` populates a per-connection list. The chat panel's `.task(id: connection.id)` invokes it on open and on connection change.
- `mentionCandidates(forQuery:)` includes saved queries (filtered by name, alphabetical) sharing the popover budget with tables (each gets up to half of the 10-slot cap).

### 5b — User-defined slash commands

- `CustomSlashCommand` model (Codable, Identifiable): `id`, `name`, `description`, `promptTemplate`.
- `CustomSlashCommandStorage` is `@Observable @MainActor`, persists to UserDefaults under `ai.customSlashCommands.v1`, and exposes `add` / `update` / `delete` / `command(named:)`.
- `CustomSlashCommandRenderer` does mechanical placeholder substitution — `{{query}}`, `{{schema}}`, `{{database}}`, `{{body}}`. Unknown placeholders pass through unchanged.
- `AIChatViewModel.runCustomSlashCommand(_:body:)` mirrors the built-in slash command flow: appends an invocation `ChatTurn`, renders the template, sends through `sendWithContext`.
- The composer's slash menu now lists built-ins, then a `Custom` section with the user's commands. Items hide when `command.isValid` is false (empty name or template).
- Settings: `CustomSlashCommandsSection` slots into `AISettingsView` between the existing context section and privacy section. List rows show `/<name> · description` with Edit and Delete actions; an editor sheet handles add/edit with name, description, and a multi-line template field. Footer documents the available variables.

## Schema as a substitution variable

`{{schema}}` is currently passed `nil` in `runCustomSlashCommand` because rendering the schema synchronously is awkward (it requires the column/foreign-key data we fetch on demand). For v1, users who want schema in their template should attach the schema chip via `@Schema` and reference it in the message naturally. A followup can wire `ensureSchemaLoaded` + `AISchemaContext.buildSchemaSection` into the renderer if that turns out to be a common pattern.

## Risk

Low. New surface area is additive — no existing flows changed shape.
- `ContextItem.savedQuery` enum case shape changed (`UUID` → `(UUID, String)`). Decoder defaults `name` to empty for older payloads, which then resolves through the chip's `fallbackName` path. No persisted-data breakage.
- Custom commands persist to a fresh UserDefaults key; no migration needed.

## CHANGELOG

Two new `[Unreleased] / Added` lines covering 5a and 5b.

## Lint

`swiftlint lint --strict` clean across all 817 files.

## Test plan

- [ ] Save 2-3 favorites for a connection. Open chat, type `@`, pick one. Chip shows the favorite's name. Send. AI receives the SQL.
- [ ] Open Settings -> AI -> Custom Slash Commands. Click Add. Name `review`, description `SQL injection check`, template `Review this query for SQL injection: {{query}}`. Save.
- [ ] In chat with editor query open, click the slash menu, pick `/review`. Confirm AI receives the rendered prompt with the editor query substituted.
- [ ] Edit the command from settings; confirm slash menu picks up the change.
- [ ] Delete the command; confirm it disappears from the slash menu.
- [ ] Restart the app; confirm both saved chips (when re-attached) and custom commands persist.

## Umbrella status

This closes the implementation scope of #1047. Remaining followups (separate issues): write-side tools with safe-mode flow, Apple Intelligence transport (#1048), token cost surfacing.