### PR TITLE
fix(datagrid): isolate per-tab state in structure view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal: tab session registry binds automatically when a coordinator falls back to creating its own registry, so unit tests no longer trip the filter-state debug assertion
 - Connection-only payloads no longer create an empty `Query 1` tab when there is no query, title, or source file to populate it
 - Import from Other App: cancelling a macOS keychain prompt now stops the import loop instead of silently continuing through every remaining password. The loading screen has a Cancel button, and an explainer alert before reading passwords sets expectations about the per-item prompts (#1134)
+- Structure view: switching between Columns / Indexes / Foreign Keys no longer shows stale data from the previous tab. The data grid now invalidates its display cache on schema change, scopes column widths and row selection per tab, and refresh re-fetches all tabs so badge counts persist (#1110)
 
 ## [0.39.1] - 2026-05-08
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -493,7 +493,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         tableView.scrollRowToVisible(0)
     }
 
-    func rebuildColumnMetadataCache(from tableRows: TableRows) {
+    @discardableResult
+    func rebuildColumnMetadataCache(from tableRows: TableRows) -> Bool {
         var enumSet = Set<Int>()
         var fkSet = Set<Int>()
         let columns = tableRows.columns
@@ -517,9 +518,10 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         fkColumns = fkSet
 
         let nextSchema = ColumnIdentitySchema(columns: columns)
-        if nextSchema != identitySchema {
-            identitySchema = nextSchema
-        }
+        guard nextSchema != identitySchema else { return false }
+        identitySchema = nextSchema
+        displayCache.removeAllObjects()
+        return true
     }
 
     // MARK: - Font Updates

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -173,10 +173,10 @@ struct DataGridView: NSViewRepresentable {
         let oldColumnCount = coordinator.cachedColumnCount
 
         let structureChanged = oldRowCount != rowDisplayCount || oldColumnCount != columnCount
-        let needsFullReload = structureChanged
 
         coordinator.updateCache()
-        coordinator.rebuildColumnMetadataCache(from: latestRows)
+        let schemaChanged = coordinator.rebuildColumnMetadataCache(from: latestRows)
+        let needsFullReload = structureChanged || schemaChanged
 
         if oldRowCount == 0, rowDisplayCount > 0 {
             let rowH = tableView.rowHeight

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -46,14 +46,16 @@ extension TableStructureView {
 
     func loadTabDataIfNeeded(_ tab: StructureTab) async {
         guard !loadedTabs.contains(tab) else { return }
+        await fetchTabData(tab)
+    }
+
+    func fetchTabData(_ tab: StructureTab) async {
         guard let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
 
         do {
             switch tab {
             case .columns:
-                if columns.isEmpty {
-                    columns = try await driver.fetchColumns(table: tableName)
-                }
+                columns = try await driver.fetchColumns(table: tableName)
             case .indexes:
                 indexes = try await driver.fetchIndexes(table: tableName)
             case .foreignKeys:
@@ -77,7 +79,7 @@ extension TableStructureView {
                     ddlStatement = preamble + "\n" + baseDDL
                 }
             case .parts:
-                break
+                return
             }
             loadedTabs.insert(tab)
         } catch {
@@ -165,14 +167,13 @@ extension TableStructureView {
     }
 
     private func reloadAllTabs() async {
-        loadedTabs.removeAll()
         await loadColumns()
-        await loadTabDataIfNeeded(.indexes)
+        await fetchTabData(.indexes)
         if connection.type.supportsForeignKeys {
-            await loadTabDataIfNeeded(.foreignKeys)
+            await fetchTabData(.foreignKeys)
         }
-        if selectedTab == .ddl || selectedTab == .parts {
-            await loadTabDataIfNeeded(selectedTab)
+        if selectedTab == .ddl {
+            await fetchTabData(.ddl)
         }
     }
 }

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -106,6 +106,7 @@ extension TableStructureView {
         searchText = ""
         structureSortDescriptor = nil
         sortState = SortState()
+        selectedRows = []
         displayVersion += 1
         Task {
             await loadTabDataIfNeeded(new)
@@ -152,18 +153,26 @@ extension TableStructureView {
 
                 if confirmed {
                     discardChanges()
-                    loadedTabs.removeAll()
-                    await loadColumns()
-                    await loadTabDataIfNeeded(selectedTab)
+                    await reloadAllTabs()
                 }
             }
             // If cancelled, do nothing
         } else {
             Task { @MainActor in
-                loadedTabs.removeAll()
-                await loadColumns()
-                await loadTabDataIfNeeded(selectedTab)
+                await reloadAllTabs()
             }
+        }
+    }
+
+    private func reloadAllTabs() async {
+        loadedTabs.removeAll()
+        await loadColumns()
+        await loadTabDataIfNeeded(.indexes)
+        if connection.type.supportsForeignKeys {
+            await loadTabDataIfNeeded(.foreignKeys)
+        }
+        if selectedTab == .ddl || selectedTab == .parts {
+            await loadTabDataIfNeeded(selectedTab)
         }
     }
 }

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -48,7 +48,7 @@ struct TableStructureView: View {
     @State var wrappedChangeManager: AnyChangeManager
     @State var selectedRows: Set<Int> = []
     @State var sortState = SortState()
-    @State var structureColumnLayout = ColumnLayoutState()
+    @State var structureColumnLayouts: [StructureTab: ColumnLayoutState] = [:]
     @State var columnLayoutPersister: any ColumnLayoutPersisting = FileColumnLayoutPersister()
     @State var actionHandler = StructureViewActionHandler()
     @State var gridDelegate: StructureGridDelegate
@@ -208,6 +208,13 @@ struct TableStructureView: View {
         )
     }
 
+    private func columnLayoutBinding(for tab: StructureTab) -> Binding<ColumnLayoutState> {
+        Binding(
+            get: { structureColumnLayouts[tab] ?? ColumnLayoutState() },
+            set: { structureColumnLayouts[tab] = $0 }
+        )
+    }
+
     func updateGridDelegate() {
         let provider = makeCurrentProvider()
         let canEdit = connection.type.supportsSchemaEditing
@@ -284,7 +291,7 @@ struct TableStructureView: View {
             layoutPersister: columnLayoutPersister,
             selectedRowIndices: $selectedRows,
             sortState: $sortState,
-            columnLayout: $structureColumnLayout
+            columnLayout: columnLayoutBinding(for: selectedTab)
         )
         .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {


### PR DESCRIPTION
Fixes #1110

## Root cause

Two distinct bugs from the same architectural assumption: a single `DataGridView` instance was being reused across the Columns / Indexes / Foreign Keys sub-tabs of the structure view, but state scoped to "this DataGridView" was bleeding between tabs.

### Bug 1: stale data on tab switch

`DataGridCoordinator.displayCache` is keyed by `RowIDKey(row.id)`. `TableRows.from(queryRows:...)` mints IDs as `.existing(0)`, `.existing(1)`, ... by array index, so row 0 of Columns and row 0 of Indexes share the same key. When SwiftUI re-renders to swap datasets between tabs, `updateNSView` rebuilt `identitySchema` and reloaded the table, but never flushed `displayCache`. Each cell call hit the cache and rendered the previous tab's value.

The DDL → back fix worked by accident: routing through a non-grid view forces SwiftUI to tear down the NSTableView, so `makeNSView` built a fresh coordinator with an empty cache.

`applyFullReplace()` already invalidates this cache, but it only fires on change-manager Delta events. Tab switches go through SwiftUI re-render and bypass that path entirely.

### Bug 2: badge counts disappear on refresh

`onRefreshData` cleared `loadedTabs` then only re-fetched columns and the active tab. `tabLabel(for:)` shows a count only when the tab is in `loadedTabs`, so the two non-active tabs lost their badges. `loadInitialData` loads all three by contrast, which is why counts appear correct on first open.

### Cross-tab state pollution

While tracing the cache bug, the same single-instance assumption showed up in two more places:
- `selectedRows` (`@State` on `TableStructureView`) carried selection across tabs even though row N has no shared meaning between Columns and Indexes.
- `structureColumnLayout` (`@State`) was a single `ColumnLayoutState`, so `DataGridColumnPool.reconcile` saw `willRestoreWidths = true` for the new tab, looked up Indexes column names in the Columns widths dict, missed, and fell back to a hardcoded width of 100 instead of running the auto-fit `widthCalculator`.

## Fixes

1. `DataGridCoordinator.rebuildColumnMetadataCache` now returns whether the schema changed and invalidates `displayCache` when it does. `DataGridView.updateNSView` rolls a schema change into `needsFullReload`. This generalizes — query tabs that re-execute with a different schema benefit too.
2. `TableStructureView+DataLoading.onRefreshData` re-fetches columns + indexes + foreign keys (when supported), so badge counts persist across refresh just like initial load.
3. `onSelectedTabChanged` resets `selectedRows = []`.
4. `structureColumnLayout` becomes `[StructureTab: ColumnLayoutState]` with a per-tab `Binding`, so each sub-tab keeps its own widths, order, and hidden columns without polluting siblings.

## Test plan

- [ ] PostgreSQL table with both columns and indexes: open Structure → Indexes. Indexes data should show on first display, no need to detour through DDL.
- [ ] Switch back to Columns. Columns data should be correct.
- [ ] Resize a column in Columns tab, switch to Indexes, resize there, switch back to Columns. Each tab should remember its own widths.
- [ ] Select row 2 in Columns, switch to Indexes. Indexes should open with no selection, not row 2 highlighted.
- [ ] Open a table with all three tabs populated. Confirm all three badges show counts. Hit Cmd+R / refresh. All three counts should still show after the reload.
- [ ] Click DDL tab and back to Columns: still works (regression check).
- [ ] Run a query in a query tab, then run a different query with a different schema in the same tab. Result grid should show new data, not stale rows from the previous query (this is the latent benefit of fix 1).