### PR TITLE
chore(ios): P2 polish - strip headers, cleanup orphan UserDefaults, accessibility labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- iOS: VoiceOver now reads connection rows and table rows as a single combined element with type, name, host or row count, and includes a hint about what tapping does
+- iOS: toolbar icon-only buttons (Add Connection, Sync with iCloud, Settings) gain accessibility labels for VoiceOver
+- Internal: per-connection `UserDefaults` keys (`lastTab.<uuid>`, `lastDB.<uuid>`, `lastSchema.<uuid>`, `lastQuery.<uuid>`) clear when a connection is deleted, so they no longer accumulate over time
+- Internal: drop redundant 4-line Xcode-generated file headers from every iOS source file (~58 files)
 - Internal: iOS query editor uses a `Binding<Bool>` focus channel into `SQLHighlightTextView` to dismiss the keyboard before running a query, replacing the `UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder))` call. Keyboard behavior is unchanged
 - Internal: iOS row detail (edit lifecycle, save SQL build, lazy cell value load, primary key extraction, success-toast auto-dismiss) moves out of the View into `RowDetailViewModel`. The View now keeps only sheet flags and haptic triggers; behavior is unchanged
 - Internal: iOS connection form (test connection, save, file picker handlers, default port resolution, credential hydration) moves out of the View into `ConnectionFormViewModel`. The View drops from 53 to 5 `@State` properties; behavior is unchanged

--- a/TableProMobile/TableProMobile/AppState.swift
+++ b/TableProMobile/TableProMobile/AppState.swift
@@ -1,8 +1,3 @@
-//
-//  AppState.swift
-//  TableProMobile
-//
-
 import CoreSpotlight
 import Foundation
 import Observation
@@ -114,11 +109,20 @@ final class AppState {
         try? secureStore.delete(forKey: "com.TablePro.sshpassword.\(connection.id.uuidString)")
         try? secureStore.delete(forKey: "com.TablePro.keypassphrase.\(connection.id.uuidString)")
         try? secureStore.delete(forKey: "com.TablePro.sshkeydata.\(connection.id.uuidString)")
+        clearPerConnectionPreferences(for: connection.id)
         storage.save(connections)
         updateWidgetData()
         updateSpotlightIndex()
         syncCoordinator.markDeleted(connection.id)
         syncCoordinator.scheduleSyncAfterChange()
+    }
+
+    private func clearPerConnectionPreferences(for id: UUID) {
+        let suffix = id.uuidString
+        let defaults = UserDefaults.standard
+        for prefix in ["lastTab.", "lastDB.", "lastSchema.", "lastQuery."] {
+            defaults.removeObject(forKey: prefix + suffix)
+        }
     }
 
     // MARK: - Groups

--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionCoordinator.swift
-//  TableProMobile
-//
-
 import Foundation
 import Observation
 import os

--- a/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
@@ -1,10 +1,3 @@
-//
-//  MySQLDriver.swift
-//  TableProMobile
-//
-//  MySQL driver conforming to DatabaseDriver directly (no plugin layer).
-//
-
 import CMariaDB
 import Foundation
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -1,10 +1,3 @@
-//
-//  PostgreSQLDriver.swift
-//  TableProMobile
-//
-//  PostgreSQL driver conforming to DatabaseDriver directly (no plugin layer).
-//
-
 import CLibPQ
 import Foundation
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
@@ -1,11 +1,3 @@
-//
-//  RedisDriver.swift
-//  TableProMobile
-//
-//  Redis driver conforming to DatabaseDriver directly (no plugin layer).
-//  Maps Redis key-value concepts to the relational DatabaseDriver protocol.
-//
-
 import CRedis
 import Foundation
 import os

--- a/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
@@ -1,10 +1,3 @@
-//
-//  SQLiteDriver.swift
-//  TableProMobile
-//
-//  SQLite driver conforming to DatabaseDriver directly (no plugin layer).
-//
-
 import Foundation
 import SQLite3
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Helpers/AppError.swift
+++ b/TableProMobile/TableProMobile/Helpers/AppError.swift
@@ -1,8 +1,3 @@
-//
-//  AppError.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProModels

--- a/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
+++ b/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
@@ -1,8 +1,3 @@
-//
-//  ClipboardExporter.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProModels
 import UIKit

