### PR TITLE
fix: clear remaining test failures + content-less query tab regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Chat: `@` mention detection no longer breaks when the cursor sits right after an emoji or other non-BMP character
 - AI Chat: Fix Error prompt now reads "MongoDB query" and "Redis command" using the database display name, instead of the raw query language label
 - Internal: tab session registry binds automatically when a coordinator falls back to creating its own registry, so unit tests no longer trip the filter-state debug assertion
+- Connection-only payloads no longer create an empty `Query 1` tab when there is no query, title, or source file to populate it
 
 ## [0.39.1] - 2026-05-08
 

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -123,12 +123,17 @@ enum SessionStateFactory {
                         tabMgr.addTab(databaseName: payload.databaseName ?? activeDatabaseName)
                     }
                 case .query:
-                    tabMgr.addTab(
-                        initialQuery: payload.initialQuery,
-                        title: payload.tabTitle,
-                        databaseName: payload.databaseName ?? activeDatabaseName,
-                        sourceFileURL: payload.sourceFileURL
-                    )
+                    let hasContent = payload.initialQuery != nil
+                        || payload.tabTitle != nil
+                        || payload.sourceFileURL != nil
+                    if hasContent {
+                        tabMgr.addTab(
+                            initialQuery: payload.initialQuery,
+                            title: payload.tabTitle,
+                            databaseName: payload.databaseName ?? activeDatabaseName,
+                            sourceFileURL: payload.sourceFileURL
+                        )
+                    }
                 case .createTable:
                     tabMgr.addCreateTableTab(
                         databaseName: payload.databaseName ?? activeDatabaseName

--- a/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelMentionsTests.swift
@@ -58,8 +58,8 @@ struct AIChatViewModelMentionsTests {
         #expect(vm.attachedContext.isEmpty)
     }
 
-    @Test("Sending with currentQuery attachment embeds the query text in the prompt")
-    func currentQueryResolved() {
+    @Test("Sending with currentQuery attachment resolves the query text on the wire")
+    func currentQueryResolved() async {
         let vm = AIChatViewModel()
         vm.connection = TestFixtures.makeConnection(type: .mysql)
         vm.inputText = "Explain"
@@ -67,8 +67,12 @@ struct AIChatViewModelMentionsTests {
 
         vm.sendMessage()
 
-        let userTurn = vm.messages.first(where: { $0.role == .user })
-        let prompt = userTurn?.plainText ?? ""
+        guard let userTurn = vm.messages.first(where: { $0.role == .user }) else {
+            Issue.record("expected a user turn after sendMessage")
+            return
+        }
+        let wire = await vm.resolveTurnForWire(userTurn)
+        let prompt = wire.plainText
         #expect(prompt.contains("Explain"))
         #expect(prompt.contains("SELECT * FROM Customer"))
         #expect(prompt.contains("## Current Query"))

--- a/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
@@ -140,11 +140,14 @@ struct MainContentCoordinatorLazyLoadTests {
     func skipsWhenAlreadyExecuting() {
         let (coordinator, tabManager) = makeCoordinator()
         let tabId = addTableTab(to: tabManager)
+        seedRows(coordinator, for: tabId, rowCount: 1)
         guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
             Issue.record("expected tab to exist")
             return
         }
+        tabManager.tabs[idx].execution.lastExecutedAt = Date()
         tabManager.tabs[idx].execution.isExecuting = true
+        coordinator.tabSessionRegistry.evict(for: tabId)
 
         coordinator.lazyLoadCurrentTabIfNeeded()
         #expect(coordinator.needsLazyLoad == false)


### PR DESCRIPTION
## Summary

Three loose ends from the AI audit work, two test-only and one real production fix.

## What changed

### `test(ai-chat): resolve currentQuery via resolveTurnForWire instead of asserting on raw turn` (`b5bdac41`)

`AIChatViewModelMentionsTests.currentQueryResolved` was asserting on `userTurn.plainText` directly after `sendMessage()`. The design intentionally keeps `.attachment` blocks raw until `resolveTurnForWire` runs (sibling tests `Stored user turn keeps typed text raw` and `resolveTurnForWire expands attachments` both pass and confirm this contract). Updated the test to call `await vm.resolveTurnForWire(userTurn)` first and assert on the wire-resolved text. Test-only change.

### `test(coordinator): seed lazy-load skip path with execution timestamp and registry eviction` (`0e2b0aec`)

`MainContentCoordinatorLazyLoadTests.skipsWhenAlreadyExecuting` was missing setup that mirrors a real "tab is currently executing" state: rows seeded, `lastExecutedAt` set, registry evicted. Without those, the coordinator would compute `needsLazyLoad = true` for an unrelated reason, so the assertion was racing the actual early-return. Added the missing fixture state. Test-only change.

### `fix(session): do not auto-create empty query tab for content-less query payloads` (`59ac47bf`)

`SessionStateFactory.create` was unconditionally calling `tabMgr.addTab(...)` on `.query` payloads. When the payload had `nil` initialQuery, `nil` tabTitle, and `nil` sourceFileURL (the "connection-only" case), users got an empty `Query 1` tab they didn't ask for. Added a `hasContent` guard so empty `.query` payloads result in an empty tab manager, matching the existing `.connectionOnlyPayload_createsEmptyTabManager` test expectation. **User-visible**: opening a connection without an explicit tab payload no longer pre-populates an empty query tab.

## Test plan

- [x] `xcodebuild build` green
- [x] `swiftlint lint --strict` clean on every touched file
- [x] All three previously failing tests now pass
- [x] No regressions in the broader test sweep (`AIChatViewModelMentionsTests`, `MainContentCoordinatorLazyLoadTests`, `SessionStateFactoryTests`, `OpenTableTabTests`)
- [ ] Manual: open a connection from Welcome screen, confirm a fresh `Query 1` tab still appears (the `isNewTab=true` path is unchanged)
- [ ] Manual: restore a session that has no persisted tabs, confirm no empty `Query 1` tab is created