### PR TITLE
feat: write-side chat tools and provider wire-encoding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supported providers: Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
 - AI Chat: attach a saved query as a chip via `@`. Type `@` and pick a saved SQL query to send its name and body to the AI alongside your message.
 - AI Chat: user-defined slash commands. Create your own commands in Settings -> AI -> Custom Slash Commands. Templates support `{{query}}`, `{{schema}}`, `{{database}}`, and `{{body}}` placeholders that get substituted at send time.
+- AI Chat: tool calling can now run write queries (`execute_query`) and destructive DDL (`confirm_destructive_operation` after the AI passes the verbatim phrase). The connection's safe mode policy still gates execution, so the user remains the final approver.
 
 ### Changed
 

--- a/TablePro/Core/AI/AnthropicProvider.swift
+++ b/TablePro/Core/AI/AnthropicProvider.swift
@@ -220,7 +220,7 @@ final class AnthropicProvider: ChatTransport {
         return request
     }
 
-    private static func encodeToolSpec(_ spec: ChatToolSpec) throws -> [String: Any] {
+    static func encodeToolSpec(_ spec: ChatToolSpec) throws -> [String: Any] {
         [
             "name": spec.name,
             "description": spec.description,
@@ -228,7 +228,7 @@ final class AnthropicProvider: ChatTransport {
         ]
     }
 
-    private static func encodeTurn(_ turn: ChatTurn) throws -> [String: Any]? {
+    static func encodeTurn(_ turn: ChatTurn) throws -> [String: Any]? {
         let blocks = turn.blocks
         let needsTypedBlocks = blocks.contains { block in
             switch block {
@@ -250,7 +250,7 @@ final class AnthropicProvider: ChatTransport {
         return ["role": turn.role.rawValue, "content": text]
     }
 
-    private static func encodeBlock(_ block: ChatContentBlock) throws -> [String: Any]? {
+    static func encodeBlock(_ block: ChatContentBlock) throws -> [String: Any]? {
         switch block {
         case .text(let text):
             guard !text.isEmpty else { return nil }
@@ -277,7 +277,7 @@ final class AnthropicProvider: ChatTransport {
         }
     }
 
-    private static func jsonObject(from value: JSONValue) throws -> Any {
+    static func jsonObject(from value: JSONValue) throws -> Any {
         let data = try JSONEncoder().encode(value)
         return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
     }

--- a/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
+++ b/TablePro/Core/AI/Chat/ChatToolArgumentDecoder.swift
@@ -37,6 +37,24 @@ enum ChatToolArgumentDecoder {
         }
         return bool
     }
+
+    static func optionalInt(
+        _ args: JSONValue,
+        key: String,
+        default fallback: Int,
+        clamp: ClosedRange<Int>? = nil
+    ) -> Int? {
+        guard case .object(let dict) = args, let value = dict[key] else { return fallback }
+        let raw: Int?
+        switch value {
+        case .integer(let int): raw = Int(int)
+        case .number(let double): raw = Int(double)
+        default: raw = nil
+        }
+        guard let raw else { return fallback }
+        if let clamp { return max(clamp.lowerBound, min(raw, clamp.upperBound)) }
+        return raw
+    }
 }
 
 enum ChatToolArgumentError: Error, LocalizedError {

--- a/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
+++ b/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
@@ -21,5 +21,7 @@ enum ChatToolBootstrap {
         registry.register(ListTablesChatTool())
         registry.register(DescribeTableChatTool())
         registry.register(GetTableDDLChatTool())
+        registry.register(ExecuteQueryChatTool())
+        registry.register(ConfirmDestructiveOperationChatTool())
     }
 }

--- a/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
+++ b/TablePro/Core/AI/Chat/ChatToolBootstrap.swift
@@ -11,6 +11,7 @@ import Foundation
 @MainActor
 enum ChatToolBootstrap {
     static let bridge = MCPConnectionBridge()
+    static let authPolicy = MCPAuthPolicy()
 
     static func register() {
         let registry = ChatToolRegistry.shared

--- a/TablePro/Core/AI/Chat/ChatToolContext.swift
+++ b/TablePro/Core/AI/Chat/ChatToolContext.swift
@@ -6,9 +6,12 @@
 import Foundation
 
 /// Per-call context passed to `ChatTool.execute(input:context:)`. Carries the
-/// active chat connection (so tools can default `connection_id` arguments) and
-/// the shared `MCPConnectionBridge` actor that does the underlying database work.
+/// active chat connection (so tools can default `connection_id` arguments),
+/// the shared `MCPConnectionBridge` actor that does the underlying database
+/// work, and the `MCPAuthPolicy` that gates write/destructive queries through
+/// the connection's safe-mode dialog.
 struct ChatToolContext: Sendable {
     let connectionId: UUID?
     let bridge: MCPConnectionBridge
+    let authPolicy: MCPAuthPolicy
 }

--- a/TablePro/Core/AI/Chat/Tools/ConfirmDestructiveOperationChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ConfirmDestructiveOperationChatTool.swift
@@ -10,6 +10,10 @@ import Foundation
 /// safe-mode dialog still runs before the query executes, so the user remains
 /// the final gate even if the AI mis-uses this tool.
 struct ConfirmDestructiveOperationChatTool: ChatTool {
+    /// Intentionally NOT localized: this is a wire-level contract the AI must
+    /// reproduce verbatim in `confirmation_phrase`. Translating it would change
+    /// the contract per locale and break model prompts that depend on the
+    /// English string.
     static let requiredPhrase = "I understand this is irreversible"
 
     let name = "confirm_destructive_operation"
@@ -67,16 +71,19 @@ struct ConfirmDestructiveOperationChatTool: ChatTool {
             )
         }
 
-        let authPolicy = MCPAuthPolicy()
-        try await authPolicy.checkSafeModeDialog(
-            sql: query,
-            connectionId: connectionId,
-            databaseType: meta.databaseType,
-            safeModeLevel: meta.safeModeLevel
-        )
+        do {
+            try await context.authPolicy.checkSafeModeDialog(
+                sql: query,
+                connectionId: connectionId,
+                databaseType: meta.databaseType,
+                safeModeLevel: meta.safeModeLevel
+            )
+        } catch {
+            return ChatToolResult(content: "User declined to run this query.", isError: true)
+        }
 
         let mcpSettings = await MainActor.run { AppSettingsManager.shared.mcp }
-        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: authPolicy)
+        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: context.authPolicy)
         let payload = try await ToolQueryExecutor.executeAndLog(
             services: services,
             query: query,
@@ -84,7 +91,7 @@ struct ConfirmDestructiveOperationChatTool: ChatTool {
             databaseName: meta.databaseName,
             maxRows: 0,
             timeoutSeconds: mcpSettings.queryTimeoutSeconds,
-            principalLabel: "AI Chat"
+            principalLabel: String(localized: "AI Chat")
         )
         return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
     }

--- a/TablePro/Core/AI/Chat/Tools/ConfirmDestructiveOperationChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ConfirmDestructiveOperationChatTool.swift
@@ -1,0 +1,91 @@
+//
+//  ConfirmDestructiveOperationChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Execute a destructive DDL query (DROP, TRUNCATE, ALTER...DROP) after the AI
+/// includes the verbatim confirmation phrase in the arguments. The connection's
+/// safe-mode dialog still runs before the query executes, so the user remains
+/// the final gate even if the AI mis-uses this tool.
+struct ConfirmDestructiveOperationChatTool: ChatTool {
+    static let requiredPhrase = "I understand this is irreversible"
+
+    let name = "confirm_destructive_operation"
+    let description = String(localized: """
+        Execute a destructive DDL query (DROP, TRUNCATE, ALTER...DROP) after explicit confirmation.\
+         Pass confirmation_phrase exactly as: I understand this is irreversible
+        """)
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the active connection")
+            ]),
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("The destructive query to execute")
+            ]),
+            "confirmation_phrase": .object([
+                "type": .string("string"),
+                "description": .string("Must be exactly: I understand this is irreversible")
+            ])
+        ]),
+        "required": .array([
+            .string("connection_id"),
+            .string("query"),
+            .string("confirmation_phrase")
+        ])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let query = try ChatToolArgumentDecoder.requireString(input, key: "query")
+        let confirmationPhrase = try ChatToolArgumentDecoder.requireString(input, key: "confirmation_phrase")
+
+        guard confirmationPhrase == Self.requiredPhrase else {
+            return ChatToolResult(
+                content: "confirmation_phrase must be exactly: \(Self.requiredPhrase)",
+                isError: true
+            )
+        }
+        guard !QueryClassifier.isMultiStatement(query) else {
+            return ChatToolResult(
+                content: "Multi-statement queries are not supported. Send one statement at a time.",
+                isError: true
+            )
+        }
+
+        let meta = try await ToolConnectionMetadata.resolve(connectionId: connectionId)
+        let tier = QueryClassifier.classifyTier(query, databaseType: meta.databaseType)
+        guard tier == .destructive else {
+            return ChatToolResult(
+                content: "This tool only accepts destructive queries (DROP, TRUNCATE, ALTER...DROP). Use execute_query for other queries.",
+                isError: true
+            )
+        }
+
+        let authPolicy = MCPAuthPolicy()
+        try await authPolicy.checkSafeModeDialog(
+            sql: query,
+            connectionId: connectionId,
+            databaseType: meta.databaseType,
+            safeModeLevel: meta.safeModeLevel
+        )
+
+        let mcpSettings = await MainActor.run { AppSettingsManager.shared.mcp }
+        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: authPolicy)
+        let payload = try await ToolQueryExecutor.executeAndLog(
+            services: services,
+            query: query,
+            connectionId: connectionId,
+            databaseName: meta.databaseName,
+            maxRows: 0,
+            timeoutSeconds: mcpSettings.queryTimeoutSeconds,
+            principalLabel: "AI Chat"
+        )
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/Chat/Tools/ExecuteQueryChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ExecuteQueryChatTool.swift
@@ -78,13 +78,10 @@ struct ExecuteQueryChatTool: ChatTool {
         ) ?? mcpSettings.queryTimeoutSeconds
 
         let meta = try await ToolConnectionMetadata.resolve(connectionId: connectionId)
-        if let database {
-            _ = try await context.bridge.switchDatabase(connectionId: connectionId, database: database)
-        }
-        if let schema {
-            _ = try await context.bridge.switchSchema(connectionId: connectionId, schema: schema)
-        }
 
+        // Classify BEFORE mutating session state. A destructive query asked for
+        // a database/schema switch should not leave the user on the new context
+        // when we then refuse to run it.
         let tier = QueryClassifier.classifyTier(query, databaseType: meta.databaseType)
         if tier == .destructive {
             return ChatToolResult(
@@ -93,15 +90,25 @@ struct ExecuteQueryChatTool: ChatTool {
             )
         }
 
-        let authPolicy = MCPAuthPolicy()
-        try await authPolicy.checkSafeModeDialog(
-            sql: query,
-            connectionId: connectionId,
-            databaseType: meta.databaseType,
-            safeModeLevel: meta.safeModeLevel
-        )
+        if let database {
+            _ = try await context.bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+        if let schema {
+            _ = try await context.bridge.switchSchema(connectionId: connectionId, schema: schema)
+        }
 
-        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: authPolicy)
+        do {
+            try await context.authPolicy.checkSafeModeDialog(
+                sql: query,
+                connectionId: connectionId,
+                databaseType: meta.databaseType,
+                safeModeLevel: meta.safeModeLevel
+            )
+        } catch {
+            return ChatToolResult(content: "User declined to run this query.", isError: true)
+        }
+
+        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: context.authPolicy)
         let payload = try await ToolQueryExecutor.executeAndLog(
             services: services,
             query: query,
@@ -109,7 +116,7 @@ struct ExecuteQueryChatTool: ChatTool {
             databaseName: meta.databaseName,
             maxRows: maxRows,
             timeoutSeconds: timeoutSeconds,
-            principalLabel: "AI Chat"
+            principalLabel: String(localized: "AI Chat")
         )
         return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
     }

--- a/TablePro/Core/AI/Chat/Tools/ExecuteQueryChatTool.swift
+++ b/TablePro/Core/AI/Chat/Tools/ExecuteQueryChatTool.swift
@@ -1,0 +1,116 @@
+//
+//  ExecuteQueryChatTool.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Run a SQL query against the active connection. Destructive statements
+/// (DROP, TRUNCATE, ALTER...DROP) are rejected here; the AI must use the
+/// `confirm_destructive_operation` tool with the explicit confirmation phrase.
+/// Write queries trigger the connection's safe-mode dialog flow.
+struct ExecuteQueryChatTool: ChatTool {
+    let name = "execute_query"
+    let description = String(localized: """
+        Execute a SQL query against a connection. The connection's safe mode policy applies.\
+         Multi-statement queries are rejected. Destructive operations (DROP, TRUNCATE, ALTER...DROP)\
+         are blocked here; use confirm_destructive_operation instead.
+        """)
+    let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "connection_id": .object([
+                "type": .string("string"),
+                "description": .string("UUID of the connection")
+            ]),
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("SQL or NoSQL query text")
+            ]),
+            "max_rows": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum rows to return (default 500, max 10000)")
+            ]),
+            "timeout_seconds": .object([
+                "type": .string("integer"),
+                "description": .string("Query timeout in seconds (default 30, max 300)")
+            ]),
+            "database": .object([
+                "type": .string("string"),
+                "description": .string("Switch to this database before executing")
+            ]),
+            "schema": .object([
+                "type": .string("string"),
+                "description": .string("Switch to this schema before executing")
+            ])
+        ]),
+        "required": .array([.string("connection_id"), .string("query")])
+    ])
+
+    func execute(input: JSONValue, context: ChatToolContext) async throws -> ChatToolResult {
+        let connectionId = try resolveConnectionId(input: input, context: context)
+        let query = try ChatToolArgumentDecoder.requireString(input, key: "query")
+        let database = ChatToolArgumentDecoder.optionalString(input, key: "database")
+        let schema = ChatToolArgumentDecoder.optionalString(input, key: "schema")
+
+        guard (query as NSString).length <= 102_400 else {
+            return ChatToolResult(content: "Query exceeds 100KB limit", isError: true)
+        }
+        guard !QueryClassifier.isMultiStatement(query) else {
+            return ChatToolResult(
+                content: "Multi-statement queries are not supported. Send one statement at a time.",
+                isError: true
+            )
+        }
+
+        let mcpSettings = await MainActor.run { AppSettingsManager.shared.mcp }
+        let maxRows = ChatToolArgumentDecoder.optionalInt(
+            input,
+            key: "max_rows",
+            default: mcpSettings.defaultRowLimit,
+            clamp: 1...mcpSettings.maxRowLimit
+        ) ?? mcpSettings.defaultRowLimit
+        let timeoutSeconds = ChatToolArgumentDecoder.optionalInt(
+            input,
+            key: "timeout_seconds",
+            default: mcpSettings.queryTimeoutSeconds,
+            clamp: 1...300
+        ) ?? mcpSettings.queryTimeoutSeconds
+
+        let meta = try await ToolConnectionMetadata.resolve(connectionId: connectionId)
+        if let database {
+            _ = try await context.bridge.switchDatabase(connectionId: connectionId, database: database)
+        }
+        if let schema {
+            _ = try await context.bridge.switchSchema(connectionId: connectionId, schema: schema)
+        }
+
+        let tier = QueryClassifier.classifyTier(query, databaseType: meta.databaseType)
+        if tier == .destructive {
+            return ChatToolResult(
+                content: "Destructive queries (DROP, TRUNCATE, ALTER...DROP) are blocked here. Use confirm_destructive_operation with the explicit confirmation phrase.",
+                isError: true
+            )
+        }
+
+        let authPolicy = MCPAuthPolicy()
+        try await authPolicy.checkSafeModeDialog(
+            sql: query,
+            connectionId: connectionId,
+            databaseType: meta.databaseType,
+            safeModeLevel: meta.safeModeLevel
+        )
+
+        let services = MCPToolServices(connectionBridge: context.bridge, authPolicy: authPolicy)
+        let payload = try await ToolQueryExecutor.executeAndLog(
+            services: services,
+            query: query,
+            connectionId: connectionId,
+            databaseName: meta.databaseName,
+            maxRows: maxRows,
+            timeoutSeconds: timeoutSeconds,
+            principalLabel: "AI Chat"
+        )
+        return ChatToolResult(content: try ChatToolJSONFormatter.string(from: payload))
+    }
+}