--- a/TableProMobile/TableProMobile/Helpers/GroupPersistence.swift
+++ b/TableProMobile/TableProMobile/Helpers/GroupPersistence.swift
@@ -1,8 +1,3 @@
-//
-//  GroupPersistence.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
+++ b/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
@@ -1,8 +1,3 @@
-//
-//  IndexedRow.swift
-//  TableProMobile
-//
-
 import Foundation
 
 /// Identifiable wrapper used by iOS lists that need both the row payload and

--- a/TableProMobile/TableProMobile/Helpers/QueryHistoryStorage.swift
+++ b/TableProMobile/TableProMobile/Helpers/QueryHistoryStorage.swift
@@ -1,8 +1,3 @@
-//
-//  QueryHistoryStorage.swift
-//  TableProMobile
-//
-
 import Foundation
 
 struct QueryHistoryItem: Identifiable, Codable, Hashable {

--- a/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
+++ b/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
@@ -1,8 +1,3 @@
-//
-//  SQLBuilder.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProModels
 import TableProPluginKit

--- a/TableProMobile/TableProMobile/Helpers/StreamingExporter.swift
+++ b/TableProMobile/TableProMobile/Helpers/StreamingExporter.swift
@@ -1,8 +1,3 @@
-//
-//  StreamingExporter.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Helpers/String+SHA256.swift
+++ b/TableProMobile/TableProMobile/Helpers/String+SHA256.swift
@@ -1,8 +1,3 @@
-//
-//  String+SHA256.swift
-//  TableProMobile
-//
-
 import CryptoKit
 import Foundation
 

--- a/TableProMobile/TableProMobile/Helpers/TagPersistence.swift
+++ b/TableProMobile/TableProMobile/Helpers/TagPersistence.swift
@@ -1,8 +1,3 @@
-//
-//  TagPersistence.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Intents/ConnectionEntity.swift
+++ b/TableProMobile/TableProMobile/Intents/ConnectionEntity.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionEntity.swift
-//  TableProMobile
-//
-
 import AppIntents
 import Foundation
 

--- a/TableProMobile/TableProMobile/Intents/ConnectionEntityQuery.swift
+++ b/TableProMobile/TableProMobile/Intents/ConnectionEntityQuery.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionEntityQuery.swift
-//  TableProMobile
-//
-
 import AppIntents
 import Foundation
 

--- a/TableProMobile/TableProMobile/Intents/OpenConnectionIntent.swift
+++ b/TableProMobile/TableProMobile/Intents/OpenConnectionIntent.swift
@@ -1,8 +1,3 @@
-//
-//  OpenConnectionIntent.swift
-//  TableProMobile
-//
-
 import AppIntents
 import Foundation
 import UIKit

--- a/TableProMobile/TableProMobile/Intents/TableProShortcuts.swift
+++ b/TableProMobile/TableProMobile/Intents/TableProShortcuts.swift
@@ -1,8 +1,3 @@
-//
-//  TableProShortcuts.swift
-//  TableProMobile
-//
-
 import AppIntents
 
 struct TableProShortcuts: AppShortcutsProvider {

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -20,6 +20,16 @@
         }
       }
     },
+    "%@ -> %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ -> %2$@"
+          }
+        }
+      }
+    },
     "%@ · %@" : {
       "localizations" : {
         "en" : {
@@ -43,6 +53,7 @@
       }
     },
     "%@ → %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -489,7 +500,6 @@
       }
     },
     "Cannot Save" : {
-      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -1471,7 +1481,11 @@
         }
       }
     },
