### PR TITLE
refactor(ios): extract RowItemLabel and consolidate per-database-type constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Internal: extract `RowItemLabel` shared row component for the connection list and table list, dropping the inline HStack scaffolding from both
+- Internal: move per-database-type constants (`defaultPort`, `mobileDisplayName`, `mobileSupportedTypes`) onto a `DatabaseType` extension; the connection form picker and info screen read from the same source instead of duplicating the type-to-string switch
 - iOS: SQL syntax highlighter uses Swift Regex literals for static patterns (numbers, comments, strings) and consolidates the six per-pattern enumeration loops into a single typed helper
 - iOS: VoiceOver now reads connection rows and table rows as a single combined element with type, name, host or row count, and includes a hint about what tapping does
 - iOS: toolbar icon-only buttons (Add Connection, Sync with iCloud, Settings) gain accessibility labels for VoiceOver

--- a/TableProMobile/TableProMobile/Helpers/DatabaseType+Mobile.swift
+++ b/TableProMobile/TableProMobile/Helpers/DatabaseType+Mobile.swift
@@ -1,0 +1,35 @@
+import Foundation
+import TableProModels
+
+extension DatabaseType {
+    var defaultPort: String {
+        switch self {
+        case .mysql, .mariadb: return "3306"
+        case .postgresql: return "5432"
+        case .redshift: return "5439"
+        case .redis: return "6379"
+        case .sqlite: return ""
+        default: return "3306"
+        }
+    }
+
+    var mobileDisplayName: String {
+        switch self {
+        case .mysql: "MySQL"
+        case .mariadb: "MariaDB"
+        case .postgresql: "PostgreSQL"
+        case .redshift: "Redshift"
+        case .sqlite: "SQLite"
+        case .redis: "Redis"
+        default: rawValue.uppercased()
+        }
+    }
+
+    static let mobileSupportedTypes: [DatabaseType] = [
+        .mysql,
+        .mariadb,
+        .postgresql,
+        .sqlite,
+        .redis
+    ]
+}

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -129,14 +129,7 @@ final class ConnectionFormViewModel {
     }
 
     private func updateDefaultPort() {
-        switch type {
-        case .mysql, .mariadb: port = "3306"
-        case .postgresql: port = "5432"
-        case .redshift: port = "5439"
-        case .redis: port = "6379"
-        case .sqlite: port = ""
-        default: port = "3306"
-        }
+        port = type.defaultPort
     }
 
     // MARK: - File Picker

