### PR TITLE
feat(ios): add iCloud sync toggle, default page size, and default safe mode to Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iOS Settings: iCloud Sync toggle (off keeps connections, groups, and tags on this device only and disables the sync toolbar button), Rows per Page picker (50/100/200/500, applied to new data browser sessions), Default Safe Mode picker (applied when adding a new connection)
 - iOS: alert when the active connection is deleted mid-session (for example via iCloud sync from another device), so a stale screen no longer fails silently on the next action
 - iOS: Face ID, Touch ID, or Optic ID lock with cold-launch protection and idle timeout (1, 5, 15, or 60 minutes), opt-in from Settings
 - iOS: Connection Info tab replaces the per-connection Settings tab, showing host, SSL, SSH tunnel, active database, and live connection status

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -75,6 +75,46 @@
         }
       }
     },
+    "%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
+    "%@, %@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@, %3$@"
+          }
+        }
+      }
+    },
+    "%@, %@, %@, tag %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@, %3$@, tag %4$@"
+          }
+        }
+      }
+    },
+    "%@, %@, %lld rows" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@, %3$lld rows"
+          }
+        }
+      }
+    },
     "%@.%@" : {
       "localizations" : {
         "en" : {
@@ -1219,6 +1259,9 @@
     "Default DB" : {
 
     },
+    "Default Safe Mode" : {
+
+    },
     "Default: %@" : {
       "localizations" : {
         "vi" : {
@@ -1234,6 +1277,9 @@
           }
         }
       }
+    },
+    "Defaults applied when adding a new connection and when opening a table for the first time." : {
+
     },
     "Delete" : {
       "localizations" : {
@@ -1923,6 +1969,9 @@
         }
       }
     },
+    "iCloud Sync" : {
+
+    },
     "Immediately" : {
 
     },
@@ -2174,6 +2223,9 @@
           }
         }
       }
+    },
+    "New Connections" : {
+
     },
     "New Database" : {
       "localizations" : {
@@ -2628,6 +2680,12 @@
           }
         }
       }
+    },
+    "Opens table data" : {
+
+    },
+    "Opens this connection" : {
+
     },
     "Operator" : {
       "localizations" : {
@@ -3582,6 +3640,9 @@
         }
       }
     },
+    "Sync" : {
+
+    },
     "Sync from iCloud" : {
       "localizations" : {
         "vi" : {
@@ -3597,6 +3658,9 @@
           }
         }
       }
+    },
+    "Sync with iCloud" : {
+
     },
     "Syncing from iCloud..." : {
       "localizations" : {
@@ -3630,6 +3694,9 @@
           }
         }
       }
+    },
+    "Table" : {
+
     },
     "Table Structure" : {
       "localizations" : {
@@ -4072,6 +4139,9 @@
         }
       }
     },
+    "View" : {
+
+    },
     "Views" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4104,6 +4174,9 @@
           }
         }
       }
