### PR TITLE
fix(welcome): use explicit self for services capture inside [weak self] sink

### DIFF
--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -189,7 +189,8 @@ final class WelcomeViewModel {
         linkedFoldersCancellable = services.appEvents.linkedFoldersDidUpdate
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.linkedConnections = services.linkedFolderWatcher.linkedConnections
+                guard let self else { return }
+                self.linkedConnections = self.services.linkedFolderWatcher.linkedConnections
             }
 
         loadConnections()


### PR DESCRIPTION
## Summary

Inside the `[weak self]` Combine sink for `linkedFoldersDidUpdate`, the right-hand side `services.linkedFolderWatcher.linkedConnections` was a bare property access that Swift treated as an implicit `self` capture and rejected with:

> Reference to property 'services' in closure requires explicit use of 'self' to make capture semantics explicit

Added `guard let self else { return }` so the assignment uses an unwrapped strong `self`, then `self.services.linkedFolderWatcher.linkedConnections` reads through it.

## Why this matters

Compile error introduced by PR #1152 when the LinkedFolderWatcher access switched from `LinkedFolderWatcher.shared` (no self capture) to `services.linkedFolderWatcher` (which is `self.services.linkedFolderWatcher`). The two pre-existing similar sites in `MainContentCoordinator` already use the `guard let self` pattern, which is why they compile. This PR brings WelcomeViewModel in line.

## Test plan

- [ ] Build succeeds.
- [ ] Toggle a linked SQL folder and confirm the welcome sidebar refreshes.
- [ ] swiftlint --strict clean.