### PR TITLE
feat: GitHub Copilot tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- AI Chat: tool calling support for the GitHub Copilot provider. Copilot can now invoke the same database tools (list_tables, describe_table, execute_query, etc.) the other providers do, gated by chat mode and the per-card approval flow. Older Copilot language servers without the `conversation/registerTools` API gracefully degrade to chat-only.
 - AI Chat: per-card tool approval. Write and destructive AI tool calls now show inline `Run`, `Always for this connection`, and `Cancel` buttons on the tool card instead of interrupting with a modal dialog. "Always for this connection" persists the tool name on the connection so future calls run without prompting. Cancel ends only that tool call; the assistant sees an error result and continues the conversation. Read-only tools auto-run; Read-only safe mode still blocks writes outright.
 - AI Chat: panel layout redesign. The right inspector has a Details / AI Chat segmented picker at the top, with conversation history and new-conversation actions trailing on the same row. The chat tab is composer-focused: composer is a pill-shaped input with an Apple Intelligence focus glow, and a single-row footer (mention, slash commands, mode picker, model picker, send). The mode picker (Ask / Edit / Agent) is saved to settings but does not yet change provider behavior.
 - AI Chat: inline model picker in the composer with per-turn model attribution. Switch between configured providers and any of their available models without leaving the chat. The model that produced each assistant turn is shown in the message footer.
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Chat: tool calling. The AI can look up your database on demand instead of relying on context you attached up front.
   - Read-only tools: `list_connections`, `get_connection_status`, `list_databases`, `list_schemas`, `list_tables`, `describe_table`, `get_table_ddl`.
   - Tool calls and their results render as expandable pills in the assistant's reply.
-  - Supported providers: Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), and custom OpenAI-compatible endpoints. GitHub Copilot is not yet supported.
+  - Supported providers: Anthropic, OpenAI, OpenRouter, Gemini, Ollama (model-dependent), GitHub Copilot, and custom OpenAI-compatible endpoints.
 - AI Chat: attach a saved query as a chip via `@`. Type `@` and pick a saved SQL query to send its name and body to the AI alongside your message.
 - AI Chat: user-defined slash commands. Create your own commands in Settings -> AI -> Custom Slash Commands. Templates support `{{query}}`, `{{schema}}`, `{{database}}`, and `{{body}}` placeholders that get substituted at send time.
 - AI Chat: tool calling can now run write queries (`execute_query`) and destructive DDL (`confirm_destructive_operation` after the AI passes the verbatim phrase). The connection's safe mode policy still gates execution, so the user remains the final approver.

--- a/TablePro/Core/AI/Chat/ChatToolSpec+Copilot.swift
+++ b/TablePro/Core/AI/Chat/ChatToolSpec+Copilot.swift
@@ -10,7 +10,15 @@ extension ChatToolSpec {
         CopilotLanguageModelToolInformation(
             name: name,
             description: description,
-            inputSchema: inputSchema
+            inputSchema: Self.normalizeForCopilot(inputSchema)
         )
+    }
+
+    private static func normalizeForCopilot(_ schema: JSONValue) -> JSONValue {
+        guard case .object(var dict) = schema else { return schema }
+        if dict["required"] == nil {
+            dict["required"] = .array([])
+        }
+        return .object(dict)
     }
 }

--- a/TablePro/Core/AI/Chat/ChatToolSpec+Copilot.swift
+++ b/TablePro/Core/AI/Chat/ChatToolSpec+Copilot.swift
@@ -1,0 +1,16 @@
+//
+//  ChatToolSpec+Copilot.swift
+//  TablePro
+//
+
+import Foundation
+
+extension ChatToolSpec {
+    func asCopilotToolInformation() -> CopilotLanguageModelToolInformation {
+        CopilotLanguageModelToolInformation(
+            name: name,
+            description: description,
+            inputSchema: inputSchema
+        )
+    }
+}

