### PR TITLE
refactor: phase 4 step 0 — extract pure helper services

### DIFF
--- a/TablePro/Core/Database/LazyLoadColumnsService.swift
+++ b/TablePro/Core/Database/LazyLoadColumnsService.swift
@@ -1,0 +1,63 @@
+//
+//  LazyLoadColumnsService.swift
+//  TablePro
+//
+
+import Foundation
+import os
+import TableProPluginKit
+
+@MainActor
+struct LazyLoadColumnsService {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "LazyLoadColumns")
+
+    let connectionId: UUID
+    let databaseType: DatabaseType
+    let queryBuilder: TableQueryBuilder
+
+    func fetchValues(
+        tableName: String,
+        primaryKeyColumn: String,
+        primaryKeyValue: String,
+        excludedColumnNames: [String]
+    ) async throws -> [String: String?] {
+        guard !excludedColumnNames.isEmpty else { return [:] }
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
+            throw DatabaseError.notConnected
+        }
+
+        let quotedCols = excludedColumnNames.map { queryBuilder.quoteIdentifier($0) }
+        let quotedTable = queryBuilder.quoteIdentifier(tableName)
+        let quotedPK = queryBuilder.quoteIdentifier(primaryKeyColumn)
+
+        let paramStyle = PluginMetadataRegistry.shared
+            .snapshot(forTypeId: databaseType.pluginTypeId)?.parameterStyle ?? .questionMark
+        let placeholder: String
+        switch paramStyle {
+        case .dollar:
+            placeholder = "$1"
+        case .questionMark:
+            placeholder = "?"
+        }
+
+        let query = "SELECT \(quotedCols.joined(separator: ", ")) FROM \(quotedTable) WHERE \(quotedPK) = \(placeholder)"
+
+        Self.logger.debug("Lazy-loading excluded columns: \(excludedColumnNames.joined(separator: ", "), privacy: .public)")
+
+        let result = try await driver.executeParameterized(
+            query: query,
+            parameters: [primaryKeyValue]
+        )
+
+        guard let row = result.rows.first else {
+            Self.logger.warning("No row returned for lazy-load query")
+            return [:]
+        }
+
+        var dict: [String: String?] = [:]
+        for (index, colName) in excludedColumnNames.enumerated() where index < row.count {
+            dict[colName] = row[index]
+        }
+        return dict
+    }
+}

