### PR TITLE
fix(storage): forward since/until/allowedConnectionIds in QueryHistoryManager.fetchHistory

### DIFF
--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -83,14 +83,20 @@ final class QueryHistoryManager {
         offset: Int = 0,
         connectionId: UUID? = nil,
         searchText: String? = nil,
-        dateFilter: DateFilter = .all
+        dateFilter: DateFilter = .all,
+        since: Date? = nil,
+        until: Date? = nil,
+        allowedConnectionIds: Set<UUID>? = nil
     ) async -> [QueryHistoryEntry] {
         await storage.fetchHistory(
             limit: limit,
             offset: offset,
             connectionId: connectionId,
             searchText: searchText,
-            dateFilter: dateFilter
+            dateFilter: dateFilter,
+            since: since,
+            until: until,
+            allowedConnectionIds: allowedConnectionIds
         )
     }
 


### PR DESCRIPTION
## Summary

Hotfix for the build error introduced by PR #1176.

`SearchQueryHistoryTool.searchHistory` calls `QueryHistoryManager.shared.fetchHistory(...)` with `since`, `until`, and `allowedConnectionIds` arguments. PR #1176 migrated that call site from `QueryHistoryStorage.shared` to `QueryHistoryManager.shared`, but `QueryHistoryManager.fetchHistory` exposed only the first five parameters (`limit`, `offset`, `connectionId`, `searchText`, `dateFilter`). Storage's signature includes three more (`since`, `until`, `allowedConnectionIds`).

Compiler error:
```
SearchQueryHistoryTool.swift:79:68 Extra arguments at positions #6, #7, #8 in call
```

This PR widens the Manager's `fetchHistory` to forward all eight parameters to Storage so the call site compiles unchanged. The new parameters all default to `nil`, so other callers (`HistoryDataProvider`, `MCPConnectionBridge`, `HistoryPanelView`) keep their current behavior.

## Test plan

- [ ] Build succeeds.
- [ ] MCP `search_query_history` tool with date-range and allowedConnectionIds filtering returns the same results it did before #1176.
- [ ] swiftlint --strict clean.