### PR TITLE
fix: strip port from MongoDB SRV host (mongodb+srv URI spec)

### DIFF
--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -178,7 +178,8 @@ final class MongoDBConnection: @unchecked Sendable {
         }
 
         if useSrv {
-            let encodedHost = host.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? host
+            let srvHost = Self.stripPort(fromSrvHost: host)
+            let encodedHost = srvHost.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? srvHost
             uri += encodedHost
         } else if host.contains(",") {
             let segments = host.split(separator: ",").compactMap { segment -> String? in
@@ -266,6 +267,19 @@ final class MongoDBConnection: @unchecked Sendable {
 
         uri += "?" + params.joined(separator: "&")
         return uri
+    }
+
+    /// Strips a trailing `:port` from a hostname intended for an SRV URI.
+    ///
+    /// MongoDB's SRV scheme prohibits ports — the port is resolved from the DNS
+    /// SRV record. IPv6 literals are also invalid in SRV (FQDN only), so a
+    /// single trailing `:digits` segment is unambiguously a port.
+    static func stripPort(fromSrvHost host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespaces)
+        guard let colonIndex = trimmed.lastIndex(of: ":") else { return trimmed }
+        let portPart = trimmed[trimmed.index(after: colonIndex)...]
+        guard !portPart.isEmpty, portPart.allSatisfy(\.isNumber) else { return trimmed }
+        return String(trimmed[..<colonIndex])
     }
 
     // MARK: - Connection Management

--- a/TableProTests/Core/MongoDB/MongoDBSrvHostTests.swift
+++ b/TableProTests/Core/MongoDB/MongoDBSrvHostTests.swift
@@ -1,0 +1,40 @@
+//
+//  MongoDBSrvHostTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MongoDBConnection.stripPort(fromSrvHost:)")
+struct MongoDBSrvHostTests {
+    @Test("strips trailing :port from SRV host")
+    func stripsTrailingPort() {
+        let result = MongoDBConnection.stripPort(fromSrvHost: "tablepro.7uzbwhl.mongodb.net:27017")
+        #expect(result == "tablepro.7uzbwhl.mongodb.net")
+    }
+
+    @Test("leaves bare host unchanged")
+    func leavesBareHostUnchanged() {
+        let result = MongoDBConnection.stripPort(fromSrvHost: "tablepro.7uzbwhl.mongodb.net")
+        #expect(result == "tablepro.7uzbwhl.mongodb.net")
+    }
+
+    @Test("trims surrounding whitespace")
+    func trimsWhitespace() {
+        let result = MongoDBConnection.stripPort(fromSrvHost: "  cluster.mongodb.net:27017  ")
+        #expect(result == "cluster.mongodb.net")
+    }
+
+    @Test("does not strip non-numeric trailing segment")
+    func preservesNonNumericSuffix() {
+        let result = MongoDBConnection.stripPort(fromSrvHost: "host.example.com:abc")
+        #expect(result == "host.example.com:abc")
+    }
+
+    @Test("empty string passes through")
+    func emptyHost() {
+        #expect(MongoDBConnection.stripPort(fromSrvHost: "") == "")
+    }
+}


### PR DESCRIPTION
## Summary

Test Connection on a MongoDB Atlas cluster failed with:

```
Connecting to MongoDB at tablepro.7uzbwhl.mongodb.net:27017:27017
WARNING: client: Error parsing URI: 'Port numbers are prohibited in an SRV URI'
Failed to create MongoDB client
```

Root cause: when the host field contains `cluster.xxxxx.mongodb.net:27017` (e.g. typed in by hand or pasted from Atlas docs that show host with port), the SRV branch of `buildUri()` passes it through unchanged. `CharacterSet.urlHostAllowed` includes `:` (for IPv6 literals), so the colon is not percent-encoded, and the URI emitted to `mongoc_client_new` is `mongodb+srv://user:pw@cluster.xxxxx.mongodb.net:27017/...`. Per the MongoDB connection-string spec, an SRV URI **must not** carry a port — the port comes from the DNS SRV record — so libmongoc rejects it.

## Fix

Strip a trailing `:digits` segment from the SRV host before building the URI. IPv6 literals are not valid in SRV hosts (FQDN only), so a single trailing `:digits` is unambiguously a stray port.

- `Plugins/MongoDBDriverPlugin/MongoDBConnection.swift` — added `static func stripPort(fromSrvHost:)` and applied it in the `useSrv` branch of `buildUri()`. Non-SRV branches are untouched.
- `TableProTests/Core/MongoDB/MongoDBSrvHostTests.swift` — 5 tests: strips trailing port, leaves bare host alone, trims whitespace, preserves non-numeric trailing segments (`:abc`), handles empty string.

Per spec references:
- [MongoDB connection string format](https://www.mongodb.com/docs/manual/reference/connection-string/) — `mongodb+srv://` "may not include a port number"
- [Initial DNS Seedlist Discovery spec](https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.md) — SRV URIs prohibit ports

## Test plan

- [ ] Open MongoDB connection form, paste/type host as `cluster.xxxxx.mongodb.net:27017`, enable SRV, click Test Connection. Expect connection to succeed.
- [ ] Run `xcodebuild test -only-testing:TableProTests/MongoDBSrvHostTests` — all 5 pass.
- [ ] Existing manual paste-connection-string flow (`mongodb+srv://...`) still works.
- [ ] Non-SRV `mongodb://host:27017` flow unchanged (port still appended).

## Plugin release

After merge, tag `plugin-mongodb-v<next>` from `main` to ship the fixed plugin.