### PR TITLE
refactor: phase 5 tail — migrate 12 domain notifications to AppEvents

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     private var hasRunPostLaunchActivation = false
+    private var pluginsRejectedCancellable: AnyCancellable?
 
     // MARK: - URL & File Open
 
@@ -77,10 +78,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self, selector: #selector(windowWillClose(_:)),
             name: NSWindow.willCloseNotification, object: nil
         )
-        NotificationCenter.default.addObserver(
-            self, selector: #selector(handlePluginsRejected(_:)),
-            name: .pluginsRejected, object: nil
-        )
+        pluginsRejectedCancellable = AppEvents.shared.pluginsRejected
+            .receive(on: RunLoop.main)
+            .sink { [weak self] rejected in
+                self?.handlePluginsRejected(rejected)
+            }
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleFocusConnectionForm),
             name: .focusConnectionFormWindowRequested, object: nil
@@ -154,9 +156,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Plugin Rejection Alert
 
-    @objc private func handlePluginsRejected(_ notification: Notification) {
-        guard let rejected = notification.object as? [RejectedPlugin],
-              !rejected.isEmpty else { return }
+    private func handlePluginsRejected(_ rejected: [RejectedPlugin]) {
+        guard !rejected.isEmpty else { return }
         let details = rejected.map { "\($0.name): \($0.reason)" }.joined(separator: "\n")
         Task {
             let alert = NSAlert()

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import os
 import SwiftUI
 
@@ -198,7 +199,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 $0 !== window && AppLaunchCoordinator.isMainWindow($0) && $0.isVisible
             }.count
             if remaining == 0 {
-                NotificationCenter.default.post(name: .mainWindowWillClose, object: nil)
+                AppEvents.shared.mainWindowWillClose.send(())
                 WindowOpener.shared.openWelcome()
             }
         }

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Combine
 import Foundation
 import os
 import TableProPluginKit
@@ -297,8 +298,7 @@ extension DatabaseManager {
                 await startHealthMonitor(for: sessionId)
             }
 
-            // Post connection notification for schema reload
-            NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
+            AppEvents.shared.databaseDidConnect.send(DatabaseDidConnect(connectionId: sessionId))
 
             Self.logger.info("Manual reconnect succeeded for: \(session.connection.name)")
         } catch {

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -140,7 +140,7 @@ extension DatabaseManager {
             appSettingsStorage.saveLastConnectionId(connection.id)
 
             MacAnalyticsProvider.shared.markConnectionSucceeded()
-            NotificationCenter.default.post(name: .databaseDidConnect, object: nil)
+            AppEvents.shared.databaseDidConnect.send(DatabaseDidConnect(connectionId: connection.id))
 
             let supportsHealth = PluginMetadataRegistry.shared.snapshot(
                 forTypeId: connection.type.pluginTypeId

--- a/TablePro/Core/Events/AppEvents.swift
+++ b/TablePro/Core/Events/AppEvents.swift
@@ -10,9 +10,13 @@ import Foundation
 final class AppEvents {
     static let shared = AppEvents()
 
+    // MARK: - Theme & Accessibility
+
     let themeChanged = PassthroughSubject<Void, Never>()
 
-    let connectionStatusChanged = PassthroughSubject<ConnectionStatusChange, Never>()
+    let accessibilityTextSizeChanged = PassthroughSubject<Void, Never>()
+
+    // MARK: - Settings
 
     let editorSettingsChanged = PassthroughSubject<Void, Never>()
 
@@ -22,7 +26,43 @@ final class AppEvents {
 
     let terminalSettingsChanged = PassthroughSubject<Void, Never>()
 
-    let accessibilityTextSizeChanged = PassthroughSubject<Void, Never>()
+    // MARK: - Connections
+
+    let connectionStatusChanged = PassthroughSubject<ConnectionStatusChange, Never>()
+
+    let connectionUpdated = PassthroughSubject<Void, Never>()
+
+    let databaseDidConnect = PassthroughSubject<DatabaseDidConnect, Never>()
+
+    let mainCoordinatorTeardown = PassthroughSubject<MainCoordinatorTeardown, Never>()
+
+    // MARK: - Window
+
+    let mainWindowWillClose = PassthroughSubject<Void, Never>()
+
+    // MARK: - Data Sources
+
+    let queryHistoryDidUpdate = PassthroughSubject<Void, Never>()
+
+    let sqlFavoritesDidUpdate = PassthroughSubject<Void, Never>()
+
+    let linkedFoldersDidUpdate = PassthroughSubject<Void, Never>()
+
+    let linkedSQLFoldersDidUpdate = PassthroughSubject<Void, Never>()
+
+    // MARK: - License & Sync
+
+    let licenseStatusDidChange = PassthroughSubject<Void, Never>()
+
+    let syncChangeTracked = PassthroughSubject<Void, Never>()
+
+    // MARK: - MCP
+
+    let mcpAuditLogChanged = PassthroughSubject<Void, Never>()
+
+    // MARK: - Plugins
+
+    let pluginsRejected = PassthroughSubject<[RejectedPlugin], Never>()
 
     private init() {}
 }
@@ -30,4 +70,12 @@ final class AppEvents {
 struct ConnectionStatusChange: Sendable {
     let connectionId: UUID
     let status: ConnectionStatus
+}
+
+struct DatabaseDidConnect: Sendable {
+    let connectionId: UUID
+}
+
+struct MainCoordinatorTeardown: Sendable {
+    let connectionId: UUID
 }

--- a/TablePro/Core/MCP/MCPAuditLogStorage.swift
+++ b/TablePro/Core/MCP/MCPAuditLogStorage.swift
@@ -1,10 +1,7 @@
+import Combine
 import Foundation
 import os
 import SQLite3
-
-extension Notification.Name {
-    static let mcpAuditLogChanged = Notification.Name("com.TablePro.mcp.auditLogChanged")
-}
 
 actor MCPAuditLogStorage {
     static let shared = MCPAuditLogStorage()
@@ -160,7 +157,7 @@ actor MCPAuditLogStorage {
         let inserted = sqlite3_step(statement) == SQLITE_DONE
         if inserted {
             Task { @MainActor in
-                NotificationCenter.default.post(name: .mcpAuditLogChanged, object: nil)
+                AppEvents.shared.mcpAuditLogChanged.send(())
             }
         }
         return inserted

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import Foundation
 import os
 import Security
@@ -191,7 +192,7 @@ final class PluginManager {
             let eagerCount = validated.count
             Self.logger.info("Loaded \(self.plugins.count) plugin(s): \(lazyCount) lazy + \(eagerCount) eager (\(self.driverPlugins.count) driver(s) active, \(self.exportPlugins.count) export(s) active, \(self.importPlugins.count) import(s) active)")
             if !self.rejectedPlugins.isEmpty {
-                NotificationCenter.default.post(name: .pluginsRejected, object: self.rejectedPlugins)
+                AppEvents.shared.pluginsRejected.send(self.rejectedPlugins)
             }
         }
     }

--- a/TablePro/Core/Plugins/PluginModels.swift
+++ b/TablePro/Core/Plugins/PluginModels.swift
@@ -28,7 +28,7 @@ enum PluginSource {
     case userInstalled
 }
 
-struct RejectedPlugin {
+struct RejectedPlugin: Sendable {
     let url: URL
     let bundleId: String?
     let registryId: String?

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import Foundation
 import os
 import UniformTypeIdentifiers
@@ -565,7 +566,7 @@ enum ConnectionExportService {
         }
 
         if importedCount > 0 {
-            NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+            AppEvents.shared.connectionUpdated.send(())
             logger.info("Imported \(importedCount) connections")
         }
 

--- a/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
+++ b/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
@@ -6,6 +6,7 @@
 //  Rescans on filesystem changes with 1s debounce.
 //
 
+import Combine
 import CryptoKit
 import Foundation
 import os
@@ -58,7 +59,7 @@ final class LinkedFolderWatcher {
         debounceTask = Task { @MainActor [weak self] in
             let results = await Self.scanFoldersAsync(folders)
             self?.linkedConnections = results
-            NotificationCenter.default.post(name: .linkedFoldersDidUpdate, object: nil)
+            AppEvents.shared.linkedFoldersDidUpdate.send(())
         }
     }
 
@@ -70,7 +71,7 @@ final class LinkedFolderWatcher {
             let folders = LinkedFolderStorage.shared.loadFolders()
             let results = await Self.scanFoldersAsync(folders)
             self?.linkedConnections = results
-            NotificationCenter.default.post(name: .linkedFoldersDidUpdate, object: nil)
+            AppEvents.shared.linkedFoldersDidUpdate.send(())
         }
     }
 

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -16,8 +16,6 @@ extension Notification.Name {
 
     // MARK: - Connections
 
-    static let connectionUpdated = Notification.Name("connectionUpdated")
-    static let databaseDidConnect = Notification.Name("databaseDidConnect")
     static let exportConnections = Notification.Name("exportConnections")
     static let importConnections = Notification.Name("importConnections")
     static let importConnectionsFromApp = Notification.Name("importConnectionsFromApp")

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -19,10 +19,6 @@ extension Notification.Name {
     static let openSampleDatabaseRequested = Notification.Name("openSampleDatabaseRequested")
     static let resetSampleDatabaseRequested = Notification.Name("resetSampleDatabaseRequested")
 
-    // MARK: - License
-
-    static let licenseStatusDidChange = Notification.Name("licenseStatusDidChange")
-
     // MARK: - Export
 
     static let exportQueryResults = Notification.Name("exportQueryResults")
@@ -30,10 +26,6 @@ extension Notification.Name {
     // MARK: - SQL Favorites
 
     static let saveAsFavoriteRequested = Notification.Name("saveAsFavoriteRequested")
-
-    // MARK: - Plugins
-
-    static let pluginsRejected = Notification.Name("pluginsRejected")
 
     // MARK: - Feedback
 

--- a/TablePro/Core/Services/Infrastructure/AppNotifications.swift
+++ b/TablePro/Core/Services/Infrastructure/AppNotifications.swift
@@ -10,16 +10,11 @@
 import Foundation
 
 extension Notification.Name {
-    // MARK: - Query History
-
-    static let queryHistoryDidUpdate = Notification.Name("queryHistoryDidUpdate")
-
     // MARK: - Connections
 
     static let exportConnections = Notification.Name("exportConnections")
     static let importConnections = Notification.Name("importConnections")
     static let importConnectionsFromApp = Notification.Name("importConnectionsFromApp")
-    static let linkedFoldersDidUpdate = Notification.Name("linkedFoldersDidUpdate")
     static let focusConnectionFormWindowRequested = Notification.Name("focusConnectionFormWindowRequested")
     static let openSampleDatabaseRequested = Notification.Name("openSampleDatabaseRequested")
     static let resetSampleDatabaseRequested = Notification.Name("resetSampleDatabaseRequested")
@@ -34,7 +29,6 @@ extension Notification.Name {
 
     // MARK: - SQL Favorites
 
-    static let sqlFavoritesDidUpdate = Notification.Name("sqlFavoritesDidUpdate")
     static let saveAsFavoriteRequested = Notification.Name("saveAsFavoriteRequested")
 
     // MARK: - Plugins

--- a/TablePro/Core/Services/Infrastructure/WelcomeRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/WelcomeRouter.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import Foundation
 import Observation
 
@@ -16,14 +17,14 @@ internal final class WelcomeRouter {
     private(set) var pendingConnectionShare: URL?
     private(set) var pendingSQLFiles: [URL] = []
 
+    @ObservationIgnored private var databaseDidConnectCancellable: AnyCancellable?
+
     private init() {
-        NotificationCenter.default.addObserver(
-            forName: .databaseDidConnect, object: nil, queue: .main
-        ) { _ in
-            MainActor.assumeIsolated {
+        databaseDidConnectCancellable = AppEvents.shared.databaseDidConnect
+            .receive(on: RunLoop.main)
+            .sink { _ in
                 WelcomeRouter.shared.drainPendingSQLFiles()
             }
-        }
     }
 
     private func drainPendingSQLFiles() {

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -5,6 +5,7 @@
 //  Orchestrates license activation, offline verification, and periodic re-validation
 //
 
+import Combine
 import Foundation
 import Observation
 import os
@@ -289,7 +290,7 @@ final class LicenseManager {
 
     private func notifyIfChanged(from previousStatus: LicenseStatus) {
         if status != previousStatus {
-            NotificationCenter.default.post(name: .licenseStatusDidChange, object: nil)
+            AppEvents.shared.licenseStatusDidChange.send(())
         }
     }
 }

--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -3,13 +3,10 @@
 //  TablePro
 //
 
+import Combine
 import CoreServices
 import Foundation
 import os
-
-internal extension Notification.Name {
-    static let linkedSQLFoldersDidUpdate = Notification.Name("com.TablePro.linkedSQLFoldersDidUpdate")
-}
 
 @MainActor
 @Observable
@@ -105,7 +102,7 @@ internal final class SQLFolderWatcher {
         debounceTask = Task { @MainActor [weak self] in
             await Self.rescan(folders: folders)
             self?.lastScanCompletedAt = Date()
-            NotificationCenter.default.post(name: .linkedSQLFoldersDidUpdate, object: nil)
+            AppEvents.shared.linkedSQLFoldersDidUpdate.send(())
         }
     }
 
@@ -120,7 +117,7 @@ internal final class SQLFolderWatcher {
             let folders = LinkedSQLFolderStorage.shared.loadFolders().filter(\.isEnabled)
             await Self.rescan(folders: folders)
             self?.lastScanCompletedAt = Date()
-            NotificationCenter.default.post(name: .linkedSQLFoldersDidUpdate, object: nil)
+            AppEvents.shared.linkedSQLFoldersDidUpdate.send(())
         }
     }
 

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 final class QueryHistoryManager {
@@ -59,10 +60,7 @@ final class QueryHistoryManager {
             let success = await storage.addHistory(entry)
             if success {
                 await MainActor.run {
-                    NotificationCenter.default.post(
-                        name: .queryHistoryDidUpdate,
-                        object: nil
-                    )
+                    AppEvents.shared.queryHistoryDidUpdate.send(())
                 }
             }
         }
@@ -97,7 +95,7 @@ final class QueryHistoryManager {
         let success = await storage.deleteHistory(id: id)
         if success {
             await MainActor.run {
-                NotificationCenter.default.post(name: .queryHistoryDidUpdate, object: nil)
+                AppEvents.shared.queryHistoryDidUpdate.send(())
             }
         }
         return success
@@ -111,7 +109,7 @@ final class QueryHistoryManager {
         let success = await storage.clearAllHistory()
         if success {
             await MainActor.run {
-                NotificationCenter.default.post(name: .queryHistoryDidUpdate, object: nil)
+                AppEvents.shared.queryHistoryDidUpdate.send(())
             }
         }
         return success

--- a/TablePro/Core/Storage/SQLFavoriteManager.swift
+++ b/TablePro/Core/Storage/SQLFavoriteManager.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import Foundation
 import os
 
@@ -150,8 +151,8 @@ internal final class SQLFavoriteManager: @unchecked Sendable {
     // MARK: - Notifications
 
     private func postUpdateNotification() {
-        Task {
-            NotificationCenter.default.post(name: .sqlFavoritesDidUpdate, object: nil)
+        Task { @MainActor in
+            AppEvents.shared.sqlFavoritesDidUpdate.send(())
         }
     }
 }

--- a/TablePro/Core/Sync/SyncChangeTracker.swift
+++ b/TablePro/Core/Sync/SyncChangeTracker.swift
@@ -5,12 +5,9 @@
 //  Tracks local changes that need to be synced to CloudKit
 //
 
+import Combine
 import Foundation
 import os
-
-extension Notification.Name {
-    static let syncChangeTracked = Notification.Name("com.TablePro.syncChangeTracked")
-}
 
 /// Tracks dirty entities and deletions for sync
 final class SyncChangeTracker {
@@ -18,7 +15,6 @@ final class SyncChangeTracker {
     private static let logger = Logger(subsystem: "com.TablePro", category: "SyncChangeTracker")
 
     private let metadataStorage: SyncMetadataStorage
-    private let notificationCenter: NotificationCenter
 
     /// When true, changes are not tracked (used during remote apply to avoid sync loops)
     private let suppressionLock = OSAllocatedUnfairLock(initialState: false)
@@ -28,12 +24,8 @@ final class SyncChangeTracker {
         set { suppressionLock.withLock { $0 = newValue } }
     }
 
-    init(
-        metadataStorage: SyncMetadataStorage = .shared,
-        notificationCenter: NotificationCenter = .default
-    ) {
+    init(metadataStorage: SyncMetadataStorage = .shared) {
         self.metadataStorage = metadataStorage
-        self.notificationCenter = notificationCenter
     }
 
     // MARK: - Mark Dirty
@@ -83,6 +75,8 @@ final class SyncChangeTracker {
     // MARK: - Private
 
     private func postChangeNotification() {
-        notificationCenter.post(name: .syncChangeTracked, object: self)
+        Task { @MainActor in
+            AppEvents.shared.syncChangeTracked.send(())
+        }
     }
 }

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -26,8 +26,8 @@ final class SyncCoordinator {
     @ObservationIgnored private let metadataStorage = SyncMetadataStorage.shared
     @ObservationIgnored private let conflictResolver = ConflictResolver.shared
     @ObservationIgnored private var accountObserver: NSObjectProtocol?
-    @ObservationIgnored private var changeObserver: NSObjectProtocol?
-    @ObservationIgnored private var licenseObserver: NSObjectProtocol?
+    @ObservationIgnored private var changeCancellable: AnyCancellable?
+    @ObservationIgnored private var licenseCancellable: AnyCancellable?
     @ObservationIgnored private var syncTask: Task<Void, Never>?
     @ObservationIgnored private var hasStarted = false
 
@@ -37,8 +37,6 @@ final class SyncCoordinator {
 
     deinit {
         if let accountObserver { NotificationCenter.default.removeObserver(accountObserver) }
-        if let changeObserver { NotificationCenter.default.removeObserver(changeObserver) }
-        if let licenseObserver { NotificationCenter.default.removeObserver(licenseObserver) }
         syncTask?.cancel()
     }
 
@@ -586,15 +584,11 @@ final class SyncCoordinator {
     }
 
     private func observeLocalChanges() {
-        changeObserver = NotificationCenter.default.addObserver(
-            forName: .syncChangeTracked,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+        changeCancellable = AppEvents.shared.syncChangeTracked
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
                 guard let self else { return }
                 guard syncStatus.isEnabled, !syncStatus.isSyncing else { return }
-                // Debounce: schedule sync after a short delay
                 syncTask?.cancel()
                 syncTask = Task {
                     try? await Task.sleep(for: .seconds(2))
@@ -602,24 +596,18 @@ final class SyncCoordinator {
                     await self.syncNow()
                 }
             }
-        }
     }
 
     private func observeLicenseChanges() {
-        licenseObserver = NotificationCenter.default.addObserver(
-            forName: .licenseStatusDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+        licenseCancellable = AppEvents.shared.licenseStatusDidChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
                 guard let self else { return }
                 evaluateStatus()
-
                 if syncStatus.isEnabled {
-                    await syncNow()
+                    Task { await self.syncNow() }
                 }
             }
-        }
     }
 
     // MARK: - Account

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import CloudKit
+import Combine
 import Foundation
 import Observation
 import os
@@ -466,7 +467,7 @@ final class SyncCoordinator {
         }
 
         if actualConnectionChanges || groupsOrTagsChanged {
-            NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+            AppEvents.shared.connectionUpdated.send(())
         }
     }
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -696,9 +696,6 @@ extension Notification.Name {
 
     // File opening notifications
     static let openSQLFiles = Notification.Name("openSQLFiles")
-
-    // Window lifecycle notifications
-    static let mainWindowWillClose = Notification.Name("mainWindowWillClose")
 }
 
 // MARK: - Check for Updates

--- a/TablePro/ViewModels/ConnectionDataCache.swift
+++ b/TablePro/ViewModels/ConnectionDataCache.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import Foundation
 import Observation
 
@@ -26,40 +27,24 @@ internal final class ConnectionDataCache {
     private(set) var linkedFilesByFolderId: [UUID: [LinkedSQLFavorite]] = [:]
     private(set) var isInitialLoadComplete: Bool = false
 
-    @ObservationIgnored private var favoritesObserver: NSObjectProtocol?
-    @ObservationIgnored private var linkedObserver: NSObjectProtocol?
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
 
     private init(connectionId: UUID) {
         self.connectionId = connectionId
 
-        let reload: @Sendable (Notification) -> Void = { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.scheduleRefresh()
-            }
-        }
+        AppEvents.shared.sqlFavoritesDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.scheduleRefresh() }
+            .store(in: &cancellables)
 
-        favoritesObserver = NotificationCenter.default.addObserver(
-            forName: .sqlFavoritesDidUpdate,
-            object: nil,
-            queue: .main,
-            using: reload
-        )
-        linkedObserver = NotificationCenter.default.addObserver(
-            forName: .linkedSQLFoldersDidUpdate,
-            object: nil,
-            queue: .main,
-            using: reload
-        )
+        AppEvents.shared.linkedSQLFoldersDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.scheduleRefresh() }
+            .store(in: &cancellables)
     }
 
     deinit {
-        if let favoritesObserver {
-            NotificationCenter.default.removeObserver(favoritesObserver)
-        }
-        if let linkedObserver {
-            NotificationCenter.default.removeObserver(linkedObserver)
-        }
         refreshTask?.cancel()
     }
 

--- a/TablePro/ViewModels/ERDiagramViewModel.swift
+++ b/TablePro/ViewModels/ERDiagramViewModel.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import os
 import SwiftUI
@@ -127,7 +128,7 @@ final class ERDiagramViewModel {
     private func waitForConnection() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
-            let observerBox = OSAllocatedUnfairLock<NSObjectProtocol?>(initialState: nil)
+            let cancellableBox = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
             let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
             @Sendable func resumeOnce() {
@@ -138,23 +139,16 @@ final class ERDiagramViewModel {
                 }
                 guard !alreadyResumed else { return }
                 timeoutTaskBox.withLock { $0?.cancel(); $0 = nil }
-                let observer = observerBox.withLock { current -> NSObjectProtocol? in
-                    let value = current
-                    current = nil
-                    return value
-                }
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
-                }
+                cancellableBox.withLock { $0 = nil }
                 continuation.resume()
             }
 
-            let observer = NotificationCenter.default.addObserver(
-                forName: .databaseDidConnect, object: nil, queue: .main
-            ) { _ in
-                resumeOnce()
-            }
-            observerBox.withLock { $0 = observer }
+            let cancellable = AppEvents.shared.databaseDidConnect
+                .receive(on: RunLoop.main)
+                .sink { _ in
+                    resumeOnce()
+                }
+            cancellableBox.withLock { $0 = cancellable }
 
             let timeoutTask = Task {
                 try? await Task.sleep(for: .seconds(10))

--- a/TablePro/ViewModels/WelcomeViewModel+Sample.swift
+++ b/TablePro/ViewModels/WelcomeViewModel+Sample.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import Foundation
 import os
 
@@ -39,7 +40,7 @@ internal enum SampleDatabaseLauncher {
             installedURL: installedURL,
             connectionStorage: connectionStorage
         )
-        NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+        AppEvents.shared.connectionUpdated.send(())
         bumpSampleOpenedCounter()
         launchSampleConnection(connection, onError: onError)
     }
@@ -173,7 +174,7 @@ internal enum SampleDatabaseLauncher {
         if let sampleConnection {
             do {
                 try await DatabaseManager.shared.ensureConnected(sampleConnection)
-                NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+                AppEvents.shared.connectionUpdated.send(())
             } catch {
                 logger.warning(
                     "Reopening sample after reset failed: \(error.localizedDescription, privacy: .public)"

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import os
 import SwiftUI
 
@@ -77,10 +78,10 @@ final class WelcomeViewModel {
 
     // MARK: - Notification Observers
 
-    @ObservationIgnored private var connectionUpdatedObserver: NSObjectProtocol?
+    @ObservationIgnored private var connectionUpdatedCancellable: AnyCancellable?
+    @ObservationIgnored private var linkedFoldersCancellable: AnyCancellable?
     @ObservationIgnored private var exportObserver: NSObjectProtocol?
     @ObservationIgnored private var importObserver: NSObjectProtocol?
-    @ObservationIgnored private var linkedFoldersObserver: NSObjectProtocol?
     @ObservationIgnored private var importFromAppObserver: NSObjectProtocol?
     @ObservationIgnored private var welcomeRouterTask: Task<Void, Never>?
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
@@ -143,7 +144,7 @@ final class WelcomeViewModel {
     // MARK: - Setup & Teardown
 
     func setUp() {
-        guard connectionUpdatedObserver == nil else { return }
+        guard connectionUpdatedCancellable == nil else { return }
 
         if expandedGroupIds.isEmpty {
             let allGroupIds = Set(groupStorage.loadGroups().map(\.id))
@@ -152,13 +153,11 @@ final class WelcomeViewModel {
             }
         }
 
-        connectionUpdatedObserver = NotificationCenter.default.addObserver(
-            forName: .connectionUpdated, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+        connectionUpdatedCancellable = AppEvents.shared.connectionUpdated
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
                 self?.loadConnections()
             }
-        }
 
         exportObserver = NotificationCenter.default.addObserver(
             forName: .exportConnections, object: nil, queue: .main
@@ -185,13 +184,11 @@ final class WelcomeViewModel {
             }
         }
 
-        linkedFoldersObserver = NotificationCenter.default.addObserver(
-            forName: .linkedFoldersDidUpdate, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+        linkedFoldersCancellable = AppEvents.shared.linkedFoldersDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
                 self?.linkedConnections = LinkedFolderWatcher.shared.linkedConnections
             }
-        }
 
         loadConnections()
         linkedConnections = LinkedFolderWatcher.shared.linkedConnections
@@ -260,8 +257,7 @@ final class WelcomeViewModel {
     deinit {
         welcomeRouterTask?.cancel()
         searchDebounceTask?.cancel()
-        [connectionUpdatedObserver, exportObserver, importObserver,
-         importFromAppObserver, linkedFoldersObserver].forEach {
+        [exportObserver, importObserver, importFromAppObserver].forEach {
             if let observer = $0 {
                 NotificationCenter.default.removeObserver(observer)
             }

--- a/TablePro/Views/Connection/WelcomeContextMenus.swift
+++ b/TablePro/Views/Connection/WelcomeContextMenus.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import SwiftUI
 
 extension WelcomeWindowView {
@@ -63,7 +64,7 @@ extension WelcomeWindowView {
                     updated.localOnly = !allLocalOnly
                     ConnectionStorage.shared.updateConnection(updated)
                 }
-                NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+                AppEvents.shared.connectionUpdated.send(())
             } label: {
                 Label(
                     allLocalOnly
@@ -172,7 +173,7 @@ extension WelcomeWindowView {
                 var updated = connection
                 updated.localOnly.toggle()
                 ConnectionStorage.shared.updateConnection(updated)
-                NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+                AppEvents.shared.connectionUpdated.send(())
             } label: {
                 Label(
                     connection.localOnly

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import os
 import SwiftUI
 import TableProPluginKit
@@ -165,7 +166,7 @@ final class ConnectionFormCoordinator {
               let connection = storage.loadConnections().first(where: { $0.id == id }) else { return }
         storage.deleteConnection(connection)
         dismissAction?()
-        NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+        AppEvents.shared.connectionUpdated.send(())
     }
 
     // MARK: - Type change
@@ -310,7 +311,7 @@ final class ConnectionFormCoordinator {
                 SyncChangeTracker.shared.markDirty(.connection, id: connectionToSave.id.uuidString)
             }
             dismissAction?()
-            NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+            AppEvents.shared.connectionUpdated.send(())
             if connect {
                 connectToDatabase(connectionToSave)
             }
@@ -325,7 +326,7 @@ final class ConnectionFormCoordinator {
                 SyncChangeTracker.shared.markDirty(.connection, id: connectionToSave.id.uuidString)
             }
             dismissAction?()
-            NotificationCenter.default.post(name: .connectionUpdated, object: nil)
+            AppEvents.shared.connectionUpdated.send(())
         }
     }
 

--- a/TablePro/Views/Editor/HistoryPanelView.swift
+++ b/TablePro/Views/Editor/HistoryPanelView.swift
@@ -50,7 +50,7 @@ struct HistoryPanelView: View {
             restoreFilterState()
             loadData()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .queryHistoryDidUpdate)) { _ in
+        .onReceive(AppEvents.shared.queryHistoryDidUpdate) { _ in
             loadData()
         }
         .sheet(item: $favoriteDialogQuery) { item in

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -9,6 +9,7 @@ import AppKit
 import CodeEditLanguages
 import CodeEditSourceEditor
 import CodeEditTextView
+import Combine
 import SwiftUI
 
 // MARK: - SQLEditorView
@@ -35,8 +36,7 @@ struct SQLEditorView: View {
     @State private var coordinator = SQLEditorCoordinator()
     @State private var editorReady = false
     @State private var editorConfiguration = makeConfiguration()
-    @State private var favoritesObserver: NSObjectProtocol?
-    @State private var linkedFoldersObserver: NSObjectProtocol?
+    @State private var favoritesCancellables: Set<AnyCancellable> = []
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -154,18 +154,20 @@ struct SQLEditorView: View {
         refreshFavoriteKeywords()
         let adapter = completionAdapter
         let connId = connectionId
-        let refresh: @Sendable (Notification) -> Void = { _ in
+        let refresh: () -> Void = {
             Task { @MainActor in
                 let keywords = await SQLFavoriteManager.shared.fetchKeywordMap(connectionId: connId)
                 adapter?.updateFavoriteKeywords(keywords)
             }
         }
-        favoritesObserver = NotificationCenter.default.addObserver(
-            forName: .sqlFavoritesDidUpdate, object: nil, queue: .main, using: refresh
-        )
-        linkedFoldersObserver = NotificationCenter.default.addObserver(
-            forName: .linkedSQLFoldersDidUpdate, object: nil, queue: .main, using: refresh
-        )
+        AppEvents.shared.sqlFavoritesDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { _ in refresh() }
+            .store(in: &favoritesCancellables)
+        AppEvents.shared.linkedSQLFoldersDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { _ in refresh() }
+            .store(in: &favoritesCancellables)
     }
 
     private func refreshFavoriteKeywords() {
@@ -177,14 +179,7 @@ struct SQLEditorView: View {
     }
 
     private func teardownFavoritesObserver() {
-        if let observer = favoritesObserver {
-            NotificationCenter.default.removeObserver(observer)
-            favoritesObserver = nil
-        }
-        if let observer = linkedFoldersObserver {
-            NotificationCenter.default.removeObserver(observer)
-            linkedFoldersObserver = nil
-        }
+        favoritesCancellables.removeAll()
     }
 
     // MARK: - Configuration

--- a/TablePro/Views/Integrations/IntegrationsActivityLogPane.swift
+++ b/TablePro/Views/Integrations/IntegrationsActivityLogPane.swift
@@ -23,9 +23,6 @@ struct IntegrationsActivityLogPane: View {
     @State private var hasLoaded = false
     @State private var showInspector = false
 
-    private let auditChanges = NotificationCenter.default
-        .publisher(for: .mcpAuditLogChanged)
-
     var body: some View {
         ActivityLogTable(
             entries: filteredEntries,
@@ -44,7 +41,7 @@ struct IntegrationsActivityLogPane: View {
         .navigationTitle(IntegrationsActivitySection.activityLog.title)
         .navigationSubtitle(retentionSubtitle)
         .task { await reload() }
-        .onReceive(auditChanges) { _ in
+        .onReceive(AppEvents.shared.mcpAuditLogChanged) { _ in
             Task { await reload() }
         }
         .onChange(of: selectedTokenId) { _, _ in Task { await reload() } }

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -8,6 +8,7 @@
 //
 
 import AppKit
+import Combine
 import Foundation
 import Observation
 import os
@@ -41,6 +42,9 @@ final class MainContentCommandActions {
 
     /// Task handles for async notification observers; cancelled on deinit.
     @ObservationIgnored private var notificationTasks: [Task<Void, Never>] = []
+
+    /// Combine subscriptions for typed AppEvents publishers.
+    @ObservationIgnored private var eventCancellables: Set<AnyCancellable> = []
 
     // MARK: - Initialization
 
@@ -819,7 +823,10 @@ final class MainContentCommandActions {
     // MARK: Database Broadcasts
 
     private func setupDatabaseBroadcastObservers() {
-        observe(.databaseDidConnect) { [weak self] _ in self?.handleDatabaseDidConnect() }
+        AppEvents.shared.databaseDidConnect
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.handleDatabaseDidConnect() }
+            .store(in: &eventCancellables)
     }
 
     private func handleDatabaseDidConnect() {
@@ -839,11 +846,14 @@ final class MainContentCommandActions {
     // MARK: Window Broadcasts
 
     private func setupWindowObservers() {
-        observe(.mainWindowWillClose) { [weak self] _ in
-            guard let coordinator = self?.coordinator else { return }
-            guard !MainContentCoordinator.isAppTerminating else { return }
-            coordinator.persistence.saveOrClearAggregated()
-        }
+        AppEvents.shared.mainWindowWillClose
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let coordinator = self?.coordinator else { return }
+                guard !MainContentCoordinator.isAppTerminating else { return }
+                coordinator.persistence.saveOrClearAggregated()
+            }
+            .store(in: &eventCancellables)
     }
 
     // MARK: File Open Broadcasts

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -7,6 +7,7 @@
 //
 
 import CodeEditSourceEditor
+import Combine
 import Foundation
 import Observation
 import os
@@ -72,10 +73,6 @@ final class MainContentCoordinator {
         switchSeq += 1
         return switchSeq
     }
-
-    /// Posted during teardown so DataGridView coordinators can release cell views.
-    /// Object is the connection UUID.
-    static let teardownNotification = Notification.Name("MainContentCoordinator.teardown")
 
     // MARK: - Dependencies
 
@@ -162,7 +159,7 @@ final class MainContentCoordinator {
     @ObservationIgnored private var changeManagerUpdateTask: Task<Void, Never>?
     @ObservationIgnored private var activeSortTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var terminationObserver: NSObjectProtocol?
-    @ObservationIgnored private var pluginDriverObserver: NSObjectProtocol?
+    @ObservationIgnored private var pluginDriverCancellable: AnyCancellable?
     @ObservationIgnored private var externalFileModObserver: NSObjectProtocol?
 
     var fileConflictRequest: FileConflictRequest?
@@ -424,13 +421,13 @@ final class MainContentCoordinator {
         startFileWatcherIfNeeded()
         // Retry when driver becomes available (connection may still be in progress)
         if changeManager.pluginDriver == nil {
-            pluginDriverObserver = NotificationCenter.default.addObserver(
-                forName: .databaseDidConnect, object: nil, queue: .main
-            ) { [weak self] _ in
-                Task {
-                    self?.setupPluginDriver()
+            pluginDriverCancellable = AppEvents.shared.databaseDidConnect
+                .receive(on: RunLoop.main)
+                .sink { [weak self] _ in
+                    Task {
+                        self?.setupPluginDriver()
+                    }
                 }
-            }
         }
         Self.lifecycleLogger.info(
             "[open] MainContentCoordinator.markActivated done connId=\(self.connection.id, privacy: .public) elapsedMs=\(Int(Date().timeIntervalSince(start) * 1_000))"
@@ -476,10 +473,8 @@ final class MainContentCoordinator {
         let pluginDriver = driver.queryBuildingPluginDriver
         queryBuilder.setPluginDriver(pluginDriver)
         changeManager.pluginDriver = pluginDriver
-        // Remove observer once successfully set up
-        if pluginDriver != nil, let observer = pluginDriverObserver {
-            NotificationCenter.default.removeObserver(observer)
-            pluginDriverObserver = nil
+        if pluginDriver != nil {
+            pluginDriverCancellable = nil
         }
     }
 
@@ -547,10 +542,7 @@ final class MainContentCoordinator {
             NotificationCenter.default.removeObserver(observer)
             terminationObserver = nil
         }
-        if let observer = pluginDriverObserver {
-            NotificationCenter.default.removeObserver(observer)
-            pluginDriverObserver = nil
-        }
+        pluginDriverCancellable = nil
         if let observer = externalFileModObserver {
             NotificationCenter.default.removeObserver(observer)
             externalFileModObserver = nil
@@ -566,9 +558,8 @@ final class MainContentCoordinator {
         for task in activeSortTasks.values { task.cancel() }
         activeSortTasks.removeAll()
 
-        NotificationCenter.default.post(
-            name: Self.teardownNotification,
-            object: connection.id
+        AppEvents.shared.mainCoordinatorTeardown.send(
+            MainCoordinatorTeardown(connectionId: connection.id)
         )
 
         tabSessionRegistry.removeAll()

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -160,7 +160,7 @@ final class MainContentCoordinator {
     @ObservationIgnored private var activeSortTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var terminationObserver: NSObjectProtocol?
     @ObservationIgnored private var pluginDriverCancellable: AnyCancellable?
-    @ObservationIgnored private var externalFileModObserver: NSObjectProtocol?
+    @ObservationIgnored private var externalFileModCancellable: AnyCancellable?
 
     var fileConflictRequest: FileConflictRequest?
 
@@ -386,13 +386,11 @@ final class MainContentCoordinator {
 
         _ = Self.registerTerminationObserver
 
-        externalFileModObserver = NotificationCenter.default.addObserver(
-            forName: .linkedSQLFoldersDidUpdate, object: nil, queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
+        externalFileModCancellable = AppEvents.shared.linkedSQLFoldersDidUpdate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
                 self?.checkOpenTabsForExternalModification()
             }
-        }
 
         Self.lifecycleLogger.info(
             "[open] MainContentCoordinator.init done connId=\(connection.id, privacy: .public) elapsedMs=\(Int(Date().timeIntervalSince(initStart) * 1_000))"
@@ -543,10 +541,7 @@ final class MainContentCoordinator {
             terminationObserver = nil
         }
         pluginDriverCancellable = nil
-        if let observer = externalFileModObserver {
-            NotificationCenter.default.removeObserver(observer)
-            externalFileModObserver = nil
-        }
+        externalFileModCancellable = nil
         fileWatcher?.stopWatching(connectionId: connectionId)
         fileWatcher = nil
         currentQueryTask?.cancel()

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -183,15 +183,14 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     }
 
     func observeTeardown(connectionId: UUID) {
-        teardownObserver = NotificationCenter.default.addObserver(
-            forName: MainContentCoordinator.teardownNotification,
-            object: connectionId,
-            queue: .main
-        ) { [weak self] _ in
-            Task {
-                self?.releaseData()
+        teardownCancellable = AppEvents.shared.mainCoordinatorTeardown
+            .filter { $0.connectionId == connectionId }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task {
+                    self?.releaseData()
+                }
             }
-        }
     }
 
     private func releaseData() {
@@ -215,13 +214,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         activeFKPreviewPopover = nil
     }
 
-    private(set) var teardownObserver: NSObjectProtocol?
-
-    deinit {
-        if let observer = teardownObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-    }
+    private(set) var teardownCancellable: AnyCancellable?
 
     func updateCache() {
         let tableRows = tableRowsProvider()

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -45,10 +45,14 @@ struct DataGridView: NSViewRepresentable {
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
         scrollView.borderType = .noBorder
+        scrollView.contentView.wantsLayer = true
+        scrollView.contentView.layerContentsRedrawPolicy = .onSetNeedsDisplay
 
         let tableView = KeyHandlingTableView()
         tableView.coordinator = context.coordinator
         tableView.style = .plain
+        tableView.wantsLayer = true
+        tableView.layerContentsRedrawPolicy = .onSetNeedsDisplay
         tableView.setAccessibilityLabel(String(localized: "Data grid"))
         tableView.setAccessibilityRole(.table)
         let settings = AppSettingsManager.shared.dataGrid
@@ -156,7 +160,7 @@ struct DataGridView: NSViewRepresentable {
             }
         }
 
-        if let connectionId = configuration.connectionId, coordinator.teardownObserver == nil {
+        if let connectionId = configuration.connectionId, coordinator.teardownCancellable == nil {
             coordinator.observeTeardown(connectionId: connectionId)
         }
 

--- a/TablePro/Views/Terminal/TerminalTabContentView.swift
+++ b/TablePro/Views/Terminal/TerminalTabContentView.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import Combine
 import GhosttyTerminal
 import SwiftUI
 
@@ -107,9 +108,9 @@ struct TerminalTabContentView: View {
 
     private func waitForSSHTunnel(timeout: Duration) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                for await _ in NotificationCenter.default.notifications(named: .databaseDidConnect) {
-                    if DatabaseManager.shared.session(for: self.connectionId)?.effectiveConnection != nil {
+            group.addTask { @MainActor [connectionId] in
+                for await _ in AppEvents.shared.databaseDidConnect.values {
+                    if DatabaseManager.shared.session(for: connectionId)?.effectiveConnection != nil {
                         return true
                     }
                 }


### PR DESCRIPTION
## Summary

Phase 5 tail. 12 remaining domain notifications migrated to typed AppEvents publishers. Punch list now empty for domain events. Tier 3 command-style notifications stay on NotificationCenter until the command-bus pass.

## Migrated

**Connection events:**
- databaseDidConnect → DatabaseDidConnect{connectionId} (typed)
- connectionUpdated → Void (no observer reads payload)
- mainWindowWillClose → Void
- MainContentCoordinator.teardownNotification → mainCoordinatorTeardown (typed)

**Data update events:**
- queryHistoryDidUpdate, sqlFavoritesDidUpdate, linkedFoldersDidUpdate, linkedSQLFoldersDidUpdate (Void)

**Misc:**
- licenseStatusDidChange, syncChangeTracked, mcpAuditLogChanged (Void)
- pluginsRejected → [RejectedPlugin] (typed payload)

## Commits

1. 07d6da21 - migrate connection events
2. d3bbafbf - migrate data update events
3. 05c80cda - migrate misc app events

## Notes

- SyncChangeTracker: dropped the unused NotificationCenter init parameter (test injection point with no callers).
- AppNotifications.swift kept (still holds Tier 3 command names: exportConnections, importConnections, focusConnectionFormWindowRequested, openSampleDatabaseRequested, resetSampleDatabaseRequested, exportQueryResults, saveAsFavoriteRequested, showFeedbackWindow, refreshData, deleteSelectedRows, etc.).
- TableProApp.swift mainWindowWillClose declaration removed; refreshData and other Tier 3 commands remain.

## Test plan

- [ ] Build clean (verified)
- [ ] swiftlint clean on all 27 touched files (verified, 0 violations)
- [ ] Connect/disconnect a database, confirm sidebar status updates
- [ ] Save query, confirm history panel reloads
- [ ] Star a query, confirm favorites sidebar reloads
- [ ] Edit a connection, confirm welcome list refreshes
- [ ] License activation, confirm UI reflects new state
- [ ] Reject an outdated plugin, confirm alert shows with rejected list
- [ ] Edit linked folder, confirm linked sidebar refreshes