### PR TITLE
fix(quick-switcher): use queryHistoryManager after queryHistoryStorage was removed from AppServices

### DIFF
--- a/TablePro/ViewModels/QuickSwitcherViewModel.swift
+++ b/TablePro/ViewModels/QuickSwitcherViewModel.swift
@@ -110,7 +110,7 @@ internal final class QuickSwitcherViewModel {
         }
 
         // Recent query history (last 50)
-        let historyEntries = await services.queryHistoryStorage.fetchHistory(
+        let historyEntries = await services.queryHistoryManager.fetchHistory(
             limit: 50,
             connectionId: connectionId
         )


### PR DESCRIPTION
## Summary

Second hotfix for PR #1176. Removing `queryHistoryStorage` from `AppServices` and migrating its callers caught the MCP tool sites and `HistoryDataProvider`, but missed `QuickSwitcherViewModel.loadItems` which still read `services.queryHistoryStorage.fetchHistory(...)`.

Compiler error:
```
QuickSwitcherViewModel.swift:113:45 Value of type 'AppServices' has no member 'queryHistoryStorage'
```

One-line migration: `services.queryHistoryStorage.fetchHistory(...)` -> `services.queryHistoryManager.fetchHistory(...)`. Manager's signature now accepts the same parameters Storage did (extended in PR #1178), so the call site is unchanged otherwise.

## Test plan

- [ ] Build succeeds.
- [ ] Quick switcher (Cmd+K or whatever the binding is) lists recent query history alongside tables/views/databases.
- [ ] swiftlint --strict clean.