### PR TITLE
fix: stop reconstructing ConnectionFormCoordinator on every render

### DIFF
--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -81,12 +81,17 @@ final class ConnectionFormCoordinator {
             && advanced.validationIssues.isEmpty
     }
 
+    private let pendingInitialType: DatabaseType?
+    private let pendingInitialParsedURL: ParsedConnectionURL?
+
     init(
         connectionId: UUID?,
         initialType: DatabaseType? = nil,
         initialParsedURL: ParsedConnectionURL? = nil
     ) {
         self.connectionId = connectionId
+        self.pendingInitialType = initialType
+        self.pendingInitialParsedURL = initialParsedURL
         self.network = NetworkPaneViewModel()
         self.auth = AuthPaneViewModel()
         self.ssh = SSHPaneViewModel()
@@ -103,8 +108,15 @@ final class ConnectionFormCoordinator {
         customization.coordinator = ref
         advanced.coordinator = ref
         aiRules.coordinator = ref
+    }
 
-        let resolvedInitialType = initialParsedURL?.type ?? initialType
+    /// Performs the one-time side-effecting setup: applying initial type
+    /// defaults, loading the existing connection from storage, and overlaying
+    /// any parsed URL the form was opened with. Idempotent.
+    func start() {
+        guard !hasLoadedData else { return }
+
+        let resolvedInitialType = pendingInitialParsedURL?.type ?? pendingInitialType
         if let resolvedInitialType {
             network.type = resolvedInitialType
             network.port = String(resolvedInitialType.defaultPort)
@@ -113,8 +125,8 @@ final class ConnectionFormCoordinator {
 
         loadInitialData()
 
-        if let initialParsedURL {
-            applyParsed(initialParsedURL)
+        if let parsed = pendingInitialParsedURL {
+            applyParsed(parsed)
         }
     }
 

--- a/TablePro/Views/ConnectionForm/ConnectionFormView.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormView.swift
@@ -9,28 +9,45 @@ import TableProPluginKit
 struct ConnectionFormView: View {
     let connectionId: UUID?
 
-    @State private var coordinator: ConnectionFormCoordinator
+    @State private var coordinator: ConnectionFormCoordinator?
     @Environment(\.dismiss) private var dismiss
 
-    init(connectionId: UUID?) {
-        self.connectionId = connectionId
-        let pendingImport = connectionId == nil
-            ? PendingNewConnectionImport.shared.consume()
-            : nil
-        let pendingType = connectionId == nil
-            ? PendingNewConnectionType.shared.consume()
-            : nil
-        _coordinator = State(initialValue: ConnectionFormCoordinator(
-            connectionId: connectionId,
-            initialType: pendingType,
-            initialParsedURL: pendingImport
-        ))
+    var body: some View {
+        Group {
+            if let coordinator {
+                ConnectionFormContent(coordinator: coordinator, dismiss: dismiss)
+            } else {
+                Color.clear
+                    .frame(minWidth: 720, minHeight: 560)
+            }
+        }
+        .task(id: connectionId) {
+            guard coordinator == nil else { return }
+            let pendingImport = connectionId == nil
+                ? PendingNewConnectionImport.shared.consume()
+                : nil
+            let pendingType = connectionId == nil
+                ? PendingNewConnectionType.shared.consume()
+                : nil
+            let new = ConnectionFormCoordinator(
+                connectionId: connectionId,
+                initialType: pendingType,
+                initialParsedURL: pendingImport
+            )
+            new.dismissAction = { dismiss() }
+            new.start()
+            new.detectClipboardConnectionStringIfNeeded()
+            coordinator = new
+        }
     }
+}
+
+private struct ConnectionFormContent: View {
+    @Bindable var coordinator: ConnectionFormCoordinator
+    let dismiss: DismissAction
 
     var body: some View {
-        @Bindable var bindable = coordinator
-
-        return NavigationSplitView {
+        NavigationSplitView {
             ConnectionFormSidebar(coordinator: coordinator)
         } detail: {
             ConnectionFormDetail(coordinator: coordinator)
@@ -45,12 +62,12 @@ struct ConnectionFormView: View {
         .toolbar {
             ConnectionFormToolbar(coordinator: coordinator)
         }
-        .sheet(item: $bindable.pluginDiagnostic) { item in
+        .sheet(item: $coordinator.pluginDiagnostic) { item in
             PluginDiagnosticSheet(item: item) {
                 coordinator.pluginDiagnostic = nil
             }
         }
-        .pluginInstallPrompt(connection: $bindable.pluginInstallConnection) { connection in
+        .pluginInstallPrompt(connection: $coordinator.pluginInstallConnection) { connection in
             coordinator.connectAfterInstall(connection)
         }
         .alert(
@@ -66,10 +83,6 @@ struct ConnectionFormView: View {
             }
         } message: { error in
             Text(error)
-        }
-        .task {
-            coordinator.dismissAction = { dismiss() }
-            coordinator.detectClipboardConnectionStringIfNeeded()
         }
     }
 }


### PR DESCRIPTION
## Summary

The console was spamming on every render of the connection form:

```
[trace] load connectionId=05A4B646-… isNew=false
[trace] load found existing id=05A4B646-… name='MongoDB tablepro.…' promptForPassword=false
[trace] load connectionId=05A4B646-… isNew=false
[trace] load found existing id=05A4B646-… name='MongoDB tablepro.…' promptForPassword=false
…
```

Root cause is in `ConnectionFormView.init`:

```swift
init(connectionId: UUID?) {
    …
    _coordinator = State(initialValue: ConnectionFormCoordinator(
        connectionId: connectionId,
        initialType: pendingType,
        initialParsedURL: pendingImport
    ))
}
```

SwiftUI's `@State` correctly keeps the originally-stored coordinator across re-inits, but the right-hand expression `ConnectionFormCoordinator(...)` is evaluated **every time the parent view tree re-evaluates** the form. The throwaway coordinator's `init` calls `loadInitialData()`, which:

- allocates 7 pane view models
- reads `ConnectionStorage.shared.loadConnections()` (disk hit)
- emits the `[trace] load …` log lines

Under any sustained Observable churn upstream of the WindowGroup, that loop runs continuously.

## Fix

Apple's documented pattern: `init` stays pure, side-effects move to `.task`.

- `ConnectionFormView`: `@State private var coordinator: ConnectionFormCoordinator?`, no work in `init`. A single `.task(id: connectionId)` constructs the coordinator once, wires `dismissAction`, calls `start()`, and consumes `PendingNewConnectionImport`/`PendingNewConnectionType`. The body shows `Color.clear` for the brief moment before the coordinator is ready (invisible inside the sheet's present animation).
- `ConnectionFormCoordinator`: `init` only constructs the pane view models and stashes `pendingInitialType` / `pendingInitialParsedURL`. A new `start()` method does the one-time `applyTypeDefaults` → `loadInitialData` → `applyParsed` work, guarded by the existing `hasLoadedData` flag so it's idempotent.

`hasLoadedData` was already there but only set, never used to guard reentry. It's now load-bearing.

## Why this is HIG / API-correct

- [`@State` documentation](https://developer.apple.com/documentation/swiftui/state) states the initial value is used only on first creation, but the value expression is evaluated every time SwiftUI builds the view. The fix moves the expensive construction out of that path.
- [`.task(id:)`](https://developer.apple.com/documentation/swiftui/view/task(id:priority:_:)) is Apple's documented place for one-time async setup tied to view identity. Idempotent guard handles the (rare) re-mount case.

No introspection, no quick-win flag, no debounce — just removing work from the wrong lifecycle phase.

## Test plan

- [ ] Open an existing MongoDB connection in the form, edit a field, watch Console.app (`com.TablePro` subsystem). Expect a single `[trace] load …` pair, not a stream.
- [ ] Open a new-connection form via menu / Welcome `+` — coordinator initializes, pending clipboard import flow works as before.
- [ ] Open a new-connection form via the URL-import flow (`tablepro://…`) — `applyParsed` overlays the parsed URL on top of the loaded connection.
- [ ] Edit type via the General pane — `applyTypeDefaults` still fires (coordinator's `didChangeType` already gates on `hasLoadedData`).
- [ ] Save and dismiss — `dismissAction` callback works (wired in `.task`, before the form becomes interactive).