### PR TITLE
fix: inline assistant + tool registry compile errors

### DIFF
--- a/TablePro/Core/AI/Chat/ChatToolRegistry.swift
+++ b/TablePro/Core/AI/Chat/ChatToolRegistry.swift
@@ -69,7 +69,7 @@ final class ChatToolRegistry {
         allTools(for: mode).map(\.spec)
     }
 
-    static func isToolAllowed(name: String, in mode: AIChatMode) -> Bool {
+    nonisolated static func isToolAllowed(name: String, in mode: AIChatMode) -> Bool {
         switch mode {
         case .ask:
             return readOnlyToolNames.contains(name)

--- a/TablePro/Core/AI/InlineAssistant/InlineAssistantSession.swift
+++ b/TablePro/Core/AI/InlineAssistant/InlineAssistantSession.swift
@@ -131,10 +131,6 @@ final class InlineAssistantSession {
         task = nil
     }
 
-    deinit {
-        task?.cancel()
-    }
-
     // MARK: - Helpers
 
     private func languageTag() -> String {

--- a/TablePro/Views/Editor/InlineAssistant/InlineAssistantPresenter.swift
+++ b/TablePro/Views/Editor/InlineAssistant/InlineAssistantPresenter.swift
@@ -110,7 +110,7 @@ final class InlineAssistantPresenter {
         let replacement = session.proposedText
         textView.replaceCharacters(in: anchorRange, with: replacement)
         let newRange = NSRange(location: anchorRange.location, length: (replacement as NSString).length)
-        textView.setSelectedRange(newRange)
+        textView.selectionManager.setSelectedRange(newRange)
         dismiss()
     }
 


### PR DESCRIPTION
## Summary

Three compile errors after #1084 (inline assistant) and #1079 (mode-gated tools) merged to main.

### 1. `TextView.setSelectedRange` does not exist

`InlineAssistantPresenter.swift:113` called `textView.setSelectedRange(newRange)`. CodeEditTextView's `TextView` exposes selection through `selectionManager`. Fix: route through `textView.selectionManager.setSelectedRange(_:)`.

### 2. Main-actor isolated `task` accessed from nonisolated `deinit`

`InlineAssistantSession.swift:135` had `deinit { task?.cancel() }`. The class is `@MainActor`, so `task` is main-actor isolated; `deinit` is nonisolated and cannot read it. Fix: drop the deinit. The streaming task already uses `[weak self]` + `guard let self else { return }`, so it bails naturally when the session is released. `teardown()` remains the explicit cancellation path.

### 3. `ChatToolRegistry.isToolAllowed` called from nonisolated context

`AIChatViewModel.swift:1143` (inside `nonisolated static func runToolUse(...)`) called the main-actor isolated `ChatToolRegistry.isToolAllowed(name:in:)`. The function is pure logic over immutable static `Set<String>` data with no main-actor state. Fix: mark `isToolAllowed` `nonisolated static`. Other registry methods (`tool(named:in:)`) still go through `MainActor.run` because they read instance state.

## Test plan

- [ ] Build the project. All three errors gone.
- [ ] Open the SQL editor, select text, press Ctrl+Return. The inline assistant prompt panel appears, accept replaces selection cleanly.
- [ ] Switch chat mode to Ask. Ask the AI to "delete all rows from users". The assistant attempts `execute_query`; the tool dispatch returns the "not available in Ask mode" message via `isToolAllowed` defense in depth.
- [ ] Switch to Agent. Same prompt routes through normally with safe-mode policy.