### PR TITLE
feat(ios): background sync, Cmd+F search focus, scene-restored search text, regex literal highlighter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iOS: iCloud sync runs every 30 minutes in the background via `BGAppRefreshTask` while the app is closed (gated by the iCloud Sync setting); iOS schedules the actual cadence based on usage and battery
+- iOS: Cmd+F focuses the search field in Tables and Data Browser (iPad keyboard canonical)
+- iOS: search text in Tables and Data Browser persists across process kill via `@SceneStorage` (per-window on iPad)
 - iOS Settings: iCloud Sync toggle (off keeps connections, groups, and tags on this device only and disables the sync toolbar button), Rows per Page picker (50/100/200/500, applied to new data browser sessions), Default Safe Mode picker (applied when adding a new connection)
 - iOS: alert when the active connection is deleted mid-session (for example via iCloud sync from another device), so a stale screen no longer fails silently on the next action
 - iOS: Face ID, Touch ID, or Optic ID lock with cold-launch protection and idle timeout (1, 5, 15, or 60 minutes), opt-in from Settings
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- iOS: SQL syntax highlighter uses Swift Regex literals for static patterns (numbers, comments, strings) and consolidates the six per-pattern enumeration loops into a single typed helper
 - iOS: VoiceOver now reads connection rows and table rows as a single combined element with type, name, host or row count, and includes a hint about what tapping does
 - iOS: toolbar icon-only buttons (Add Connection, Sync with iCloud, Settings) gain accessibility labels for VoiceOver
 - Internal: per-connection `UserDefaults` keys (`lastTab.<uuid>`, `lastDB.<uuid>`, `lastSchema.<uuid>`, `lastQuery.<uuid>`) clear when a connection is deleted, so they no longer accumulate over time

--- a/TableProMobile/TableProMobile/Info.plist
+++ b/TableProMobile/TableProMobile/Info.plist
@@ -20,5 +20,14 @@
 		<string>com.TablePro.viewConnection</string>
 		<string>com.TablePro.viewTable</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.TablePro.sync</string>
+	</array>
 </dict>
 </plist>

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -1776,6 +1776,9 @@
         }
       }
     },
+    "Focus search" : {
+
+    },
     "Foreign Keys" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -1,4 +1,6 @@
+import BackgroundTasks
 import CoreSpotlight
+import os
 import SwiftUI
 import TableProAnalytics
 import TableProDatabase
@@ -6,6 +8,9 @@ import TableProModels
 
 @main
 struct TableProMobileApp: App {
+    static let backgroundSyncIdentifier = "com.TablePro.sync"
+    private static let backgroundLogger = Logger(subsystem: "com.TablePro", category: "BackgroundSync")
+
     @State private var appState = AppState()
     @State private var lockState = AppLockState()
     @State private var syncTask: Task<Void, Never>?
@@ -88,9 +93,37 @@ struct TableProMobileApp: App {
                 heartbeatTask = nil
                 heartbeatService = nil
                 Task { await appState.connectionManager.disconnectAll() }
+                scheduleBackgroundSync()
             default:
                 break
             }
         }
