### PR TITLE
fix(datagrid): show dimmed chevron on deleted rows per HIG disabled-appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Result-grid cells on rows marked for deletion keep their dropdown / date / JSON / blob chevron visible at reduced opacity instead of hiding it, so the cell type is still legible while clearly inactive. Click on the dimmed chevron is a no-op; FK arrow navigation is unchanged. Matches the macOS HIG "disabled appearance" guideline.
 - Tables sidebar refreshes automatically after a successful SQL import; the refresh notification now fires after the success sheet's dismissal animation, so the main window is key when the observer runs (#1114)
 - PostgreSQL connections honor the import dialog's "Disable foreign key checks" option via `SET session_replication_role = replica` (requires REPLICATION role or superuser; managed Postgres typically rejects it) (#1114)
 - PostgreSQL SQL exports preserve GENERATED ALWAYS AS IDENTITY values on round-trip (using OVERRIDING SYSTEM VALUE) and skip GENERATED ... STORED columns (#1114)

--- a/TablePro/Views/Results/Cells/DataGridCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellView.swift
@@ -36,6 +36,7 @@ final class DataGridCellView: NSView {
 
     private static let chevronNormal = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .secondaryLabelColor)
     private static let chevronEmphasized = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .alternateSelectedControlTextColor)
+    private static let chevronDisabled = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .tertiaryLabelColor)
     private static let fkArrowNormal = makeAccessoryImage("arrow.right.circle.fill", pointSize: 14, color: .secondaryLabelColor)
     private static let fkArrowEmphasized = makeAccessoryImage("arrow.right.circle.fill", pointSize: 14, color: .alternateSelectedControlTextColor)
 
@@ -263,7 +264,7 @@ final class DataGridCellView: NSView {
             let y = (bounds.height - size.height) / 2
             return NSRect(x: x, y: y, width: size.width, height: size.height)
         case .dropdown, .boolean, .date, .json, .blob:
-            guard isEditableCell, !visualState.isDeleted else { return .zero }
+            guard isEditableCell else { return .zero }
             let size = NSSize(width: 12, height: 14)
             let x = bounds.maxX - DataGridMetrics.cellHorizontalInset - size.width
             let y = (bounds.height - size.height) / 2
@@ -280,7 +281,13 @@ final class DataGridCellView: NSView {
         case .foreignKey:
             image = onEmphasizedSelection ? Self.fkArrowEmphasized : Self.fkArrowNormal
         case .dropdown, .boolean, .date, .json, .blob:
-            image = onEmphasizedSelection ? Self.chevronEmphasized : Self.chevronNormal
+            if visualState.isDeleted {
+                image = Self.chevronDisabled
+            } else if onEmphasizedSelection {
+                image = Self.chevronEmphasized
+            } else {
+                image = Self.chevronNormal
+            }
         }
         image.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0, respectFlipped: true, hints: nil)
     }
@@ -300,6 +307,10 @@ final class DataGridCellView: NSView {
                 accessoryDelegate?.dataGridCellDidClickFKArrow(row: cellRow, columnIndex: cellColumnIndex)
                 return
             case .dropdown, .boolean, .date, .json, .blob:
+                guard !visualState.isDeleted else {
+                    super.mouseDown(with: event)
+                    return
+                }
                 accessoryDelegate?.dataGridCellDidClickChevron(row: cellRow, columnIndex: cellColumnIndex)
                 return
             case .text:

--- a/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
@@ -88,7 +88,7 @@ extension TableViewCoordinator {
         let cellState = DataGridCellState(
             visualState: state,
             isFocused: isFocused,
-            isEditable: isEditable && !state.isDeleted,
+            isEditable: isEditable,
             isLargeDataset: isLargeDataset,
             row: row,
             columnIndex: columnIndex


### PR DESCRIPTION
## Summary

When a row is marked for deletion in the data grid (red strikethrough state), the dropdown / date / JSON / blob inline-edit chevron disappears entirely. The FK arrow stays visible. This inconsistency removes structural information about cell type and violates the macOS HIG "Disabled Appearance" rule:

> "When disabling controls, indicate the disabled state visually but keep the control's structural presence. Users should still see what's possible — just understand they can't act on it right now."

Apple's own apps (Reminders.app for completed items) keep controls visible at reduced opacity rather than removing them. Removing controls disrupts spatial memory and structural information about cell type.

### What changes

**`DataGridView+Columns.swift:91`** — `isEditable` passed to the cell now reflects table-level editability only, decoupled from row-level deletion state. Deletion gating still happens in `editEligibility` (the actual edit gate) where it belongs.

**`DataGridCellView.swift`** — three small changes:

1. New cached `chevronDisabled` SF Symbol image variant in `tertiaryLabelColor` (third color tier; matches Apple's "disabled" semantic alongside `secondaryLabelColor` for normal and `alternateSelectedControlTextColor` for emphasized selection).
2. `computeAccessoryRect()` no longer hides the chevron when `visualState.isDeleted`. The accessory rect is computed whenever the column is structurally editable.
3. `drawAccessory()` picks the disabled variant when `visualState.isDeleted`, falls through to emphasized/normal variants otherwise.
4. `mouseDown(with:)` no-ops the chevron click when the row is deleted (forwards to `super.mouseDown` so row selection still works).

### Diff stats
- 3 files, +15 / −3 LoC

## Test plan

- [ ] Mark a row for deletion in an editable table (right-click → Delete, or select + Delete key)
- [ ] Row gets red strikethrough state
- [ ] Cells in dropdown / boolean / date / JSON / blob columns: chevron stays visible at reduced opacity
- [ ] Click the dimmed chevron: nothing happens (no popover, no editor opens)
- [ ] FK arrow on deleted row: still works (read-only navigation), unchanged
- [ ] Right-click on deleted row → Undo Delete: row reverts, chevrons go back to full opacity
- [ ] Read-only table (e.g., view, query result): chevron still hidden as before
- [ ] Normal editable rows: chevron renders normally (unchanged)
- [ ] Selected emphasized row with chevron: still uses `alternateSelectedControlTextColor` (white)