### PR TITLE
fix: route Cmd+T through newWindowForTab responder chain to prevent focus flash

### DIFF
--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -20,9 +20,10 @@ import AppKit
 import os
 import SwiftUI
 
-/// NSWindow subclass that routes Cmd+W (performClose:) through the coordinator's
-/// closeTab() instead of AppKit's default close. This ensures the last tab clears
-/// to the empty "No tabs open" state instead of closing the entire window.
+/// NSWindow subclass that routes the standard tab-related responder selectors
+/// (`performClose:`, `newWindowForTab:`) through the coordinator. Menus and
+/// toolbar buttons reach this via `NSApp.sendAction(_:to:nil:from:)`, the same
+/// pattern AppKit uses for `selectNextTab:` and `selectPreviousTab:`.
 @MainActor
 private final class EditorWindow: NSWindow {
     override func performClose(_ sender: Any?) {
@@ -32,6 +33,15 @@ private final class EditorWindow: NSWindow {
         } else {
             super.performClose(sender)
         }
+    }
+
+    override func newWindowForTab(_ sender: Any?) {
+        guard let coordinator = MainContentCoordinator.coordinator(forWindow: self),
+              let actions = coordinator.commandActions else {
+            super.newWindowForTab(sender)
+            return
+        }
+        actions.newTab()
     }
 }
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -211,7 +211,7 @@ struct AppMenuCommands: Commands {
 
         CommandGroup(after: .newItem) {
             Button("New Tab") {
-                actions?.newTab()
+                NSApp.sendAction(#selector(NSWindow.newWindowForTab(_:)), to: nil, from: nil)
             }
             .optionalKeyboardShortcut(shortcut(for: .newTab))
             .disabled(!(actions?.isConnected ?? false))


### PR DESCRIPTION
## Summary

- **Bug**: in a native NSWindow tab group, Cmd+T opens the new query tab and it briefly becomes key, then focus jumps back to the previous tab.
- **Root cause**: SwiftUI menu's `Button("New Tab")` called `actions?.newTab()` directly, bypassing AppKit's tab-aware focus management. After the menu key-equivalent dispatch returned, AppKit reasserted the previously-key window.
- **Fix**: route Cmd+T through the standard AppKit responder chain by overriding `newWindowForTab(_:)` on `EditorWindow` (matches the existing `performClose(_:)` override pattern), and dispatching from the SwiftUI menu and toolbar button via `NSApp.sendAction(#selector(NSWindow.newWindowForTab(_:)), to: nil, from: nil)` — the same pattern already used for `selectNextTab(_:)` / `selectPreviousTab(_:)` in this file.

## Test plan

- [ ] Open a table tab, press Cmd+T → new query tab stays focused, no flash back.
- [ ] Click the toolbar `+` button → same behavior.
- [ ] Empty connection window (no tabs yet) → Cmd+T adds an in-window query tab.
- [ ] Multiple connection windows open → Cmd+T opens new tab in the focused connection.
- [ ] AppKit's auto-injected "Window > New Tab" menu item → routes through the same override.
- [ ] Cmd+W still routes through `closeTab()` (regression check on `performClose(_:)`).