+        .backgroundTask(.appRefresh(Self.backgroundSyncIdentifier)) {
+            await runBackgroundSync()
+        }
+    }
+
+    private func scheduleBackgroundSync() {
+        guard AppPreferences.isCloudSyncEnabled else { return }
+        let request = BGAppRefreshTaskRequest(identifier: Self.backgroundSyncIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 30 * 60)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            Self.backgroundLogger.warning("Failed to schedule background sync: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    @Sendable
+    private func runBackgroundSync() async {
+        scheduleBackgroundSync()
+        guard AppPreferences.isCloudSyncEnabled else { return }
+        Self.backgroundLogger.info("Background sync starting")
+        await appState.syncCoordinator.sync(
+            localConnections: appState.connections,
+            localGroups: appState.groups,
+            localTags: appState.tags
+        )
+        Self.backgroundLogger.info("Background sync completed")
     }
 }

--- a/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
@@ -5,7 +5,7 @@ enum SQLSyntaxHighlighter {
 
     private static let defaultFont = UIFont.monospacedSystemFont(ofSize: 15, weight: .regular)
 
-    private static let keywordPattern: NSRegularExpression = {
+    private static let keywordRegex: Regex<Substring> = {
         let keywords = [
             "SELECT", "FROM", "WHERE", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER",
             "TABLE", "INDEX", "VIEW", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER", "CROSS", "FULL",
@@ -17,12 +17,12 @@ enum SQLSyntaxHighlighter {
             "UNIQUE", "ADD", "COLUMN", "RENAME", "TO", "DATABASE", "SCHEMA", "USE",
             "GRANT", "REVOKE", "WITH", "RECURSIVE", "FETCH", "NEXT", "ROWS", "ONLY"
         ]
-        let pattern = "\\b(" + keywords.joined(separator: "|") + ")\\b"
+        let pattern = #"\b("# + keywords.joined(separator: "|") + #")\b"#
         // swiftlint:disable:next force_try
-        return try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        return try! Regex(pattern, as: Substring.self).ignoresCase()
     }()
 
-    private static let functionPattern: NSRegularExpression = {
+    private static let functionRegex: Regex<Substring> = {
         let functions = [
             "COUNT", "SUM", "AVG", "MIN", "MAX", "COALESCE", "IFNULL", "NULLIF",
             "UPPER", "LOWER", "TRIM", "LTRIM", "RTRIM", "LENGTH", "SUBSTRING", "SUBSTR",
@@ -31,35 +31,19 @@ enum SQLSyntaxHighlighter {
             "DATE", "TIME", "YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND",
             "GROUP_CONCAT", "STRING_AGG", "ARRAY_AGG", "JSON_EXTRACT", "JSON_VALUE"
         ]
-        let pattern = "\\b(" + functions.joined(separator: "|") + ")\\s*(?=\\()"
+        let pattern = #"\b("# + functions.joined(separator: "|") + #")\s*(?=\()"#
         // swiftlint:disable:next force_try
-        return try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        return try! Regex(pattern, as: Substring.self).ignoresCase()
     }()
 
-    private static let numberPattern: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "\\b\\d+\\.?\\d*\\b", options: [])
-    }()
-
-    private static let singleLineCommentPattern: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "--[^\\n]*", options: [])
-    }()
-
-    private static let blockCommentPattern: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "/\\*[\\s\\S]*?\\*/", options: [])
-    }()
-
-    private static let stringPattern: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "'(?:[^']|'')*'", options: [])
-    }()
+    private static let numberRegex = #/\b\d+\.?\d*\b/#
+    private static let lineCommentRegex = #/--[^\n]*/#
+    private static let blockCommentRegex = #/\/\*[\s\S]*?\*\//#
+    private static let stringRegex = #/'(?:[^']|'')*'/#
 
     static func highlight(_ textStorage: NSTextStorage, in editedRange: NSRange) {
         let fullLength = textStorage.length
-        guard fullLength > 0 else { return }
-        guard editedRange.location < fullLength else { return }
+        guard fullLength > 0, editedRange.location < fullLength else { return }
 
         let cappedLength = min(fullLength, maxHighlightLength)
         let nsString = textStorage.string as NSString
@@ -79,65 +63,46 @@ enum SQLSyntaxHighlighter {
             highlightRange = NSRange(location: lineStart, length: min(lineEnd - lineStart, cappedLength - lineStart))
         }
 
-        guard highlightRange.length > 0 else { return }
-
-        let text = nsString.substring(with: highlightRange) as NSString
+        guard highlightRange.length > 0,
+              let scanRange = Range(highlightRange, in: textStorage.string) else { return }
 
         textStorage.beginEditing()
 
-        let defaultAttrs: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.label,
-            .font: defaultFont
-        ]
-        textStorage.setAttributes(defaultAttrs, range: highlightRange)
+        textStorage.setAttributes(
+            [.foregroundColor: UIColor.label, .font: defaultFont],
+            range: highlightRange
+        )
 
-        var protectedRanges: [NSRange] = []
+        let fullText = textStorage.string
+        let scanText = fullText[scanRange]
+        var protected: [Range<String.Index>] = []
 