--- a/TablePro/Core/AI/Chat/ChatTransport.swift
+++ b/TablePro/Core/AI/Chat/ChatTransport.swift
@@ -50,4 +50,17 @@ enum ChatStreamEvent: Sendable {
     case toolUseDelta(id: String, inputJSONDelta: String)
     case toolUseEnd(id: String)
     case usage(AITokenUsage)
+    case toolInvocationRequest(block: ToolUseBlock, replyToken: ToolReplyToken)
+}
+
+final class ToolReplyToken: Sendable {
+    private let onReply: @Sendable (ChatToolResult) async -> Void
+
+    init(onReply: @escaping @Sendable (ChatToolResult) async -> Void) {
+        self.onReply = onReply
+    }
+
+    func reply(_ result: ChatToolResult) async {
+        await onReply(result)
+    }
 }

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -187,9 +187,15 @@ final class CopilotChatProvider: ChatTransport {
             params = envelope.params
         } catch {
             Self.logger.error("Failed to decode invokeClientTool params: \(error.localizedDescription, privacy: .public)")
+            if let raw = String(data: data, encoding: .utf8) {
+                Self.logger.error("Raw invokeClientTool payload: \(raw, privacy: .public)")
+            }
             await Self.sendErrorReply(requestId: requestId, message: "Failed to decode tool invocation")
             return
         }
