### PR TITLE
fix: surface MCPProtocolError message via LocalizedError

### DIFF
--- a/TablePro/Core/MCP/Transport/MCPProtocolError.swift
+++ b/TablePro/Core/MCP/Transport/MCPProtocolError.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-public struct MCPProtocolError: Error, Sendable, Equatable {
+public struct MCPProtocolError: LocalizedError, Sendable, Equatable {
+    public var errorDescription: String? { message }
     public let code: Int
     public let message: String
     public let httpStatus: HttpStatus


### PR DESCRIPTION
## Summary

`MCPProtocolError` carries a `message: String` that holds the underlying SQL or transport detail (e.g., `"Unknown column 'active' in 'field list'"`), but the type didn't conform to `LocalizedError`. `Error.localizedDescription` therefore fell back to the Swift default formatter, which produces uninformative text like:

```
TablePro.MCPProtocolError error 1
```

This is what the AI chat user sees when a tool call fails, so the assistant has nothing to explain back beyond a generic guess at "connection issues / permissions / column existence".

## Fix

Conform `MCPProtocolError` to `LocalizedError` and return `message` from `errorDescription`. Single-line change.

## Effect

`error.localizedDescription` now returns the protocol's own message string. The chat tool result already uses `localizedDescription` when wrapping the failure, so failures like:

```
"Unknown column 'active' in 'field list'"
"Connection refused"
"User declined to run this query."
```

now surface verbatim instead of being masked.

## Test plan

- [ ] Build the project.
- [ ] In AI Chat, ask the assistant to `update users set is_inactive = 1 where id = 1` against a database where `is_inactive` does not exist.
- [ ] Tool result content shows `"Error: Unknown column 'is_inactive' in 'field list'"` (or the equivalent error from the underlying driver), not `"TablePro.MCPProtocolError error 1"`.