### PR TITLE
polish(ios): empty state actions and VoiceOver custom actions for swipe-only deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iOS: VoiceOver "Delete row" / "Delete group" / "Delete tag" custom actions on rows whose only deletion path was a swipe gesture
+- iOS: empty Groups and Tags screens show a Create button so the action is reachable without opening the toolbar
+- iOS: "No Results" empty state in Query Editor explains the query returned no rows
 - iOS: iCloud sync runs every 30 minutes in the background via `BGAppRefreshTask` while the app is closed (gated by the iCloud Sync setting); iOS schedules the actual cadence based on usage and battery
 - iOS: Cmd+F focuses the search field in Tables and Data Browser (iPad keyboard canonical)
 - iOS: search text in Tables and Data Browser persists across process kill via `@SceneStorage` (per-window on iPad)

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -267,6 +267,11 @@ struct DataBrowserView: View {
                 .tint(.red)
             }
         }
+        .accessibilityAction(named: Text("Delete row")) {
+            guard !isView, viewModel.hasPrimaryKeys, !connection.safeModeLevel.blocksWrites else { return }
+            deleteTarget = viewModel.primaryKeyValues(for: row)
+            showDeleteConfirmation = true
+        }
     }
 
     @ViewBuilder

--- a/TableProMobile/TableProMobile/Views/GroupManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/GroupManagementView.swift
@@ -46,6 +46,9 @@ struct GroupManagementView: View {
                         }
                         .tint(.red)
                     }
+                    .accessibilityAction(named: Text("Delete group")) {
+                        groupToDelete = group
+                    }
                 }
                 .onMove { source, destination in
                     var sorted = appState.groups.sorted(by: { $0.sortOrder < $1.sortOrder })
@@ -62,6 +65,9 @@ struct GroupManagementView: View {
                         Label("No Groups", systemImage: "folder")
                     } description: {
                         Text("Create a group to organize your connections.")
+                    } actions: {
+                        Button("Create Group") { showingAddGroup = true }
+                            .buttonStyle(.borderedProminent)
                     }
                 }
             }

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -207,8 +207,12 @@ struct QueryEditorView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if viewModel.legacyRows.isEmpty {
-                    ContentUnavailableView("No Results", systemImage: "tray")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "tray",
+                        description: Text("The query returned no rows.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     resultList
                 }

--- a/TableProMobile/TableProMobile/Views/TagManagementView.swift
+++ b/TableProMobile/TableProMobile/Views/TagManagementView.swift
@@ -47,6 +47,10 @@ struct TagManagementView: View {
                             }
                         }
                     }
+                    .accessibilityAction(named: Text("Delete tag")) {
+                        guard !tag.isPreset else { return }
+                        appState.deleteTag(tag.id)
+                    }
                 }
             }
             .overlay {
@@ -55,6 +59,9 @@ struct TagManagementView: View {
                         Label("No Tags", systemImage: "tag")
                     } description: {
                         Text("Create a tag to organize your connections.")
+                    } actions: {
+                        Button("Create Tag") { showingAddTag = true }
+                            .buttonStyle(.borderedProminent)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Final UX consistency pass before the audit closes out. Two small categories of fixes.

### Empty state polish

- `GroupManagementView` empty state gains a "Create Group" button so the user does not need to find the toolbar `+` button
- `TagManagementView` same: "Create Tag" button on the empty state
- `QueryEditorView` "No Results" gets a description: "The query returned no rows." Matches the description-included shape used by every other empty state (Tables, Indexes, FKs, History)

### VoiceOver custom actions

Audit revealed three rows whose only deletion path was a trailing swipe gesture, which VoiceOver users cannot trigger. Added `.accessibilityAction(named:)` so those deletions show up in the standard "Custom Actions" rotor:

- `DataBrowserView` row → "Delete row"
- `GroupManagementView` row → "Delete group"
- `TagManagementView` row → "Delete tag" (only when not a preset tag)

`ConnectionListView` rows already expose Edit / Duplicate / Delete via context menu, which VoiceOver picks up automatically; no extra accessibility action needed there. `QueryHistoryView` uses `.onDelete` which provides the standard accessibility delete action for free.

## Test plan

- [ ] Open Groups with no groups created: empty state shows "Create Group" button, tapping opens the form sheet
- [ ] Same for Tags
- [ ] Run a SELECT that returns no rows: Query Editor shows "No Results" + description
- [ ] VoiceOver on, navigate to a Data Browser row, swipe up on the rotor to "Custom Actions" → "Delete row" appears and triggers the delete confirmation
- [ ] Same flow for a Group row and a non-preset Tag row