+        Self.logger.info(
+            "Copilot invoked tool '\(params.name, privacy: .public)' (turn=\(params.turnId, privacy: .public))"
+        )
 
         let toolBlock = ToolUseBlock(
             id: "\(params.conversationId)-\(params.turnId)-\(params.name)",
@@ -217,6 +223,10 @@ final class CopilotChatProvider: ChatTransport {
         let lspResult = CopilotLanguageModelToolResult(
             status: status,
             content: [CopilotLanguageModelToolResultContent(value: .string(result.content))]
+        )
+        let preview = result.content.prefix(200)
+        Self.logger.info(
+            "Replying to invokeClientTool requestId=\(requestId) status=\(status.rawValue, privacy: .public) preview=\(preview, privacy: .public)"
         )
         do {
             try await client.sendInvokeClientToolResponse(id: requestId, result: lspResult)

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -15,6 +15,11 @@ final class CopilotChatProvider: ChatTransport {
         initialState: [String: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation]()
     )
     private var isProgressHandlerRegistered = false
+    private var isInvokeClientToolHandlerRegistered = false
+    private var registeredToolNames: Set<String> = []
+    private let invokeContinuations = OSAllocatedUnfairLock(
+        initialState: [String: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation]()
+    )
 
     func streamChat(
         turns: [ChatTurn],
@@ -38,8 +43,11 @@ final class CopilotChatProvider: ChatTransport {
                     }
 
                     await self.ensureProgressHandler()
+                    await self.ensureInvokeClientToolHandler()
+                    await self.ensureToolsRegistered(tools: options.tools)
 
                     self.progressHandlers.withLock { $0[token] = continuation }
+                    self.invokeContinuations.withLock { $0["__active"] = continuation }
 
                     let userMessage = turns.last(where: { $0.role == .user })?.plainText ?? ""
                     let effectiveModel: String? = options.model.isEmpty ? nil : options.model
@@ -123,6 +131,100 @@ final class CopilotChatProvider: ChatTransport {
             guard let client = CopilotService.shared.client else { return }
             try? await client.conversationTurnDelete(conversationId: conversationId, turnId: turnId)
         }
+    }
+
+    @MainActor
+    private func ensureToolsRegistered(tools: [ChatToolSpec]) async {
+        let names = Set(tools.map(\.name))
+        guard names != registeredToolNames else { return }
+        guard let client = CopilotService.shared.client else { return }
+        do {
+            let info = tools.map { $0.asCopilotToolInformation() }
+            try await client.registerTools(CopilotRegisterToolsParams(tools: info))
+            registeredToolNames = names
+            Self.logger.info("Registered \(info.count) Copilot tools")
+        } catch {
+            Self.logger.warning(
+                "Copilot tools registration failed (likely older language server): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    @MainActor
+    private func ensureInvokeClientToolHandler() async {
+        guard !isInvokeClientToolHandlerRegistered else { return }
+        isInvokeClientToolHandlerRegistered = true
+        guard let client = CopilotService.shared.client else { return }
+        let invokeContinuations = invokeContinuations
+        await client.onDeferredRequest(method: "conversation/invokeClientTool") { data, requestId in
+            Task { @MainActor in
+                await Self.handleInvokeClientTool(
+                    data: data,
+                    requestId: requestId,
+                    invokeContinuations: invokeContinuations
+                )
+            }
+        }
+    }
+
+    private struct InvokeClientToolEnvelope: Decodable {
+        let params: CopilotInvokeClientToolParams
+    }
+
+    @MainActor
+    private static func handleInvokeClientTool(
+        data: Data,
+        requestId: Int,
+        invokeContinuations: OSAllocatedUnfairLock<[String: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation]>
+    ) async {
+        let params: CopilotInvokeClientToolParams
+        do {
+            let envelope = try JSONDecoder().decode(InvokeClientToolEnvelope.self, from: data)
+            params = envelope.params
+        } catch {
+            Self.logger.error("Failed to decode invokeClientTool params: \(error.localizedDescription, privacy: .public)")
+            await Self.sendErrorReply(requestId: requestId, message: "Failed to decode tool invocation")
+            return
+        }
+
+        let toolBlock = ToolUseBlock(
+            id: "\(params.conversationId)-\(params.turnId)-\(params.name)",
+            name: params.name,
+            input: params.input ?? .object([:]),
+            approvalState: .pending
+        )
+
+        let replyToken = ToolReplyToken { result in
+            await Self.sendToolReply(requestId: requestId, result: result)
+        }
+
+        guard let continuation = invokeContinuations.withLock({ $0["__active"] }) else {
+            Self.logger.warning("No active stream continuation for invokeClientTool; cancelling")
+            await Self.sendErrorReply(requestId: requestId, message: "No active chat session")
+            return
+        }
+        continuation.yield(.toolInvocationRequest(block: toolBlock, replyToken: replyToken))
+    }
+
+    @MainActor
+    private static func sendToolReply(requestId: Int, result: ChatToolResult) async {
+        guard let client = CopilotService.shared.client else { return }
+        let status: CopilotToolInvocationStatus = result.isError ? .error : .success
+        let lspResult = CopilotLanguageModelToolResult(
+            status: status,
+            content: [CopilotLanguageModelToolResultContent(value: .string(result.content))]
+        )
+        do {
+            try await client.sendInvokeClientToolResponse(id: requestId, result: lspResult)
+        } catch {
+            Self.logger.error("Failed to reply to invokeClientTool: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    @MainActor
+    private static func sendErrorReply(requestId: Int, message: String) async {
+        let result = ChatToolResult(content: message, isError: true)
+        await sendToolReply(requestId: requestId, result: result)
     }
 
     @MainActor

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -17,8 +17,9 @@ final class CopilotChatProvider: ChatTransport {
     private var isProgressHandlerRegistered = false
     private var isInvokeClientToolHandlerRegistered = false
     private var registeredToolNames: Set<String> = []
-    private let invokeContinuations = OSAllocatedUnfairLock(
-        initialState: [String: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation]()
+    private var lastChatMode: String?
+    private let activeStream = OSAllocatedUnfairLock<(UUID, AsyncThrowingStream<ChatStreamEvent, Error>.Continuation)?>(
+        initialState: nil
     )
 
     func streamChat(
@@ -26,6 +27,12 @@ final class CopilotChatProvider: ChatTransport {
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
         AsyncThrowingStream { continuation in
+            let sessionId = UUID()
+            continuation.onTermination = { [weak self] _ in
+                self?.activeStream.withLock { current in
+                    if current?.0 == sessionId { current = nil }
+                }
+            }
             let task = Task { @MainActor [weak self] in
                 guard let self else {
                     continuation.finish()
@@ -46,8 +53,19 @@ final class CopilotChatProvider: ChatTransport {
                     await self.ensureInvokeClientToolHandler()
                     await self.ensureToolsRegistered(tools: options.tools)
 
+                    let desiredChatMode: String? = (!options.tools.isEmpty && !self.registeredToolNames.isEmpty)
+                        ? "Agent" : nil
+                    if self.conversationId != nil, self.lastChatMode != desiredChatMode {
+                        Self.logger.info(
+                            "Copilot chat mode changed; resetting conversation to apply new mode"
+                        )
+                        self.conversationId = nil
+                        self.turnIds.removeAll()
+                    }
+                    self.lastChatMode = desiredChatMode
+
                     self.progressHandlers.withLock { $0[token] = continuation }
-                    self.invokeContinuations.withLock { $0["__active"] = continuation }
+                    self.activeStream.withLock { $0 = (sessionId, continuation) }
 
                     let userMessage = turns.last(where: { $0.role == .user })?.plainText ?? ""
                     let effectiveModel: String? = options.model.isEmpty ? nil : options.model
@@ -159,13 +177,13 @@ final class CopilotChatProvider: ChatTransport {
         guard !isInvokeClientToolHandlerRegistered else { return }
         isInvokeClientToolHandlerRegistered = true
         guard let client = CopilotService.shared.client else { return }
-        let invokeContinuations = invokeContinuations
+        let activeStream = activeStream
         await client.onDeferredRequest(method: "conversation/invokeClientTool") { data, requestId in
             Task { @MainActor in
                 await Self.handleInvokeClientTool(
                     data: data,
                     requestId: requestId,
-                    invokeContinuations: invokeContinuations
+                    activeStream: activeStream
                 )
             }
         }
@@ -179,7 +197,7 @@ final class CopilotChatProvider: ChatTransport {
     private static func handleInvokeClientTool(
         data: Data,
         requestId: Int,
-        invokeContinuations: OSAllocatedUnfairLock<[String: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation]>
+        activeStream: OSAllocatedUnfairLock<(UUID, AsyncThrowingStream<ChatStreamEvent, Error>.Continuation)?>
     ) async {
         let params: CopilotInvokeClientToolParams
         do {
@@ -198,7 +216,7 @@ final class CopilotChatProvider: ChatTransport {
         )
 
         let toolBlock = ToolUseBlock(
-            id: "\(params.conversationId)-\(params.turnId)-\(params.name)",
+            id: "\(params.conversationId)-\(params.turnId)-\(params.name)-\(UUID().uuidString)",
             name: params.name,
             input: params.input ?? .object([:]),
             approvalState: .pending
@@ -208,7 +226,7 @@ final class CopilotChatProvider: ChatTransport {
             await Self.sendToolReply(requestId: requestId, result: result)
         }
 
-        guard let continuation = invokeContinuations.withLock({ $0["__active"] }) else {
+        guard let continuation = activeStream.withLock({ $0?.1 }) else {
             Self.logger.warning("No active stream continuation for invokeClientTool; cancelling")
             await Self.sendErrorReply(requestId: requestId, message: "No active chat session")
             return

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -59,6 +59,7 @@ final class CopilotChatProvider: ChatTransport {
                             response: "",
                             turnId: ""
                         )]
+                        let toolsAvailable = !options.tools.isEmpty && !self.registeredToolNames.isEmpty
                         let params = CopilotConversationCreateParams(
                             workDoneToken: token,
                             turns: conversationTurns,
@@ -68,7 +69,10 @@ final class CopilotChatProvider: ChatTransport {
                             ),
                             source: "panel",
                             model: effectiveModel,
-                            workspaceFolders: nil
+                            workspaceFolders: nil,
+                            chatMode: toolsAvailable ? "Agent" : nil,
+                            customChatModeId: toolsAvailable ? "Agent" : nil,
+                            needToolCallConfirmation: toolsAvailable ? true : nil
                         )
                         let result = try await client.conversationCreate(params: params)
                         self.conversationId = result.conversationId

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -90,7 +90,7 @@ final class CopilotChatProvider: ChatTransport {
                             workspaceFolders: nil,
                             chatMode: toolsAvailable ? "Agent" : nil,
                             customChatModeId: toolsAvailable ? "Agent" : nil,
-                            needToolCallConfirmation: toolsAvailable ? true : nil
+                            needToolCallConfirmation: toolsAvailable ? false : nil
                         )
                         let result = try await client.conversationCreate(params: params)
                         self.conversationId = result.conversationId

--- a/TablePro/Core/LSP/LSPClient.swift
+++ b/TablePro/Core/LSP/LSPClient.swift
@@ -200,6 +200,6 @@ actor LSPClient {
     }
 
     func sendInvokeClientToolResponse(id: Int, result: CopilotLanguageModelToolResult) async throws {
-        try await transport.sendDeferredResponse(id: id, result: result)
+        try await transport.sendDeferredArrayResponse(id: id, result: result)
     }
 }

--- a/TablePro/Core/LSP/LSPClient.swift
+++ b/TablePro/Core/LSP/LSPClient.swift
@@ -188,4 +188,18 @@ actor LSPClient {
     func onRequest(method: String, handler: @escaping @Sendable (Data) -> Any?) async {
         await transport.onRequest(method: method, handler: handler)
     }
+
+    func onDeferredRequest(method: String, handler: @escaping @Sendable (Data, Int) -> Void) async {
+        await transport.onDeferredRequest(method: method, handler: handler)
+    }
+
+    // MARK: - Copilot tool calling
+
+    func registerTools(_ params: CopilotRegisterToolsParams) async throws {
+        _ = try await transport.sendRequest(method: "conversation/registerTools", params: params)
+    }
+
+    func sendInvokeClientToolResponse(id: Int, result: CopilotLanguageModelToolResult) async throws {
+        try await transport.sendDeferredResponse(id: id, result: result)
+    }
 }

--- a/TablePro/Core/LSP/LSPTransport.swift
+++ b/TablePro/Core/LSP/LSPTransport.swift
@@ -188,6 +188,15 @@ actor LSPTransport {
         try writeMessage(data)
     }
 
+    func sendDeferredArrayResponse<R: Encodable>(id: Int, result: R) async throws {
+        let resultData = try JSONEncoder().encode(result)
+        let resultObj = try JSONSerialization.jsonObject(with: resultData)
+        let wrapped: [Any] = [resultObj, NSNull()]
+        let response: [String: Any] = ["jsonrpc": "2.0", "id": id, "result": wrapped]
+        let data = try JSONSerialization.data(withJSONObject: response)
+        try writeMessage(data)
+    }
+
     // MARK: - Private
 
     private func writeMessage(_ data: Data) throws {

--- a/TablePro/Core/LSP/LSPTransport.swift
+++ b/TablePro/Core/LSP/LSPTransport.swift
@@ -44,6 +44,7 @@ actor LSPTransport {
     private var pendingRequests: [Int: CheckedContinuation<Data, Error>] = [:]
     private var notificationHandlers: [String: @Sendable (Data) -> Void] = [:]
     private var requestHandlers: [String: @Sendable (Data) -> Any?] = [:]
+    private var deferredRequestHandlers: [String: @Sendable (Data, Int) -> Void] = [:]
     private var readerQueue: DispatchQueue?
 
     // MARK: - Lifecycle
@@ -175,6 +176,18 @@ actor LSPTransport {
         requestHandlers[method] = handler
     }
 
+    func onDeferredRequest(method: String, handler: @escaping @Sendable (Data, Int) -> Void) {
+        deferredRequestHandlers[method] = handler
+    }
+
+    func sendDeferredResponse<R: Encodable>(id: Int, result: R) async throws {
+        let resultData = try JSONEncoder().encode(result)
+        let resultObj = try JSONSerialization.jsonObject(with: resultData)
+        let response: [String: Any] = ["jsonrpc": "2.0", "id": id, "result": resultObj]
+        let data = try JSONSerialization.data(withJSONObject: response)
+        try writeMessage(data)
+    }
+
     // MARK: - Private
 
     private func writeMessage(_ data: Data) throws {
@@ -286,6 +299,10 @@ actor LSPTransport {
             }
             // Server-initiated request (has both id and method) — reply with handler result or null
             if let id {
+                if let deferred = deferredRequestHandlers[method] {
+                    deferred(data, id)
+                    return
+                }
                 var result: Any = NSNull()
                 if let requestHandler = requestHandlers[method] {
                     result = requestHandler(data) ?? NSNull()

--- a/TablePro/Core/LSP/LSPTypes.swift
+++ b/TablePro/Core/LSP/LSPTypes.swift
@@ -180,6 +180,31 @@ struct CopilotConversationCreateParams: Codable, Sendable {
     let source: String
     let model: String?
     let workspaceFolders: [LSPWorkspaceFolder]?
+    let chatMode: String?
+    let customChatModeId: String?
+    let needToolCallConfirmation: Bool?
+
+    init(
+        workDoneToken: String,
+        turns: [CopilotConversationTurn],
+        capabilities: CopilotConversationCapabilities,
+        source: String,
+        model: String?,
+        workspaceFolders: [LSPWorkspaceFolder]?,
+        chatMode: String? = nil,
+        customChatModeId: String? = nil,
+        needToolCallConfirmation: Bool? = nil
+    ) {
+        self.workDoneToken = workDoneToken
+        self.turns = turns
+        self.capabilities = capabilities
+        self.source = source
+        self.model = model
+        self.workspaceFolders = workspaceFolders
+        self.chatMode = chatMode
+        self.customChatModeId = customChatModeId
+        self.needToolCallConfirmation = needToolCallConfirmation
+    }
 }
 
 struct CopilotConversationCreateResult: Codable, Sendable {

--- a/TablePro/Core/LSP/LSPTypes.swift
+++ b/TablePro/Core/LSP/LSPTypes.swift
@@ -321,3 +321,37 @@ enum AnyCodableValue: Sendable, Equatable {
         }
     }
 }
+
+// MARK: - Copilot tool calling
+
+struct CopilotLanguageModelToolInformation: Codable, Sendable {
+    let name: String
+    let description: String
+    let inputSchema: JSONValue?
+}
+
+struct CopilotRegisterToolsParams: Codable, Sendable {
+    let tools: [CopilotLanguageModelToolInformation]
+}
+
+struct CopilotInvokeClientToolParams: Codable, Sendable {
+    let name: String
+    let input: JSONValue?
+    let conversationId: String
+    let turnId: String
+}
+
+enum CopilotToolInvocationStatus: String, Codable, Sendable {
+    case success
+    case error
+    case cancelled
+}
+
+struct CopilotLanguageModelToolResultContent: Codable, Sendable {
+    let value: JSONValue
+}
+
+struct CopilotLanguageModelToolResult: Codable, Sendable {
+    let status: CopilotToolInvocationStatus
+    let content: [CopilotLanguageModelToolResultContent]
+}

--- a/TablePro/ViewModels/AIChatViewModel+ToolApproval.swift
+++ b/TablePro/ViewModels/AIChatViewModel+ToolApproval.swift
@@ -99,6 +99,83 @@ extension AIChatViewModel {
         ConnectionStorage.shared.updateConnection(current)
     }
 
+    func dispatchCopilotInvocation(
+        block: ToolUseBlock,
+        replyToken: ToolReplyToken,
+        assistantID: UUID,
+        mode: AIChatMode
+    ) async {
+        let context = ChatToolContext(
+            connectionId: connection?.id,
+            bridge: ChatToolBootstrap.bridge,
+            authPolicy: ChatToolBootstrap.authPolicy
+        )
+        await handleCopilotToolInvocation(
+            block: block, replyToken: replyToken,
+            assistantID: assistantID, context: context, mode: mode
+        )
+    }
+
+    func handleCopilotToolInvocation(
+        block: ToolUseBlock,
+        replyToken: ToolReplyToken,
+        assistantID: UUID,
+        context: ChatToolContext,
+        mode: AIChatMode
+    ) async {
+        let initialState = computeInitialApprovalState(for: block.name)
+        let pendingBlock = ToolUseBlock(
+            id: block.id, name: block.name, input: block.input, approvalState: initialState
+        )
+        appendPendingToolUseBlocks([pendingBlock], assistantID: assistantID)
+
+        let finalState: ToolApprovalState
+        if case .pending = initialState {
+            let decision = await ToolApprovalCenter.shared.awaitDecision(for: block.id)
+            switch decision {
+            case .run:
+                finalState = .approved
+            case .alwaysAllow:
+                persistAlwaysAllowed(toolName: block.name)
+                finalState = .approved
+            case .cancel:
+                finalState = .cancelled
+            }
+            updateApprovalState(blockID: block.id, newState: finalState, assistantID: assistantID)
+        } else {
+            finalState = initialState
+        }
+
+        let result: ChatToolResult
+        switch finalState {
+        case .approved:
+            guard ChatToolRegistry.isToolAllowed(name: block.name, in: mode) else {
+                result = ChatToolResult(
+                    content: "Tool '\(block.name)' is not available in \(mode.displayName) mode",
+                    isError: true
+                )
+                break
+            }
+            let tool = ChatToolRegistry.shared.tool(named: block.name, in: mode)
+            guard let tool else {
+                result = ChatToolResult(content: "Tool '\(block.name)' is not registered", isError: true)
+                break
+            }
+            do {
+                result = try await tool.execute(input: block.input, context: context)
+            } catch {
+                result = ChatToolResult(content: "Error: \(error.localizedDescription)", isError: true)
+            }
+        case .cancelled:
+            result = ChatToolResult(content: "User cancelled this tool call.", isError: true)
+        case .denied(let reason):
+            result = ChatToolResult(content: reason, isError: true)
+        case .pending:
+            result = ChatToolResult(content: "Tool approval was not resolved.", isError: true)
+        }
+        await replyToken.reply(result)
+    }
+
     nonisolated static func synthesizeResults(
         for blocks: [ToolUseBlock],
         executed: [ToolResultBlock]

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -882,6 +882,11 @@ final class AIChatViewModel {
                             toolUseInputs[id, default: ""] += inputJSONDelta
                         case .toolUseEnd:
                             break
+                        case .toolInvocationRequest(let block, let replyToken):
+                            await self.dispatchCopilotInvocation(
+                                block: block, replyToken: replyToken,
+                                assistantID: assistantIDForRound, mode: chatMode
+                            )
                         }
 
                         if ContinuousClock.now - lastFlushTime >= flushInterval {


### PR DESCRIPTION
## Summary

Closes the long-standing gap noted in CHANGELOG ("GitHub Copilot is not yet supported"). Brings Copilot to feature parity with Anthropic, OpenAI, and Gemini for AI chat tool calls — list/describe tables, execute queries, etc.

## Protocol

GitHub Copilot's language server doesn't speak OpenAI-style tool_use blocks. It uses a server-initiated JSON-RPC callback model:

- Client → Server: `conversation/registerTools` with the array of tools the IDE exposes (name, description, input schema).
- Server → Client (during streaming): `conversation/invokeClientTool` with `{ name, input, conversationId, turnId }`. The client must reply with `LanguageModelToolResult { status, content }`.
- Failure case: older Copilot language servers don't know `conversation/registerTools` and reject the request. We log a warning and continue chat-only — no crash, no degraded text response.

Reference: [`github/CopilotForXcode`](https://github.com/github/CopilotForXcode/tree/main/Tool/Sources/ConversationServiceProvider) — the wire shapes are mirrored 1:1.

## Architecture

The protocol mismatch with the other providers is real: Anthropic/OpenAI/Gemini stream `ToolUseBlock`s in the response and the viewmodel runs them in a post-pass. Copilot pauses streaming and asks the client synchronously. To keep one tool-execution code path, this PR introduces a new event:

```swift
case toolInvocationRequest(block: ToolUseBlock, replyToken: ToolReplyToken)
```

`ToolReplyToken` is a `Sendable` callback that routes back to the LSP transport. The viewmodel receives the event from the stream loop, runs the existing per-card approval flow (PR #1091) with `ToolApprovalCenter`, executes the tool through `ChatToolRegistry`, and calls `replyToken.reply(result)` which writes the `LanguageModelToolResult` JSON-RPC response.

`LSPTransport` gained a `deferredRequestHandlers` map and a `sendDeferredResponse(id:result:)` method so the server-initiated request can stay in-flight while the user thinks about an approval pill.

`CopilotChatProvider`:
- Calls `conversation/registerTools` once per change in `options.tools` (mode change is automatically picked up because `options.tools` is already mode-filtered upstream).
- Registers a single deferred request handler for `conversation/invokeClientTool`.
- Tracks one "active" stream continuation; the handler emits the new event into it.
- Older LSP versions: `registerTools` failure is caught and logged, chat continues without tools.

## Files

- `Core/LSP/LSPTypes.swift` (+50): Codable types for register/invoke/result.
- `Core/LSP/LSPTransport.swift` (+25): `deferredRequestHandlers`, `sendDeferredResponse`, dispatch path that skips auto-reply when a deferred handler is registered.
- `Core/LSP/LSPClient.swift` (+15): `registerTools`, `onDeferredRequest`, `sendInvokeClientToolResponse`.
- `Core/AI/Chat/ChatTransport.swift` (+15): `toolInvocationRequest` event variant, `ToolReplyToken`.
- `Core/AI/Chat/ChatToolSpec+Copilot.swift` (new, 15): mapping helper.
- `Core/AI/Copilot/CopilotChatProvider.swift` (+115): tool registration, invoke handler, reply path.
- `ViewModels/AIChatViewModel.swift` (+5): dispatch new event from stream loop.
- `ViewModels/AIChatViewModel+ToolApproval.swift` (+75): `dispatchCopilotInvocation` + `handleCopilotToolInvocation` reusing the PR E approval lifecycle.
- `CHANGELOG.md`: drops "GitHub Copilot is not yet supported", adds Copilot tool-calling Added entry.

## Test plan

- [ ] Build the project. Lint clean on touched files.
- [ ] Sign in to Copilot in Settings -> AI. Pick Copilot as active provider.
- [ ] In AI Chat (Edit or Agent mode), ask `list all tables in this database`. Tool card renders, runs through the approval pills, and the model gets a structured tool result.
- [ ] Ask `update users set last_seen = now() where id = 1` against a writable connection with Safe Mode = Alert (Full). Approval pills show. Click Run; the query executes, result returns.
- [ ] Switch chat mode mid-conversation from Edit to Ask. Ask the same write again. Tool registration updates; the model is told the tool isn't available.
- [ ] Connect to a Copilot LSP build that doesn't support `conversation/registerTools` (or temporarily revert it). Confirm Copilot still chats; warning is logged but no error to the user.
- [ ] Cancel a pending tool call. The Copilot server gets an error result and continues the conversation.