### PR TITLE
fix: raise AI chat tool roundtrip limit from 5 to 10

### DIFF
--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -819,7 +819,7 @@ final class AIChatViewModel {
         }
     }
 
-    private static let maxToolRoundtrips = 5
+    private static let maxToolRoundtrips = 10
 
     private func runStream(
         chatMessages: [ChatTurn],


### PR DESCRIPTION
## Summary

`AIChatViewModel.maxToolRoundtrips` was set to 5. The assistant hit the cap on routine tasks: discovering a table schema after a column error, retrying a query, then proposing a corrected version uses 3–4 roundtrips on its own. Multi-step migrations or "find and fix" tasks blow through 5 immediately, leaving the user with a generic "AI made too many tool calls in one response" banner and no recourse other than rephrasing.

Bumps the cap to 10. Single-line change. The cap remains a safety against runaway tool-calling loops, but at a level that fits real iteration patterns.

## Follow-ups (not in this PR)

- Cancelled tool calls should arguably not consume a roundtrip — a "Cancel" cancels the call but should let the user redirect, not burn quota.
- A user-visible "Continue" affordance once the cap hits, so the user can opt in to more rounds rather than starting over.
- A user setting if 10 turns out to be insufficient for some workflows.

## Test plan

- [ ] Build the project.
- [ ] Trigger a multi-step assistant task (e.g., "find all tables with a deprecated column and rename it"). Confirm the assistant can chain at least 8–9 tool roundtrips before the cap.
- [ ] Confirm the cap still fires for genuinely runaway loops (e.g., manufactured infinite tool calls in tests, if any).