### PR TITLE
test: AI chat coverage backfill (rules persistence, approval center, Copilot schema)

### DIFF
--- a/TableProTests/Core/AI/ChatToolSpecCopilotTests.swift
+++ b/TableProTests/Core/AI/ChatToolSpecCopilotTests.swift
@@ -1,0 +1,73 @@
+//
+//  ChatToolSpecCopilotTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatToolSpec.asCopilotToolInformation")
+struct ChatToolSpecCopilotTests {
+    @Test("schema missing required gets empty required array")
+    func addsRequiredWhenMissing() throws {
+        let spec = ChatToolSpec(
+            name: "list_tables",
+            description: "List tables",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object(["connection_id": .object(["type": .string("string")])])
+            ])
+        )
+
+        let info = spec.asCopilotToolInformation()
+        guard case .object(let dict) = info.inputSchema else {
+            Issue.record("inputSchema should remain an object")
+            return
+        }
+        #expect(dict["required"] == .array([]))
+    }
+
+    @Test("schema with existing required is preserved")
+    func preservesExistingRequired() throws {
+        let spec = ChatToolSpec(
+            name: "describe_table",
+            description: "Describe table",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object(["table": .object(["type": .string("string")])]),
+                "required": .array([.string("table")])
+            ])
+        )
+
+        let info = spec.asCopilotToolInformation()
+        guard case .object(let dict) = info.inputSchema else {
+            Issue.record("inputSchema should remain an object")
+            return
+        }
+        #expect(dict["required"] == .array([.string("table")]))
+    }
+
+    @Test("non-object schema is passed through unchanged")
+    func nonObjectSchemaUnchanged() throws {
+        let spec = ChatToolSpec(
+            name: "noop",
+            description: "no schema",
+            inputSchema: .null
+        )
+        let info = spec.asCopilotToolInformation()
+        #expect(info.inputSchema == .null)
+    }
+
+    @Test("name and description carry through")
+    func passesNameAndDescription() throws {
+        let spec = ChatToolSpec(
+            name: "execute_query",
+            description: "Execute a SQL query",
+            inputSchema: .object(["type": .string("object")])
+        )
+        let info = spec.asCopilotToolInformation()
+        #expect(info.name == "execute_query")
+        #expect(info.description == "Execute a SQL query")
+    }
+}

--- a/TableProTests/Core/AI/ToolApprovalCenterTests.swift
+++ b/TableProTests/Core/AI/ToolApprovalCenterTests.swift
@@ -1,0 +1,79 @@
+//
+//  ToolApprovalCenterTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ToolApprovalCenter")
+@MainActor
+struct ToolApprovalCenterTests {
+    @Test("resolve delivers decision to awaiting caller")
+    func resolveDelivers() async {
+        let center = ToolApprovalCenter()
+        let waiter = Task {
+            await center.awaitDecision(for: "tool-1")
+        }
+        await Task.yield()
+        center.resolve(toolUseId: "tool-1", decision: .run)
+        let decision = await waiter.value
+        if case .run = decision {
+            #expect(true)
+        } else {
+            Issue.record("expected .run, got \(decision)")
+        }
+    }
+
+    @Test("resolve unknown id is a no-op")
+    func resolveUnknown() {
+        let center = ToolApprovalCenter()
+        center.resolve(toolUseId: "missing", decision: .cancel)
+        #expect(center.hasPending == false)
+    }
+
+    @Test("cancelAll resolves every pending continuation as cancel")
+    func cancelAllResolvesAll() async {
+        let center = ToolApprovalCenter()
+        let firstWaiter = Task { await center.awaitDecision(for: "a") }
+        let secondWaiter = Task { await center.awaitDecision(for: "b") }
+        await Task.yield()
+        center.cancelAll()
+        let firstDecision = await firstWaiter.value
+        let secondDecision = await secondWaiter.value
+        if case .cancel = firstDecision {} else { Issue.record("first should cancel") }
+        if case .cancel = secondDecision {} else { Issue.record("second should cancel") }
+        #expect(center.hasPending == false)
+    }
+
+    @Test("duplicate awaitDecision cancels the prior continuation")
+    func duplicateAwaitCancelsPrior() async {
+        let center = ToolApprovalCenter()
+        let firstWaiter = Task { await center.awaitDecision(for: "tool-1") }
+        await Task.yield()
+        let secondWaiter = Task { await center.awaitDecision(for: "tool-1") }
+        await Task.yield()
+        let firstDecision = await firstWaiter.value
+        if case .cancel = firstDecision {} else {
+            Issue.record("first should auto-cancel when overwritten, got \(firstDecision)")
+        }
+        center.resolve(toolUseId: "tool-1", decision: .alwaysAllow)
+        let secondDecision = await secondWaiter.value
+        if case .alwaysAllow = secondDecision {} else {
+            Issue.record("second should resolve to alwaysAllow, got \(secondDecision)")
+        }
+    }
+
+    @Test("hasPending reflects in-flight continuations")
+    func hasPendingReflectsState() async {
+        let center = ToolApprovalCenter()
+        #expect(center.hasPending == false)
+        let waiter = Task { await center.awaitDecision(for: "tool-1") }
+        await Task.yield()
+        #expect(center.hasPending == true)
+        center.resolve(toolUseId: "tool-1", decision: .run)
+        _ = await waiter.value
+        #expect(center.hasPending == false)
+    }
+}