+    "Enter a page number (1-%lld)" : {
+
+    },
     "Enter a page number (1–%lld)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -2354,7 +2368,6 @@
       }
     },
     "No primary key values found." : {
-      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -3913,7 +3926,6 @@
       }
     },
     "This table needs a primary key to identify the row." : {
-      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {

--- a/TableProMobile/TableProMobile/Models/ConnectedTab.swift
+++ b/TableProMobile/TableProMobile/Models/ConnectedTab.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectedTab.swift
-//  TableProMobile
-//
-
 enum ConnectedTab: String, CaseIterable, Sendable {
     case tables
     case query

--- a/TableProMobile/TableProMobile/Models/RowWindow.swift
+++ b/TableProMobile/TableProMobile/Models/RowWindow.swift
@@ -1,8 +1,3 @@
-//
-//  RowWindow.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Platform/AppLockState.swift
+++ b/TableProMobile/TableProMobile/Platform/AppLockState.swift
@@ -1,8 +1,3 @@
-//
-//  AppLockState.swift
-//  TableProMobile
-//
-
 import Foundation
 import Observation
 import os

--- a/TableProMobile/TableProMobile/Platform/BiometricAuthService.swift
+++ b/TableProMobile/TableProMobile/Platform/BiometricAuthService.swift
@@ -1,8 +1,3 @@
-//
-//  BiometricAuthService.swift
-//  TableProMobile
-//
-
 import Foundation
 import LocalAuthentication
 import os

--- a/TableProMobile/TableProMobile/Platform/IOSAnalyticsProvider.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSAnalyticsProvider.swift
@@ -1,8 +1,3 @@
-//
-//  IOSAnalyticsProvider.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProAnalytics

--- a/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
@@ -1,8 +1,3 @@
-//
-//  IOSDriverFactory.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
+++ b/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
@@ -1,8 +1,3 @@
-//
-//  KeychainSecureStore.swift
-//  TableProMobile
-//
-
 import Foundation
 import Security
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Platform/LocalNetworkPermission.swift
+++ b/TableProMobile/TableProMobile/Platform/LocalNetworkPermission.swift
@@ -1,8 +1,3 @@
-//
-//  LocalNetworkPermission.swift
-//  TableProMobile
-//
-
 import Foundation
 import Network
 import os

--- a/TableProMobile/TableProMobile/Platform/MemoryPressureMonitor.swift
+++ b/TableProMobile/TableProMobile/Platform/MemoryPressureMonitor.swift
@@ -1,8 +1,3 @@
-//
-//  MemoryPressureMonitor.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 

--- a/TableProMobile/TableProMobile/SSH/IOSSSHProvider.swift
+++ b/TableProMobile/TableProMobile/SSH/IOSSSHProvider.swift
@@ -1,8 +1,3 @@
-//
-//  IOSSSHProvider.swift
-//  TableProMobile
-//
-
 import Foundation
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
@@ -1,10 +1,3 @@
-//
-//  SSHTunnel.swift
-//  TableProMobile
-//
-//  Actor-based SSH tunnel using libssh2 C API via CLibSSH2 bridge.
-//
-
 import Foundation
 import CLibSSH2
 import os

--- a/TableProMobile/TableProMobile/SSH/SSHTunnelError.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnelError.swift
@@ -1,8 +1,3 @@
-//
-//  SSHTunnelError.swift
-//  TableProMobile
-//
-
 import Foundation
 
 enum SSHTunnelError: Error, LocalizedError {

--- a/TableProMobile/TableProMobile/SSH/SSHTunnelFactory.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnelFactory.swift
@@ -1,10 +1,3 @@
-//
-//  SSHTunnelFactory.swift
-//  TableProMobile
-//
-//  Stateless factory that creates fully-connected, authenticated SSH tunnels.
-//
-
 import CLibSSH2
 import Foundation
 import TableProModels

--- a/TableProMobile/TableProMobile/Sync/IOSSyncCoordinator.swift
+++ b/TableProMobile/TableProMobile/Sync/IOSSyncCoordinator.swift
@@ -1,8 +1,3 @@
-//
-//  IOSSyncCoordinator.swift
-//  TableProMobile
-//
-
 import CloudKit
 import Foundation
 import Observation

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -1,8 +1,3 @@
-//
-//  TableProMobileApp.swift
-//  TableProMobile
-//
-
 import CoreSpotlight
 import SwiftUI
 import TableProAnalytics

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionFormViewModel.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProDatabase

--- a/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
@@ -1,8 +1,3 @@
-//
-//  DataBrowserViewModel.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProDatabase

--- a/TableProMobile/TableProMobile/ViewModels/QueryEditorViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/QueryEditorViewModel.swift
@@ -1,8 +1,3 @@
-//
-//  QueryEditorViewModel.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProDatabase

--- a/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
@@ -1,8 +1,3 @@
-//
-//  RowDetailViewModel.swift
-//  TableProMobile
-//
-
 import Foundation
 import os
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Views/Components/ActivityViewController.swift
+++ b/TableProMobile/TableProMobile/Views/Components/ActivityViewController.swift
@@ -1,8 +1,3 @@
-//
-//  ActivityViewController.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import UIKit
 

--- a/TableProMobile/TableProMobile/Views/Components/ConnectionColorPicker.swift
+++ b/TableProMobile/TableProMobile/Views/Components/ConnectionColorPicker.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionColorPicker.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/Components/DatabaseIconView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/DatabaseIconView.swift
@@ -1,8 +1,3 @@
-//
-//  DatabaseIconView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/Components/ErrorView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/ErrorView.swift
@@ -1,8 +1,3 @@
-//
-//  ErrorView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 
 struct ErrorView: View {

--- a/TableProMobile/TableProMobile/Views/Components/FKPreviewView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/FKPreviewView.swift
@@ -1,8 +1,3 @@
-//
-//  FKPreviewView.swift
-//  TableProMobile
-//
-
 import os
 import SwiftUI
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Views/Components/FilterSheetView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/FilterSheetView.swift
@@ -1,8 +1,3 @@
-//
-//  FilterSheetView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/Components/GroupFormSheet.swift
+++ b/TableProMobile/TableProMobile/Views/Components/GroupFormSheet.swift
@@ -1,8 +1,3 @@
-//
-//  GroupFormSheet.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/Components/MetadataBadge.swift
+++ b/TableProMobile/TableProMobile/Views/Components/MetadataBadge.swift
@@ -1,8 +1,3 @@
-//
-//  MetadataBadge.swift
-//  TableProMobile
-//
-
 import SwiftUI
 
 struct MetadataBadge<Background: ShapeStyle>: View {

--- a/TableProMobile/TableProMobile/Views/Components/RowCard.swift
+++ b/TableProMobile/TableProMobile/Views/Components/RowCard.swift
@@ -1,8 +1,3 @@
-//
-//  RowCard.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
@@ -1,8 +1,3 @@
-//
-//  SQLHighlightTextView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import UIKit
 

--- a/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
@@ -1,8 +1,3 @@
-//
-//  SQLSyntaxHighlighter.swift
-//  TableProMobile
-//
-
 import UIKit
 
 enum SQLSyntaxHighlighter {

--- a/TableProMobile/TableProMobile/Views/Components/TagFormSheet.swift
+++ b/TableProMobile/TableProMobile/Views/Components/TagFormSheet.swift
@@ -1,8 +1,3 @@
-//
-//  TagFormSheet.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectedView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionFormView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionInfoView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -1,8 +1,3 @@
-//
-//  ConnectionListView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 import TableProSync
@@ -83,6 +78,7 @@ struct ConnectionListView: View {
                             Image(systemName: "plus")
                         }
                         .keyboardShortcut("n", modifiers: .command)
+                        .accessibilityLabel(Text("Add Connection"))
                     }
                     ToolbarItemGroup(placement: .topBarLeading) {
                         Button {
@@ -102,12 +98,14 @@ struct ConnectionListView: View {
                             }
                         }
                         .disabled(isSyncing)
+                        .accessibilityLabel(Text("Sync with iCloud"))
 
                         Button {
                             showingSettings = true
                         } label: {
                             Image(systemName: "gear")
                         }
+                        .accessibilityLabel(Text("Settings"))
                     }
                 }
             .onChange(of: appState.pendingConnectionId) { _, newId in
@@ -458,6 +456,20 @@ private struct ConnectionRow: View {
                     )
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(Text("Opens this connection"))
     }
 
+    private var accessibilityLabel: Text {
+        let displayName = connection.name.isEmpty ? connection.host : connection.name
+        let typeName = connection.type.rawValue.uppercased()
+        let location: String = connection.type == .sqlite
+            ? (connection.database.components(separatedBy: "/").last ?? "database")
+            : "\(connection.host) port \(connection.port)"
+        if let tag {
+            return Text("\(typeName), \(displayName), \(location), tag \(tag.name)")
+        }
+        return Text("\(typeName), \(displayName), \(location)")
+    }
 }

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -1,8 +1,3 @@
-//
-//  DataBrowserView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Views/GroupManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/GroupManagementView.swift
@@ -1,8 +1,3 @@
-//
-//  GroupManagementView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -1,8 +1,3 @@
-//
-//  InsertRowView.swift
-//  TableProMobile
-//
-
 import os
 import SwiftUI
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Views/LockScreenView.swift
+++ b/TableProMobile/TableProMobile/Views/LockScreenView.swift
@@ -1,8 +1,3 @@
-//
-//  LockScreenView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 
 struct LockScreenView: View {

--- a/TableProMobile/TableProMobile/Views/OnboardingView.swift
+++ b/TableProMobile/TableProMobile/Views/OnboardingView.swift
@@ -1,8 +1,3 @@
-//
-//  OnboardingView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 
 struct OnboardingView: View {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -1,8 +1,3 @@
-//
-//  QueryEditorView.swift
-//  TableProMobile
-//
-
 import os
 import SwiftUI
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
@@ -1,8 +1,3 @@
-//
-//  QueryHistoryView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import UIKit
 

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -1,8 +1,3 @@
-//
-//  RowDetailView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels

--- a/TableProMobile/TableProMobile/Views/SettingsView.swift
+++ b/TableProMobile/TableProMobile/Views/SettingsView.swift
@@ -1,8 +1,3 @@
-//
-//  SettingsView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 
 struct SettingsView: View {

--- a/TableProMobile/TableProMobile/Views/StructureView.swift
+++ b/TableProMobile/TableProMobile/Views/StructureView.swift
@@ -1,8 +1,3 @@
-//
-//  StructureView.swift
-//  TableProMobile
-//
-
 import os
 import SwiftUI
 import TableProDatabase

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -1,8 +1,3 @@
-//
-//  TableListView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProDatabase
 import TableProModels
@@ -180,9 +175,11 @@ struct TableListView: View {
 private struct TableRow: View {
     let table: TableInfo
 
+    private var isView: Bool { table.type == .view || table.type == .materializedView }
+
     var body: some View {
         HStack {
-            Image(systemName: table.type == .view || table.type == .materializedView ? "eye" : "tablecells")
+            Image(systemName: isView ? "eye" : "tablecells")
                 .foregroundStyle(.secondary)
                 .frame(width: 24)
 
@@ -195,6 +192,17 @@ private struct TableRow: View {
                 MetadataBadge(formatRowCount(rowCount))
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(Text("Opens table data"))
+    }
+
+    private var accessibilityLabel: Text {
+        let kind = isView ? String(localized: "View") : String(localized: "Table")
+        if let rowCount = table.rowCount {
+            return Text("\(kind), \(table.name), \(rowCount) rows")
+        }
+        return Text("\(kind), \(table.name)")
     }
 
     private func formatRowCount(_ count: Int) -> String {

--- a/TableProMobile/TableProMobile/Views/TagManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/TagManagementView.swift
@@ -1,8 +1,3 @@
-//
-//  TagManagementView.swift
-//  TableProMobile
-//
-
 import SwiftUI
 import TableProModels
 

--- a/TableProMobile/TableProWidget/Helpers/DatabaseTypeStyle.swift
+++ b/TableProMobile/TableProWidget/Helpers/DatabaseTypeStyle.swift
@@ -1,8 +1,3 @@
-//
-//  DatabaseTypeStyle.swift
-//  TableProWidget
-//
-
 import SwiftUI
 
 enum DatabaseTypeStyle {

--- a/TableProMobile/TableProWidget/QuickConnectEntry.swift
+++ b/TableProMobile/TableProWidget/QuickConnectEntry.swift
@@ -1,8 +1,3 @@
-//
-//  QuickConnectEntry.swift
-//  TableProWidget
-//
-
 import WidgetKit
 
 struct QuickConnectEntry: TimelineEntry {

--- a/TableProMobile/TableProWidget/QuickConnectProvider.swift
+++ b/TableProMobile/TableProWidget/QuickConnectProvider.swift
@@ -1,8 +1,3 @@
-//
-//  QuickConnectProvider.swift
-//  TableProWidget
-//
-
 import WidgetKit
 
 struct QuickConnectProvider: TimelineProvider {

--- a/TableProMobile/TableProWidget/QuickConnectWidget.swift
+++ b/TableProMobile/TableProWidget/QuickConnectWidget.swift
@@ -1,8 +1,3 @@
-//
-//  QuickConnectWidget.swift
-//  TableProWidget
-//
-
 import SwiftUI
 import WidgetKit
 

--- a/TableProMobile/TableProWidget/Shared/SharedConnectionStore.swift
+++ b/TableProMobile/TableProWidget/Shared/SharedConnectionStore.swift
@@ -1,8 +1,3 @@
-//
-//  SharedConnectionStore.swift
-//  TableProWidget
-//
-
 import Foundation
 
 enum SharedConnectionStore {

--- a/TableProMobile/TableProWidget/Shared/WidgetConnectionItem.swift
+++ b/TableProMobile/TableProWidget/Shared/WidgetConnectionItem.swift
@@ -1,8 +1,3 @@
-//
-//  WidgetConnectionItem.swift
-//  TableProWidget
-//
-
 import Foundation
 
 struct WidgetConnectionItem: Codable, Identifiable, Hashable {

--- a/TableProMobile/TableProWidget/Views/MediumWidgetView.swift
+++ b/TableProMobile/TableProWidget/Views/MediumWidgetView.swift
@@ -1,8 +1,3 @@
-//
-//  MediumWidgetView.swift
-//  TableProWidget
-//
-
 import SwiftUI
 
 struct MediumWidgetView: View {

--- a/TableProMobile/TableProWidget/Views/QuickConnectEntryView.swift
+++ b/TableProMobile/TableProWidget/Views/QuickConnectEntryView.swift
@@ -1,8 +1,3 @@
-//
-//  QuickConnectEntryView.swift
-//  TableProWidget
-//
-
 import SwiftUI
 import WidgetKit
 

--- a/TableProMobile/TableProWidget/Views/SmallWidgetView.swift
+++ b/TableProMobile/TableProWidget/Views/SmallWidgetView.swift
@@ -1,8 +1,3 @@
-//
-//  SmallWidgetView.swift
-//  TableProWidget
-//
-
 import SwiftUI
 import WidgetKit
 


### PR DESCRIPTION
## Summary

P2 polish pass bundling three independent items into one PR. Each item is small enough on its own that splitting into three PRs adds review overhead without payoff.

### P2 #10 - Strip Xcode-generated file headers

Drop the 4-line `//\n//  X.swift\n//  TableProMobile\n//\n` boilerplate from every iOS source file. CLAUDE.md rule: no comments. Six files (drivers + SSH) had an extra one-liner description after the header; those descriptions are stripped too since the type names are self-explanatory and any non-obvious purpose belongs in a `///` doc comment on the type, not as a floating top-of-file note.

Touched 58 files in `TableProMobile/` and 9 in `TableProWidget/`.

### P2 #9 - Cleanup orphan UserDefaults on connection delete

`AppState.removeConnection` now also calls `clearPerConnectionPreferences(for:)` which removes:

- `lastTab.<uuid>` (selected tab on Connected screen)
- `lastDB.<uuid>` (active database)
- `lastSchema.<uuid>` (active schema)
- `lastQuery.<uuid>` (last typed query in the editor)

Previously, deleting a connection silently leaked these four `UserDefaults` keys forever. Repeated add and delete cycles built up unbounded keychain-adjacent state.

### P2 #8 - Accessibility labels on high-impact surfaces

Audit found 9 accessibility annotations across the entire app and zero hints. This pass adds the most-used surfaces:

- `TableRow` (table list): combines type, name, and row count into a single accessibility element with hint "Opens table data"
- `ConnectionRow` (connection list): combines type, display name, host or SQLite filename, and tag name into a single element with hint "Opens this connection"
- ConnectionList toolbar: Add Connection, Sync with iCloud, and Settings icon-only buttons gain explicit `accessibilityLabel`

Other toolbar items (Sort, Filter, Insert Row in DataBrowser; Edit Connection in ConnectedView) already had labels.

## Test plan

- [ ] Header strip: app builds, no broken `import` statements (the strip is mechanical, but verify the diff in a couple of driver files)
- [ ] Add a connection, delete it, then `defaults read` the app's bundle ID: the four `last*.<uuid>` keys for that connection are gone
- [ ] VoiceOver on: navigate the connection list, hear "MySQL, Local, 127.0.0.1 port 3306. Opens this connection." Same shape for tables.
- [ ] VoiceOver on toolbar: hear "Add Connection. Button.", "Sync with iCloud. Button.", "Settings. Button."