### PR TITLE
fix: persist Connection.aiRules through StoredConnection and CloudKit sync

### DIFF
--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -446,6 +446,9 @@ private struct StoredConnection: Codable {
     // AI policy
     let aiPolicy: String?
 
+    // AI rules text included in the system prompt for this connection
+    let aiRules: String?
+
     // AI tools whitelisted for this connection
     let aiAlwaysAllowedTools: [String]?
 
@@ -527,6 +530,7 @@ private struct StoredConnection: Codable {
 
         // AI policy
         self.aiPolicy = connection.aiPolicy?.rawValue
+        self.aiRules = connection.aiRules
         self.aiAlwaysAllowedTools = connection.aiAlwaysAllowedTools.isEmpty
             ? nil
             : Array(connection.aiAlwaysAllowedTools).sorted()
@@ -574,6 +578,7 @@ private struct StoredConnection: Codable {
         case safeModeLevel
         case isReadOnly // Legacy key for migration reading only
         case aiPolicy
+        case aiRules
         case aiAlwaysAllowedTools
         case mongoAuthSource, mongoReadPreference, mongoWriteConcern, redisDatabase
         case mssqlSchema, oracleServiceName, startupCommands, sortOrder
@@ -613,6 +618,7 @@ private struct StoredConnection: Codable {
         try container.encodeIfPresent(sshProfileId, forKey: .sshProfileId)
         try container.encode(safeModeLevel, forKey: .safeModeLevel)
         try container.encodeIfPresent(aiPolicy, forKey: .aiPolicy)
+        try container.encodeIfPresent(aiRules, forKey: .aiRules)
         try container.encodeIfPresent(aiAlwaysAllowedTools, forKey: .aiAlwaysAllowedTools)
         try container.encodeIfPresent(redisDatabase, forKey: .redisDatabase)
         try container.encodeIfPresent(startupCommands, forKey: .startupCommands)
@@ -674,6 +680,7 @@ private struct StoredConnection: Codable {
             safeModeLevel = wasReadOnly ? SafeModeLevel.readOnly.rawValue : SafeModeLevel.silent.rawValue
         }
         aiPolicy = try container.decodeIfPresent(String.self, forKey: .aiPolicy)
+        aiRules = try container.decodeIfPresent(String.self, forKey: .aiRules)
         aiAlwaysAllowedTools = try container.decodeIfPresent([String].self, forKey: .aiAlwaysAllowedTools)
         mongoAuthSource = try container.decodeIfPresent(String.self, forKey: .mongoAuthSource)
         mongoReadPreference = try container.decodeIfPresent(String.self, forKey: .mongoReadPreference)
@@ -768,6 +775,7 @@ private struct StoredConnection: Codable {
             sshTunnelMode: resolvedTunnelMode,
             safeModeLevel: SafeModeLevel(rawValue: safeModeLevel) ?? .silent,
             aiPolicy: parsedAIPolicy,
+            aiRules: aiRules,
             aiAlwaysAllowedTools: Set(aiAlwaysAllowedTools ?? []),
             redisDatabase: redisDatabase,
             startupCommands: startupCommands,

--- a/TablePro/Core/Sync/SyncRecordMapper.swift
+++ b/TablePro/Core/Sync/SyncRecordMapper.swift
@@ -73,6 +73,9 @@ struct SyncRecordMapper {
         if let aiPolicy = connection.aiPolicy {
             record["aiPolicy"] = aiPolicy.rawValue as CKRecordValue
         }
+        if let aiRules = connection.aiRules, !aiRules.isEmpty {
+            record["aiRules"] = aiRules as CKRecordValue
+        }
         if !connection.aiAlwaysAllowedTools.isEmpty {
             let sorted = Array(connection.aiAlwaysAllowedTools).sorted()
             record["aiAlwaysAllowedTools"] = sorted as CKRecordValue
@@ -135,6 +138,7 @@ struct SyncRecordMapper {
         let tagId = (record["tagId"] as? String).flatMap { UUID(uuidString: $0) }
         let groupId = (record["groupId"] as? String).flatMap { UUID(uuidString: $0) }
         let aiPolicyRaw = record["aiPolicy"] as? String
+        let aiRulesRaw = record["aiRules"] as? String
         let aiAlwaysAllowedToolsArray = record["aiAlwaysAllowedTools"] as? [String] ?? []
         let redisDatabase = (record["redisDatabase"] as? Int64).map { Int($0) }
         let startupCommands = record["startupCommands"] as? String
@@ -175,6 +179,7 @@ struct SyncRecordMapper {
             sshProfileId: sshProfileId,
             safeModeLevel: SafeModeLevel(rawValue: safeModeLevelRaw) ?? .silent,
             aiPolicy: aiPolicyRaw.flatMap { AIConnectionPolicy(rawValue: $0) },
+            aiRules: aiRulesRaw,
             aiAlwaysAllowedTools: Set(aiAlwaysAllowedToolsArray),
             redisDatabase: redisDatabase,
             startupCommands: startupCommands,


### PR DESCRIPTION
## Summary

PR #1081 (per-connection AI rules) added `aiRules: String?` to `DatabaseConnection.Codable`, but missed two downstream layers:

1. **`StoredConnection`** (private struct in `ConnectionStorage.swift`) is the on-disk JSON format — separate from `DatabaseConnection.Codable`. Without `aiRules` here, the field is silently dropped on every `saveConnections` / `loadConnections` round-trip. **User-visible bug**: set rules in the AI Rules pane, save, relaunch the app — rules are gone.

2. **`SyncRecordMapper`** (`Core/Sync/SyncRecordMapper.swift`) maps `DatabaseConnection` to `CKRecord` for iCloud sync. Without `aiRules` here, the field never propagates between devices.

This PR adds `aiRules` to both layers, mirroring the established pattern (e.g. `aiPolicy`, `aiAlwaysAllowedTools` from PR E).

## Test plan

- [ ] Edit a connection, set custom AI Rules text, click Save.
- [ ] Quit and relaunch the app. Open the connection's AI Rules pane — text persists.
- [ ] On a second iCloud-synced device: connection's AI Rules text matches.
- [ ] Verify the rules are still injected into the chat system prompt for that connection (existing PR G behavior — no regression).