-        blockCommentPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range else { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemGray, range: absolute)
-            protectedRanges.append(matchRange)
-        }
-
-        singleLineCommentPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range else { return }
-            if protectedRanges.contains(where: { NSIntersectionRange($0, matchRange).length > 0 }) { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemGray, range: absolute)
-            protectedRanges.append(matchRange)
-        }
-
-        stringPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range else { return }
-            if protectedRanges.contains(where: { NSIntersectionRange($0, matchRange).length > 0 }) { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemRed, range: absolute)
-            protectedRanges.append(matchRange)
-        }
-
-        func isProtected(_ range: NSRange) -> Bool {
-            protectedRanges.contains { NSIntersectionRange($0, range).length > 0 }
-        }
-
-        keywordPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range, !isProtected(matchRange) else { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: absolute)
-        }
-
-        functionPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range, !isProtected(matchRange) else { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemPurple, range: absolute)
-        }
-
-        numberPattern.enumerateMatches(in: text as String, range: NSRange(location: 0, length: text.length)) { match, _, _ in
-            guard let matchRange = match?.range, !isProtected(matchRange) else { return }
-            let absolute = NSRange(location: highlightRange.location + matchRange.location, length: matchRange.length)
-            textStorage.addAttribute(.foregroundColor, value: UIColor.systemOrange, range: absolute)
-        }
+        apply(blockCommentRegex, color: .systemGray, scanText: scanText, in: fullText, on: textStorage, protected: &protected)
+        apply(lineCommentRegex, color: .systemGray, scanText: scanText, in: fullText, on: textStorage, protected: &protected)
+        apply(stringRegex, color: .systemRed, scanText: scanText, in: fullText, on: textStorage, protected: &protected)
+        apply(keywordRegex, color: .systemBlue, scanText: scanText, in: fullText, on: textStorage, protected: &protected, recordsProtection: false)
+        apply(functionRegex, color: .systemPurple, scanText: scanText, in: fullText, on: textStorage, protected: &protected, recordsProtection: false)
+        apply(numberRegex, color: .systemOrange, scanText: scanText, in: fullText, on: textStorage, protected: &protected, recordsProtection: false)
 
         textStorage.endEditing()
+    }
+
+    private static func apply<Output>(
+        _ regex: Regex<Output>,
+        color: UIColor,
+        scanText: Substring,
+        in fullText: String,
+        on storage: NSTextStorage,
+        protected: inout [Range<String.Index>],
+        recordsProtection: Bool = true
+    ) {
+        for match in scanText.matches(of: regex) {
+            if protected.contains(where: { $0.overlaps(match.range) }) { continue }
+            let nsRange = NSRange(match.range, in: fullText)
+            storage.addAttribute(.foregroundColor, value: color, range: nsRange)
+            if recordsProtection {
+                protected.append(match.range)
+            }
+        }
     }
 }

--- a/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLSyntaxHighlighter.swift
@@ -17,7 +17,7 @@ enum SQLSyntaxHighlighter {
             "UNIQUE", "ADD", "COLUMN", "RENAME", "TO", "DATABASE", "SCHEMA", "USE",
             "GRANT", "REVOKE", "WITH", "RECURSIVE", "FETCH", "NEXT", "ROWS", "ONLY"
         ]
-        let pattern = #"\b("# + keywords.joined(separator: "|") + #")\b"#
+        let pattern = #"\b(?:"# + keywords.joined(separator: "|") + #")\b"#
         // swiftlint:disable:next force_try
         return try! Regex(pattern, as: Substring.self).ignoresCase()
     }()
@@ -31,7 +31,7 @@ enum SQLSyntaxHighlighter {
             "DATE", "TIME", "YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND",
             "GROUP_CONCAT", "STRING_AGG", "ARRAY_AGG", "JSON_EXTRACT", "JSON_VALUE"
         ]
