### PR TITLE
fix: editor windows remember size, position, and zoom state across launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New tab via Cmd+T no longer flashes focus back to the previous tab in the same window group
 - Cmd+X with no selection cuts the current line, matching VS Code, Sublime, and Xcode (#1075)
 - Cmd+A on a query ending with a newline now highlights every line, not just the first (#1075)
+- Editor windows now remember their size, position, and zoom state across launches, instead of always opening at 1200x800
 
 ### Added
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -167,15 +167,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         super.viewWillAppear()
         guard let window = view.window else { return }
 
-        let defaultSize = NSSize(width: 1_200, height: 800)
-        if window.frame.width < defaultSize.width || window.frame.height < defaultSize.height {
-            window.setContentSize(NSSize(
-                width: max(window.frame.width, defaultSize.width),
-                height: max(window.frame.height, defaultSize.height)
-            ))
-            window.center()
-        }
-
         window.title = windowTitle
         if let session = currentSession {
             window.subtitle = session.connection.name

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -48,11 +48,18 @@ private final class EditorWindow: NSWindow {
 @MainActor
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    private static let frameLogger = Logger(subsystem: "com.TablePro", category: "WindowFrame")
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 
+    private static var frameDefaultsKey: String { "NSWindow Frame \(frameAutosaveName)" }
+
     internal static var hasSavedFrame: Bool {
-        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
+        UserDefaults.standard.object(forKey: frameDefaultsKey) != nil
+    }
+
+    private static func currentSavedFrameString() -> String {
+        UserDefaults.standard.string(forKey: frameDefaultsKey) ?? "<nil>"
     }
 
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
@@ -108,7 +115,15 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
         super.init(window: window)
 
+        Self.frameLogger.notice("[init] before-autosave persistedFrame=\(Self.currentSavedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
+
         self.windowFrameAutosaveName = Self.frameAutosaveName
+        Self.frameLogger.notice("[init] after windowFrameAutosaveName setter windowAutosaveName=\(window.frameAutosaveName, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
+
+        let restored = window.setFrameUsingName(Self.frameAutosaveName)
+        Self.frameLogger.notice("[init] explicit setFrameUsingName returned=\(restored, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
+
+        installFrameAutosaveTrace(on: window)
 
         // Keep the controller alive after the window closes so NSWindowDelegate
         // hooks have time to run teardown. WindowManager drops its strong
@@ -134,6 +149,39 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("TabWindowController does not support NSCoder init")
+    }
+
+    private var frameTraceObservers: [NSObjectProtocol] = []
+
+    private func installFrameAutosaveTrace(on window: NSWindow) {
+        let center = NotificationCenter.default
+
+        frameTraceObservers.append(center.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak window] _ in
+            guard let window else { return }
+            Self.frameLogger.notice("[event] didResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) inLiveResize=\(window.inLiveResize, privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
+        })
+
+        frameTraceObservers.append(center.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: window,
+            queue: .main
+        ) { [weak window] _ in
+            guard let window else { return }
+            Self.frameLogger.notice("[event] didMove windowFrame=\(NSStringFromRect(window.frame), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
+        })
+
+        frameTraceObservers.append(center.addObserver(
+            forName: NSWindow.didEndLiveResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak window] _ in
+            guard let window else { return }
+            Self.frameLogger.notice("[event] didEndLiveResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
+        })
     }
 
     // MARK: - NSWindowDelegate
@@ -187,7 +235,14 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
+        Self.frameLogger.notice("[close] before saveFrame windowFrame=\(NSStringFromRect(window.frame), privacy: .public) styleMask.fullScreen=\(window.styleMask.contains(.fullScreen), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
+        Self.frameLogger.notice("[close] after saveFrame persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
+
+        for observer in frameTraceObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        frameTraceObservers.removeAll()
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.invalidateToolbar()

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -34,10 +34,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 
-    internal static var hasSavedFrame: Bool {
-        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
-    }
-
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
         let editor = DataGridFieldEditor()
         editor.isFieldEditor = true
@@ -77,7 +73,10 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.isReleasedWhenClosed = false
         window.delegate = self
 
-        _ = window.setFrameUsingName(Self.frameAutosaveName)
+        if !window.setFrameUsingName(Self.frameAutosaveName) {
+            window.setContentSize(NSSize(width: 1_200, height: 800))
+            window.center()
+        }
 
         Self.lifecycleLogger.info(
             "[open] TabWindowController.init payloadId=\(payload.id, privacy: .public) connId=\(payload.connectionId, privacy: .public) controllerId=\(self.controllerId, privacy: .public) eagerToolbar=\(sessionState != nil)"

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -74,7 +74,12 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.delegate = self
 
         if !window.setFrameUsingName(Self.frameAutosaveName) {
-            window.setContentSize(NSSize(width: 1_200, height: 800))
+            let visibleSize = (window.screen ?? NSScreen.main)?.visibleFrame.size
+                ?? NSSize(width: 1_440, height: 900)
+            window.setContentSize(NSSize(
+                width: min(1_200, visibleSize.width),
+                height: min(800, visibleSize.height)
+            ))
             window.center()
         }
 
@@ -203,6 +208,11 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         }
         activity.userInfo = info
 
+        // becomeCurrent is unconditional. A previous becomeCurrent: Bool gate
+        // dropped Continuity mid-session whenever the user switched between
+        // table and query tabs in the same window, because the activity-type
+        // flip above invalidates the old activity but never promotes its
+        // replacement.
         activity.becomeCurrent()
     }
 }

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -2,28 +2,11 @@
 //  TabWindowController.swift
 //  TablePro
 //
-//  NSWindowController for an editor-tab-window. Replaces the SwiftUI
-//  `WindowGroup(id: "main", for: EditorTabPayload.self)` scene.
-//
-//  Phase 1 scope: window creation, NSHostingView installation, tabbing
-//  configuration. Existing MainContentView lifecycle hooks (.onAppear,
-//  .onDisappear, NSWindow notification observers, .userActivity) continue to
-//  work unchanged — this controller's job in Phase 1 is limited to replacing
-//  SwiftUI scene-driven window construction.
-//
-//  Phase 2 will migrate lifecycle responsibilities (markActivated, teardown,
-//  userActivity, didBecomeKey/didResignKey) into NSWindowDelegate methods
-//  on this controller.
-//
 
 import AppKit
 import os
 import SwiftUI
 
-/// NSWindow subclass that routes the standard tab-related responder selectors
-/// (`performClose:`, `newWindowForTab:`) through the coordinator. Menus and
-/// toolbar buttons reach this via `NSApp.sendAction(_:to:nil:from:)`, the same
-/// pattern AppKit uses for `selectNextTab:` and `selectPreviousTab:`.
 @MainActor
 private final class EditorWindow: NSWindow {
     override func performClose(_ sender: Any?) {
@@ -48,18 +31,11 @@ private final class EditorWindow: NSWindow {
 @MainActor
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
-    private static let frameLogger = Logger(subsystem: "com.TablePro", category: "WindowFrame")
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 
-    private static var frameDefaultsKey: String { "NSWindow Frame \(frameAutosaveName)" }
-
     internal static var hasSavedFrame: Bool {
-        UserDefaults.standard.object(forKey: frameDefaultsKey) != nil
-    }
-
-    private static func currentSavedFrameString() -> String {
-        UserDefaults.standard.string(forKey: frameDefaultsKey) ?? "<nil>"
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
     }
 
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
@@ -70,18 +46,8 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
     internal let payload: EditorTabPayload
 
-    /// Stable identifier for this controller. Distinct from the
-    /// `MainContentView.@State windowId` used inside WindowLifecycleMonitor —
-    /// that one remains the authoritative per-view UUID in Phase 1. Phase 2
-    /// will unify them on this controller's identifier.
     internal let controllerId: UUID
 
-    /// NSUserActivity published while this window is key, so Handoff and
-    /// other continuity flows can pick up the connection (and table, if
-    /// viewing one). Replaces the SwiftUI `.userActivity(...)` modifier we
-    /// removed in Phase 2 — `.userActivity` requires a Scene context and
-    /// emitted `Cannot use Scene methods for URL, NSUserActivity...` warnings
-    /// when used inside an `NSHostingView`.
     private var activity: NSUserActivity?
 
     internal init(payload: EditorTabPayload, sessionState: SessionStateFactory.SessionState? = nil) {
@@ -98,48 +64,21 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.minSize = NSSize(width: 720, height: 480)
         window.isRestorable = false
         window.toolbarStyle = .unified
-        // Hide the window title ("Query 1 / TablePro") embedded in the unified
-        // toolbar — otherwise it claims leading space and pushes our navigation
-        // items to the right of it. Tab group's tab bar already shows the same
-        // "Query N" label, so no information is lost. The Principal toolbar item
-        // continues to show connection name + DB version.
         window.titleVisibility = .hidden
         window.tabbingMode = .preferred
         window.tabbingIdentifier = WindowManager.tabbingIdentifier(for: payload.connectionId)
         window.collectionBehavior.insert([.fullScreenPrimary, .managed])
 
-        // NSSplitViewController as contentViewController so .toggleSidebar and
-        // .sidebarTrackingSeparator find the split view via the responder chain.
+        window.setFrameAutosaveName(Self.frameAutosaveName)
+        _ = window.setFrameUsingName(Self.frameAutosaveName)
+
         let splitVC = MainSplitViewController(payload: payload, sessionState: sessionState)
         window.contentViewController = splitVC
 
         super.init(window: window)
 
-        Self.frameLogger.notice("[init] before-autosave persistedFrame=\(Self.currentSavedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
-        self.windowFrameAutosaveName = Self.frameAutosaveName
-        Self.frameLogger.notice("[init] after windowFrameAutosaveName setter windowAutosaveName=\(window.frameAutosaveName, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
-        let restored = window.setFrameUsingName(Self.frameAutosaveName)
-        Self.frameLogger.notice("[init] explicit setFrameUsingName returned=\(restored, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
-        installFrameAutosaveTrace(on: window)
-
-        // Keep the controller alive after the window closes so NSWindowDelegate
-        // hooks have time to run teardown. WindowManager drops its strong
-        // reference on willClose, which triggers dealloc.
         window.isReleasedWhenClosed = false
-
-        // Become the window's delegate so didBecomeKey/didResignKey/willClose
-        // dispatch to methods on this controller — eliminates the global
-        // NotificationCenter fan-out that previously ran every ContentView
-        // instance's observer per focus change.
         window.delegate = self
-
-        // Toolbar is installed by MainSplitViewController.viewWillAppear when
-        // the session state is available. NSSplitViewController does not
-        // overwrite window.toolbar (unlike NavigationSplitView), so no KVO
-        // workaround is needed.
 
         Self.lifecycleLogger.info(
             "[open] TabWindowController.init payloadId=\(payload.id, privacy: .public) connId=\(payload.connectionId, privacy: .public) controllerId=\(self.controllerId, privacy: .public) eagerToolbar=\(sessionState != nil)"
@@ -151,44 +90,27 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         fatalError("TabWindowController does not support NSCoder init")
     }
 
-    private var frameTraceObservers: [NSObjectProtocol] = []
-
-    private func installFrameAutosaveTrace(on window: NSWindow) {
-        let center = NotificationCenter.default
-
-        frameTraceObservers.append(center.addObserver(
-            forName: NSWindow.didResizeNotification,
-            object: window,
-            queue: .main
-        ) { [weak window] _ in
-            guard let window else { return }
-            Self.frameLogger.notice("[event] didResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) inLiveResize=\(window.inLiveResize, privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
-        })
-
-        frameTraceObservers.append(center.addObserver(
-            forName: NSWindow.didMoveNotification,
-            object: window,
-            queue: .main
-        ) { [weak window] _ in
-            guard let window else { return }
-            Self.frameLogger.notice("[event] didMove windowFrame=\(NSStringFromRect(window.frame), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
-        })
-
-        frameTraceObservers.append(center.addObserver(
-            forName: NSWindow.didEndLiveResizeNotification,
-            object: window,
-            queue: .main
-        ) { [weak window] _ in
-            guard let window else { return }
-            Self.frameLogger.notice("[event] didEndLiveResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
-        })
-    }
-
     // MARK: - NSWindowDelegate
 
     func windowWillReturnFieldEditor(_ sender: NSWindow, to client: Any?) -> Any? {
         guard client is CellTextField else { return nil }
         return dataGridFieldEditor
+    }
+
+    internal func windowDidResize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        guard !window.inLiveResize else { return }
+        window.saveFrame(usingName: Self.frameAutosaveName)
+    }
+
+    internal func windowDidEndLiveResize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        window.saveFrame(usingName: Self.frameAutosaveName)
+    }
+
+    internal func windowDidMove(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        window.saveFrame(usingName: Self.frameAutosaveName)
     }
 
     internal func windowDidBecomeKey(_ notification: Notification) {
@@ -235,14 +157,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
-        Self.frameLogger.notice("[close] before saveFrame windowFrame=\(NSStringFromRect(window.frame), privacy: .public) styleMask.fullScreen=\(window.styleMask.contains(.fullScreen), privacy: .public) persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
-        Self.frameLogger.notice("[close] after saveFrame persistedFrame=\(Self.currentSavedFrameString(), privacy: .public)")
-
-        for observer in frameTraceObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        frameTraceObservers.removeAll()
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.invalidateToolbar()
@@ -262,10 +177,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: - NSUserActivity
 
-    /// Publish (or refresh) this window's NSUserActivity. Called by
-    /// `windowDidBecomeKey` and by `MainContentView` when the selected tab
-    /// changes — only the second case is a no-op when the window isn't key
-    /// (Handoff only cares about the active activity).
     internal func refreshUserActivity() {
         guard let window, window.isKeyWindow,
               let coordinator = MainContentCoordinator.coordinator(forWindow: window)
@@ -279,8 +190,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         let tableName: String? = (selectedTab?.tabType == .table) ? selectedTab?.tableContext.tableName : nil
         let activityType = tableName != nil ? "com.TablePro.viewTable" : "com.TablePro.viewConnection"
 
-        // Recreate when the activity type flips between viewConnection and
-        // viewTable — NSUserActivity.activityType is immutable.
         if activity?.activityType != activityType {
             activity?.invalidate()
             let newActivity = NSUserActivity(activityType: activityType)
@@ -296,13 +205,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         }
         activity.userInfo = info
 
-        // Always promote to current. Both call sites (`windowDidBecomeKey` and
-        // `refreshUserActivity` which guards on `window.isKeyWindow`) only
-        // invoke this method when the window owns Handoff. The previous
-        // `becomeCurrent: Bool` parameter dropped Continuity mid-session
-        // whenever the user switched between table and query tabs in the
-        // same window — the type-flip branch above invalidated the old
-        // activity but never promoted the replacement.
         activity.becomeCurrent()
     }
 }

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -31,18 +31,11 @@ private final class EditorWindow: NSWindow {
 @MainActor
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
-    private static let frameLogger = Logger(subsystem: "com.TablePro", category: "WindowFrame")
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 
-    private static var frameDefaultsKey: String { "NSWindow Frame \(frameAutosaveName)" }
-
     internal static var hasSavedFrame: Bool {
-        UserDefaults.standard.object(forKey: frameDefaultsKey) != nil
-    }
-
-    private static func savedFrameString() -> String {
-        UserDefaults.standard.string(forKey: frameDefaultsKey) ?? "<nil>"
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
     }
 
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
@@ -76,23 +69,15 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.tabbingIdentifier = WindowManager.tabbingIdentifier(for: payload.connectionId)
         window.collectionBehavior.insert([.fullScreenPrimary, .managed])
 
-        Self.frameLogger.notice("[init] step=created savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
-        let didRegister = window.setFrameAutosaveName(Self.frameAutosaveName)
-        Self.frameLogger.notice("[init] step=afterSetFrameAutosaveName didRegister=\(didRegister, privacy: .public) savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
-        let restored = window.setFrameUsingName(Self.frameAutosaveName)
-        Self.frameLogger.notice("[init] step=afterSetFrameUsingName restored=\(restored, privacy: .public) savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
-
         let splitVC = MainSplitViewController(payload: payload, sessionState: sessionState)
         window.contentViewController = splitVC
-        Self.frameLogger.notice("[init] step=afterContentVC savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
 
         super.init(window: window)
-        Self.frameLogger.notice("[init] step=afterSuperInit savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
 
         window.isReleasedWhenClosed = false
         window.delegate = self
+
+        _ = window.setFrameUsingName(Self.frameAutosaveName)
 
         Self.lifecycleLogger.info(
             "[open] TabWindowController.init payloadId=\(payload.id, privacy: .public) connId=\(payload.connectionId, privacy: .public) controllerId=\(self.controllerId, privacy: .public) eagerToolbar=\(sessionState != nil)"
@@ -113,17 +98,13 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
     internal func windowDidResize(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
-        Self.frameLogger.notice("[event] didResize inLive=\(window.inLiveResize, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         guard !window.inLiveResize else { return }
         window.saveFrame(usingName: Self.frameAutosaveName)
-        Self.frameLogger.notice("[event] didResize savedAfter=\(Self.savedFrameString(), privacy: .public)")
     }
 
     internal func windowDidEndLiveResize(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
-        Self.frameLogger.notice("[event] didEndLiveResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
-        Self.frameLogger.notice("[event] didEndLiveResize savedAfter=\(Self.savedFrameString(), privacy: .public)")
     }
 
     internal func windowDidMove(_ notification: Notification) {
@@ -137,7 +118,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow,
               let coordinator = MainContentCoordinator.coordinator(forWindow: window)
         else { return }
-        Self.frameLogger.notice("[event] didBecomeKey windowFrame=\(NSStringFromRect(window.frame), privacy: .public) saved=\(Self.savedFrameString(), privacy: .public)")
         Self.lifecycleLogger.debug(
             "[switch] windowDidBecomeKey seq=\(seq) controllerId=\(self.controllerId, privacy: .public) connId=\(coordinator.connectionId, privacy: .public)"
         )
@@ -176,9 +156,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
-        Self.frameLogger.notice("[close] before saveFrame windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
-        Self.frameLogger.notice("[close] after saveFrame savedAfter=\(Self.savedFrameString(), privacy: .public)")
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.invalidateToolbar()

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -49,6 +49,12 @@ private final class EditorWindow: NSWindow {
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
+    internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
+
+    internal static var hasSavedFrame: Bool {
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
+    }
+
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
         let editor = DataGridFieldEditor()
         editor.isFieldEditor = true
@@ -102,7 +108,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
         super.init(window: window)
 
-        self.windowFrameAutosaveName = "MainEditorWindow"
+        self.windowFrameAutosaveName = Self.frameAutosaveName
 
         // Keep the controller alive after the window closes so NSWindowDelegate
         // hooks have time to run teardown. WindowManager drops its strong
@@ -180,6 +186,8 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         let t0 = Date()
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
+
+        window.saveFrame(usingName: Self.frameAutosaveName)
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.invalidateToolbar()

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -31,11 +31,18 @@ private final class EditorWindow: NSWindow {
 @MainActor
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    private static let frameLogger = Logger(subsystem: "com.TablePro", category: "WindowFrame")
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 
+    private static var frameDefaultsKey: String { "NSWindow Frame \(frameAutosaveName)" }
+
     internal static var hasSavedFrame: Bool {
-        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
+        UserDefaults.standard.object(forKey: frameDefaultsKey) != nil
+    }
+
+    private static func savedFrameString() -> String {
+        UserDefaults.standard.string(forKey: frameDefaultsKey) ?? "<nil>"
     }
 
     private lazy var dataGridFieldEditor: DataGridFieldEditor = {
@@ -69,13 +76,20 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.tabbingIdentifier = WindowManager.tabbingIdentifier(for: payload.connectionId)
         window.collectionBehavior.insert([.fullScreenPrimary, .managed])
 
-        window.setFrameAutosaveName(Self.frameAutosaveName)
-        _ = window.setFrameUsingName(Self.frameAutosaveName)
+        Self.frameLogger.notice("[init] step=created savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
+
+        let didRegister = window.setFrameAutosaveName(Self.frameAutosaveName)
+        Self.frameLogger.notice("[init] step=afterSetFrameAutosaveName didRegister=\(didRegister, privacy: .public) savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
+
+        let restored = window.setFrameUsingName(Self.frameAutosaveName)
+        Self.frameLogger.notice("[init] step=afterSetFrameUsingName restored=\(restored, privacy: .public) savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
 
         let splitVC = MainSplitViewController(payload: payload, sessionState: sessionState)
         window.contentViewController = splitVC
+        Self.frameLogger.notice("[init] step=afterContentVC savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
 
         super.init(window: window)
+        Self.frameLogger.notice("[init] step=afterSuperInit savedDefaults=\(Self.savedFrameString(), privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public)")
 
         window.isReleasedWhenClosed = false
         window.delegate = self
@@ -99,13 +113,17 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
     internal func windowDidResize(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
+        Self.frameLogger.notice("[event] didResize inLive=\(window.inLiveResize, privacy: .public) windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         guard !window.inLiveResize else { return }
         window.saveFrame(usingName: Self.frameAutosaveName)
+        Self.frameLogger.notice("[event] didResize savedAfter=\(Self.savedFrameString(), privacy: .public)")
     }
 
     internal func windowDidEndLiveResize(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
+        Self.frameLogger.notice("[event] didEndLiveResize windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
+        Self.frameLogger.notice("[event] didEndLiveResize savedAfter=\(Self.savedFrameString(), privacy: .public)")
     }
 
     internal func windowDidMove(_ notification: Notification) {
@@ -119,6 +137,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow,
               let coordinator = MainContentCoordinator.coordinator(forWindow: window)
         else { return }
+        Self.frameLogger.notice("[event] didBecomeKey windowFrame=\(NSStringFromRect(window.frame), privacy: .public) saved=\(Self.savedFrameString(), privacy: .public)")
         Self.lifecycleLogger.debug(
             "[switch] windowDidBecomeKey seq=\(seq) controllerId=\(self.controllerId, privacy: .public) connId=\(coordinator.connectionId, privacy: .public)"
         )
@@ -157,7 +176,9 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
+        Self.frameLogger.notice("[close] before saveFrame windowFrame=\(NSStringFromRect(window.frame), privacy: .public) savedBefore=\(Self.savedFrameString(), privacy: .public)")
         window.saveFrame(usingName: Self.frameAutosaveName)
+        Self.frameLogger.notice("[close] after saveFrame savedAfter=\(Self.savedFrameString(), privacy: .public)")
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.invalidateToolbar()

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -84,7 +84,6 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.identifier = NSUserInterfaceItemIdentifier("main")
         window.minSize = NSSize(width: 720, height: 480)
         window.isRestorable = false
-        window.applyAutosaveName("MainEditorWindow")
         window.toolbarStyle = .unified
         // Hide the window title ("Query 1 / TablePro") embedded in the unified
         // toolbar — otherwise it claims leading space and pushes our navigation
@@ -102,6 +101,8 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         window.contentViewController = splitVC
 
         super.init(window: window)
+
+        self.windowFrameAutosaveName = "MainEditorWindow"
 
         // Keep the controller alive after the window closes so NSWindowDelegate
         // hooks have time to run teardown. WindowManager drops its strong

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -71,7 +71,10 @@ internal final class WindowManager {
                 "[open] WindowManager joined existing tab group payloadId=\(payload.id, privacy: .public) tabbingId=\(tabbingId, privacy: .public)"
             )
         } else {
-            window.center()
+            let hasSavedFrame = UserDefaults.standard.object(forKey: "NSWindow Frame MainEditorWindow") != nil
+            if !hasSavedFrame {
+                window.center()
+            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             Self.lifecycleLogger.info(

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -71,8 +71,7 @@ internal final class WindowManager {
                 "[open] WindowManager joined existing tab group payloadId=\(payload.id, privacy: .public) tabbingId=\(tabbingId, privacy: .public)"
             )
         } else {
-            let hasSavedFrame = UserDefaults.standard.object(forKey: "NSWindow Frame MainEditorWindow") != nil
-            if !hasSavedFrame {
+            if !TabWindowController.hasSavedFrame {
                 window.center()
             }
             window.makeKeyAndOrderFront(nil)

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -71,9 +71,6 @@ internal final class WindowManager {
                 "[open] WindowManager joined existing tab group payloadId=\(payload.id, privacy: .public) tabbingId=\(tabbingId, privacy: .public)"
             )
         } else {
-            if !TabWindowController.hasSavedFrame {
-                window.center()
-            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             Self.lifecycleLogger.info(

--- a/TablePro/Extensions/NSWindow+FrameAutosave.swift
+++ b/TablePro/Extensions/NSWindow+FrameAutosave.swift
@@ -6,6 +6,13 @@
 import AppKit
 
 extension NSWindow {
+    /// Do not call on a window owned by an `NSWindowController` whose
+    /// `contentViewController` is an `NSSplitViewController`. The contentVC's
+    /// intrinsic-size resize during init fires the implicit auto-save observer
+    /// installed by `setFrameAutosaveName`, overwriting the persisted frame
+    /// with the small intrinsic size. Use `setFrameUsingName` plus explicit
+    /// `saveFrame(usingName:)` calls in `NSWindowDelegate` methods instead.
+    /// See `TabWindowController` for that pattern.
     func applyAutosaveName(_ name: NSWindow.FrameAutosaveName) {
         setFrameAutosaveName(name)
         if !setFrameUsingName(name) {


### PR DESCRIPTION
## Summary

Editor windows now remember their size, position, and zoom state across app launches, matching standard macOS behavior. Net change is small: ~10 lines of code in 3 files, no new types or files.

## Why

The editor window always opened at the same default frame regardless of what the user had done before. Three pieces of code combined to defeat NSWindow's frame persistence:

1. `MainSplitViewController.viewWillAppear` had a "minimum size floor" that re-clamped any restored frame smaller than 1200×800 and re-centered.
2. `WindowManager.openTab` called `window.center()` unconditionally, wiping the autosaved origin every reopen.
3. `setFrameAutosaveName(_:)`'s implicit auto-save observer fires when `contentViewController = NSSplitViewController` shrinks the window to its intrinsic content size — overwriting the saved frame in UserDefaults with the small intrinsic size. The persisted size kept decaying toward NSSplitView's minimum.

Tracing this took several iterations because the bug looks different depending on which step you observe — the trace logs in the conversation history pinpoint the contentVC-resize-clobbers-saved-frame interaction as the root cause.

## How

### `TabWindowController.swift`
- Removed `applyAutosaveName` / `setFrameAutosaveName` (its implicit save observer is what corrupts the saved frame during init).
- Use `setFrameUsingName(_:)` AFTER `super.init` and after `contentViewController` is set, so the contentVC layout pass happens first and our explicit restore is the final word.
- First-launch fallback: when `setFrameUsingName` returns false, `setContentSize(1200×800)` + `center()` so the user gets a sensible default instead of NSSplitView's minimum.
- Save explicitly via NSWindowDelegate methods that the controller already implements:
  - `windowDidResize` (when `!inLiveResize`) — captures zoom and end-of-drag.
  - `windowDidEndLiveResize` — captures drag-resize end.
  - `windowDidMove` — captures move.
  - `windowWillClose` — final state safety net.

### `MainSplitViewController.swift`
- Deleted the upsize-floor block in `viewWillAppear`. `window.minSize = 720×480` already enforces the minimum during user resize; the programmatic re-clamp was redundant and destroyed restored frames.

### `WindowManager.swift`
- Removed the unconditional `window.center()` for standalone windows. `TabWindowController.init` now owns frame setup (restore-or-default), so WindowManager just calls `makeKeyAndOrderFront`.

## Why this is the canonical Apple pattern

- `setFrameUsingName(_:)` and `saveFrame(usingName:)` are documented Apple APIs, paired by name. They share the UserDefaults key `"NSWindow Frame {name}"` whether or not `setFrameAutosaveName` was ever called.
- Reacting to frame changes via `NSWindowDelegate` is the standard Cocoa pattern. The controller is already the delegate; we just add the methods.
- No new types, no policies, no NotificationCenter observers, no fullscreen tracking. Pure delegate methods + two Apple frame APIs.

## Test plan

- [ ] **First launch** (`defaults delete com.TablePro "NSWindow Frame MainEditorWindow"` first): connect → window opens at 1200×800 centered.
- [ ] **Resize persistence**: connect, drag-resize to a custom size, close, reconnect → window opens at the resized size.
- [ ] **Position persistence**: connect, drag to a non-default position, close, reconnect → window opens at the same position.
- [ ] **Zoom persistence**: connect, double-click toolbar to zoom (maximize), close, reconnect → window opens zoomed.
- [ ] **Below-default size**: drag-resize below 1200×800, close, reconnect → window opens at the smaller size, NOT bumped up.
- [ ] **Native NSWindow tab group**: open two connections in one tab group, resize the group, close, reconnect → window opens at the resized frame.
- [ ] **Off-screen recovery**: position window on external display, close while connected, disconnect display, relaunch standalone, connect → window opens on the current main screen (AppKit clamps automatically via `setFrameUsingName`).