### PR TITLE
fix: tab session registry binding and fix-error prompt phrasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - AI Chat: `@` mention detection no longer breaks when the cursor sits right after an emoji or other non-BMP character
+- AI Chat: Fix Error prompt now reads "MongoDB query" and "Redis command" using the database display name, instead of the raw query language label
 - Internal: tab session registry binds automatically when a coordinator falls back to creating its own registry, so unit tests no longer trip the filter-state debug assertion
 
 ## [0.39.1] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - AI Chat: `@` mention detection no longer breaks when the cursor sits right after an emoji or other non-BMP character
+- Internal: tab session registry binds automatically when a coordinator falls back to creating its own registry, so unit tests no longer trip the filter-state debug assertion
 
 ## [0.39.1] - 2026-05-08
 

--- a/TablePro/Core/AI/AIPromptTemplates.swift
+++ b/TablePro/Core/AI/AIPromptTemplates.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 /// Centralized prompt templates for AI-powered editor features
 enum AIPromptTemplates {
@@ -42,8 +43,20 @@ enum AIPromptTemplates {
     }
 
     @MainActor private static func queryInfo(for databaseType: DatabaseType) -> (typeName: String, language: String) {
-        let langName = PluginManager.shared.queryLanguageName(for: databaseType)
-        let lang = PluginManager.shared.editorLanguage(for: databaseType).codeBlockTag
-        return ("\(langName) query", lang)
+        let snapshot = PluginMetadataRegistry.shared.snapshot(forTypeId: databaseType.pluginTypeId)
+        let editorLanguage = snapshot?.editorLanguage ?? .sql
+        let lang = editorLanguage.codeBlockTag
+        let typeName: String
+        switch editorLanguage {
+        case .sql:
+            typeName = "\(snapshot?.queryLanguageName ?? "SQL") query"
+        case .bash:
+            typeName = "\(snapshot?.displayName ?? databaseType.rawValue) command"
+        case .javascript:
+            typeName = "\(snapshot?.displayName ?? databaseType.rawValue) query"
+        case .custom:
+            typeName = "\(snapshot?.displayName ?? databaseType.rawValue) query"
+        }
+        return (typeName, lang)
     }
 }

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -38,6 +38,13 @@ final class QueryTabManager {
         self.tabSessionRegistry = tabSessionRegistry
     }
 
+    func bindTabSessionRegistry(_ registry: TabSessionRegistry) {
+        tabSessionRegistry = registry
+        for tab in tabs where registry.session(for: tab.id) == nil {
+            registry.register(TabSession(queryTab: tab))
+        }
+    }
+
     private func syncTabSessionRegistry(oldTabs: [QueryTab], newTabs: [QueryTab]) {
         guard let registry = tabSessionRegistry else { return }
         let oldIds = Set(oldTabs.map(\.id))

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
@@ -308,7 +308,7 @@ extension MainContentCoordinator {
             filterStateLog.error(
                 "TabSession missing for selected tab \(tabId, privacy: .public); QueryTab updated but session mirror skipped"
             )
-            assertionFailure("TabSession missing for selected tab — registry sync regression")
+            assertionFailure("TabSession missing for selected tab: registry sync regression")
         }
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -343,7 +343,9 @@ final class MainContentCoordinator {
         self.tabManager = tabManager
         self.changeManager = changeManager
         self.toolbarState = toolbarState
-        self.tabSessionRegistry = tabSessionRegistry ?? TabSessionRegistry()
+        let resolvedRegistry = tabSessionRegistry ?? TabSessionRegistry()
+        self.tabSessionRegistry = resolvedRegistry
+        tabManager.bindTabSessionRegistry(resolvedRegistry)
         self.queryExecutor = queryExecutor ?? QueryExecutor(connection: connection)
         let dialect = PluginManager.shared.sqlDialect(for: connection.type)
         self.queryBuilder = TableQueryBuilder(


### PR DESCRIPTION
## Summary

Two fixes that landed during AI Wave 2 test cleanup. One is a real user-facing bug discovered while diagnosing test failures; the other tightens an internal contract that was masking test-only crashes.

## What changed

### `fix(coordinator): bind tab session registry when coordinator owns the fallback` (`8f5853a9`)

Production builds the `TabSessionRegistry` once in `SessionStateFactory.create` and hands it to both `QueryTabManager` AND `MainContentCoordinator`, so `tabs.didSet` keeps the registry in sync. When the coordinator falls back to creating its own registry (e.g. tests, or any composition that builds the coordinator without going through the factory), `QueryTabManager` had no way to know about it. `tabs.didSet` early-returned, no `TabSession` was registered, and `restoreLastFilters` tripped the `assertionFailure` at `MainContentCoordinator+FilterState.swift:311`.

Added `QueryTabManager.bindTabSessionRegistry(_:)`. The coordinator calls it after resolving the fallback registry, which back-fills sessions for any pre-existing tabs. The assertion stays — it now only fires on real registry-sync regressions, which is what it was always supposed to do.

Also fixed the em-dash style violation in the assertion message.

### `fix(ai-chat): use display name and editor language for fix-error prompt phrasing` (`dec24036`)

`AIPromptTemplates.fixError` always built its prompt as `"This <queryLanguageName> query failed"`. For SQL that produces "This SQL query failed" (correct). For MongoDB it produced "This MQL query failed" (the AI doesn't always recognize MQL). For Redis it produced "This Redis CLI query failed" (Redis ops are commands, not queries).

`queryInfo(for:)` now switches on the plugin's `editorLanguage` and uses `displayName` for non-SQL languages, plus `"command"` instead of `"query"` for bash:
- SQL: `"SQL query"` (unchanged)
- JavaScript / others: `"<DisplayName> query"` ("MongoDB query")
- Bash: `"<DisplayName> command"` ("Redis command")

This is a user-facing improvement — Fix Error prompts now read naturally for non-SQL backends, which improves the AI response quality.

## Test plan

- [x] `xcodebuild build` green
- [x] `swiftlint lint --strict` clean on every touched file
- [x] Previously failing tests now pass: `OpenTableTabTests/addsTabDirectlyWhenTabsEmptyNotSwitching`, `AIChatViewModelActionTests/fixErrorMongoDBConnection`, `AIChatViewModelActionTests/fixErrorRedisConnection`
- [ ] Manual smoke: open a MongoDB or Redis connection, run a query that errors, click "Fix Error", confirm the AI message reads naturally

## Out of scope

Two pre-existing baseline failures unrelated to this PR:
- `MainContentCoordinatorLazyLoadTests/Returns early when tab is already executing`
- `SessionStateFactoryTests/Connection-only payload without isNewTab creates empty tab manager`

`AIChatViewModelMentionsTests/currentQueryResolved` also fails but is asserting on the wrong API (expects `plainText` to contain attachment text before `resolveTurnForWire` runs; sibling tests confirm raw-then-expanded is the intended design). Either the test or the assertion needs updating, separate from this PR.