--- a/TablePro/Core/AI/GeminiProvider.swift
+++ b/TablePro/Core/AI/GeminiProvider.swift
@@ -231,7 +231,7 @@ final class GeminiProvider: ChatTransport {
         return request
     }
 
-    private func encodeContents(turns: [ChatTurn]) -> [[String: Any]] {
+    func encodeContents(turns: [ChatTurn]) -> [[String: Any]] {
         var encoded: [[String: Any]] = []
         for (index, turn) in turns.enumerated() where turn.role != .system {
             let priorTurns = Array(turns.prefix(index))
@@ -241,7 +241,7 @@ final class GeminiProvider: ChatTransport {
         return encoded
     }
 
-    private func encodeTurn(_ turn: ChatTurn, priorTurns: [ChatTurn]) -> [String: Any]? {
+    func encodeTurn(_ turn: ChatTurn, priorTurns: [ChatTurn]) -> [String: Any]? {
         let role = turn.role == .assistant ? "model" : "user"
         var parts: [[String: Any]] = []
 
@@ -283,7 +283,7 @@ final class GeminiProvider: ChatTransport {
         return ["role": role, "parts": parts]
     }
 
-    private func resolveToolName(forToolUseId id: String, in priorTurns: [ChatTurn]) -> String? {
+    func resolveToolName(forToolUseId id: String, in priorTurns: [ChatTurn]) -> String? {
         for turn in priorTurns.reversed() {
             for block in turn.blocks {
                 if case .toolUse(let useBlock) = block, useBlock.id == id {
@@ -294,7 +294,7 @@ final class GeminiProvider: ChatTransport {
         return nil
     }
 
-    private func jsonValueToAny(_ value: JSONValue) -> Any? {
+    func jsonValueToAny(_ value: JSONValue) -> Any? {
         switch value {
         case .null:
             return NSNull()

--- a/TablePro/Core/AI/OpenAICompatibleProvider.swift
+++ b/TablePro/Core/AI/OpenAICompatibleProvider.swift
@@ -361,7 +361,7 @@ final class OpenAICompatibleProvider: ChatTransport {
         return request
     }
 
-    private func encodeTurn(_ turn: ChatTurn) -> [[String: Any]] {
+    func encodeTurn(_ turn: ChatTurn) -> [[String: Any]] {
         let toolUseBlocks = turn.blocks.compactMap { block -> ToolUseBlock? in
             if case .toolUse(let useBlock) = block { return useBlock }
             return nil
@@ -416,7 +416,7 @@ final class OpenAICompatibleProvider: ChatTransport {
         ]]
     }
 
-    private func encodeTool(_ tool: ChatToolSpec) throws -> [String: Any] {
+    func encodeTool(_ tool: ChatToolSpec) throws -> [String: Any] {
         let parameters = try jsonObject(from: tool.inputSchema)
         return [
             "type": "function",
@@ -428,7 +428,7 @@ final class OpenAICompatibleProvider: ChatTransport {
         ]
     }
 
-    private func jsonString(from value: JSONValue) -> String {
+    func jsonString(from value: JSONValue) -> String {
         guard let data = try? JSONEncoder().encode(value),
               let string = String(data: data, encoding: .utf8)
         else {
@@ -437,7 +437,7 @@ final class OpenAICompatibleProvider: ChatTransport {
         return string
     }
 
-    private func jsonObject(from value: JSONValue) throws -> Any {
+    func jsonObject(from value: JSONValue) throws -> Any {
         let data = try JSONEncoder().encode(value)
         return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
     }

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -930,7 +930,8 @@ final class AIChatViewModel {
                     let context = await MainActor.run {
                         ChatToolContext(
                             connectionId: self.connection?.id,
-                            bridge: ChatToolBootstrap.bridge
+                            bridge: ChatToolBootstrap.bridge,
+                            authPolicy: ChatToolBootstrap.authPolicy
                         )
                     }
                     let toolResultBlocks = await Self.executeToolUses(toolUseBlocks, context: context)

--- a/TableProTests/Core/AI/AnthropicProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/AnthropicProviderEncodingTests.swift
@@ -1,0 +1,74 @@
+//
+//  AnthropicProviderEncodingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AnthropicProvider wire encoding")
+struct AnthropicProviderEncodingTests {
+    @Test("Tool spec encodes with input_schema (snake_case)")
+    func toolSpecKeyCasing() throws {
+        let spec = ChatToolSpec(
+            name: "list_tables",
+            description: "List tables",
+            inputSchema: .object(["type": .string("object")])
+        )
+        let encoded = try AnthropicProvider.encodeToolSpec(spec)
+        #expect(encoded["name"] as? String == "list_tables")
+        #expect(encoded["description"] as? String == "List tables")
+        #expect(encoded["input_schema"] != nil)
+    }
+
+    @Test("Plain text turn renders content as a string")
+    func plainTextTurn() throws {
+        let turn = ChatTurn(role: .user, blocks: [.text("hello")])
+        let encoded = try AnthropicProvider.encodeTurn(turn)
+        #expect(encoded?["role"] as? String == "user")
+        #expect(encoded?["content"] as? String == "hello")
+    }
+
+    @Test("Turn with toolUse becomes a typed-block array, not a flat string")
+    func turnWithToolUseIsBlockArray() throws {
+        let toolUse = ToolUseBlock(id: "abc", name: "list_tables", input: .object([:]))
+        let turn = ChatTurn(role: .assistant, blocks: [.text("checking"), .toolUse(toolUse)])
+        let encoded = try AnthropicProvider.encodeTurn(turn)
+        #expect(encoded?["role"] as? String == "assistant")
+        let blocks = encoded?["content"] as? [[String: Any]]
+        #expect(blocks?.count == 2)
+        #expect((blocks?[0])?["type"] as? String == "text")
+        #expect((blocks?[1])?["type"] as? String == "tool_use")
+        #expect((blocks?[1])?["id"] as? String == "abc")
+    }
+
+    @Test("Turn with toolResult uses tool_use_id and omits is_error when false")
+    func turnWithSuccessfulToolResult() throws {
+        let result = ToolResultBlock(toolUseId: "abc", content: "ok", isError: false)
+        let turn = ChatTurn(role: .user, blocks: [.toolResult(result)])
+        let encoded = try AnthropicProvider.encodeTurn(turn)
+        let blocks = encoded?["content"] as? [[String: Any]]
+        #expect(blocks?.count == 1)
+        #expect((blocks?[0])?["type"] as? String == "tool_result")
+        #expect((blocks?[0])?["tool_use_id"] as? String == "abc")
+        #expect((blocks?[0])?["content"] as? String == "ok")
+        #expect((blocks?[0])?["is_error"] == nil)
+    }
+
+    @Test("toolResult with isError emits is_error: true")
+    func turnWithErrorToolResult() throws {
+        let result = ToolResultBlock(toolUseId: "abc", content: "boom", isError: true)
+        let turn = ChatTurn(role: .user, blocks: [.toolResult(result)])
+        let encoded = try AnthropicProvider.encodeTurn(turn)
+        let blocks = encoded?["content"] as? [[String: Any]]
+        #expect((blocks?[0])?["is_error"] as? Bool == true)
+    }
+
+    @Test("Empty text turn is dropped")
+    func emptyTurnReturnsNil() throws {
+        let turn = ChatTurn(role: .user, blocks: [.text("")])
+        let encoded = try AnthropicProvider.encodeTurn(turn)
+        #expect(encoded == nil)
+    }
+}

--- a/TableProTests/Core/AI/ChatToolArgumentDecoderTests.swift
+++ b/TableProTests/Core/AI/ChatToolArgumentDecoderTests.swift
@@ -64,4 +64,37 @@ struct ChatToolArgumentDecoderTests {
         let args: JSONValue = .object(["enabled": .bool(false)])
         #expect(ChatToolArgumentDecoder.optionalBool(args, key: "enabled", default: true) == false)
     }
+
+    @Test("optionalInt returns fallback when key is missing")
+    func optionalIntMissing() {
+        let args: JSONValue = .object([:])
+        #expect(ChatToolArgumentDecoder.optionalInt(args, key: "max_rows", default: 500) == 500)
+    }
+
+    @Test("optionalInt accepts integer values")
+    func optionalIntInteger() {
+        let args: JSONValue = .object(["max_rows": .integer(120)])
+        #expect(ChatToolArgumentDecoder.optionalInt(args, key: "max_rows", default: 500) == 120)
+    }
+
+    @Test("optionalInt coerces number (Double) to Int")
+    func optionalIntFromDouble() {
+        let args: JSONValue = .object(["max_rows": .number(120.7)])
+        #expect(ChatToolArgumentDecoder.optionalInt(args, key: "max_rows", default: 500) == 120)
+    }
+
+    @Test("optionalInt clamps to the supplied range")
+    func optionalIntClamps() {
+        let args: JSONValue = .object(["max_rows": .integer(50_000)])
+        #expect(
+            ChatToolArgumentDecoder.optionalInt(args, key: "max_rows", default: 500, clamp: 1...10_000)
+            == 10_000
+        )
+    }
+
+    @Test("optionalInt returns fallback for non-numeric value")
+    func optionalIntWrongType() {
+        let args: JSONValue = .object(["max_rows": .string("ten")])
+        #expect(ChatToolArgumentDecoder.optionalInt(args, key: "max_rows", default: 500) == 500)
+    }
 }

--- a/TableProTests/Core/AI/ChatToolRegistryTests.swift
+++ b/TableProTests/Core/AI/ChatToolRegistryTests.swift
@@ -28,7 +28,11 @@ struct ChatToolRegistryTests {
         }
     }
 
-    private static let stubContext = ChatToolContext(connectionId: nil, bridge: MCPConnectionBridge())
+    private static let stubContext = ChatToolContext(
+        connectionId: nil,
+        bridge: MCPConnectionBridge(),
+        authPolicy: MCPAuthPolicy()
+    )
 
     @Test("Registered tool can be looked up by name")
     func lookupByName() {

--- a/TableProTests/Core/AI/GeminiProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/GeminiProviderEncodingTests.swift
@@ -1,0 +1,94 @@
+//
+//  GeminiProviderEncodingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("GeminiProvider wire encoding")
+struct GeminiProviderEncodingTests {
+    private func makeProvider() -> GeminiProvider {
+        GeminiProvider(
+            endpoint: "https://generativelanguage.googleapis.com",
+            apiKey: "test"
+        )
+    }
+
+    @Test("Plain text user turn becomes parts:[{text:...}] with role user")
+    func plainTextTurn() throws {
+        let turn = ChatTurn(role: .user, blocks: [.text("hello")])
+        let encoded = try #require(makeProvider().encodeTurn(turn, priorTurns: []))
+        #expect(encoded["role"] as? String == "user")
+        let parts = encoded["parts"] as? [[String: Any]]
+        #expect(parts?.count == 1)
+        #expect((parts?[0])?["text"] as? String == "hello")
+    }
+
+    @Test("Assistant role maps to model")
+    func assistantRoleMapsToModel() throws {
+        let turn = ChatTurn(role: .assistant, blocks: [.text("hi")])
+        let encoded = try #require(makeProvider().encodeTurn(turn, priorTurns: []))
+        #expect(encoded["role"] as? String == "model")
+    }
+
+    @Test("toolUse becomes functionCall part with args as JSON object")
+    func toolUseAsFunctionCall() throws {
+        let toolUse = ToolUseBlock(
+            id: "call_1",
+            name: "list_tables",
+            input: .object(["connection_id": .string("abc")])
+        )
+        let turn = ChatTurn(role: .assistant, blocks: [.toolUse(toolUse)])
+        let encoded = try #require(makeProvider().encodeTurn(turn, priorTurns: []))
+        let parts = encoded["parts"] as? [[String: Any]]
+        let functionCall = (parts?[0])?["functionCall"] as? [String: Any]
+        #expect(functionCall?["name"] as? String == "list_tables")
+        // args MUST be a JSON object (not a string, unlike OpenAI).
+        let args = functionCall?["args"] as? [String: Any]
+        #expect(args?["connection_id"] as? String == "abc")
+    }
+
+    @Test("toolResult resolves the originating tool name from prior turns")
+    func toolResultLookupAcrossTurns() throws {
+        let toolUse = ToolUseBlock(id: "call_1", name: "list_tables", input: .object([:]))
+        let assistantTurn = ChatTurn(role: .assistant, blocks: [.toolUse(toolUse)])
+        let interveningTurn = ChatTurn(role: .user, blocks: [.text("ok")])
+        let resultTurn = ChatTurn(
+            role: .user,
+            blocks: [.toolResult(ToolResultBlock(toolUseId: "call_1", content: "rows", isError: false))]
+        )
+        // resultTurn is at index 2, priorTurns includes both assistantTurn and interveningTurn.
+        let encoded = try #require(makeProvider().encodeTurn(
+            resultTurn,
+            priorTurns: [assistantTurn, interveningTurn]
+        ))
+        let parts = encoded["parts"] as? [[String: Any]]
+        let functionResponse = (parts?[0])?["functionResponse"] as? [String: Any]
+        #expect(functionResponse?["name"] as? String == "list_tables")
+        let response = functionResponse?["response"] as? [String: Any]
+        #expect(response?["content"] as? String == "rows")
+    }
+
+    @Test("toolResult with no matching toolUse falls back to toolUseId as name")
+    func toolResultFallback() throws {
+        let resultTurn = ChatTurn(
+            role: .user,
+            blocks: [.toolResult(ToolResultBlock(toolUseId: "unknown", content: "x", isError: false))]
+        )
+        let encoded = try #require(makeProvider().encodeTurn(resultTurn, priorTurns: []))
+        let parts = encoded["parts"] as? [[String: Any]]
+        let functionResponse = (parts?[0])?["functionResponse"] as? [String: Any]
+        #expect(functionResponse?["name"] as? String == "unknown")
+    }
+
+    @Test("System turns are skipped from encoded contents")
+    func systemTurnsSkipped() {
+        let system = ChatTurn(role: .system, blocks: [.text("ignored")])
+        let user = ChatTurn(role: .user, blocks: [.text("hello")])
+        let contents = makeProvider().encodeContents(turns: [system, user])
+        #expect(contents.count == 1)
+        #expect(contents[0]["role"] as? String == "user")
+    }
+}

--- a/TableProTests/Core/AI/OpenAICompatibleProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/OpenAICompatibleProviderEncodingTests.swift
@@ -1,0 +1,100 @@
+//
+//  OpenAICompatibleProviderEncodingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("OpenAICompatibleProvider wire encoding")
+struct OpenAICompatibleProviderEncodingTests {
+    private func makeProvider() -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            endpoint: "https://api.example.com",
+            apiKey: "test",
+            providerType: .openAI,
+            model: "gpt-4"
+        )
+    }
+
+    @Test("Tool spec wraps in type:function with parameters key")
+    func toolSpecKeyShape() throws {
+        let spec = ChatToolSpec(
+            name: "list_tables",
+            description: "List tables",
+            inputSchema: .object(["type": .string("object")])
+        )
+        let encoded = try makeProvider().encodeTool(spec)
+        #expect(encoded["type"] as? String == "function")
+        let function = encoded["function"] as? [String: Any]
+        #expect(function?["name"] as? String == "list_tables")
+        #expect(function?["description"] as? String == "List tables")
+        #expect(function?["parameters"] != nil)
+    }
+
+    @Test("Plain text turn renders flat content string")
+    func plainTextTurn() {
+        let turn = ChatTurn(role: .user, blocks: [.text("hello")])
+        let encoded = makeProvider().encodeTurn(turn)
+        #expect(encoded.count == 1)
+        #expect(encoded[0]["role"] as? String == "user")
+        #expect(encoded[0]["content"] as? String == "hello")
+    }
+
+    @Test("Assistant turn with toolUse emits tool_calls with arguments-as-string")
+    func assistantWithToolUse() {
+        let toolUse = ToolUseBlock(id: "call_1", name: "list_tables", input: .object([:]))
+        let turn = ChatTurn(role: .assistant, blocks: [.text("checking"), .toolUse(toolUse)])
+        let messages = makeProvider().encodeTurn(turn)
+        #expect(messages.count == 1)
+        let message = messages[0]
+        #expect(message["role"] as? String == "assistant")
+        #expect(message["content"] as? String == "checking")
+        let toolCalls = message["tool_calls"] as? [[String: Any]]
+        #expect(toolCalls?.count == 1)
+        #expect((toolCalls?[0])?["id"] as? String == "call_1")
+        #expect((toolCalls?[0])?["type"] as? String == "function")
+        let function = (toolCalls?[0])?["function"] as? [String: Any]
+        #expect(function?["name"] as? String == "list_tables")
+        // OpenAI requires arguments be a JSON-encoded STRING, not an object.
+        #expect(function?["arguments"] is String)
+    }
+
+    @Test("Assistant turn with toolUse but no text emits content: NSNull")
+    func assistantWithoutText() {
+        let toolUse = ToolUseBlock(id: "call_1", name: "list_tables", input: .object([:]))
+        let turn = ChatTurn(role: .assistant, blocks: [.toolUse(toolUse)])
+        let messages = makeProvider().encodeTurn(turn)
+        #expect(messages[0]["content"] is NSNull)
+    }
+
+    @Test("User turn with toolResult emits role:tool with tool_call_id")
+    func toolResultBecomesToolMessage() {
+        let result = ToolResultBlock(toolUseId: "call_1", content: "rows", isError: false)
+        let turn = ChatTurn(role: .user, blocks: [.toolResult(result)])
+        let messages = makeProvider().encodeTurn(turn)
+        #expect(messages.count == 1)
+        #expect(messages[0]["role"] as? String == "tool")
+        #expect(messages[0]["tool_call_id"] as? String == "call_1")
+        #expect(messages[0]["content"] as? String == "rows")
+    }
+
+    @Test("Multiple toolResult blocks expand to multiple tool messages")
+    func multipleToolResults() {
+        let r1 = ToolResultBlock(toolUseId: "call_1", content: "a", isError: false)
+        let r2 = ToolResultBlock(toolUseId: "call_2", content: "b", isError: false)
+        let turn = ChatTurn(role: .user, blocks: [.toolResult(r1), .toolResult(r2)])
+        let messages = makeProvider().encodeTurn(turn)
+        #expect(messages.count == 2)
+        #expect(messages[0]["tool_call_id"] as? String == "call_1")
+        #expect(messages[1]["tool_call_id"] as? String == "call_2")
+    }
+
+    @Test("Empty text turn returns no messages")
+    func emptyTurnYieldsNothing() {
+        let turn = ChatTurn(role: .user, blocks: [.text("")])
+        let messages = makeProvider().encodeTurn(turn)
+        #expect(messages.isEmpty)
+    }
+}

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -137,6 +137,13 @@ The AI can look up your database on demand by calling a tool. You'll see a pill 
 
 Read-only tools available now: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`. Supported on Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
 
+Write-side tools route through the connection's safe mode policy. The AI proposes the call, but you approve every state-changing query in the safe-mode dialog before it runs:
+
+- `execute_query`: runs `SELECT`, `INSERT`, `UPDATE`, `DELETE`. Multi-statement input is rejected. Destructive DDL (`DROP`, `TRUNCATE`, `ALTER...DROP`) is blocked here.
+- `confirm_destructive_operation`: runs destructive DDL after the AI passes the verbatim phrase `I understand this is irreversible`. The safe-mode dialog still applies, so a misuse from the model is contained.
+
+If a connection has safe mode set to **Silent**, the dialog is suppressed and writes execute without prompting. Set it to **Confirm Writes** or higher for AI-assisted query execution if you want to keep the per-query approval gate.
+
 <Frame caption="Streaming response">
   <img
     className="block dark:hidden"


### PR DESCRIPTION
## Summary

Two phase-4 followups bundled because they share a theme (filling out the chat-tool surface area):

1. **Write-side chat tools.** Adds `execute_query` and `confirm_destructive_operation` as `ChatTool` wrappers, mirroring the existing MCP versions. The connection's safe-mode dialog flow gates execution, so the user is still the final approver for any state-changing query.
2. **Provider wire-encoding tests.** Phase 4 shipped 1100 LOC of request/response encoding across Anthropic / OpenAI-compatible / Gemini with zero unit tests. This adds 23 round-trip tests that lock the JSON shape contracts.

## Write-side tools

- `ExecuteQueryChatTool` (`Tools/ExecuteQueryChatTool.swift`):
  - Decodes `connection_id` (or falls back to active connection), `query`, optional `max_rows`, `timeout_seconds`, `database`, `schema`.
  - Rejects multi-statement queries and queries over 100KB.
  - Routes through `ToolConnectionMetadata.resolve`, optional database/schema switch, `QueryClassifier.classifyTier`.
  - **Destructive queries (DROP / TRUNCATE / ALTER...DROP) are blocked here** — the AI gets a `ChatToolResult(isError: true)` directing it to the confirm tool.
  - **Write queries trigger `MCPAuthPolicy.checkSafeModeDialog`** — the connection's safe-mode policy decides whether to surface a native confirmation dialog before executing.
  - Executes via `ToolQueryExecutor.executeAndLog` with `principalLabel: "AI Chat"` so query history attribution is clear.

- `ConfirmDestructiveOperationChatTool` (`Tools/ConfirmDestructiveOperationChatTool.swift`):
  - Requires `confirmation_phrase` to match `"I understand this is irreversible"` exactly.
  - Validates the query is destructive (rejects non-destructive queries with a hint to use `execute_query`).
  - Same safe-mode dialog gate before execution.

Both are registered in `ChatToolBootstrap.register()` so they ship live to all providers that emit tool calls.

`ChatToolArgumentDecoder.optionalInt(_:key:default:clamp:)` added — needed by `execute_query` for `max_rows` / `timeout_seconds` clamping.

## Provider tests

`Anthropic` / `OpenAICompatible` / `Gemini` had `private` encoding helpers. Demoted to internal so tests can call them directly without mocking URLSession or the full streamChat pipeline.

- `AnthropicProviderEncodingTests` (6 tests): tool spec uses `input_schema` snake_case key; plain text vs typed-block array dispatch; `tool_use` shape; `tool_result` with and without `is_error`; empty turn drops out.
- `OpenAICompatibleProviderEncodingTests` (7 tests): tool spec wrapped in `type: "function"`; assistant turn with `tool_calls` and arguments-as-string (NOT object, per OpenAI spec); `content: NSNull` when no text; `role: "tool"` for results; multiple tool results expand to multiple messages.
- `GeminiProviderEncodingTests` (6 tests): assistant maps to `model` role; `functionCall.args` is a JSON object (not string, unlike OpenAI); `functionResponse.name` resolves correctly even when the originating `toolUse` is two turns back; fallback to `toolUseId` as name when not found; system turns skipped.

## Why bundle these in one PR

Both touch chat-tool plumbing. Demoting access on provider encoders is small enough not to need its own PR. Splitting would mean a write-tools PR with no test coverage and a tests-only PR — the combined story is "fill out the phase 4 surface area."

## Risk

- The two new tools execute SQL through the existing safe-mode flow, so user confirmation gates state changes. The fail-closed default (destructive queries blocked unless explicit phrase) matches MCP behavior.
- Demoting provider encoder helpers from `private` to internal is a tiny widening of the same-module surface area. No external module is affected (we already demoted `ChatTool` foundation to internal in #1064).

## Lint

`swiftlint lint --strict` clean across all 819 files.

## Test plan

- [ ] Open chat with a connection. Type "Update the orders table to set status='paid' where id=1". Verify AI calls `execute_query`. Verify the safe-mode dialog appears (if the connection has safe mode enabled).
- [ ] Type "Drop the temp_log table". Verify AI calls `confirm_destructive_operation` with the phrase, and that the dialog still appears.
- [ ] Without safe-mode confirmation, click Cancel. Verify the tool returns an error and the table is intact.
- [ ] Run `xcodebuild test -only-testing:TableProTests/AnthropicProviderEncodingTests` and the OpenAI / Gemini equivalents.