### PR TITLE
feat(ios): alert when active connection is deleted mid-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iOS: alert when the active connection is deleted mid-session (for example via iCloud sync from another device), so a stale screen no longer fails silently on the next action
 - iOS: Face ID, Touch ID, or Optic ID lock with cold-launch protection and idle timeout (1, 5, 15, or 60 minutes), opt-in from Settings
 - iOS: Connection Info tab replaces the per-connection Settings tab, showing host, SSL, SSH tunnel, active database, and live connection status
 - MCP Setup sheet adds Zed alongside Claude Desktop, Claude Code, and Cursor with a one-paste `context_servers` snippet

--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -33,7 +33,7 @@ final class ConnectionCoordinator {
         }
     }
     var pendingQuery: String?
-    var navigationPath = NavigationPath()
+    var tablesPath = NavigationPath()
     var showingEditSheet = false
 
     private(set) var queryHistory: [QueryHistoryItem] = []
@@ -281,7 +281,7 @@ final class ConnectionCoordinator {
         appState.pendingTableName = nil
         selectedTab = .tables
         Task { @MainActor in
-            navigationPath.append(table)
+            tablesPath.append(table)
         }
     }
 

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -832,6 +832,9 @@
         }
       }
     },
+    "Connection Deleted" : {
+
+    },
     "Connection Failed" : {
       "localizations" : {
         "vi" : {
@@ -3825,6 +3828,9 @@
           }
         }
       }
+    },
+    "This connection no longer exists. It may have been removed from another device." : {
+
     },
     "This database has no tables." : {
       "localizations" : {

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -18,6 +18,7 @@ struct ConnectedView: View {
     @State private var coordinator: ConnectionCoordinator?
     @State private var hapticSuccess = false
     @State private var hapticError = false
+    @State private var showDeletedAlert = false
 
     var body: some View {
         Group {
@@ -38,6 +39,16 @@ struct ConnectedView: View {
         }
         .navigationTitle(connection.name.isEmpty ? connection.host : connection.name)
         .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: appState.connections) { _, newConnections in
+            if !newConnections.contains(where: { $0.id == connection.id }) {
+                showDeletedAlert = true
+            }
+        }
+        .alert(String(localized: "Connection Deleted"), isPresented: $showDeletedAlert) {
+            Button("OK", role: .cancel) { dismiss() }
+        } message: {
+            Text("This connection no longer exists. It may have been removed from another device.")
+        }
         .task {
             if let cached = cachedCoordinator {
                 coordinator = cached
@@ -88,7 +99,7 @@ struct ConnectedView: View {
 
     private func connectedContent(_ coordinator: ConnectionCoordinator) -> some View {
         @Bindable var coordinator = coordinator
-        return NavigationStack(path: $coordinator.navigationPath) {
+        return NavigationStack(path: $coordinator.tablesPath) {
             TabView(selection: $coordinator.selectedTab) {
                 Tab("Tables", systemImage: "tablecells", value: .tables) {
                     TableListView()

--- a/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
@@ -51,8 +51,6 @@ struct ConnectionInfoView: View {
 
             statsSection
         }
-        .navigationTitle("Info")
-        .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: Binding(
             get: { coordinator.showingEditSheet },
             set: { coordinator.showingEditSheet = $0 }


### PR DESCRIPTION
## Summary

Small UX win extracted from a P1 navigation refactor experiment that did not pan out (iOS 26 TabView and per-tab NavigationStack tug over the navbar surface, so the canonical Apple pattern is unusable here for now).

What lands:

- When the connection currently shown in `ConnectedView` is removed from `appState.connections` mid-session (for example via iCloud sync from another device), an alert appears: *"This connection no longer exists. It may have been removed from another device."*. Tapping OK calls `dismiss()`, which pops back to the connection list on iPhone or clears the detail column on iPad. Without this, the next data action would fail with a generic error and the user would not know the connection vanished.
- Internal: `ConnectionCoordinator.navigationPath` renamed to `tablesPath`. Only the Tables tab actually drives drill-down (`TableInfo` → `DataBrowserView`), so the new name reflects intent. `navigateToPendingTable()` and the `NavigationStack(path:)` binding are updated atomically.
- Internal: drop the duplicate `.navigationTitle("Info")` on `ConnectionInfoView`. `ConnectedView.tabTitle()` already returns "Info" for the Info tab and applies it on the outer NavigationStack.

## Test plan

- [ ] Open Connection A on iPhone, navigate into a table, then delete Connection A from another device with iCloud sync on. iCloud sync arrives, alert appears, OK pops back to the connection list.
- [ ] Same scenario on iPad: detail column clears to the empty state.
- [ ] Deep link `tablepro://connect/<uuid>` → `pendingTableName` push still works (uses `tablesPath.append(table)`).
- [ ] Info tab navbar title still reads "Info" with the pencil edit button to its right.