### PR TITLE
feat(mcp): add Zed client to MCP setup sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MCP Setup sheet adds Zed alongside Claude Desktop, Claude Code, and Cursor with a one-paste `context_servers` snippet
+
 ### Changed
 
 - PostgreSQL SQL export emits foreign key constraints via `ALTER TABLE ... ADD CONSTRAINT` after data load and resyncs sequences via `setval` so a re-imported dump round-trips cleanly even when child tables sort before parents (#1114)

--- a/TablePro/Views/Integrations/IntegrationsSetupSheet.swift
+++ b/TablePro/Views/Integrations/IntegrationsSetupSheet.swift
@@ -107,6 +107,12 @@ private struct IntegrationsSetupInstructions: View {
                 String(localized: "Click \"+ Add new global MCP server\""),
                 String(localized: "Paste the JSON below and save")
             ]
+        case .zed:
+            [
+                String(localized: "Open Zed and click the Agent Panel icon in the right side of the title bar"),
+                String(localized: "Click the menu in the Agent Panel header and choose Settings"),
+                String(localized: "Under MCP Servers click \"+ Add Custom Server\", select the Local tab, paste the JSON below, then click Add Server")
+            ]
         }
     }
 
@@ -119,6 +125,15 @@ private struct IntegrationsSetupInstructions: View {
                 "tablepro": {
                   "command": "\(bridgeBinaryPath)"
                 }
+              }
+            }
+            """
+        case .zed:
+            return """
+            {
+              "tablepro": {
+                "command": "\(bridgeBinaryPath)",
+                "args": []
               }
             }
             """

--- a/TablePro/Views/Settings/Components/IntegrationClient.swift
+++ b/TablePro/Views/Settings/Components/IntegrationClient.swift
@@ -4,6 +4,7 @@ enum IntegrationClient: String, CaseIterable, Identifiable, Sendable {
     case claudeCode
     case claudeDesktop
     case cursor
+    case zed
 
     var id: String { rawValue }
 
@@ -12,6 +13,7 @@ enum IntegrationClient: String, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return String(localized: "Claude Code")
         case .claudeDesktop: return String(localized: "Claude Desktop")
         case .cursor: return String(localized: "Cursor")
+        case .zed: return String(localized: "Zed")
         }
     }
 }

--- a/TablePro/Views/Settings/Sections/MCPTokenRevealSheet.swift
+++ b/TablePro/Views/Settings/Sections/MCPTokenRevealSheet.swift
@@ -147,6 +147,17 @@ struct MCPTokenRevealSheet: View {
               }
             }
             """
+        case .zed:
+            return """
+            {
+              "tablepro": {
+                "url": "\(baseURL)",
+                "headers": {
+                  "Authorization": "Bearer \(plaintext)"
+                }
+              }
+            }
+            """
         }
     }
 

--- a/docs/external-api/mcp-clients.mdx
+++ b/docs/external-api/mcp-clients.mdx
@@ -115,21 +115,34 @@ If you prefer JSON, drop the same shape into `.continue/mcpServers/tablepro.json
 
 ## Zed
 
-Zed keys MCP servers under `context_servers`, not `mcpServers`. Edit `~/.config/zed/settings.json` (or open it via **Zed > Settings**):
+Two paths, pick one.
+
+**Add Custom Server (Agent Panel UI).** Open the Agent Panel, click the menu in its header, choose **Settings**, then under **MCP Servers** click **+ Add Custom Server** and select the **Local** tab. Paste:
+
+```json
+{
+  "tablepro": {
+    "command": "/Applications/TablePro.app/Contents/MacOS/tablepro-mcp",
+    "args": []
+  }
+}
+```
+
+Click **Add Server**. The dialog's Local schema requires `args` even though Zed's documented schema treats it as optional, so include the empty array.
+
+**Edit settings.json directly.** Open `~/.config/zed/settings.json` (or **Zed > Settings**) and add the entry under `context_servers` (Zed's key for MCP servers, not `mcpServers`):
 
 ```json
 {
   "context_servers": {
     "tablepro": {
-      "command": "/Applications/TablePro.app/Contents/MacOS/tablepro-mcp",
-      "args": [],
-      "env": {}
+      "command": "/Applications/TablePro.app/Contents/MacOS/tablepro-mcp"
     }
   }
 }
 ```
 
-Open the Agent Panel; the TablePro entry should show a green status dot.
+Here `args` and `env` are optional. Reload the Agent Panel; the TablePro entry should show a green status dot.
 
 ## Windsurf
 


### PR DESCRIPTION
## Summary

- Add Zed to the in-app MCP Setup sheet (Settings > Integrations) and the MCP Token Reveal sheet, alongside Claude Desktop, Claude Code, and Cursor.
- Snippets target Zed's "Add Custom Server" dialog: paste the inner server entry only (Zed wraps it under `context_servers` itself), and include `args: []` because the dialog's Local-tab schema rejects the field even though Zed's documented schema treats it as optional.
- Docs section now shows both paths: the Agent Panel UI ("+ Add Custom Server" → Local) and direct `~/.config/zed/settings.json` editing under `context_servers`.

## Test plan

- [ ] Open **Settings > Integrations > MCP Setup**, pick **Zed**, copy the snippet, paste into Zed's Agent Panel → **+ Add Custom Server** → **Local** tab. Verify validator passes and `tablepro` shows a green dot.
- [ ] Mint a token in **Settings > Integrations > Authentication**, switch the reveal sheet to **Zed**, paste into Zed's **+ Add Custom Server** → **Remote** tab. Verify the connection works.
- [ ] Open `docs/external-api/mcp-clients.mdx` Zed section in the rendered docs site and confirm both code blocks render correctly.

## Notes for reviewer

- The xcstrings file was NOT updated in this PR, so the 4 new `String(localized:)` calls (3 step lines + the "Zed" display label) will fall back to the source-language English at runtime until the next localization sync pass.
- Remote-tab snippet shape is inferred from the Local-tab pattern; only Local was visually verified against the validator.