--- a/TablePro/Core/Database/TableOperationSQLBuilder.swift
+++ b/TablePro/Core/Database/TableOperationSQLBuilder.swift
@@ -1,0 +1,98 @@
+//
+//  TableOperationSQLBuilder.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+struct TableOperationSQLBuilder {
+    let connectionId: UUID
+    let databaseType: DatabaseType
+    let viewNamesProvider: () -> Set<String>
+    let adapterProvider: () -> PluginDriverAdapter?
+
+    init(
+        connectionId: UUID,
+        databaseType: DatabaseType,
+        viewNamesProvider: @escaping () -> Set<String>,
+        adapterProvider: @escaping () -> PluginDriverAdapter?
+    ) {
+        self.connectionId = connectionId
+        self.databaseType = databaseType
+        self.viewNamesProvider = viewNamesProvider
+        self.adapterProvider = adapterProvider
+    }
+
+    func generate(
+        truncates: Set<String>,
+        deletes: Set<String>,
+        options: [String: TableOperationOptions],
+        includeFKHandling: Bool = true
+    ) -> [String] {
+        var statements: [String] = []
+        let sortedTruncates = truncates.sorted()
+        let sortedDeletes = deletes.sorted()
+
+        let needsDisableFK = includeFKHandling && truncates.union(deletes).contains { tableName in
+            options[tableName]?.ignoreForeignKeys == true
+        }
+
+        if needsDisableFK {
+            statements.append(contentsOf: foreignKeyDisableStatements())
+        }
+
+        for tableName in sortedTruncates {
+            let tableOptions = options[tableName] ?? TableOperationOptions()
+            statements.append(contentsOf: truncateStatements(
+                tableName: tableName, options: tableOptions
+            ))
+        }
+
+        let viewNames = viewNamesProvider()
+
+        for tableName in sortedDeletes {
+            let tableOptions = options[tableName] ?? TableOperationOptions()
+            let stmt = dropTableStatement(
+                tableName: tableName,
+                isView: viewNames.contains(tableName), options: tableOptions
+            )
+            if !stmt.isEmpty {
+                statements.append(stmt)
+            }
+        }
+
+        if needsDisableFK {
+            statements.append(contentsOf: foreignKeyEnableStatements())
+        }
+
+        return statements
+    }
+
+    func foreignKeyDisableStatements() -> [String] {
+        adapterProvider()?.foreignKeyDisableStatements() ?? []
+    }
+
+    func foreignKeyEnableStatements() -> [String] {
+        adapterProvider()?.foreignKeyEnableStatements() ?? []
+    }
+
+    private func truncateStatements(
+        tableName: String, options: TableOperationOptions
+    ) -> [String] {
+        guard let adapter = adapterProvider() else { return [] }
+        return adapter.truncateTableStatements(
+            table: tableName, schema: nil, cascade: options.cascade
+        )
+    }
+
+    private func dropTableStatement(
+        tableName: String, isView: Bool, options: TableOperationOptions
+    ) -> String {
+        let keyword = isView ? "VIEW" : "TABLE"
+        guard let adapter = adapterProvider() else { return "" }
+        return adapter.dropObjectStatement(
+            name: tableName, objectType: keyword, schema: nil, cascade: options.cascade
+        )
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LazyLoadColumns.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LazyLoadColumns.swift
@@ -2,16 +2,8 @@
 //  MainContentCoordinator+LazyLoadColumns.swift
 //  TablePro
 //
-//  Lazy-loads full values for columns truncated by ColumnExclusionPolicy.
-//
 
 import Foundation
-import os
-import TableProPluginKit
-
-private enum LazyLoadLog {
-    static let logger = Logger(subsystem: "com.TablePro", category: "LazyLoadColumns")
-}
 
 internal extension MainContentCoordinator {
     func fetchFullValuesForExcludedColumns(
@@ -20,44 +12,15 @@ internal extension MainContentCoordinator {
         primaryKeyValue: String,
         excludedColumnNames: [String]
     ) async throws -> [String: String?] {
-        guard !excludedColumnNames.isEmpty else { return [:] }
-        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
-            throw DatabaseError.notConnected
-        }
-
-        let quotedCols = excludedColumnNames.map { queryBuilder.quoteIdentifier($0) }
-        let quotedTable = queryBuilder.quoteIdentifier(tableName)
-        let quotedPK = queryBuilder.quoteIdentifier(primaryKeyColumn)
-
-        // Resolve parameter style from plugin metadata (? for MySQL/SQLite, $1 for PostgreSQL)
-        let paramStyle = PluginMetadataRegistry.shared
-            .snapshot(forTypeId: connection.type.pluginTypeId)?.parameterStyle ?? .questionMark
-        let placeholder: String
-        switch paramStyle {
-        case .dollar:
-            placeholder = "$1"
-        case .questionMark:
-            placeholder = "?"
-        }
-
-        let query = "SELECT \(quotedCols.joined(separator: ", ")) FROM \(quotedTable) WHERE \(quotedPK) = \(placeholder)"
-
-        LazyLoadLog.logger.debug("Lazy-loading excluded columns: \(excludedColumnNames.joined(separator: ", "), privacy: .public)")
-
-        let result = try await driver.executeParameterized(
-            query: query,
-            parameters: [primaryKeyValue]
+        try await LazyLoadColumnsService(
+            connectionId: connectionId,
+            databaseType: connection.type,
+            queryBuilder: queryBuilder
+        ).fetchValues(
+            tableName: tableName,
+            primaryKeyColumn: primaryKeyColumn,
+            primaryKeyValue: primaryKeyValue,
+            excludedColumnNames: excludedColumnNames
         )
-
-        guard let row = result.rows.first else {
-            LazyLoadLog.logger.warning("No row returned for lazy-load query")
-            return [:]
-        }
-
-        var dict: [String: String?] = [:]
-        for (index, colName) in excludedColumnNames.enumerated() where index < row.count {
-            dict[colName] = row[index]
-        }
-        return dict
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableOperations.swift
@@ -2,117 +2,43 @@
 //  MainContentCoordinator+TableOperations.swift
 //  TablePro
 //
-//  SQL generation for table truncate, drop, and FK handling operations.
-//
 
 import Foundation
 
 extension MainContentCoordinator {
-    // MARK: - Plugin Adapter Access
-
-    /// Returns the current connection's PluginDriverAdapter, if available.
-    private var currentPluginDriverAdapter: PluginDriverAdapter? {
-        DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter
+    private var tableOperationBuilder: TableOperationSQLBuilder {
+        TableOperationSQLBuilder(
+            connectionId: connectionId,
+            databaseType: connection.type,
+            viewNamesProvider: {
+                guard let session = DatabaseManager.shared.session(for: self.connectionId) else { return [] }
+                return Set(session.tables.filter { $0.type == .view }.map(\.name))
+            },
+            adapterProvider: {
+                DatabaseManager.shared.driver(for: self.connectionId) as? PluginDriverAdapter
+            }
+        )
     }
 
-    // MARK: - Table Operation SQL Generation
-
-    /// Generates SQL statements for table truncate/drop operations.
-    /// - Parameters:
-    ///   - truncates: Set of table names to truncate
-    ///   - deletes: Set of table names to drop
-    ///   - options: Per-table options for FK and cascade handling
-    ///   - includeFKHandling: Whether to include FK disable/enable statements (set false when caller handles FK)
-    /// - Returns: Array of SQL statements to execute
     func generateTableOperationSQL(
         truncates: Set<String>,
         deletes: Set<String>,
         options: [String: TableOperationOptions],
         includeFKHandling: Bool = true
     ) -> [String] {
-        var statements: [String] = []
-        let dbType = connection.type
-
-        // Sort tables for consistent execution order
-        let sortedTruncates = truncates.sorted()
-        let sortedDeletes = deletes.sorted()
-
-        let needsDisableFK = includeFKHandling && truncates.union(deletes).contains { tableName in
-            options[tableName]?.ignoreForeignKeys == true
-        }
-
-        // FK disable must be OUTSIDE transaction to ensure it takes effect even on rollback
-        if needsDisableFK {
-            statements.append(contentsOf: fkDisableStatements(for: dbType))
-        }
-
-        for tableName in sortedTruncates {
-            let tableOptions = options[tableName] ?? TableOperationOptions()
-            statements.append(contentsOf: truncateStatements(
-                tableName: tableName, options: tableOptions
-            ))
-        }
-
-        let viewNames: Set<String> = {
-            guard let session = DatabaseManager.shared.session(for: connectionId) else { return [] }
-            return Set(session.tables.filter { $0.type == .view }.map(\.name))
-        }()
-
-        for tableName in sortedDeletes {
-            let tableOptions = options[tableName] ?? TableOperationOptions()
-            let stmt = dropTableStatement(
-                tableName: tableName,
-                isView: viewNames.contains(tableName), options: tableOptions
-            )
-            if !stmt.isEmpty {
-                statements.append(stmt)
-            }
-        }
-
-        // FK re-enable must be OUTSIDE transaction to ensure it runs even on rollback
-        if needsDisableFK {
-            statements.append(contentsOf: fkEnableStatements(for: dbType))
-        }
-
-        return statements
+        tableOperationBuilder.generate(
+            truncates: truncates,
+            deletes: deletes,
+            options: options,
+            includeFKHandling: includeFKHandling
+        )
     }
 
-    // MARK: - Foreign Key Handling
-
     func fkDisableStatements(for dbType: DatabaseType) -> [String] {
-        guard let adapter = currentPluginDriverAdapter,
-              let stmts = adapter.foreignKeyDisableStatements() else {
-            return []
-        }
-        return stmts
+        tableOperationBuilder.foreignKeyDisableStatements()
     }
 
     func fkEnableStatements(for dbType: DatabaseType) -> [String] {
-        guard let adapter = currentPluginDriverAdapter,
-              let stmts = adapter.foreignKeyEnableStatements() else {
-            return []
-        }
-        return stmts
-    }
-
-    // MARK: - Private SQL Builders
-
-    private func truncateStatements(
-        tableName: String, options: TableOperationOptions
-    ) -> [String] {
-        guard let adapter = currentPluginDriverAdapter else { return [] }
-        return adapter.truncateTableStatements(
-            table: tableName, schema: nil, cascade: options.cascade
-        )
-    }
-
-    private func dropTableStatement(
-        tableName: String, isView: Bool, options: TableOperationOptions
-    ) -> String {
-        let keyword = isView ? "VIEW" : "TABLE"
-        guard let adapter = currentPluginDriverAdapter else { return "" }
-        return adapter.dropObjectStatement(
-            name: tableName, objectType: keyword, schema: nil, cascade: options.cascade
-        )
+        tableOperationBuilder.foreignKeyEnableStatements()
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 step 0. Extract two pure helper services from `MainContentCoordinator` extensions. Mechanical, no behavior change. Per `/tmp/audit/phase4-extraction-plan.md`, the audit found that real coordinator extractions all couple back to `tabManager.tabs` / `currentQueryTask` / `changeManager`. The safe wins are pure helpers, which is what this PR does.

## Extracted

**`TableOperationSQLBuilder`** (Core/Database/TableOperationSQLBuilder.swift):
- Encapsulates SQL generation for table truncate/drop with optional FK handling.
- Takes connectionId, databaseType, viewNamesProvider closure, adapterProvider closure at init. Pure dependencies, testable in isolation.
- Replaces 118 LOC of `MainContentCoordinator+TableOperations.swift` with a 41-line forwarder.

**`LazyLoadColumnsService`** (Core/Database/LazyLoadColumnsService.swift):
- Encapsulates the lazy-load query for excluded-column values.
- Takes connectionId, databaseType, queryBuilder. No coordinator state.
- Replaces 63 LOC of `MainContentCoordinator+LazyLoadColumns.swift` with a 26-line forwarder.

## Net effect

- 2 new pure-data services in Core/Database/
- 2 extension files now thin forwarders (preserve public API for callers)
- All 4 callers across the codebase compile unchanged (4 `generateTableOperationSQL` / `fkDisableStatements` / `fkEnableStatements` callers in extensions; 1 external `fetchFullValuesForExcludedColumns` caller in MainContentView+EventHandlers)

## Out of scope (Phase 4 multi-session)

- `MainContentCoordinatorRegistry` extraction: 40+ external call sites across AppDelegate, TableProApp, MCP tools, SessionStateFactory, TabRouter, TabWindowController. Too broad for this PR.
- `QueryAnalysis` helper move: 33 LOC, trivial wrapper around `QueryClassifier`. Net win zero.
- `TabStateMutator` (Step 1): expand `QueryTabManager` with focused mutation methods, reroute extension `tabManager.tabs[index].X = Y` patterns through the manager API. Multi-session work.
- Real coordinator extractions (FilterCoordinator, QueryExecutionCoordinator): blocked by Step 1.

## Test plan

- [ ] Build clean (verified: swiftlint 0 violations on 4 touched files)
- [ ] Truncate/drop a table from the data grid context menu (exercises `generateTableOperationSQL`)
- [ ] Save changes that contain large excluded values (exercises `fetchFullValuesForExcludedColumns`)
- [ ] SQL preview tab shows correct truncate/drop statements