### PR TITLE
fix(ios): stop ForEach indices race in row lists and validate driver port range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cmd+X with no selection cuts the current line, matching VS Code, Sublime, and Xcode (#1075)
 - Cmd+A on a query ending with a newline now highlights every line, not just the first (#1075)
 - Editor windows now remember their size, position, and zoom state across launches, instead of always opening at 1200x800
+- iOS: data browser and query result lists no longer crash with "Index out of range" when rows shrink during a SwiftUI update pass
+- iOS: connecting to MySQL, PostgreSQL, or Redis with an out-of-range port now reports a readable error instead of crashing on integer overflow
 
 ### Added
 

--- a/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
@@ -295,8 +295,14 @@ private actor MySQLActor {
             mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &sslVerify)
         }
 
+        guard let portU32 = UInt32(exactly: port), (1...65_535).contains(port) else {
+            mysql_close(handle)
+            throw MySQLError.connectionFailed(
+                "Port \(port) is out of range. Use a value between 1 and 65535."
+            )
+        }
         guard mysql_real_connect(
-            handle, host, user, password, database, UInt32(port), nil, 0
+            handle, host, user, password, database, portU32, nil, 0
         ) != nil else {
             let msg = String(cString: mysql_error(handle))
             mysql_close(handle)

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -334,6 +334,11 @@ private actor PostgreSQLActor {
     private var conn: OpaquePointer?
 
     func connect(host: String, port: Int, user: String, password: String, database: String, sslEnabled: Bool = false) throws {
+        guard (1...65_535).contains(port) else {
+            throw PostgreSQLError.connectionFailed(
+                "Port \(port) is out of range. Use a value between 1 and 65535."
+            )
+        }
         // Close existing connection if reconnecting
         if let conn { PQfinish(conn); self.conn = nil }
 

--- a/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
@@ -363,8 +363,13 @@ private actor RedisActor {
         // Close existing connection if reconnecting
         close()
 
+        guard let portI32 = Int32(exactly: port), (1...65_535).contains(port) else {
+            throw RedisError.connectionFailed(
+                "Port \(port) is out of range. Use a value between 1 and 65535."
+            )
+        }
         var tv = timeval(tv_sec: 10, tv_usec: 0)
-        guard let context = redisConnectWithTimeout(host, Int32(port), tv) else {
+        guard let context = redisConnectWithTimeout(host, portI32, tv) else {
             throw RedisError.connectionFailed("Failed to create Redis context")
         }
 

--- a/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
+++ b/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
@@ -1,0 +1,20 @@
+//
+//  IndexedRow.swift
+//  TableProMobile
+//
+
+import Foundation
+
+/// Identifiable wrapper used by iOS lists that need both the row payload and
+/// its position index. Iterating over `[IndexedRow]` instead of
+/// `rows.indices` keeps SwiftUI's `ForEach` diff stable when the underlying
+/// `[[String?]]` shrinks mid-render — the pattern that caused the
+/// `Array._checkSubscript` crashes in release 1.0 (build 11).
+struct IndexedRow: Identifiable {
+    let id: Int
+    let values: [String?]
+
+    static func wrap(_ rows: [[String?]]) -> [IndexedRow] {
+        rows.enumerated().map { IndexedRow(id: $0.offset, values: $0.element) }
+    }
+}

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -254,9 +254,15 @@ struct DataBrowserView: View {
     }
 
     private var rowList: some View {
-        List {
-            ForEach(rows.indices, id: \.self) { index in
-                let row = rows[index]
+        // Capture a snapshot to avoid race with `viewModel.legacyRows` shrinking
+        // mid-render. Wrapping each row with its index lets ForEach diff by
+        // stable identity instead of iterating `rows.indices` (which holds
+        // stale offsets when the array changes during a SwiftUI update pass).
+        let indexed = IndexedRow.wrap(rows)
+        return List {
+            ForEach(indexed) { item in
+                let index = item.id
+                let row = item.values
                 NavigationLink {
                     RowDetailView(
                         columns: columns,

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -228,9 +228,11 @@ struct QueryEditorView: View {
     }
 
     private var resultList: some View {
-        List {
-            ForEach(viewModel.legacyRows.indices, id: \.self) { rowIndex in
-                let row = viewModel.legacyRows[rowIndex]
+        let indexed = IndexedRow.wrap(viewModel.legacyRows)
+        return List {
+            ForEach(indexed) { item in
+                let rowIndex = item.id
+                let row = item.values
                 NavigationLink {
                     RowDetailView(
                         columns: viewModel.columns,

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -94,9 +94,9 @@ struct RowDetailView: View {
                 rowContent(at: currentIndex)
             } else {
                 TabView(selection: $currentIndex) {
-                    ForEach(rows.indices, id: \.self) { index in
-                        rowContent(at: index)
-                            .tag(index)
+                    ForEach(IndexedRow.wrap(rows)) { item in
+                        rowContent(at: item.id)
+                            .tag(item.id)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
@@ -450,7 +450,13 @@ struct RowDetailView: View {
         }
 
         guard !pkValues.isEmpty else {
-            operationError = AppError(category: .config, title: "Cannot Save", message: "No primary key values found.", recovery: "This table needs a primary key to identify the row.", underlying: nil)
+            operationError = AppError(
+                category: .config,
+                title: "Cannot Save",
+                message: "No primary key values found.",
+                recovery: "This table needs a primary key to identify the row.",
+                underlying: nil
+            )
             showOperationError = true
             return
         }


### PR DESCRIPTION
## Summary

Two distinct production crashes hit by TestFlight users on TableProMobile build 10/11. Both fixed in this PR.

### Crash 1 — `Array._checkSubscript` / "Index out of range"

**Stack trace** (build 11, iPhone 15, iOS 26.4.1):
```
Thread 0 Crashed:
0  Swift runtime failure: Index out of range
1  specialized Array._checkSubscript
2  specialized Array.subscript.getter
3  closure #1 in DataBrowserView.rowList.getter (DataBrowserView.swift:259)
4  ForEachChild.updateValue() (ForEach.swift:2068)
```

**Root cause**: `ForEach(rows.indices, id: \.self) { index in ... rows[index] ... }`. SwiftUI captures `rows.indices` once but `rows` is a computed property reading `viewModel.legacyRows`. When the array shrinks during a SwiftUI update pass (page change, filter, deletion), ForEach still iterates the stale indices and `rows[index]` traps. CLAUDE.md flags this exact pattern as a "Performance Pitfall".

**Fix**: introduce `IndexedRow: Identifiable` wrapper (`Helpers/IndexedRow.swift`) and iterate `[IndexedRow]` instead. SwiftUI diffs by stable id; if rows shrink, the missing ids are removed cleanly without ever subscripting a stale offset. Applied to all three sites: `DataBrowserView`, `QueryEditorView`, `RowDetailView`.

### Crash 2 — `Swift runtime failure: Not enough bits to represent the passed value`

**Stack trace** (build 10, iPhone 16):
```
Thread 6 Crashed:
0  Swift runtime failure: Not enough bits to represent the passed value
1  MySQLActor.execute(_:) (MySQLDriver.swift:297)
2  MySQLDriver.execute(query:) (MySQLDriver.swift:56)
3  DataBrowserView.loadData(isInitial:) (DataBrowserView.swift:526)
```

**Root cause**: `mysql_real_connect(..., UInt32(port), ...)` where `port: Int`. If the connection's port is negative or > UInt32.max, `UInt32(port)` traps. The form parses port via `Int(portString) ?? 3306` — a typed `-1` slips through. Same shape exists in `RedisDriver` (`Int32(port)`).

**Fix**: validate `port` is in `1...65_535` before each driver-level integer cast and throw a readable `connectionFailed` instead of trapping. Applied to MySQL, Redis, and PostgreSQL (consistency — PG was string-interpolating so it didn't crash, but it silently passed garbage to libpq).

## Test plan

- [ ] **Crash 1 manual repro**: open a table with many rows, scroll, then quickly switch tables / change filter — no crash on rapid re-render.
- [ ] **Crash 2 manual repro**: edit a connection, set port to `-1` or `99999999999`, save, tap connect. Expect a readable error sheet, no crash.
- [ ] **Regression**: normal flows (open table, paginate, run query, view row detail, swipe through rows in `RowDetailView`) work as before.

## Files changed

- `TableProMobile/Helpers/IndexedRow.swift` (new) — Identifiable wrapper
- `TableProMobile/Views/DataBrowserView.swift` — use `IndexedRow.wrap`
- `TableProMobile/Views/QueryEditorView.swift` — use `IndexedRow.wrap`
- `TableProMobile/Views/RowDetailView.swift` — use `IndexedRow.wrap`
- `TableProMobile/Drivers/MySQLDriver.swift` — port range guard before `UInt32(port)`
- `TableProMobile/Drivers/RedisDriver.swift` — port range guard before `Int32(port)`
- `TableProMobile/Drivers/PostgreSQLDriver.swift` — port range guard (parity / readable error)
- `CHANGELOG.md` — Fixed entries