+    },
+    "When off, connections, groups, and tags stay on this device only. Existing iCloud data is not deleted." : {
+
     },
     "Write Query Blocked" : {
       "localizations" : {

--- a/TableProMobile/TableProMobile/Platform/AppPreferences.swift
+++ b/TableProMobile/TableProMobile/Platform/AppPreferences.swift
@@ -1,0 +1,26 @@
+import Foundation
+import TableProModels
+
+enum AppPreferences {
+    static let cloudSyncEnabledKey = "com.TablePro.settings.cloudSyncEnabled"
+    static let defaultPageSizeKey = "com.TablePro.settings.defaultPageSize"
+    static let defaultSafeModeKey = "com.TablePro.settings.defaultSafeMode"
+
+    static let pageSizeOptions: [Int] = [50, 100, 200, 500]
+
+    static var isCloudSyncEnabled: Bool {
+        UserDefaults.standard.object(forKey: cloudSyncEnabledKey) as? Bool ?? true
+    }
+
+    static var defaultPageSize: Int {
+        guard let stored = UserDefaults.standard.object(forKey: defaultPageSizeKey) as? Int,
+              pageSizeOptions.contains(stored) else { return 100 }
+        return stored
+    }
+
+    static var defaultSafeMode: SafeModeLevel {
+        guard let raw = UserDefaults.standard.string(forKey: defaultSafeModeKey),
+              let level = SafeModeLevel(rawValue: raw) else { return .off }
+        return level
+    }
+}

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -64,13 +64,15 @@ struct TableProMobileApp: App {
             switch phase {
             case .active:
                 MemoryPressureMonitor.shared.start()
-                syncTask?.cancel()
-                syncTask = Task {
-                    await appState.syncCoordinator.sync(
-                        localConnections: appState.connections,
-                        localGroups: appState.groups,
-                        localTags: appState.tags
-                    )
+                if AppPreferences.isCloudSyncEnabled {
+                    syncTask?.cancel()
+                    syncTask = Task {
+                        await appState.syncCoordinator.sync(
+                            localConnections: appState.connections,
+                            localGroups: appState.groups,
+                            localTags: appState.tags
+                        )
+                    }
                 }
                 if heartbeatTask == nil {
                     let provider = IOSAnalyticsProvider.shared

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -61,7 +61,10 @@ final class ConnectionFormViewModel {
 
     init(editing: DatabaseConnection? = nil) {
         self.existingConnection = editing
-        guard let conn = editing else { return }
+        guard let conn = editing else {
+            safeModeLevel = AppPreferences.defaultSafeMode
+            return
+        }
         name = conn.name
         type = conn.type
         host = conn.host

--- a/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
@@ -28,7 +28,7 @@ final class DataBrowserViewModel {
 
     private(set) var columnDetails: [ColumnInfo] = []
     private(set) var foreignKeys: [ForeignKeyInfo] = []
-    private(set) var pagination = PaginationState(pageSize: 100, currentPage: 0)
+    private(set) var pagination: PaginationState
     var sortState = SortState()
     var filters: [TableFilter] = []
     var filterLogicMode: FilterLogicMode = .and
@@ -53,6 +53,7 @@ final class DataBrowserViewModel {
 
     init(windowCapacity: Int = 1_000) {
         self.window = RowWindow(capacity: windowCapacity)
+        self.pagination = PaginationState(pageSize: AppPreferences.defaultPageSize, currentPage: 0)
     }
 
     // MARK: - Computed

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -94,10 +94,12 @@ struct ConnectionListView: View {
                                 ProgressView()
                                     .controlSize(.small)
                             } else {
-                                Image(systemName: "arrow.triangle.2.circlepath.icloud")
+                                Image(systemName: AppPreferences.isCloudSyncEnabled
+                                    ? "arrow.triangle.2.circlepath.icloud"
+                                    : "icloud.slash")
                             }
                         }
-                        .disabled(isSyncing)
+                        .disabled(isSyncing || !AppPreferences.isCloudSyncEnabled)
                         .accessibilityLabel(Text("Sync with iCloud"))
 
                         Button {
@@ -221,6 +223,7 @@ struct ConnectionListView: View {
             }
             .environment(\.editMode, $editMode)
             .refreshable {
+                guard AppPreferences.isCloudSyncEnabled else { return }
                 await appState.syncCoordinator.sync(
                     localConnections: appState.connections,
                     localGroups: appState.groups,

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -13,6 +13,7 @@ struct ConnectionListView: View {
     @State private var showingTagManagement = false
     @AppStorage("lastFilterTagId") private var filterTagIdString: String?
     @AppStorage("groupByGroup") private var groupByGroup = false
+    @AppStorage(AppPreferences.cloudSyncEnabledKey) private var cloudSyncEnabled = true
     @State private var editMode: EditMode = .inactive
     @State private var connectionToDelete: DatabaseConnection?
     @State private var showingSettings = false
@@ -94,12 +95,12 @@ struct ConnectionListView: View {
                                 ProgressView()
                                     .controlSize(.small)
                             } else {
-                                Image(systemName: AppPreferences.isCloudSyncEnabled
+                                Image(systemName: cloudSyncEnabled
                                     ? "arrow.triangle.2.circlepath.icloud"
                                     : "icloud.slash")
                             }
                         }
-                        .disabled(isSyncing || !AppPreferences.isCloudSyncEnabled)
+                        .disabled(isSyncing || !cloudSyncEnabled)
                         .accessibilityLabel(Text("Sync with iCloud"))
 
                         Button {
@@ -223,7 +224,7 @@ struct ConnectionListView: View {
             }
             .environment(\.editMode, $editMode)
             .refreshable {
-                guard AppPreferences.isCloudSyncEnabled else { return }
+                guard cloudSyncEnabled else { return }
                 await appState.syncCoordinator.sync(
                     localConnections: appState.connections,
                     localGroups: appState.groups,

--- a/TableProMobile/TableProMobile/Views/SettingsView.swift
+++ b/TableProMobile/TableProMobile/Views/SettingsView.swift
@@ -1,15 +1,21 @@
 import SwiftUI
+import TableProModels
 
 struct SettingsView: View {
     @AppStorage("com.TablePro.settings.shareAnalytics") private var shareAnalytics = true
     @AppStorage(AppLockState.lockEnabledKey) private var lockEnabled = false
     @AppStorage(AppLockState.lockTimeoutKey) private var lockTimeoutSeconds = AppLockState.AutoLockTimeout.fiveMinutes.rawValue
+    @AppStorage(AppPreferences.cloudSyncEnabledKey) private var cloudSyncEnabled = true
+    @AppStorage(AppPreferences.defaultPageSizeKey) private var defaultPageSize = 100
+    @AppStorage(AppPreferences.defaultSafeModeKey) private var defaultSafeModeRaw = SafeModeLevel.off.rawValue
 
     private let auth = BiometricAuthService()
 
     var body: some View {
         Form {
             biometricSection
+            syncSection
+            defaultsSection
 
             Section("Privacy") {
                 Toggle(String(localized: "Share anonymous usage data"), isOn: $shareAnalytics)
@@ -50,6 +56,36 @@ struct SettingsView: View {
             } footer: {
                 Text("Locks TablePro when reopened after the selected idle time. Cold launches always require authentication.")
             }
+        }
+    }
+
+    private var syncSection: some View {
+        Section {
+            Toggle(String(localized: "iCloud Sync"), isOn: $cloudSyncEnabled)
+        } header: {
+            Text("Sync")
+        } footer: {
+            Text("When off, connections, groups, and tags stay on this device only. Existing iCloud data is not deleted.")
+        }
+    }
+
+    private var defaultsSection: some View {
+        Section {
+            Picker(String(localized: "Rows per Page"), selection: $defaultPageSize) {
+                ForEach(AppPreferences.pageSizeOptions, id: \.self) { size in
+                    Text("\(size) rows").tag(size)
+                }
+            }
+
+            Picker(String(localized: "Default Safe Mode"), selection: $defaultSafeModeRaw) {
+                ForEach(SafeModeLevel.allCases) { level in
+                    Text(level.displayName).tag(level.rawValue)
+                }
+            }
+        } header: {
+            Text("New Connections")
+        } footer: {
+            Text("Defaults applied when adding a new connection and when opening a table for the first time.")
         }
     }
 


### PR DESCRIPTION
## Summary

Settings was sparse: just analytics + Face ID. This PR adds the three most-requested config knobs and threads them through the consumers.

### iCloud Sync toggle

- New `@AppStorage("com.TablePro.settings.cloudSyncEnabled")` (default `true`)
- Sync entry points gated:
  - `TableProMobileApp.scenePhase .active` → skip the auto-sync `Task` when off
  - `ConnectionListView` toolbar Sync button → disables and swaps `arrow.triangle.2.circlepath.icloud` for `icloud.slash` when off
  - `ConnectionListView` pull-to-refresh → no-op when off
- Onboarding's "Sync from iCloud" button is intentionally not gated (defaults are still in effect when onboarding runs, and the button is an explicit user-initiated import)
- Existing iCloud data is not deleted; the toggle just stops further pushes/pulls

### Rows per Page (default page size)

- New `@AppStorage("com.TablePro.settings.defaultPageSize")` (default `100`)
- Picker with 50 / 100 / 200 / 500 options
- `DataBrowserViewModel.init` reads the setting on construction. The toolbar's "Rows per Page" submenu still lets users override per session

### Default Safe Mode

- New `@AppStorage("com.TablePro.settings.defaultSafeMode")` (default `.off`)
- Picker iterates `SafeModeLevel.allCases`
- `ConnectionFormViewModel.init(editing:)` applies the default when `editing == nil` (new connection); when editing existing, the connection's stored level wins

### Plumbing

- New `Platform/AppPreferences.swift` enum centralizes the keys, defaults, and `pageSizeOptions: [Int]`. Both the View (via `@AppStorage(AppPreferences.xxxKey)`) and the consumers (via `AppPreferences.isCloudSyncEnabled` / `defaultPageSize` / `defaultSafeMode`) read the same constants

## Test plan

- [ ] Settings: iCloud Sync off → ConnectionList sync button greys out and shows `icloud.slash`. Pull to refresh does nothing. Cold launch with sync off does not call `syncCoordinator.sync`. Toggle on → sync resumes immediately
- [ ] Settings: change Rows per Page to 200 → open a new table → bottom-bar shows "1-200 of N", pagination respects 200
- [ ] Settings: change Default Safe Mode to Read Only → tap "+" to add new connection → safe mode picker is pre-selected to Read Only. Edit an existing connection: its stored level is preserved