--- a/TableProTests/Core/Storage/ConnectionStorageAIFieldsTests.swift
+++ b/TableProTests/Core/Storage/ConnectionStorageAIFieldsTests.swift
@@ -1,0 +1,135 @@
+//
+//  ConnectionStorageAIFieldsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ConnectionStorage AI Fields")
+@MainActor
+struct ConnectionStorageAIFieldsTests {
+    private let storage: ConnectionStorage
+
+    init() {
+        let unique = UUID().uuidString
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-tests")
+            .appendingPathComponent("connections_\(unique).json")
+        try? FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let defaultsName = "com.TablePro.tests.ConnectionStorage.AI.\(unique)"
+        let syncName = "com.TablePro.tests.Sync.AI.\(unique)"
+        guard let defaults = UserDefaults(suiteName: defaultsName),
+              let syncDefaults = UserDefaults(suiteName: syncName) else {
+            fatalError("UserDefaults suite creation failed in test setup")
+        }
+        let metadata = SyncMetadataStorage(userDefaults: syncDefaults)
+        let tracker = SyncChangeTracker(metadataStorage: metadata)
+        self.storage = ConnectionStorage(
+            fileURL: fileURL,
+            userDefaults: defaults,
+            syncTracker: tracker
+        )
+    }
+
+    @Test("round-trip preserves aiRules")
+    func roundTripAIRules() {
+        let id = UUID()
+        let rules = "- Always filter by tenant_id\n- Avoid users.ssn"
+        let connection = DatabaseConnection(
+            id: id,
+            name: "Test",
+            type: .postgresql,
+            aiRules: rules
+        )
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiRules == rules)
+    }
+
+    @Test("round-trip preserves nil aiRules")
+    func roundTripNilAIRules() {
+        let id = UUID()
+        let connection = DatabaseConnection(id: id, name: "Test", type: .mysql)
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiRules == nil)
+    }
+
+    @Test("round-trip preserves aiAlwaysAllowedTools")
+    func roundTripAIAlwaysAllowedTools() {
+        let id = UUID()
+        let tools: Set<String> = ["execute_query", "list_tables"]
+        let connection = DatabaseConnection(
+            id: id,
+            name: "Test",
+            type: .mysql,
+            aiAlwaysAllowedTools: tools
+        )
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiAlwaysAllowedTools == tools)
+    }
+
+    @Test("round-trip preserves empty aiAlwaysAllowedTools")
+    func roundTripEmptyAIAlwaysAllowedTools() {
+        let id = UUID()
+        let connection = DatabaseConnection(id: id, name: "Test", type: .mysql)
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiAlwaysAllowedTools.isEmpty == true)
+    }
+
+    @Test("aiRules survives mutate-and-update cycle")
+    func updateAIRules() {
+        let id = UUID()
+        let connection = DatabaseConnection(
+            id: id,
+            name: "Test",
+            type: .mysql,
+            aiRules: "initial rules"
+        )
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        var updated = connection
+        updated.aiRules = "updated rules"
+        storage.updateConnection(updated)
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiRules == "updated rules")
+    }
+
+    @Test("aiAlwaysAllowedTools survives mutate-and-update cycle")
+    func updateAIAlwaysAllowedTools() {
+        let id = UUID()
+        let connection = DatabaseConnection(id: id, name: "Test", type: .mysql)
+
+        storage.addConnection(connection)
+        defer { storage.deleteConnection(connection) }
+
+        var updated = connection
+        updated.aiAlwaysAllowedTools = ["execute_query"]
+        storage.updateConnection(updated)
+
+        let loaded = storage.loadConnections().first { $0.id == id }
+        #expect(loaded?.aiAlwaysAllowedTools == ["execute_query"])
+    }
+}


### PR DESCRIPTION
## Summary

Tests for code shipped in PRs #1081 (per-connection rules), #1091 (tool approval), #1097 (Copilot tool calling), and #1098 (aiRules persistence). Locks in the contracts that user-visible regressions would break.

## Files

- `TableProTests/Core/Storage/ConnectionStorageAIFieldsTests.swift` (6 tests) — `aiRules` and `aiAlwaysAllowedTools` survive `addConnection` -> `loadConnections`. Covers nil, empty set, populated, and update-after-add. Uses an isolated temporary file + UserDefaults suite, mirroring the existing `ConnectionStorageAdditionalFieldsTests` pattern. Without #1098, the first three would fail.
- `TableProTests/Core/AI/ToolApprovalCenterTests.swift` (5 tests) — `awaitDecision` resolution path, `cancelAll` drains every continuation, duplicate `awaitDecision` for the same id auto-cancels the prior continuation, `hasPending` reflects state, `resolve` of an unknown id is a no-op. Locks in the race-handling contract from the Copilot PR review.
- `TableProTests/Core/AI/ChatToolSpecCopilotTests.swift` (4 tests) — `asCopilotToolInformation` adds `required: []` when missing, preserves an existing `required` array, passes through non-object schemas, carries name and description across the conversion. Locks in the Copilot LSP schema-validation fix.

## Test plan

- [ ] Run `xcodebuild test -only-testing:TableProTests/ConnectionStorageAIFieldsTests`. All 6 pass.
- [ ] Run `xcodebuild test -only-testing:TableProTests/ToolApprovalCenterTests`. All 5 pass.
- [ ] Run `xcodebuild test -only-testing:TableProTests/ChatToolSpecCopilotTests`. All 4 pass.
- [ ] Revert the StoredConnection `aiRules` line locally and re-run the storage tests. The aiRules round-trip tests fail, confirming they actually exercise the persistence path.