### PR TITLE
refactor(ios): drop UIApplication.sendAction keyboard dismiss for binding-driven focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Internal: iOS query editor uses a `Binding<Bool>` focus channel into `SQLHighlightTextView` to dismiss the keyboard before running a query, replacing the `UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder))` call. Keyboard behavior is unchanged
 - Internal: iOS row detail (edit lifecycle, save SQL build, lazy cell value load, primary key extraction, success-toast auto-dismiss) moves out of the View into `RowDetailViewModel`. The View now keeps only sheet flags and haptic triggers; behavior is unchanged
 - Internal: iOS connection form (test connection, save, file picker handlers, default port resolution, credential hydration) moves out of the View into `ConnectionFormViewModel`. The View drops from 53 to 5 `@State` properties; behavior is unchanged
 - Internal: iOS data browser business logic (page load, pagination, sort, filter, search, delete, foreign-key fetch, memory pressure) moves out of the View into `DataBrowserViewModel`. The View drops 30 of its 33 `@State` properties and a dozen private functions; behavior is unchanged

--- a/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
@@ -8,8 +8,14 @@ import UIKit
 
 struct SQLHighlightTextView: UIViewRepresentable {
     @Binding var text: String
+    @Binding var isFocused: Bool
 
     private static let font = UIFont.monospacedSystemFont(ofSize: 15, weight: .regular)
+
+    init(text: Binding<String>, isFocused: Binding<Bool> = .constant(false)) {
+        self._text = text
+        self._isFocused = isFocused
+    }
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
@@ -40,6 +46,11 @@ struct SQLHighlightTextView: UIViewRepresentable {
             }
             context.coordinator.isUpdating = false
         }
+        if isFocused, !textView.isFirstResponder {
+            textView.becomeFirstResponder()
+        } else if !isFocused, textView.isFirstResponder {
+            textView.resignFirstResponder()
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -56,6 +67,14 @@ struct SQLHighlightTextView: UIViewRepresentable {
         func textViewDidChange(_ textView: UITextView) {
             guard !isUpdating else { return }
             parent.text = textView.text
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            if !parent.isFocused { parent.isFocused = true }
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            if parent.isFocused { parent.isFocused = false }
         }
 
         func textStorage(

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -14,6 +14,7 @@ struct QueryEditorView: View {
     private static let logger = Logger(subsystem: "com.TablePro", category: "QueryEditorView")
 
     @State private var query = ""
+    @State private var editorFocused = false
     @State private var viewModel = QueryEditorViewModel()
     @State private var appError: AppError?
     @State private var isExecuting = false
@@ -112,7 +113,7 @@ struct QueryEditorView: View {
 
     private var editorSection: some View {
         VStack(spacing: 0) {
-            SQLHighlightTextView(text: $query)
+            SQLHighlightTextView(text: $query, isFocused: $editorFocused)
                 .frame(minHeight: 80, maxHeight: hasResult || appError != nil ? 120 : 250)
 
             actionBar
@@ -392,7 +393,7 @@ struct QueryEditorView: View {
     private func executeQueryDirect(_ trimmed: String) async {
         guard let session else { return }
 
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        editorFocused = false
         isExecuting = true
         executionStartTime = Date()
         defer {


### PR DESCRIPTION
## Summary

P1 #7: replace the imperative `UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), ...)` keyboard dismiss in `QueryEditorView.executeQueryDirect` with a SwiftUI `@Binding<Bool>` focus channel into `SQLHighlightTextView`.

What changes:

- `SQLHighlightTextView` (UIViewRepresentable) gains an `@Binding var isFocused: Bool` parameter (default `.constant(false)` so existing call sites that don't care still compile)
- `updateUIView` syncs the binding into the wrapped `UITextView` via `becomeFirstResponder()` / `resignFirstResponder()` only when state actually diverges
- Coordinator gains `textViewDidBeginEditing` and `textViewDidEndEditing` to propagate user-driven focus changes back to the binding
- `QueryEditorView` adds `@State private var editorFocused = false`, passes `$editorFocused` into the editor, and sets `editorFocused = false` before executing a query, dismissing the keyboard

Why a plain `@State Bool` and not `@FocusState`: `@FocusState`'s projected value is `FocusState<Bool>.Binding`, which doesn't satisfy `@Binding var isFocused: Bool`. The canonical iOS pattern for `UIViewRepresentable` focus is parent `@State Bool` plus two-way sync through the representable's update method and delegate callbacks. The user-visible behavior matches `@FocusState`: keyboard dismisses declaratively when state flips to `false`.

Two `resignFirstResponder()` calls remain inside `SQLHighlightTextView` itself: one in `updateUIView` (sync from binding) and one in the toolbar Done button's `@objc` handler. Both are UIKit-internal and not the imperative SwiftUI escape hatch this PR targets.

## Test plan

- [ ] Tap into the SQL editor: keyboard appears, `editorFocused` becomes true (verify by adding a `.onChange` print if needed)
- [ ] Tap "Run": keyboard dismisses immediately, query executes
- [ ] Tap "Done" on the editor's input accessory toolbar: keyboard dismisses, `editorFocused` becomes false via `textViewDidEndEditing`
- [ ] Tap into another control (e.g., switch to History tab): keyboard dismisses, focus state stays consistent
- [ ] Switch tabs and come back: typing into the editor still works, no stuck focus