### PR TITLE
fix: anchor mention popover at composer top-leading

### DIFF
--- a/TablePro/Views/AIChat/ChatComposerView.swift
+++ b/TablePro/Views/AIChat/ChatComposerView.swift
@@ -37,7 +37,7 @@ struct ChatComposerView: View {
             .onKeyPress(.escape) { handleEscape() }
             .popover(
                 isPresented: popoverBinding,
-                attachmentAnchor: .point(.top),
+                attachmentAnchor: .point(.topLeading),
                 arrowEdge: .bottom
             ) {
                 MentionSuggestionListView(


### PR DESCRIPTION
## Summary

Mention popover anchor was `.point(.top)` (top-center of composer), so the popover floated centered above the composer regardless of where the `@` character was actually typed. Since the user types `@` at the leftmost edge of the text input, the popover should hang over that edge instead of the center.

Change to `.point(.topLeading)`. Combined with `arrowEdge: .bottom`, the popover now anchors at the top-left corner of the composer with its arrow tip at that point, hanging up-and-right from there.

This is the closest pure-SwiftUI approximation of caret-anchored autocomplete (Apple Mail address autofill, VS Code mention dropdown). True caret-precise anchoring requires NSTextView selection rect math, which would reintroduce the TextKit 1 dependency we dropped in #1076.

## Test plan

- [ ] In the AI Chat composer, type `@`. The mention popover appears anchored to the top-left of the composer.
- [ ] Type more characters to filter; popover position stays stable.
- [ ] Press Esc to dismiss; popover hides cleanly.