### PR TITLE
fix: chat code block isInsertable language comparison

### DIFF
--- a/TablePro/Views/AIChat/AIChatCodeBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatCodeBlockView.swift
@@ -150,7 +150,7 @@ struct AIChatCodeBlockView: View {
     }
 
     private var isInsertable: Bool {
-        treeSitterLanguage.id != .default
+        treeSitterLanguage.id != CodeLanguage.default.id
     }
 
     private var editorHeight: CGFloat {


### PR DESCRIPTION
## Summary

Hot-fix for compile error introduced by #1077.

`AIChatCodeBlockView.isInsertable` compared `treeSitterLanguage.id != .default`. Swift's type inference resolved `.default` to `TaskPriority.default` instead of `TreeSitterLanguage`, producing:

```
Cannot convert value of type 'TreeSitterLanguage' to expected argument type 'TaskPriority'
```

Fix: qualify the comparison with `CodeLanguage.default.id` so both sides are explicitly `TreeSitterLanguage`.

## Test plan

- [ ] Build the project. The error at `AIChatCodeBlockView.swift:153` no longer fires.
- [ ] Open a chat code block produced by the AI. The Insert button is enabled when the language is recognized (sql/javascript/bash) and disabled for plain text.