--- a/TableProMobile/TableProMobile/Views/Components/RowItemLabel.swift
+++ b/TableProMobile/TableProMobile/Views/Components/RowItemLabel.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct RowItemLabel<Leading: View, Trailing: View>: View {
+    let title: String
+    let subtitle: String?
+    @ViewBuilder let leading: () -> Leading
+    @ViewBuilder let trailing: () -> Trailing
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        @ViewBuilder leading: @escaping () -> Leading,
+        @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.leading = leading
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            leading()
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            trailing()
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -16,14 +16,6 @@ struct ConnectionFormView: View {
 
     var onSave: (DatabaseConnection) -> Void
 
-    private let databaseTypes: [(DatabaseType, String)] = [
-        (.mysql, "MySQL"),
-        (.mariadb, "MariaDB"),
-        (.postgresql, "PostgreSQL"),
-        (.sqlite, "SQLite"),
-        (.redis, "Redis"),
-    ]
-
     enum ActiveFilePicker: Identifiable {
         case sqliteDatabase
         case sshKey
@@ -126,9 +118,9 @@ struct ConnectionFormView: View {
                 .textInputAutocapitalization(.never)
 
             Picker("Database Type", selection: $viewModel.type) {
-                ForEach(databaseTypes, id: \.0.rawValue) { dbType, label in
+                ForEach(DatabaseType.mobileSupportedTypes, id: \.rawValue) { dbType in
                     Label {
-                        Text(label)
+                        Text(dbType.mobileDisplayName)
                     } icon: {
                         Image(dbType.iconName)
                             .renderingMode(.template)

--- a/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionInfoView.swift
@@ -22,7 +22,7 @@ struct ConnectionInfoView: View {
                         Text("Name")
                     }
                 }
-                LabeledContent("Type", value: typeDisplayName)
+                LabeledContent("Type", value: connection.type.mobileDisplayName)
                 if connection.safeModeLevel != .off {
                     LabeledContent("Safe Mode") {
                         Label {
@@ -54,18 +54,6 @@ struct ConnectionInfoView: View {
                 appState.updateConnection(updated)
                 coordinator.showingEditSheet = false
             }
-        }
-    }
-
-    private var typeDisplayName: String {
-        switch connection.type {
-        case .mysql: "MySQL"
-        case .mariadb: "MariaDB"
-        case .postgresql: "PostgreSQL"
-        case .redshift: "Redshift"
-        case .sqlite: "SQLite"
-        case .redis: "Redis"
-        default: connection.type.rawValue.uppercased()
         }
     }
 

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -423,30 +423,24 @@ private struct ConnectionRow: View {
     let connection: DatabaseConnection
     let tag: ConnectionTag?
 
+    private var title: String {
+        connection.name.isEmpty ? connection.host : connection.name
+    }
+
+    private var subtitle: String {
+        if connection.type == .sqlite {
+            return connection.database.components(separatedBy: "/").last ?? "database"
+        }
+        return "\(connection.host):\(connection.port)"
+    }
+
     var body: some View {
-        HStack(spacing: 12) {
+        RowItemLabel(title: title, subtitle: subtitle) {
             DatabaseIconView(type: connection.type, size: 18)
                 .frame(width: 32, height: 32)
                 .background(DatabaseIconView.color(for: connection.type).opacity(0.12))
                 .clipShape(RoundedRectangle(cornerRadius: 7))
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(connection.name.isEmpty ? connection.host : connection.name)
-                    .font(.body)
-
-                if connection.type != .sqlite {
-                    Text(verbatim: "\(connection.host):\(connection.port)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(connection.database.components(separatedBy: "/").last ?? "database")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Spacer()
-
+        } trailing: {
             if let tag {
                 let tagColor = ConnectionColorPicker.swiftUIColor(for: tag.color)
                 Text(tag.name)

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -186,16 +186,11 @@ private struct TableRow: View {
     private var isView: Bool { table.type == .view || table.type == .materializedView }
 
     var body: some View {
-        HStack {
+        RowItemLabel(title: table.name) {
             Image(systemName: isView ? "eye" : "tablecells")
                 .foregroundStyle(.secondary)
                 .frame(width: 24)
-
-            Text(table.name)
-                .font(.body)
-
-            Spacer()
-
+        } trailing: {
             if let rowCount = table.rowCount {
                 MetadataBadge(formatRowCount(rowCount))
             }


### PR DESCRIPTION
## Summary

Two cleanup items from the audit backlog. Each is small enough that splitting them would be more review overhead than the changes themselves.

### G. RowItemLabel reusable

`TableRow` (TableListView) and `ConnectionRow` (ConnectionListView) both rendered the same shape: leading icon, title (+ optional subtitle), trailing accessory. The two HStack/VStack scaffoldings differed only in icon styling and the trailing slot's contents.

- New `Views/Components/RowItemLabel.swift` exposes a generic `RowItemLabel<Leading, Trailing>` with `title`, optional `subtitle`, `@ViewBuilder leading`, and `@ViewBuilder trailing` (defaults to `EmptyView`)
- `TableRow` and `ConnectionRow` now delegate the layout to `RowItemLabel` and supply only the icon and trailing accessory styling that genuinely differs
- Accessibility annotations (`accessibilityElement(children: .combine)`, `accessibilityLabel`, `accessibilityHint`) stay on each row's wrapping View since the labels are domain-specific

### H. DatabaseType per-type constants

The original audit suggested a "strategy pattern per DB type" but the actual divergence between database types in the form is just one branch (SQLite vs server). Strategy pattern would inflate the code without removing duplication. The real cleanup target is the per-type constants scattered across three files:

- `ConnectionFormViewModel.updateDefaultPort()` switch on type returning `"3306"` / `"5432"` / etc.
- `ConnectionFormView.databaseTypes: [(DatabaseType, String)]` static array of (type, display name)
- `ConnectionInfoView.typeDisplayName` switch returning the same display name strings

All three move to a single `DatabaseType` extension in `Helpers/DatabaseType+Mobile.swift`:

- `var defaultPort: String` — used by `ConnectionFormViewModel` 
- `var mobileDisplayName: String` — used by both `ConnectionFormView` (Picker label) and `ConnectionInfoView` (Type row)
- `static let mobileSupportedTypes: [DatabaseType]` — the 5 types the iOS app supports today; used by the Picker

`updateDefaultPort()` collapses to one line. `databaseTypes` static array is gone. `typeDisplayName` computed property is gone.

## Test plan

- [ ] Connection list and table list render unchanged on iPhone and iPad; VoiceOver still reads the combined accessibility label
- [ ] Connection form Picker shows the same 5 types in the same order with same icons
- [ ] Switching database type updates the port to the type's default (3306 for MySQL/MariaDB, 5432 Postgres, 5439 Redshift, 6379 Redis, empty for SQLite)
- [ ] Connection Info tab "Type" row renders "MySQL" / "PostgreSQL" / etc.