### PR TITLE
refactor: route tab mutations through QueryTabManager.mutate

### DIFF
--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -303,6 +303,22 @@ final class QueryTabManager {
         }
     }
 
+    @discardableResult
+    func mutate(tabId: UUID, _ block: (inout QueryTab) -> Void) -> Bool {
+        guard let index = tabs.firstIndex(where: { $0.id == tabId }) else {
+            return false
+        }
+        block(&tabs[index])
+        return true
+    }
+
+    @discardableResult
+    func mutate(at index: Int, _ block: (inout QueryTab) -> Void) -> Bool {
+        guard tabs.indices.contains(index) else { return false }
+        block(&tabs[index])
+        return true
+    }
+
     func markTabRenamed(_ tabId: UUID) {
         guard tabs.contains(where: { $0.id == tabId }) else { return }
         tabStructureVersion += 1

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -355,18 +355,18 @@ struct MainEditorContentView: View {
             guard let loaded = FileTextLoader.load(url) else { return }
             let mtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
             await MainActor.run {
-                guard let index = coordinator.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-                coordinator.tabManager.tabs[index].content.query = loaded.content
-                coordinator.tabManager.tabs[index].content.savedFileContent = loaded.content
-                coordinator.tabManager.tabs[index].content.loadMtime = mtime
-                coordinator.tabManager.tabs[index].content.externalModificationDetected = false
+                coordinator.tabManager.mutate(tabId: tabId) { tab in
+                    tab.content.query = loaded.content
+                    tab.content.savedFileContent = loaded.content
+                    tab.content.loadMtime = mtime
+                    tab.content.externalModificationDetected = false
+                }
             }
         }
     }
 
     private func dismissExternalModBanner(tabId: UUID) {
-        guard let index = coordinator.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-        coordinator.tabManager.tabs[index].content.externalModificationDetected = false
+        coordinator.tabManager.mutate(tabId: tabId) { $0.content.externalModificationDetected = false }
     }
 
     private func updateHasQueryText() {
@@ -387,13 +387,10 @@ struct MainEditorContentView: View {
                 // flushTextUpdate() fires on the OLD tab's EditorCoordinator when
                 // selectedTabIndex already points to the NEW tab — writing to
                 // selectedTabIndex would overwrite the new tab's query.
-                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
-                    index < tabManager.tabs.count
-                else { return }
+                guard tabManager.mutate(tabId: tabId, { $0.content.query = newValue }) else { return }
 
-                tabManager.tabs[index].content.query = newValue
-
-                if tabManager.tabs[index].content.sourceFileURL != nil {
+                if let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
+                   tabManager.tabs[index].content.sourceFileURL != nil {
                     let isDirty = tabManager.tabs[index].content.isFileDirty
                     Task { @MainActor in
                         if let window = NSApp.keyWindow {
@@ -410,8 +407,7 @@ struct MainEditorContentView: View {
         return Binding(
             get: { tab.content.queryParameters },
             set: { newValue in
-                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-                tabManager.tabs[index].content.queryParameters = newValue
+                tabManager.mutate(tabId: tabId) { $0.content.queryParameters = newValue }
             }
         )
     }
@@ -421,8 +417,7 @@ struct MainEditorContentView: View {
         return Binding(
             get: { tab.content.isParameterPanelVisible },
             set: { newValue in
-                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-                tabManager.tabs[index].content.isParameterPanelVisible = newValue
+                tabManager.mutate(tabId: tabId) { $0.content.isParameterPanelVisible = newValue }
             }
         )
     }
@@ -731,7 +726,7 @@ struct MainEditorContentView: View {
             get: { tab.sortState },
             set: { newValue in
                 if let index = tabManager.selectedTabIndex {
-                    tabManager.tabs[index].sortState = newValue
+                    tabManager.mutate(at: index) { $0.sortState = newValue }
                 }
             }
         )
@@ -743,7 +738,7 @@ struct MainEditorContentView: View {
             set: { newValue in
                 coordinator.isUpdatingColumnLayout = true
                 if let index = tabManager.selectedTabIndex {
-                    tabManager.tabs[index].columnLayout = newValue
+                    tabManager.mutate(at: index) { $0.columnLayout = newValue }
                 }
                 Task { @MainActor in
                     coordinator.isUpdatingColumnLayout = false
@@ -784,7 +779,7 @@ struct MainEditorContentView: View {
             set: { newValue in
                 Task { @MainActor in
                     if let index = tabManager.selectedTabIndex {
-                        tabManager.tabs[index].display.resultsViewMode = newValue
+                        tabManager.mutate(at: index) { $0.display.resultsViewMode = newValue }
                     }
                 }
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
@@ -61,9 +61,7 @@ extension MainContentCoordinator {
         Task {
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
 
-            if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                tabManager.tabs[idx].execution.isExecuting = true
-            }
+            tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = true }
             toolbarState.setExecuting(true)
 
             do {
@@ -75,22 +73,23 @@ extension MainContentCoordinator {
                     row.compactMap { $0 }.joined(separator: "\t")
                 }.joined(separator: "\n")
 
-                if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].display.explainText = text
-                    tabManager.tabs[idx].display.explainExecutionTime = duration
+                let parser = QueryPlanParserFactory.parser(for: connection.type)
+                tabManager.mutate(tabId: tabId) { tab in
+                    tab.display.explainText = text
+                    tab.display.explainExecutionTime = duration
 
-                    if let parser = QueryPlanParserFactory.parser(for: connection.type) {
-                        tabManager.tabs[idx].display.explainPlan = parser.parse(rawText: text)
+                    if let parser {
+                        tab.display.explainPlan = parser.parse(rawText: text)
                     } else {
-                        tabManager.tabs[idx].display.explainPlan = nil
+                        tab.display.explainPlan = nil
                     }
-                    tabManager.tabs[idx].execution.isExecuting = false
+                    tab.execution.isExecuting = false
                 }
             } catch {
-                if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].display.explainText = "Error: \(error.localizedDescription)"
-                    tabManager.tabs[idx].display.explainPlan = nil
-                    tabManager.tabs[idx].execution.isExecuting = false
+                tabManager.mutate(tabId: tabId) { tab in
+                    tab.display.explainText = "Error: \(error.localizedDescription)"
+                    tab.display.explainPlan = nil
+                    tab.execution.isExecuting = false
                 }
             }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
@@ -75,7 +75,7 @@ extension MainContentCoordinator {
         guard let index = tabManager.selectedTabIndex else { return }
         var hidden = tabManager.tabs[index].columnLayout.hiddenColumns
         mutate(&hidden)
-        tabManager.tabs[index].columnLayout.hiddenColumns = hidden
+        tabManager.mutate(at: index) { $0.columnLayout.hiddenColumns = hidden }
         let tabId = tabManager.tabs[index].id
         tabSessionRegistry.session(for: tabId)?.columnLayout.hiddenColumns = hidden
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Discard.swift
@@ -110,7 +110,7 @@ extension MainContentCoordinator {
         changeManager.clearChangesAndUndoHistory()
 
         if let (_, index) = tabManager.selectedTabAndIndex {
-            tabManager.tabs[index].pendingChanges = TabChangeSnapshot()
+            tabManager.mutate(at: index) { $0.pendingChanges = TabChangeSnapshot() }
         }
 
         Task { await refreshTables() }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -27,10 +27,10 @@ extension MainContentCoordinator {
                     sql: combinedSQL,
                     existing: tabManager.tabs[index].content.queryParameters
                 )
-                tabManager.tabs[index].content.queryParameters = reconciled
+                tabManager.mutate(at: index) { $0.content.queryParameters = reconciled }
 
                 if !tabManager.tabs[index].content.isParameterPanelVisible {
-                    tabManager.tabs[index].content.isParameterPanelVisible = true
+                    tabManager.mutate(at: index) { $0.content.isParameterPanelVisible = true }
                     return
                 }
 
@@ -48,8 +48,10 @@ extension MainContentCoordinator {
         if level == .readOnly {
             let writeStatements = statements.filter { isWriteQuery($0) }
             if !writeStatements.isEmpty {
-                tabManager.tabs[index].execution.errorMessage =
-                    String(localized: "Cannot execute write queries: connection is read only")
+                tabManager.mutate(at: index) {
+                    $0.execution.errorMessage =
+                        String(localized: "Cannot execute write queries: connection is read only")
+                }
                 return
             }
         }
@@ -95,9 +97,7 @@ extension MainContentCoordinator {
                         executeMultipleStatements(statements)
                     }
                 case .blocked(let reason):
-                    if index < tabManager.tabs.count {
-                        tabManager.tabs[index].execution.errorMessage = reason
-                    }
+                    tabManager.mutate(at: index) { $0.execution.errorMessage = reason }
                 }
             }
         } else {
@@ -119,8 +119,10 @@ extension MainContentCoordinator {
         if level == .readOnly {
             let writeStatements = statements.filter { isWriteQuery($0) }
             if !writeStatements.isEmpty {
-                tabManager.tabs[index].execution.errorMessage =
-                    String(localized: "Cannot execute write queries: connection is read only")
+                tabManager.mutate(at: index) {
+                    $0.execution.errorMessage =
+                        String(localized: "Cannot execute write queries: connection is read only")
+                }
                 return
             }
         }
@@ -160,9 +162,7 @@ extension MainContentCoordinator {
                 case .allowed:
                     executeParameterizedAfterSafeMode(statements, parameters: parameters)
                 case .blocked(let reason):
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].execution.errorMessage = reason
-                    }
+                    tabManager.mutate(tabId: tabId) { $0.execution.errorMessage = reason }
                 }
             }
         } else {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -80,7 +80,7 @@ extension MainContentCoordinator {
 
         if needsQuery, let (tab, tabIndex) = tabManager.selectedTabAndIndex {
             setActiveTableRows(TableRows(), for: tab.id)
-            tabManager.tabs[tabIndex].pagination.reset()
+            tabManager.mutate(at: tabIndex) { $0.pagination.reset() }
         }
 
         if let (tab, _) = tabManager.selectedTabAndIndex {
@@ -100,7 +100,7 @@ extension MainContentCoordinator {
                 limit: tab.pagination.pageSize,
                 offset: tab.pagination.currentOffset
             )
-            tabManager.tabs[tabIndex].content.query = filteredQuery
+            tabManager.mutate(at: tabIndex) { $0.content.query = filteredQuery }
 
             updateFilterState(filter, for: referencedTable)
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Favorites.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Favorites.swift
@@ -17,9 +17,9 @@ extension MainContentCoordinator {
            tab.tabType == .query {
             let existing = tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines)
             if existing.isEmpty {
-                tabManager.tabs[tabIndex].content.query = favorite.query
+                tabManager.mutate(at: tabIndex) { $0.content.query = favorite.query }
             } else {
-                tabManager.tabs[tabIndex].content.query += "\n\n" + favorite.query
+                tabManager.mutate(at: tabIndex) { $0.content.query += "\n\n" + favorite.query }
             }
         } else {
             runFavoriteInNewTab(favorite)
@@ -68,11 +68,13 @@ extension MainContentCoordinator {
            tab.content.sourceFileURL == nil,
            tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
            !tab.pendingChanges.hasChanges {
-            tabManager.tabs[tabIndex].content.sourceFileURL = favorite.fileURL
-            tabManager.tabs[tabIndex].content.query = loaded.content
-            tabManager.tabs[tabIndex].content.savedFileContent = loaded.content
-            tabManager.tabs[tabIndex].content.loadMtime = mtime
-            tabManager.tabs[tabIndex].title = favorite.name
+            tabManager.mutate(at: tabIndex) { tab in
+                tab.content.sourceFileURL = favorite.fileURL
+                tab.content.query = loaded.content
+                tab.content.savedFileContent = loaded.content
+                tab.content.loadMtime = mtime
+                tab.title = favorite.name
+            }
             registerWindowForSourceFile(favorite.fileURL)
             return
         }
@@ -111,7 +113,7 @@ extension MainContentCoordinator {
         if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
            tab.tabType == .query,
            tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            tabManager.tabs[tabIndex].content.query = favorite.query
+            tabManager.mutate(at: tabIndex) { $0.content.query = favorite.query }
             return
         }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
@@ -298,12 +298,12 @@ extension MainContentCoordinator {
 
     private func mutateSelectedTabFilterState(_ mutate: (inout TabFilterState) -> Void) {
         guard let index = tabManager.selectedTabIndex else { return }
-        var state = tabManager.tabs[index].filterState
-        mutate(&state)
-        tabManager.tabs[index].filterState = state
+        var newState = tabManager.tabs[index].filterState
+        mutate(&newState)
+        tabManager.mutate(at: index) { $0.filterState = newState }
         let tabId = tabManager.tabs[index].id
         if let session = tabSessionRegistry.session(for: tabId) {
-            session.filterState = state
+            session.filterState = newState
         } else {
             filterStateLog.error(
                 "TabSession missing for selected tab \(tabId, privacy: .public); QueryTab updated but session mirror skipped"

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -21,8 +21,7 @@ extension MainContentCoordinator {
             guard let self, confirmed else { return }
             guard capturedTabIndex < self.tabManager.tabs.count else { return }
 
-            // Reset pagination when filters change
-            self.tabManager.tabs[capturedTabIndex].pagination.reset()
+            self.tabManager.mutate(at: capturedTabIndex) { $0.pagination.reset() }
 
             let tab = self.tabManager.tabs[capturedTabIndex]
             let buffer = self.tabSessionRegistry.tableRows(for: tab.id)
@@ -38,7 +37,7 @@ extension MainContentCoordinator {
                 columnExclusions: exclusions
             )
 
-            self.tabManager.tabs[capturedTabIndex].content.query = newQuery
+            self.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
 
             if !capturedFilters.isEmpty {
                 self.saveLastFilters(for: capturedTableName)
@@ -70,7 +69,7 @@ extension MainContentCoordinator {
                 columnExclusions: exclusions
             )
 
-            self.tabManager.tabs[capturedTabIndex].content.query = newQuery
+            self.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
             self.runQuery()
         }
     }
@@ -115,6 +114,6 @@ extension MainContentCoordinator {
             )
         }
 
-        tabManager.tabs[tabIndex].content.query = newQuery
+        tabManager.mutate(at: tabIndex) { $0.content.query = newQuery }
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadMore.swift
@@ -24,10 +24,10 @@ extension MainContentCoordinator {
         toolbarState.setExecuting(false)
         for idx in tabManager.tabs.indices {
             if tabManager.tabs[idx].execution.isExecuting || tabManager.tabs[idx].pagination.isLoadingMore {
-                var tab = tabManager.tabs[idx]
-                tab.execution.isExecuting = false
-                tab.pagination.isLoadingMore = false
-                tabManager.tabs[idx] = tab
+                tabManager.mutate(at: idx) { tab in
+                    tab.execution.isExecuting = false
+                    tab.pagination.isLoadingMore = false
+                }
             }
         }
     }
@@ -82,7 +82,7 @@ extension MainContentCoordinator {
         let capturedGeneration = queryGeneration
         let storedParamValues = tabManager.tabs[idx].pagination.baseQueryParameterValues
 
-        tabManager.tabs[idx].pagination.isLoadingMore = true
+        tabManager.mutate(at: idx) { $0.pagination.isLoadingMore = true }
         toolbarState.setExecuting(true)
 
         currentQueryTask = Task { [weak self] in
@@ -109,9 +109,7 @@ extension MainContentCoordinator {
                 await MainActor.run { [weak self] in
                     guard let self, !isTearingDown else { return }
                     guard capturedGeneration == queryGeneration else {
-                        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                            tabManager.tabs[idx].pagination.isLoadingMore = false
-                        }
+                        tabManager.mutate(tabId: tabId) { $0.pagination.isLoadingMore = false }
                         toolbarState.setExecuting(false)
                         return
                     }
@@ -120,14 +118,14 @@ extension MainContentCoordinator {
                         return
                     }
 
-                    var tab = tabManager.tabs[idx]
-                    let replaceDelta = mutateActiveTableRows(for: tab.id) { rows in
+                    let replaceDelta = mutateActiveTableRows(for: tabId) { rows in
                         rows.replace(rows: result.rows)
                     }
-                    tab.execution.executionTime = result.executionTime
-                    tab.schemaVersion += 1
-                    tab.pagination.resetLoadMore()
-                    tabManager.tabs[idx] = tab
+                    tabManager.mutate(at: idx) { tab in
+                        tab.execution.executionTime = result.executionTime
+                        tab.schemaVersion += 1
+                        tab.pagination.resetLoadMore()
+                    }
                     dataTabDelegate?.tableViewCoordinator?.applyDelta(replaceDelta)
                     toolbarState.setExecuting(false)
                     toolbarState.lastQueryDuration = result.executionTime
@@ -139,9 +137,7 @@ extension MainContentCoordinator {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].pagination.isLoadingMore = false
-                    }
+                    tabManager.mutate(tabId: tabId) { $0.pagination.isLoadingMore = false }
                     toolbarState.setExecuting(false)
                     if capturedGeneration == queryGeneration {
                         currentQueryTask = nil

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+MultiStatement.swift
@@ -15,11 +15,11 @@ extension MainContentCoordinator {
         queryGeneration += 1
         let capturedGeneration = queryGeneration
 
-        var tab = tabManager.tabs[index]
-        tab.execution.isExecuting = true
-        tab.execution.executionTime = nil
-        tab.execution.errorMessage = nil
-        tabManager.tabs[index] = tab
+        tabManager.mutate(at: index) { tab in
+            tab.execution.isExecuting = true
+            tab.execution.executionTime = nil
+            tab.execution.errorMessage = nil
+        }
         toolbarState.setExecuting(true)
 
         let conn = connection
@@ -54,9 +54,7 @@ extension MainContentCoordinator {
                             multiStatementLogger.error("Rollback failed: \(error.localizedDescription, privacy: .public)")
                         }
                     }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].execution.isExecuting = false
-                    }
+                    tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
                 }
@@ -137,9 +135,7 @@ extension MainContentCoordinator {
                 if capturedGeneration != queryGeneration {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
-                        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                            tabManager.tabs[idx].execution.isExecuting = false
-                        }
+                        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                         currentQueryTask = nil
                         toolbarState.setExecuting(false)
                     }
@@ -158,17 +154,14 @@ extension MainContentCoordinator {
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
 
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        var errTab = tabManager.tabs[idx]
-                        errTab.execution.errorMessage = contextMsg
-                        errTab.execution.isExecuting = false
-                        errTab.execution.executionTime = cumulativeTime
+                    tabManager.mutate(tabId: tabId) { tab in
+                        tab.execution.errorMessage = contextMsg
+                        tab.execution.isExecuting = false
+                        tab.execution.executionTime = cumulativeTime
 
-                        let pinnedResults = errTab.display.resultSets.filter(\.isPinned)
-                        errTab.display.resultSets = pinnedResults + newResultSets
-                        errTab.display.activeResultSetId = newResultSets.last?.id
-
-                        tabManager.tabs[idx] = errTab
+                        let pinnedResults = tab.display.resultSets.filter(\.isPinned)
+                        tab.display.resultSets = pinnedResults + newResultSets
+                        tab.display.activeResultSetId = newResultSets.last?.id
                     }
 
                     let rawSQL = failedSQL ?? statements[min(executedCount, totalCount - 1)]
@@ -209,60 +202,62 @@ extension MainContentCoordinator {
         toolbarState.lastQueryDuration = cumulativeTime
 
         if capturedGeneration != queryGeneration {
-            if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                tabManager.tabs[idx].execution.isExecuting = false
-            }
+            tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
             return
         }
         guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
             return
         }
 
-        var updatedTab = tabManager.tabs[idx]
-
+        let currentTab = tabManager.tabs[idx]
+        let resolvedTableName: String?
         if let selectResult = lastSelectResult {
             let safeColumns = selectResult.columns.map { String($0) }
             let safeColumnTypes = selectResult.columnTypes
             let safeRows = selectResult.rows.map { row in
                 row.map { $0.map { String($0) } }
             }
-            let tableName: String?
-            if updatedTab.tabType == .table, let existing = updatedTab.tableContext.tableName {
-                tableName = existing
+            if currentTab.tabType == .table, let existing = currentTab.tableContext.tableName {
+                resolvedTableName = existing
             } else {
-                tableName = lastSelectSQL.flatMap { extractTableName(from: $0) }
+                resolvedTableName = lastSelectSQL.flatMap { extractTableName(from: $0) }
             }
 
             setActiveTableRows(
                 TableRows.from(queryRows: safeRows, columns: safeColumns, columnTypes: safeColumnTypes),
-                for: updatedTab.id
+                for: currentTab.id
             )
-            updatedTab.tableContext.tableName = tableName
-            updatedTab.tableContext.isEditable = tableName != nil && updatedTab.tableContext.isEditable
         } else {
-            setActiveTableRows(TableRows(), for: updatedTab.id)
-            if updatedTab.tabType != .table {
-                updatedTab.tableContext.tableName = nil
-            }
-            updatedTab.tableContext.isEditable = false
+            resolvedTableName = nil
+            setActiveTableRows(TableRows(), for: currentTab.id)
         }
 
-        updatedTab.schemaVersion += 1
-        updatedTab.execution.executionTime = cumulativeTime
-        updatedTab.execution.rowsAffected = totalRowsAffected
-        updatedTab.execution.isExecuting = false
-        updatedTab.execution.lastExecutedAt = Date()
-        updatedTab.execution.errorMessage = nil
+        tabManager.mutate(at: idx) { tab in
+            if lastSelectResult != nil {
+                tab.tableContext.tableName = resolvedTableName
+                tab.tableContext.isEditable = resolvedTableName != nil && tab.tableContext.isEditable
+            } else {
+                if tab.tabType != .table {
+                    tab.tableContext.tableName = nil
+                }
+                tab.tableContext.isEditable = false
+            }
 
-        let pinnedResults = updatedTab.display.resultSets.filter(\.isPinned)
-        updatedTab.display.resultSets = pinnedResults + newResultSets
-        updatedTab.display.activeResultSetId = newResultSets.last?.id
-        if updatedTab.display.isResultsCollapsed {
-            updatedTab.display.isResultsCollapsed = false
+            tab.schemaVersion += 1
+            tab.execution.executionTime = cumulativeTime
+            tab.execution.rowsAffected = totalRowsAffected
+            tab.execution.isExecuting = false
+            tab.execution.lastExecutedAt = Date()
+            tab.execution.errorMessage = nil
+
+            let pinnedResults = tab.display.resultSets.filter(\.isPinned)
+            tab.display.resultSets = pinnedResults + newResultSets
+            tab.display.activeResultSetId = newResultSets.last?.id
+            if tab.display.isResultsCollapsed {
+                tab.display.isResultsCollapsed = false
+            }
         }
         toolbarState.isResultsCollapsed = false
-
-        tabManager.tabs[idx] = updatedTab
 
         if tabManager.selectedTabId == tabId {
             changeManager.clearChangesAndUndoHistory()

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -38,7 +38,7 @@ extension MainContentCoordinator {
            current.tableContext.tableName == tableName,
            current.tableContext.databaseName == currentDatabase {
             if showStructure, let (_, tabIndex) = tabManager.selectedTabAndIndex {
-                tabManager.tabs[tabIndex].display.resultsViewMode = .structure
+                tabManager.mutate(at: tabIndex) { $0.display.resultsViewMode = .structure }
             }
             return
         }
@@ -101,10 +101,12 @@ extension MainContentCoordinator {
                 return
             }
             if let (_, tabIndex) = tabManager.selectedTabAndIndex {
-                tabManager.tabs[tabIndex].tableContext.isView = isView
-                tabManager.tabs[tabIndex].tableContext.isEditable = !isView
-                tabManager.tabs[tabIndex].tableContext.schemaName = currentSchema
-                tabManager.tabs[tabIndex].pagination.reset()
+                tabManager.mutate(at: tabIndex) { tab in
+                    tab.tableContext.isView = isView
+                    tab.tableContext.isEditable = !isView
+                    tab.tableContext.schemaName = currentSchema
+                    tab.pagination.reset()
+                }
                 toolbarState.isTableTab = true
             }
             // In-place navigation needs selectRedisDatabaseAndQuery to ensure the correct
@@ -136,7 +138,7 @@ extension MainContentCoordinator {
                     clearFilterState()
                     if let (tab, tabIndex) = tabManager.selectedTabAndIndex {
                         setActiveTableRows(TableRows(), for: tab.id)
-                        tabManager.tabs[tabIndex].pagination.reset()
+                        tabManager.mutate(at: tabIndex) { $0.pagination.reset() }
                         toolbarState.isTableTab = true
                     }
                     restoreLastHiddenColumnsForTable(tableName)
@@ -226,8 +228,10 @@ extension MainContentCoordinator {
                 if let tabIndex = previewCoordinator.tabManager.selectedTabIndex {
                     let tabId = previewCoordinator.tabManager.tabs[tabIndex].id
                     previewCoordinator.setActiveTableRows(TableRows(), for: tabId)
-                    previewCoordinator.tabManager.tabs[tabIndex].display.resultsViewMode = showStructure ? .structure : .data
-                    previewCoordinator.tabManager.tabs[tabIndex].pagination.reset()
+                    previewCoordinator.tabManager.mutate(at: tabIndex) { tab in
+                        tab.display.resultsViewMode = showStructure ? .structure : .data
+                        tab.pagination.reset()
+                    }
                     previewCoordinator.toolbarState.isTableTab = true
                 }
                 preview.window.makeKeyAndOrderFront(nil)
@@ -302,8 +306,10 @@ extension MainContentCoordinator {
             clearFilterState()
             if let (tab, tabIndex) = tabManager.selectedTabAndIndex {
                 setActiveTableRows(TableRows(), for: tab.id)
-                tabManager.tabs[tabIndex].display.resultsViewMode = showStructure ? .structure : .data
-                tabManager.tabs[tabIndex].pagination.reset()
+                tabManager.mutate(at: tabIndex) {
+                    $0.display.resultsViewMode = showStructure ? .structure : .data
+                    $0.pagination.reset()
+                }
                 toolbarState.isTableTab = true
             }
             restoreLastHiddenColumnsForTable(tableName)
@@ -329,7 +335,7 @@ extension MainContentCoordinator {
     func promotePreviewTab() {
         guard let (tab, tabIndex) = tabManager.selectedTabAndIndex,
               tab.isPreview else { return }
-        tabManager.tabs[tabIndex].isPreview = false
+        tabManager.mutate(at: tabIndex) { $0.isPreview = false }
 
         if let wid = windowId {
             WindowLifecycleMonitor.shared.setPreview(false, for: wid)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Pagination.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Pagination.swift
@@ -58,10 +58,10 @@ extension MainContentCoordinator {
         let tabId = tabManager.tabs[tabIndex].id
         confirmDiscardChangesIfNeeded(action: .pagination) { [weak self] confirmed in
             guard let self, confirmed else { return }
-            guard let idx = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-
-            mutate(&self.tabManager.tabs[idx].pagination)
-            self.tabManager.tabs[idx].paginationVersion += 1
+            guard self.tabManager.mutate(tabId: tabId, { tab in
+                mutate(&tab.pagination)
+                tab.paginationVersion += 1
+            }) else { return }
             self.pendingScrollToTopAfterReplace.insert(tabId)
             self.reloadCurrentPage()
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -70,19 +70,11 @@ extension MainContentCoordinator {
     ) {
         guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
 
-        var updatedTab = tabManager.tabs[idx]
+        let existingTabId = tabManager.tabs[idx].id
         var columnEnumValues: [String: [String]] = [:]
         var columnDefaults: [String: String?] = [:]
         var columnForeignKeys: [String: ForeignKeyInfo] = [:]
         var columnNullable: [String: Bool] = [:]
-        updatedTab.schemaVersion += 1
-        updatedTab.execution.executionTime = executionTime
-        updatedTab.execution.rowsAffected = rowsAffected
-        updatedTab.execution.statusMessage = statusMessage
-        updatedTab.execution.isExecuting = false
-        updatedTab.execution.lastExecutedAt = Date()
-        updatedTab.tableContext.tableName = tableName
-        updatedTab.tableContext.isEditable = isEditable
         for (index, colType) in columnTypes.enumerated() {
             if case .enumType(_, let values) = colType, let vals = values, index < columns.count {
                 columnEnumValues[columns[index]] = vals
@@ -96,21 +88,14 @@ extension MainContentCoordinator {
             for (col, vals) in metadata.columnEnumValues {
                 columnEnumValues[col] = vals
             }
-            if let approxCount = metadata.approximateRowCount, approxCount > 0 {
-                updatedTab.pagination.totalRowCount = approxCount
-                updatedTab.pagination.isApproximateRowCount = true
-            }
         } else {
-            let existing = tabSessionRegistry.tableRows(for: updatedTab.id)
+            let existing = tabSessionRegistry.tableRows(for: existingTabId)
             columnDefaults = existing.columnDefaults
             columnForeignKeys = existing.columnForeignKeys
             columnNullable = existing.columnNullable
             for (col, vals) in existing.columnEnumValues where columnEnumValues[col] == nil {
                 columnEnumValues[col] = vals
             }
-        }
-        if hasSchema {
-            updatedTab.metadataVersion += 1
         }
 
         let newTableRows = TableRows.from(
@@ -122,36 +107,51 @@ extension MainContentCoordinator {
             columnEnumValues: columnEnumValues,
             columnNullable: columnNullable
         )
-        setActiveTableRows(newTableRows, for: updatedTab.id)
+        setActiveTableRows(newTableRows, for: existingTabId)
 
-        let rs = ResultSet(label: tableName ?? "Result", tableRows: newTableRows)
-        rs.executionTime = updatedTab.execution.executionTime
-        rs.rowsAffected = updatedTab.execution.rowsAffected
-        rs.statusMessage = updatedTab.execution.statusMessage
-        rs.tableName = updatedTab.tableContext.tableName
-        rs.isEditable = updatedTab.tableContext.isEditable
-        rs.metadataVersion = updatedTab.metadataVersion
+        tabManager.mutate(at: idx) { tab in
+            tab.schemaVersion += 1
+            tab.execution.executionTime = executionTime
+            tab.execution.rowsAffected = rowsAffected
+            tab.execution.statusMessage = statusMessage
+            tab.execution.isExecuting = false
+            tab.execution.lastExecutedAt = Date()
+            tab.tableContext.tableName = tableName
+            tab.tableContext.isEditable = isEditable
 
-        // Keep pinned results, replace unpinned
-        let pinned = updatedTab.display.resultSets.filter(\.isPinned)
-        updatedTab.display.resultSets = pinned + [rs]
-        updatedTab.display.activeResultSetId = rs.id
+            if let metadata, let approxCount = metadata.approximateRowCount, approxCount > 0 {
+                tab.pagination.totalRowCount = approxCount
+                tab.pagination.isApproximateRowCount = true
+            }
+            if hasSchema {
+                tab.metadataVersion += 1
+            }
 
-        if isTruncated {
-            updatedTab.pagination.hasMoreRows = true
-            updatedTab.pagination.baseQueryForMore = sql
-            updatedTab.pagination.isLoadingMore = false
-        } else {
-            updatedTab.pagination.resetLoadMore()
-        }
+            let rs = ResultSet(label: tableName ?? "Result", tableRows: newTableRows)
+            rs.executionTime = tab.execution.executionTime
+            rs.rowsAffected = tab.execution.rowsAffected
+            rs.statusMessage = tab.execution.statusMessage
+            rs.tableName = tab.tableContext.tableName
+            rs.isEditable = tab.tableContext.isEditable
+            rs.metadataVersion = tab.metadataVersion
 
-        // Auto-expand results panel when new data arrives
-        if updatedTab.display.isResultsCollapsed {
-            updatedTab.display.isResultsCollapsed = false
+            let pinned = tab.display.resultSets.filter(\.isPinned)
+            tab.display.resultSets = pinned + [rs]
+            tab.display.activeResultSetId = rs.id
+
+            if isTruncated {
+                tab.pagination.hasMoreRows = true
+                tab.pagination.baseQueryForMore = sql
+                tab.pagination.isLoadingMore = false
+            } else {
+                tab.pagination.resetLoadMore()
+            }
+
+            if tab.display.isResultsCollapsed {
+                tab.display.isResultsCollapsed = false
+            }
         }
         toolbarState.isResultsCollapsed = false
-
-        tabManager.tabs[idx] = updatedTab
 
         // Cache column types for selective queries on subsequent page/filter/sort reloads.
         // Only cache from schema-backed table loads (not arbitrary SELECTs which may have partial columns).
@@ -172,7 +172,7 @@ extension MainContentCoordinator {
         }
 
         if !resolvedPKs.isEmpty {
-            tabManager.tabs[idx].tableContext.primaryKeyColumns = resolvedPKs
+            tabManager.mutate(at: idx) { $0.tableContext.primaryKeyColumns = resolvedPKs }
         }
 
         if tabManager.selectedTabId == tabId {
@@ -260,9 +260,9 @@ extension MainContentCoordinator {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     guard capturedGeneration == queryGeneration else { return }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].pagination.totalRowCount = count
-                        tabManager.tabs[idx].pagination.isApproximateRowCount = isApproximate
+                    tabManager.mutate(tabId: tabId) { tab in
+                        tab.pagination.totalRowCount = count
+                        tab.pagination.isApproximateRowCount = isApproximate
                     }
                 }
             }
@@ -301,24 +301,23 @@ extension MainContentCoordinator {
                 guard let self else { return }
                 guard capturedGeneration == queryGeneration else { return }
                 guard !Task.isCancelled else { return }
-                if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    let existing = tabSessionRegistry.tableRows(for: tabId)
-                    let hasNewValues = columnEnumValues.contains { key, value in
-                        existing.columnEnumValues[key] != value
+                guard tabManager.tabs.contains(where: { $0.id == tabId }) else { return }
+                let existing = tabSessionRegistry.tableRows(for: tabId)
+                let hasNewValues = columnEnumValues.contains { key, value in
+                    existing.columnEnumValues[key] != value
+                }
+                if hasNewValues {
+                    mutateActiveTableRows(for: tabId) { rows in
+                        for (col, vals) in columnEnumValues {
+                            rows.columnEnumValues[col] = vals
+                        }
+                        return .columnsReplaced
                     }
-                    if hasNewValues {
-                        mutateActiveTableRows(for: tabId) { rows in
-                            for (col, vals) in columnEnumValues {
-                                rows.columnEnumValues[col] = vals
-                            }
-                            return .columnsReplaced
-                        }
-                        tabManager.tabs[idx].metadataVersion += 1
-                        if let activeIdx = tabManager.selectedTabIndex,
-                           activeIdx < tabManager.tabs.count,
-                           tabManager.tabs[activeIdx].id == tabId {
-                            dataTabDelegate?.tableViewCoordinator?.refreshForeignKeyColumns()
-                        }
+                    tabManager.mutate(tabId: tabId) { $0.metadataVersion += 1 }
+                    if let activeIdx = tabManager.selectedTabIndex,
+                       activeIdx < tabManager.tabs.count,
+                       tabManager.tabs[activeIdx].id == tabId {
+                        dataTabDelegate?.tableViewCoordinator?.refreshForeignKeyColumns()
                     }
                 }
             }
@@ -376,9 +375,9 @@ extension MainContentCoordinator {
             if let count {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].pagination.totalRowCount = count
-                        tabManager.tabs[idx].pagination.isApproximateRowCount = isApproximate
+                    tabManager.mutate(tabId: tabId) { tab in
+                        tab.pagination.totalRowCount = count
+                        tab.pagination.isApproximateRowCount = isApproximate
                     }
                 }
             }
@@ -393,12 +392,10 @@ extension MainContentCoordinator {
         connection conn: DatabaseConnection
     ) {
         currentQueryTask = nil
-        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-            var errTab = tabManager.tabs[idx]
-            errTab.execution.errorMessage = error.localizedDescription
-            errTab.execution.isExecuting = false
-            errTab.execution.lastExecutedAt = Date()
-            tabManager.tabs[idx] = errTab
+        tabManager.mutate(tabId: tabId) { tab in
+            tab.execution.errorMessage = error.localizedDescription
+            tab.execution.isExecuting = false
+            tab.execution.lastExecutedAt = Date()
         }
         toolbarState.setExecuting(false)
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryParameters.swift
@@ -16,10 +16,12 @@ extension MainContentCoordinator {
             !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if let firstMissing = missing.first {
-            tabManager.tabs[index].execution.errorMessage = String(
-                format: String(localized: "Missing value for parameter: %@"),
-                ":\(firstMissing.name)"
-            )
+            tabManager.mutate(at: index) {
+                $0.execution.errorMessage = String(
+                    format: String(localized: "Missing value for parameter: %@"),
+                    ":\(firstMissing.name)"
+                )
+            }
             return
         }
 
@@ -61,13 +63,14 @@ extension MainContentCoordinator {
         queryGeneration += 1
         let capturedGeneration = queryGeneration
 
-        var tab = tabManager.tabs[index]
-        tab.execution.isExecuting = true
-        tab.execution.executionTime = nil
-        tab.execution.errorMessage = nil
-        tab.display.explainText = nil
-        tab.display.explainPlan = nil
-        tabManager.tabs[index] = tab
+        tabManager.mutate(at: index) { tab in
+            tab.execution.isExecuting = true
+            tab.execution.executionTime = nil
+            tab.execution.errorMessage = nil
+            tab.display.explainText = nil
+            tab.display.explainPlan = nil
+        }
+        let tab = tabManager.tabs[index]
         toolbarState.setExecuting(true)
 
         if PluginManager.shared.supportsQueryProgress(for: connection.type) {
@@ -148,11 +151,9 @@ extension MainContentCoordinator {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        var tab = tabManager.tabs[idx]
+                    tabManager.mutate(tabId: tabId) { tab in
                         tab.execution.isExecuting = false
                         tab.pagination.isLoadingMore = false
-                        tabManager.tabs[idx] = tab
                     }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
@@ -171,10 +172,12 @@ extension MainContentCoordinator {
             !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if let firstMissing = missing.first {
-            tabManager.tabs[index].execution.errorMessage = String(
-                format: String(localized: "Missing value for parameter: %@"),
-                ":\(firstMissing.name)"
-            )
+            tabManager.mutate(at: index) {
+                $0.execution.errorMessage = String(
+                    format: String(localized: "Missing value for parameter: %@"),
+                    ":\(firstMissing.name)"
+                )
+            }
             return
         }
 
@@ -186,11 +189,11 @@ extension MainContentCoordinator {
         queryGeneration += 1
         let capturedGeneration = queryGeneration
 
-        var tab = tabManager.tabs[index]
-        tab.execution.isExecuting = true
-        tab.execution.executionTime = nil
-        tab.execution.errorMessage = nil
-        tabManager.tabs[index] = tab
+        tabManager.mutate(at: index) { tab in
+            tab.execution.isExecuting = true
+            tab.execution.executionTime = nil
+            tab.execution.errorMessage = nil
+        }
         toolbarState.setExecuting(true)
 
         let conn = connection
@@ -225,9 +228,7 @@ extension MainContentCoordinator {
                             paramLog.error("Rollback failed: \(error.localizedDescription, privacy: .public)")
                         }
                     }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        tabManager.tabs[idx].execution.isExecuting = false
-                    }
+                    tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
                 }
@@ -354,9 +355,7 @@ extension MainContentCoordinator {
             toolbarState.lastQueryDuration = fetchResult.executionTime
 
             if capturedGeneration != queryGeneration || Task.isCancelled {
-                if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].execution.isExecuting = false
-                }
+                tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 return
             }
 
@@ -378,9 +377,8 @@ extension MainContentCoordinator {
                 queryParameterValues: originalParameters
             )
 
-            if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                tabManager.tabs[idx].pagination.baseQueryParameterValues =
-                    nativeParameters.map { $0 as? String }
+            tabManager.mutate(tabId: tabId) {
+                $0.pagination.baseQueryParameterValues = nativeParameters.map { $0 as? String }
             }
         }
     }
@@ -408,9 +406,7 @@ extension MainContentCoordinator {
         if capturedGeneration != queryGeneration {
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    tabManager.tabs[idx].execution.isExecuting = false
-                }
+                tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 currentQueryTask = nil
                 toolbarState.setExecuting(false)
             }
@@ -431,17 +427,14 @@ extension MainContentCoordinator {
             currentQueryTask = nil
             toolbarState.setExecuting(false)
 
-            if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                var errTab = tabManager.tabs[idx]
-                errTab.execution.errorMessage = contextMsg
-                errTab.execution.isExecuting = false
-                errTab.execution.executionTime = cumulativeTime
+            tabManager.mutate(tabId: tabId) { tab in
+                tab.execution.errorMessage = contextMsg
+                tab.execution.isExecuting = false
+                tab.execution.executionTime = cumulativeTime
 
-                let pinnedResults = errTab.display.resultSets.filter(\.isPinned)
-                errTab.display.resultSets = pinnedResults + capturedResultSets
-                errTab.display.activeResultSetId = capturedResultSets.last?.id
-
-                tabManager.tabs[idx] = errTab
+                let pinnedResults = tab.display.resultSets.filter(\.isPinned)
+                tab.display.resultSets = pinnedResults + capturedResultSets
+                tab.display.activeResultSetId = capturedResultSets.last?.id
             }
 
             let rawSQL = failedSQL ?? statements[min(executedCount, totalCount - 1)]

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+RowOperations.swift
@@ -27,7 +27,7 @@ extension MainContentCoordinator {
         guard let result = addResult else { return }
 
         selectionState.indices = [result.rowIndex]
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { $0.hasUserInteraction = true }
         querySortCache.removeValue(forKey: tabId)
         dataTabDelegate?.tableViewCoordinator?.applyDelta(result.delta)
         dataTabDelegate?.tableViewCoordinator?.beginEditing(displayRow: result.rowIndex, column: 0)
@@ -62,7 +62,7 @@ extension MainContentCoordinator {
             selectionState.indices.removeAll()
         }
 
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { $0.hasUserInteraction = true }
 
         if !deleteResult.physicallyRemovedIndices.isEmpty {
             querySortCache.removeValue(forKey: tabId)
@@ -98,7 +98,7 @@ extension MainContentCoordinator {
         guard let result = dupResult else { return }
 
         selectionState.indices = [result.rowIndex]
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { $0.hasUserInteraction = true }
         querySortCache.removeValue(forKey: tabId)
         dataTabDelegate?.tableViewCoordinator?.applyDelta(result.delta)
         dataTabDelegate?.tableViewCoordinator?.beginEditing(displayRow: result.rowIndex, column: 0)
@@ -143,7 +143,7 @@ extension MainContentCoordinator {
             selectionState.indices = adjustedSelection
         }
 
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { $0.hasUserInteraction = true }
         querySortCache.removeValue(forKey: tabId)
         dataTabDelegate?.tableViewCoordinator?.invalidateCachesForUndoRedo()
         dataTabDelegate?.tableViewCoordinator?.applyDelta(application.delta)
@@ -207,8 +207,10 @@ extension MainContentCoordinator {
         let newIndices = Set(pasteResult.pastedRows.map { $0.rowIndex })
         selectionState.indices = newIndices
 
-        tabManager.tabs[tabIndex].selectedRowIndices = newIndices
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { tab in
+            tab.selectedRowIndices = newIndices
+            tab.hasUserInteraction = true
+        }
         querySortCache.removeValue(forKey: tabId)
         dataTabDelegate?.tableViewCoordinator?.applyDelta(pasteResult.delta)
     }
@@ -219,7 +221,7 @@ extension MainContentCoordinator {
         let delta = mutateActiveTableRows(for: tabId) { rows in
             rows.edit(row: rowIndex, column: columnIndex, value: value)
         }
-        tabManager.tabs[tabIndex].hasUserInteraction = true
+        tabManager.mutate(at: tabIndex) { $0.hasUserInteraction = true }
         dataTabDelegate?.tableViewCoordinator?.applyDelta(delta)
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SaveChanges.swift
@@ -19,7 +19,9 @@ extension MainContentCoordinator {
     ) {
         guard !safeModeLevel.blocksAllWrites else {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].execution.errorMessage = String(localized: "Cannot save changes: connection is read only")
+                tabManager.mutate(at: index) {
+                    $0.execution.errorMessage = String(localized: "Cannot save changes: connection is read only")
+                }
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -44,7 +46,7 @@ extension MainContentCoordinator {
             )
         } catch {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].execution.errorMessage = error.localizedDescription
+                tabManager.mutate(at: index) { $0.execution.errorMessage = error.localizedDescription }
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -53,7 +55,9 @@ extension MainContentCoordinator {
 
         guard !allStatements.isEmpty else {
             if let index = tabManager.selectedTabIndex {
-                tabManager.tabs[index].execution.errorMessage = String(localized: "Could not generate SQL for changes.")
+                tabManager.mutate(at: index) {
+                    $0.execution.errorMessage = String(localized: "Could not generate SQL for changes.")
+                }
             }
             saveCompletionContinuation?.resume(returning: false)
             saveCompletionContinuation = nil
@@ -182,7 +186,9 @@ extension MainContentCoordinator {
             do {
                 guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
                     if let index = tabManager.selectedTabIndex {
-                        tabManager.tabs[index].execution.errorMessage = String(localized: "Not connected to database")
+                        tabManager.mutate(at: index) {
+                            $0.execution.errorMessage = String(localized: "Not connected to database")
+                        }
                     }
                     throw DatabaseError.notConnected
                 }
@@ -232,8 +238,10 @@ extension MainContentCoordinator {
 
                 changeManager.clearChangesAndUndoHistory()
                 if let index = tabManager.selectedTabIndex {
-                    tabManager.tabs[index].pendingChanges = TabChangeSnapshot()
-                    tabManager.tabs[index].execution.errorMessage = nil
+                    tabManager.mutate(at: index) {
+                        $0.pendingChanges = TabChangeSnapshot()
+                        $0.execution.errorMessage = nil
+                    }
                 }
 
                 if clearTableOps {
@@ -296,7 +304,9 @@ extension MainContentCoordinator {
                 )
 
                 if let index = tabManager.selectedTabIndex {
-                    tabManager.tabs[index].execution.errorMessage = String(format: String(localized: "Save failed: %@"), error.localizedDescription)
+                    tabManager.mutate(at: index) {
+                        $0.execution.errorMessage = String(format: String(localized: "Save failed: %@"), error.localizedDescription)
+                    }
                 }
 
                 // Show error alert to user

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -18,19 +18,21 @@ extension MainContentCoordinator {
         let rs = tabManager.tabs[tabIdx].display.resultSets.first { $0.id == id }
         guard rs?.isPinned != true else { return }
         let tabId = tabManager.tabs[tabIdx].id
-        tabManager.tabs[tabIdx].display.resultSets.removeAll { $0.id == id }
+        tabManager.mutate(at: tabIdx) { $0.display.resultSets.removeAll { $0.id == id } }
         if tabManager.tabs[tabIdx].display.activeResultSetId == id {
             let newActiveId = tabManager.tabs[tabIdx].display.resultSets.last?.id
             switchActiveResultSet(to: newActiveId, in: tabId)
         }
         if tabManager.tabs[tabIdx].display.resultSets.isEmpty {
             setActiveTableRows(TableRows(), for: tabId)
-            tabManager.tabs[tabIdx].execution.errorMessage = nil
-            tabManager.tabs[tabIdx].execution.rowsAffected = 0
-            tabManager.tabs[tabIdx].execution.executionTime = nil
-            tabManager.tabs[tabIdx].execution.statusMessage = nil
-            tabManager.tabs[tabIdx].schemaVersion += 1
-            tabManager.tabs[tabIdx].display.isResultsCollapsed = true
+            tabManager.mutate(at: tabIdx) { tab in
+                tab.execution.errorMessage = nil
+                tab.execution.rowsAffected = 0
+                tab.execution.executionTime = nil
+                tab.execution.statusMessage = nil
+                tab.schemaVersion += 1
+                tab.display.isResultsCollapsed = true
+            }
             toolbarState.isResultsCollapsed = true
         }
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -32,7 +32,8 @@ extension MainContentCoordinator {
            let oldIndex = tabManager.tabs.firstIndex(where: { $0.id == oldId })
         {
             if changeManager.hasChanges {
-                tabManager.tabs[oldIndex].pendingChanges = changeManager.saveState()
+                let savedState = changeManager.saveState()
+                tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
             }
             if let tableName = tabManager.tabs[oldIndex].tableContext.tableName {
                 FilterSettingsStorage.shared.saveLastFilters(
@@ -145,12 +146,7 @@ extension MainContentCoordinator {
 
         for entry in toEvict {
             tabSessionRegistry.evict(for: entry.tab.id)
-            if let index = tabManager.tabs.firstIndex(where: { $0.id == entry.tab.id }) {
-                // Bump QueryTab.loadEpoch to invalidate the `.task(id:)` key in
-                // MainEditorContentView, so the next selection of this tab
-                // triggers lazy-load. The session-side bump is not observed.
-                tabManager.tabs[index].loadEpoch &+= 1
-            }
+            tabManager.mutate(tabId: entry.tab.id) { $0.loadEpoch &+= 1 }
         }
         Self.lifecycleLogger.debug(
             "[switch] evictInactiveTabs evicted=\(toEvict.count) keptInactive=\(maxInactiveLoaded) elapsedMs=\(Int(Date().timeIntervalSince(start) * 1_000))"

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
@@ -33,7 +33,7 @@ extension MainContentCoordinator {
         if let outgoing = tabManager.tabs[tabIdx].display.activeResultSet {
             outgoing.tableRows = tabSessionRegistry.tableRows(for: tabId)
         }
-        tabManager.tabs[tabIdx].display.activeResultSetId = resultSetId
+        tabManager.mutate(at: tabIdx) { $0.display.activeResultSetId = resultSetId }
         if let incoming = tabManager.tabs[tabIdx].display.activeResultSet {
             tabSessionRegistry.setTableRows(incoming.tableRows, for: tabId)
             notifyFullReplaceIfActive(tabId: tabId)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -138,9 +138,8 @@ extension MainContentCoordinator {
         // `lastExecutedAt`. Clear the stale flag inline so the executor's
         // own `!tab.execution.isExecuting` guard inside
         // `executeTableTabQueryDirectly` doesn't suppress this re-fire.
-        if tab.execution.isExecuting && rows.rows.isEmpty && tab.execution.lastExecutedAt == nil,
-           let idx = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) {
-            tabManager.tabs[idx].execution.isExecuting = false
+        if tab.execution.isExecuting && rows.rows.isEmpty && tab.execution.lastExecutedAt == nil {
+            tabManager.mutate(tabId: tab.id) { $0.execution.isExecuting = false }
         } else if tab.execution.isExecuting {
             return
         }

--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -75,7 +75,7 @@ extension MainContentView {
             },
             set: { newValue in
                 if let index = coordinator.tabManager.selectedTabIndex {
-                    coordinator.tabManager.tabs[index].sortState = newValue
+                    coordinator.tabManager.mutate(at: index) { $0.sortState = newValue }
                 }
             }
         )
@@ -89,7 +89,7 @@ extension MainContentView {
             get: { coordinator.tabManager.selectedTab?.display.resultsViewMode ?? .data },
             set: { newValue in
                 if let index = coordinator.tabManager.selectedTabIndex {
-                    coordinator.tabManager.tabs[index].display.resultsViewMode = newValue
+                    coordinator.tabManager.mutate(at: index) { $0.display.resultsViewMode = newValue }
                 }
             }
         )

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -67,7 +67,7 @@ extension MainContentView {
                                 limit: selectedTab.pagination.pageSize,
                                 offset: selectedTab.pagination.currentOffset
                             )
-                            tabManager.tabs[tabIndex].content.query = filteredQuery
+                            tabManager.mutate(at: tabIndex) { $0.content.query = filteredQuery }
                         }
                         if let tableName = selectedTab.tableContext.tableName {
                             coordinator.restoreLastHiddenColumnsForTable(tableName)

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -444,11 +444,12 @@ final class MainContentCommandActions {
         Task {
             do {
                 try await SQLFileService.writeFile(content: content, to: url)
-                if let index = coordinator?.tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                    coordinator?.tabManager.tabs[index].content.savedFileContent = content
-                    coordinator?.tabManager.tabs[index].content.loadMtime = (try? FileManager.default
-                        .attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
-                    coordinator?.tabManager.tabs[index].content.externalModificationDetected = false
+                let mtime = (try? FileManager.default
+                    .attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
+                coordinator?.tabManager.mutate(tabId: tabId) { tab in
+                    tab.content.savedFileContent = content
+                    tab.content.loadMtime = mtime
+                    tab.content.externalModificationDetected = false
                 }
             } catch {
                 Self.logger.error("Failed to save file: \(error.localizedDescription)")
@@ -486,10 +487,12 @@ final class MainContentCommandActions {
                 guard let index = coordinator?.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
                 let liveQuery = coordinator?.tabManager.tabs[index].content.query
                 guard liveQuery == queryAtRequestTime else { return }
-                coordinator?.tabManager.tabs[index].content.query = loaded.content
-                coordinator?.tabManager.tabs[index].content.savedFileContent = loaded.content
-                coordinator?.tabManager.tabs[index].content.loadMtime = mtime
-                coordinator?.tabManager.tabs[index].content.externalModificationDetected = false
+                coordinator?.tabManager.mutate(at: index) { tab in
+                    tab.content.query = loaded.content
+                    tab.content.savedFileContent = loaded.content
+                    tab.content.loadMtime = mtime
+                    tab.content.externalModificationDetected = false
+                }
             }
         }
     }
@@ -612,14 +615,15 @@ final class MainContentCommandActions {
               tab.tabType == .query else { return }
         let content = tab.content.query
         let suggestedName = tab.content.sourceFileURL?.lastPathComponent ?? "\(tab.title).sql"
+        let tabId = tab.id
         Task {
             guard let url = await SQLFileService.showSavePanel(suggestedName: suggestedName) else { return }
             do {
                 try await SQLFileService.writeFile(content: content, to: url)
-                if let index = coordinator?.tabManager.tabs.firstIndex(where: { $0.id == tab.id }) {
-                    coordinator?.tabManager.tabs[index].content.sourceFileURL = url
-                    coordinator?.tabManager.tabs[index].content.savedFileContent = content
-                    coordinator?.tabManager.tabs[index].title = url.deletingPathExtension().lastPathComponent
+                coordinator?.tabManager.mutate(tabId: tabId) { mutTab in
+                    mutTab.content.sourceFileURL = url
+                    mutTab.content.savedFileContent = content
+                    mutTab.title = url.deletingPathExtension().lastPathComponent
                 }
             } catch {
                 Self.logger.error("Failed to save file: \(error.localizedDescription)")
@@ -709,7 +713,7 @@ final class MainContentCommandActions {
                 cursorOffset: 0,
                 options: options
             )
-            coordinator.tabManager.tabs[tabIndex].content.query = result.formattedSQL
+            coordinator.tabManager.mutate(at: tabIndex) { $0.content.query = result.formattedSQL }
         } catch {
             Self.logger.error("SQL Formatting error: \(error.localizedDescription, privacy: .public)")
         }
@@ -728,7 +732,7 @@ final class MainContentCommandActions {
     func toggleResults() {
         guard let coordinator,
               let (_, tabIndex) = coordinator.tabManager.selectedTabAndIndex else { return }
-        coordinator.tabManager.tabs[tabIndex].display.isResultsCollapsed.toggle()
+        coordinator.tabManager.mutate(at: tabIndex) { $0.display.isResultsCollapsed.toggle() }
         coordinator.toolbarState.isResultsCollapsed = coordinator.tabManager.tabs[tabIndex].display.isResultsCollapsed
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -305,10 +305,7 @@ final class MainContentCoordinator {
         for (index, tab) in tabManager.tabs.enumerated()
         where tab.id != selectedId && !tab.pendingChanges.hasChanges {
             tabSessionRegistry.evict(for: tab.id)
-            // Mirror the session's epoch bump back to the QueryTab so the
-            // `.task(id:)` in MainEditorContentView re-fires lazy-load on
-            // re-selection. The session bump alone is not observed by SwiftUI.
-            tabManager.tabs[index].loadEpoch &+= 1
+            tabManager.mutate(at: index) { $0.loadEpoch &+= 1 }
         }
     }
 
@@ -409,7 +406,7 @@ final class MainContentCoordinator {
 
             let modified = currentMtime > loadMtime.addingTimeInterval(0.5)
             if modified != tabManager.tabs[index].content.externalModificationDetected {
-                tabManager.tabs[index].content.externalModificationDetected = modified
+                tabManager.mutate(at: index) { $0.content.externalModificationDetected = modified }
             }
         }
     }
@@ -724,10 +721,10 @@ final class MainContentCoordinator {
                     sql: combinedSQL,
                     existing: tabManager.tabs[index].content.queryParameters
                 )
-                tabManager.tabs[index].content.queryParameters = reconciled
+                tabManager.mutate(at: index) { $0.content.queryParameters = reconciled }
 
                 if !tabManager.tabs[index].content.isParameterPanelVisible {
-                    tabManager.tabs[index].content.isParameterPanelVisible = true
+                    tabManager.mutate(at: index) { $0.content.isParameterPanelVisible = true }
                     return
                 }
 
@@ -779,9 +776,7 @@ final class MainContentCoordinator {
                 case .allowed:
                     executeQueryInternal(sql)
                 case .blocked(let reason):
-                    if index < tabManager.tabs.count {
-                        tabManager.tabs[index].execution.errorMessage = reason
-                    }
+                    tabManager.mutate(at: index) { $0.execution.errorMessage = reason }
                 }
             }
         } else {
@@ -794,8 +789,10 @@ final class MainContentCoordinator {
     func loadQueryIntoEditor(_ query: String) {
         if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
            tab.tabType == .query {
-            tabManager.tabs[tabIndex].content.query = query
-            tabManager.tabs[tabIndex].hasUserInteraction = true
+            tabManager.mutate(at: tabIndex) {
+                $0.content.query = query
+                $0.hasUserInteraction = true
+            }
         } else {
             let payload = EditorTabPayload(
                 connectionId: connection.id,
@@ -810,12 +807,14 @@ final class MainContentCoordinator {
         if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
            tab.tabType == .query {
             let existingQuery = tab.content.query
-            if existingQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                tabManager.tabs[tabIndex].content.query = query
-            } else {
-                tabManager.tabs[tabIndex].content.query = existingQuery + "\n\n" + query
+            tabManager.mutate(at: tabIndex) { mutTab in
+                if existingQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    mutTab.content.query = query
+                } else {
+                    mutTab.content.query = existingQuery + "\n\n" + query
+                }
+                mutTab.hasUserInteraction = true
             }
-            tabManager.tabs[tabIndex].hasUserInteraction = true
         } else if tabManager.tabs.isEmpty {
             tabManager.addTab(initialQuery: query, databaseName: activeDatabaseName)
         } else {
@@ -894,7 +893,9 @@ final class MainContentCoordinator {
         guard let adapter = services.databaseManager.driver(for: connectionId) as? PluginDriverAdapter,
               let explainSQL = adapter.buildExplainQuery(stmt) else {
             if let (_, index) = tabManager.selectedTabAndIndex {
-                tabManager.tabs[index].execution.errorMessage = String(localized: "EXPLAIN is not supported for this database type.")
+                tabManager.mutate(at: index) {
+                    $0.execution.errorMessage = String(localized: "EXPLAIN is not supported for this database type.")
+                }
             }
             return
         }
@@ -939,13 +940,14 @@ final class MainContentCoordinator {
         queryGeneration += 1
         let capturedGeneration = queryGeneration
 
-        var tab = tabManager.tabs[index]
-        tab.execution.isExecuting = true
-        tab.execution.executionTime = nil
-        tab.execution.errorMessage = nil
-        tab.display.explainText = nil
-        tab.display.explainPlan = nil
-        tabManager.tabs[index] = tab
+        tabManager.mutate(at: index) { tab in
+            tab.execution.isExecuting = true
+            tab.execution.executionTime = nil
+            tab.execution.errorMessage = nil
+            tab.display.explainText = nil
+            tab.display.explainPlan = nil
+        }
+        let tab = tabManager.tabs[index]
         toolbarState.setExecuting(true)
 
         if services.pluginManager.supportsQueryProgress(for: connection.type) {
@@ -995,9 +997,7 @@ final class MainContentCoordinator {
                     toolbarState.lastQueryDuration = executionResult.fetchResult.executionTime
 
                     if capturedGeneration != queryGeneration || Task.isCancelled {
-                        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                            tabManager.tabs[idx].execution.isExecuting = false
-                        }
+                        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                         return
                     }
 
@@ -1047,11 +1047,9 @@ final class MainContentCoordinator {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-                        var tab = tabManager.tabs[idx]
+                    tabManager.mutate(tabId: tabId) { tab in
                         tab.execution.isExecuting = false
                         tab.pagination.isLoadingMore = false
-                        tabManager.tabs[idx] = tab
                     }
                     currentQueryTask = nil
                     toolbarState.setExecuting(false)
@@ -1065,9 +1063,7 @@ final class MainContentCoordinator {
     /// Reset execution state when a query is cancelled
     @MainActor
     internal func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
-        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
-            tabManager.tabs[idx].execution.isExecuting = false
-        }
+        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
         currentQueryTask = nil
         toolbarState.setExecuting(false)
         toolbarState.lastQueryDuration = executionTime
@@ -1191,17 +1187,21 @@ final class MainContentCoordinator {
                 let strippedQuery = Self.stripTrailingOrderBy(from: baseQuery)
                 let quotedColumn = queryBuilder.quoteIdentifier(columnName)
                 let orderQuery = "\(strippedQuery) ORDER BY \(quotedColumn) \(direction)"
-                tabManager.tabs[tabIndex].sortState = currentSort
-                tabManager.tabs[tabIndex].hasUserInteraction = true
-                tabManager.tabs[tabIndex].pagination.resetLoadMore()
-                tabManager.tabs[tabIndex].content.query = orderQuery
+                tabManager.mutate(at: tabIndex) { tab in
+                    tab.sortState = currentSort
+                    tab.hasUserInteraction = true
+                    tab.pagination.resetLoadMore()
+                    tab.content.query = orderQuery
+                }
                 runQuery()
                 return
             }
 
-            tabManager.tabs[tabIndex].sortState = currentSort
-            tabManager.tabs[tabIndex].hasUserInteraction = true
-            tabManager.tabs[tabIndex].pagination.reset()
+            tabManager.mutate(at: tabIndex) { tab in
+                tab.sortState = currentSort
+                tab.hasUserInteraction = true
+                tab.pagination.reset()
+            }
             let tabId = tab.id
             let schemaVersion = tab.schemaVersion
             let sortColumns = currentSort.columns
@@ -1210,10 +1210,9 @@ final class MainContentCoordinator {
             let snapshotRows: [(id: RowID, values: [String?])] = storageRows.map { ($0.id, $0.values) }
 
             if storageRows.count > 1_000 {
-                // Sort on background thread to avoid UI freeze
                 activeSortTasks[tabId]?.cancel()
                 activeSortTasks.removeValue(forKey: tabId)
-                tabManager.tabs[tabIndex].execution.isExecuting = true
+                tabManager.mutate(at: tabIndex) { $0.execution.isExecuting = true }
                 toolbarState.setExecuting(true)
                 querySortCache.removeValue(forKey: tabId)
 
@@ -1239,10 +1238,10 @@ final class MainContentCoordinator {
                             direction: sortColumns.first?.direction ?? .ascending,
                             schemaVersion: schemaVersion
                         )
-                        var sortedTab = self.tabManager.tabs[idx]
-                        sortedTab.execution.isExecuting = false
-                        sortedTab.execution.executionTime = sortDuration
-                        self.tabManager.tabs[idx] = sortedTab
+                        self.tabManager.mutate(at: idx) { tab in
+                            tab.execution.isExecuting = false
+                            tab.execution.executionTime = sortDuration
+                        }
                         self.toolbarState.setExecuting(false)
                         self.toolbarState.lastQueryDuration = sortDuration
                         self.activeSortTasks.removeValue(forKey: tabId)
@@ -1261,17 +1260,18 @@ final class MainContentCoordinator {
         let capturedQuery = tab.content.query
         let capturedColumns = tableRows.columns
         confirmDiscardChangesIfNeeded(action: .sort) { [weak self] confirmed in
-            guard let self, confirmed,
-                  let idx = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-            self.tabManager.tabs[idx].sortState = capturedSort
-            self.tabManager.tabs[idx].hasUserInteraction = true
-            self.tabManager.tabs[idx].pagination.reset()
+            guard let self, confirmed else { return }
             let newQuery = self.queryBuilder.buildMultiSortQuery(
                 baseQuery: capturedQuery,
                 sortState: capturedSort,
                 columns: capturedColumns
             )
-            self.tabManager.tabs[idx].content.query = newQuery
+            guard self.tabManager.mutate(tabId: tabId, { tab in
+                tab.sortState = capturedSort
+                tab.hasUserInteraction = true
+                tab.pagination.reset()
+                tab.content.query = newQuery
+            }) else { return }
             self.runQuery()
         }
     }
@@ -1290,8 +1290,10 @@ final class MainContentCoordinator {
         let emptySort = SortState()
 
         if tab.tabType == .query {
-            tabManager.tabs[tabIndex].sortState = emptySort
-            tabManager.tabs[tabIndex].hasUserInteraction = true
+            tabManager.mutate(at: tabIndex) { tab in
+                tab.sortState = emptySort
+                tab.hasUserInteraction = true
+            }
             querySortCache.removeValue(forKey: tab.id)
             dataTabDelegate?.dataGridDidReplaceAllRows()
             return
@@ -1300,12 +1302,13 @@ final class MainContentCoordinator {
         let tabId = tab.id
         let capturedQuery = tab.content.query
         confirmDiscardChangesIfNeeded(action: .sort) { [weak self] confirmed in
-            guard let self, confirmed,
-                  let idx = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
-            self.tabManager.tabs[idx].sortState = emptySort
-            self.tabManager.tabs[idx].hasUserInteraction = true
-            self.tabManager.tabs[idx].pagination.reset()
-            self.tabManager.tabs[idx].content.query = Self.stripTrailingOrderBy(from: capturedQuery)
+            guard let self, confirmed else { return }
+            guard self.tabManager.mutate(tabId: tabId, { tab in
+                tab.sortState = emptySort
+                tab.hasUserInteraction = true
+                tab.pagination.reset()
+                tab.content.query = Self.stripTrailingOrderBy(from: capturedQuery)
+            }) else { return }
             self.runQuery()
         }
     }


### PR DESCRIPTION
## Summary

Phase 4 Step 1. Add `mutate(tabId:_:)` and `mutate(at:_:)` helpers to `QueryTabManager` and reroute every direct `tabManager.tabs[index].X = Y` write through them. Mechanical, no behavior change. Foundation for future coordinator extractions (FilterCoordinator, QueryExecutionCoordinator).

## API

```swift
@discardableResult
func mutate(tabId: UUID, _ block: (inout QueryTab) -> Void) -> Bool

@discardableResult
func mutate(at index: Int, _ block: (inout QueryTab) -> Void) -> Bool
```

Bounds-checked (returns false if id/index missing). Caller does not need to check existence.

## Migration

109 call sites across 25 files. Five commits grouped by feature:

1. 77cde32d - add mutate API to QueryTabManager
2. 24ec5d30 - pagination/filter writes
3. 8df04f93 - execution/save writes
4. 195dc48e - tab-switch and navigation writes
5. 2d15fb93 - remaining tab-state writes

## Behavior preservation

- One didSet fires per `mutate` block instead of per property write. Net effect: fewer wasted index-map rebuilds and registry diffs. No change to `tabStructureVersion` (only bumps on id-set changes), no change to `syncTabSessionRegistry` (no-op on identity preservation).
- Eliminated the temp-var `var tab = tabs[idx]; ...; tabs[idx] = tab` pattern in QueryHelpers, QueryParameters, MultiStatement, MainContentCoordinator. Same final state, fewer copies.
- Ordering preserved where it mattered: `applyPhase1Result` still calls `setActiveTableRows` before mutating the tab, so any UI delegates reading mid-call see pre-update state same as before.

## Sites left unchanged

- Reads: `let pagination = tabs[i].pagination` style stays. Pattern D in the brief.
- Class-reference reads through arrays: `tabs[idx].display.resultSets.first { $0.id == id }?.isPinned.toggle()` — `ResultSet` is a class; the array access reads a reference, no `QueryTab` struct field is mutated. (`MainEditorContentView.swift:537`)
- `Models/` files apart from `QueryTabManager.swift` (TabSession.swift, TabSessionRegistry.swift) — only doc comments referenced the old pattern; no code change needed.
- Array-level mutations (`append`, `removeAll`, structural replacement of an entire tab with a different tab type) — out of scope for this step.

## Verification

- xcodebuild Debug builds (only pre-existing Swift 6 warnings unrelated to this work).
- swiftlint --strict: 0 violations across all 839 files.
- Verification grep: no remaining property assignments through `tabManager.tabs[idx]`. All surviving `tabs[idx]` references are reads.

## Test plan

- [ ] Build clean
- [ ] Run a query, observe pagination state updates
- [ ] Apply a filter, clear a filter, reset filter state
- [ ] Switch tabs (Cmd+1..9) and observe execution state preservation
- [ ] Save changes through change manager, observe error state on failure
- [ ] FK navigation between tabs preserves source tab state
- [ ] Multi-statement query reports correct per-statement error tab state

## Next

This is the foundation. Future PRs:
- FilterCoordinator extraction (now safe — filter writes route through `mutate`)
- QueryExecutionCoordinator extraction (same)
- Other coordinator splits per /tmp/audit/phase4-extraction-plan.md