### PR TITLE
fix(ios): clean up Swift 6 build warnings and actor isolation in driver streaming

### DIFF
--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -157,7 +157,7 @@ final class ConnectionCoordinator {
     // MARK: - Database / Schema Switching
 
     func switchDatabase(to name: String) async {
-        guard let session, name != activeDatabase, !isSwitching else { return }
+        guard session != nil, name != activeDatabase, !isSwitching else { return }
         isSwitching = true
         defer { isSwitching = false }
 

--- a/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
@@ -91,7 +91,7 @@ final class MySQLDriver: DatabaseDriver, @unchecked Sendable {
                         continuation.yield(.columns(columns))
                         var emitted = 0
                         while !Task.isCancelled, emitted < options.maxRows {
-                            guard let cells = try await actor.fetchNextRow(options: options, columns: columns) else {
+                            guard let cells = await actor.fetchNextRow(options: options, columns: columns) else {
                                 break
                             }
                             continuation.yield(.row(Row(cells: cells)))

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -91,7 +91,7 @@ final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
                         continuation.yield(.columns(columns))
                         var emitted = 0
                         while !Task.isCancelled, emitted < options.maxRows {
-                            guard let cells = try await actor.fetchNextRow(options: options, columns: columns) else {
+                            guard let cells = await actor.fetchNextRow(options: options, columns: columns) else {
                                 break
                             }
                             continuation.yield(.row(Row(cells: cells)))

--- a/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
@@ -84,7 +84,7 @@ final class SQLiteDriver: DatabaseDriver, @unchecked Sendable {
                         continuation.yield(.columns(columns))
                         var emitted = 0
                         while !Task.isCancelled, emitted < options.maxRows {
-                            guard let cells = try await actor.fetchNextRow(options: options, columns: columns) else {
+                            guard let cells = await actor.fetchNextRow(options: options, columns: columns) else {
                                 break
                             }
                             continuation.yield(.row(Row(cells: cells)))

--- a/TableProMobile/TableProMobile/Helpers/StreamingExporter.swift
+++ b/TableProMobile/TableProMobile/Helpers/StreamingExporter.swift
@@ -120,7 +120,7 @@ actor StreamingExporter {
 }
 
 extension ExportFormat {
-    var fileExtension: String {
+    nonisolated var fileExtension: String {
         switch self {
         case .csv: return "csv"
         case .json: return "json"


### PR DESCRIPTION
## Summary

Five small build issues that surfaced (warnings + one Swift 6 strict-concurrency error). All low risk, mechanical fixes.

### ConnectionCoordinator: unused `session` binding

`switchDatabase(to:)` did `guard let session, ...` but never read `session` directly — the function uses `appState.connectionManager.session(for:)` to fetch a fresh handle later. The binding was a nil-check disguised as a let. Replaced with `guard session != nil`.

### Three drivers: `try` on non-throwing call

`MySQLDriver`, `PostgreSQLDriver`, `SQLiteDriver` all call `actor.fetchNextRow(options:columns:)` from `executeStreaming`. The actor method signature returns `[Cell]?` without `throws`, so `try await` is a no-op. Swift 6 warns "No calls to throwing functions occur within 'try' expression". Drop the `try`.

### StreamingExporter: actor-isolated `fileExtension`

`ExportFormat.fileExtension` extension is defined in `StreamingExporter.swift` at file scope. Under Swift 6 the file scope inherits the module's default isolation (MainActor in this build), so the extension property became MainActor-isolated. `actor StreamingExporter` then can't read it without `await`. Mark the property `nonisolated` since it's a pure pattern-match with no shared state.

## Test plan

- [ ] Build: zero warnings/errors from the listed files
- [ ] Run a streaming export (CSV / JSON / SQL) end-to-end - file generated with correct extension
- [ ] Switch databases on a MySQL / PostgreSQL connection - works as before
- [ ] Run a SELECT that streams >100 rows on each driver - rows arrive in order