-        let pattern = #"\b("# + functions.joined(separator: "|") + #")\s*(?=\()"#
+        let pattern = #"\b(?:"# + functions.joined(separator: "|") + #")\s*(?=\()"#
         // swiftlint:disable:next force_try
         return try! Regex(pattern, as: Substring.self).ignoresCase()
     }()

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -11,7 +11,8 @@ struct DataBrowserView: View {
     private var session: ConnectionSession? { coordinator.session }
 
     @State private var viewModel = DataBrowserViewModel()
-    @State private var searchText = ""
+    @SceneStorage("dataBrowser.searchText") private var searchText = ""
+    @FocusState private var searchFocused: Bool
     @State private var showInsertSheet = false
     @State private var showFilterSheet = false
     @State private var showShareSheet = false
@@ -172,6 +173,7 @@ struct DataBrowserView: View {
                 .navigationTitle(table.name)
                 .navigationBarTitleDisplayMode(.inline)
                 .searchable(text: $searchText, prompt: "Search all columns")
+                .searchFocused($searchFocused)
                 .textInputAutocapitalization(.never)
                 .onSubmit(of: .search) {
                     Task { await viewModel.applySearch(searchText) }
@@ -180,6 +182,12 @@ struct DataBrowserView: View {
                     if newValue.isEmpty, !oldValue.isEmpty, viewModel.hasActiveSearch {
                         Task { await viewModel.clearSearch() }
                     }
+                }
+                .background {
+                    Button("") { searchFocused = true }
+                        .keyboardShortcut("f", modifiers: .command)
+                        .accessibilityLabel(Text("Focus search"))
+                        .hidden()
                 }
         }
     }

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -9,7 +9,8 @@ struct TableListView: View {
     private var tables: [TableInfo] { coordinator.tables }
     private var session: ConnectionSession? { coordinator.session }
 
-    @State private var searchText = ""
+    @SceneStorage("tableList.searchText") private var searchText = ""
+    @FocusState private var searchFocused: Bool
     @State private var tableToTruncate: TableInfo?
     @State private var tableToDrop: TableInfo?
     @State private var errorMessage = ""
@@ -97,12 +98,19 @@ struct TableListView: View {
         }
         .listStyle(.insetGrouped)
         .searchable(text: $searchText, prompt: "Search tables")
+        .searchFocused($searchFocused)
         .textInputAutocapitalization(.never)
         .refreshable {
             await coordinator.refreshTables()
         }
         .onAppear {
             coordinator.navigateToPendingTable()
+        }
+        .background {
+            Button("") { searchFocused = true }
+                .keyboardShortcut("f", modifiers: .command)
+                .accessibilityLabel(Text("Focus search"))
+                .hidden()
         }
         .overlay {
             if tables.isEmpty {


### PR DESCRIPTION
## Summary

Bundle of four small iOS polish items from the audit backlog. Each one stands alone; bundling because total LOC is small and review surfaces are independent.

### D. Background sync via `BGAppRefreshTask`

- `TableProMobileApp` declares `static let backgroundSyncIdentifier = "com.TablePro.sync"` and uses `.backgroundTask(.appRefresh(_:))` (iOS 17 SwiftUI native API) to register the sync handler
- On `.background` scenePhase, schedule the next `BGAppRefreshTaskRequest` with `earliestBeginDate = +30min`. iOS picks the actual fire time based on usage and battery
- The handler reschedules first (so the loop continues) then runs `syncCoordinator.sync(...)` if `AppPreferences.isCloudSyncEnabled`
- Logged via `os.Logger("com.TablePro", "BackgroundSync")`
- `Info.plist` gains `UIBackgroundModes` (`fetch`, `processing`) and `BGTaskSchedulerPermittedIdentifiers` array

### E. Cmd+F focuses search

- `DataBrowserView` and `TableListView` add `@FocusState searchFocused: Bool`, apply `.searchFocused($searchFocused)` on the searchable, and place a hidden Cmd+F button in `.background` that sets `searchFocused = true`
- iPad with external keyboard: Cmd+F snaps focus to the search field (canonical macOS-style)

### C. State restoration via `@SceneStorage`

- `searchText` in `DataBrowserView` and `TableListView` switches from `@State` to `@SceneStorage("dataBrowser.searchText")` and `@SceneStorage("tableList.searchText")`
- Survives process kill; per-scene on iPad multi-window
- Tradeoff: cross-table search text persists within a scene (key is not table-scoped). User clearing or retyping is the natural reset; full table-scoping needs explicit `init` plumbing not worth the complexity here

### F. SQL syntax highlighter Regex literals

- 4 static patterns (number, line comment, block comment, string) become `Regex<Substring>` literals (`#/.../#`) — compile-time validated, no `try!`
- 2 dynamic patterns (keyword and function lists built from arrays) keep the runtime-built pattern but typed as `Regex<Substring>` via `Regex(_:as:)` instead of `NSRegularExpression`
- 6 repeated `enumerateMatches` blocks consolidate into a single `apply(_ regex:color:scanText:in:on:protected:recordsProtection:)` generic helper. The helper takes any `Regex<Output>` so static and dynamic patterns share one code path
- Bridges Swift `Range<String.Index>` to `NSRange` once via `NSRange(_:in:)` for `NSTextStorage.addAttribute`

## Test plan

- [ ] Open the SQL editor, type a query with comments, strings, keywords, functions, numbers - colors match before/after this PR
- [ ] Type a long block comment with embedded keywords - keyword inside comment stays gray (protected range logic works)
- [ ] iPad with keyboard: in Tables list, press Cmd+F - search field gains focus and the keyboard appears. Same in Data Browser
- [ ] Type "users" in Data Browser search, force-quit the app from Recents, relaunch - search field still shows "users"
- [ ] Settings -> iCloud Sync off -> background the app -> wait 30+ minutes (or trigger via Xcode `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.TablePro.sync"]`) - sync handler runs but exits early because of the gate
- [ ] Settings -> iCloud Sync on -> same trigger - sync runs, log shows "Background sync starting" then "Background sync completed"