### PR TITLE
feat(ios): Live Activity for running queries and iPad multi-window support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- iOS: Live Activity for running queries shows query preview, elapsed time, and row count on the lock screen and Dynamic Island
+- iOS: multi-window support on iPad - drag a tab off to open a second window, each window remembers its own selected connection across launches
 - iOS: VoiceOver "Delete row" / "Delete group" / "Delete tag" custom actions on rows whose only deletion path was a swipe gesture
 - iOS: empty Groups and Tags screens show a Create button so the action is reachable without opening the toolbar
 - iOS: "No Results" empty state in Query Editor explains the query returned no rows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS: iCloud sync runs every 30 minutes in the background via `BGAppRefreshTask` while the app is closed (gated by the iCloud Sync setting); iOS schedules the actual cadence based on usage and battery
 - iOS: Cmd+F focuses the search field in Tables and Data Browser (iPad keyboard canonical)
 - iOS: search text in Tables and Data Browser persists across process kill via `@SceneStorage` (per-window on iPad)
-- iOS Settings: iCloud Sync toggle (off keeps connections, groups, and tags on this device only and disables the sync toolbar button), Rows per Page picker (50/100/200/500, applied to new data browser sessions), Default Safe Mode picker (applied when adding a new connection)
+- iOS Settings: iCloud Sync toggle (off keeps connections, groups, and tags on this device only and disables the sync toolbar button), Rows per Page picker (50/100/200/500, applied to new data browser sessions), Default Safe Mode picker (applied when adding a new connection), "Hide query in Live Activities" toggle that swaps the SQL preview for a generic "Running query" label on the lock screen and Dynamic Island
 - iOS: alert when the active connection is deleted mid-session (for example via iCloud sync from another device), so a stale screen no longer fails silently on the next action
 - iOS: Face ID, Touch ID, or Optic ID lock with cold-launch protection and idle timeout (1, 5, 15, or 60 minutes), opt-in from Settings
 - iOS: Connection Info tab replaces the per-connection Settings tab, showing host, SSL, SSH tunnel, active database, and live connection status

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 			membershipExceptions = (
 				Shared/SharedConnectionStore.swift,
 				Shared/WidgetConnectionItem.swift,
+				Shared/QueryActivityAttributes.swift,
 			);
 			target = 5AB9F3D82F7C1C12001F3337 /* TableProMobile */;
 		};

--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -132,25 +132,28 @@ final class ConnectionCoordinator {
 
     func reconnectIfNeeded() async {
         guard let session, !isSwitching, !isReconnecting else { return }
+        do {
+            _ = try await session.driver.ping()
+            return
+        } catch {
+            // Ping failed; fall through to actual reconnect path below.
+        }
+
         isReconnecting = true
         defer { isReconnecting = false }
         do {
-            _ = try await session.driver.ping()
+            await appState.sshProvider.setPendingConnectionId(connection.id)
+            let newSession = try await appState.connectionManager.connect(connection)
+            self.session = newSession
         } catch {
-            do {
-                await appState.sshProvider.setPendingConnectionId(connection.id)
-                let newSession = try await appState.connectionManager.connect(connection)
-                self.session = newSession
-            } catch {
-                let context = ErrorContext(
-                    operation: "reconnect",
-                    databaseType: connection.type,
-                    host: connection.host,
-                    sshEnabled: connection.sshEnabled
-                )
-                phase = .error(ErrorClassifier.classify(error, context: context))
-                self.session = nil
-            }
+            let context = ErrorContext(
+                operation: "reconnect",
+                databaseType: connection.type,
+                host: connection.host,
+                sshEnabled: connection.sshEnabled
+            )
+            phase = .error(ErrorClassifier.classify(error, context: context))
+            self.session = nil
         }
     }
 

--- a/TableProMobile/TableProMobile/Info.plist
+++ b/TableProMobile/TableProMobile/Info.plist
@@ -15,11 +15,18 @@
 		<string>_postgresql._tcp</string>
 		<string>_redis._tcp</string>
 	</array>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.TablePro.viewConnection</string>
 		<string>com.TablePro.viewTable</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -1262,6 +1262,9 @@
         }
       }
     },
+    "Create Group" : {
+
+    },
     "Create New Database" : {
       "localizations" : {
         "vi" : {
@@ -1277,6 +1280,9 @@
           }
         }
       }
+    },
+    "Create Tag" : {
+
     },
     "Database" : {
       "localizations" : {
@@ -1462,6 +1468,9 @@
         }
       }
     },
+    "Delete group" : {
+
+    },
     "Delete Group" : {
       "localizations" : {
         "vi" : {
@@ -1478,6 +1487,9 @@
         }
       }
     },
+    "Delete row" : {
+
+    },
     "Delete Row" : {
       "localizations" : {
         "vi" : {
@@ -1493,6 +1505,9 @@
           }
         }
       }
+    },
+    "Delete tag" : {
+
     },
     "Descending" : {
       "localizations" : {
@@ -4209,6 +4224,9 @@
           }
         }
       }
+    },
+    "The query returned no rows." : {
+
     },
     "The server is not responding. Check the host and port." : {
       "localizations" : {

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -1263,7 +1263,14 @@
       }
     },
     "Create Group" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo nhóm"
+          }
+        }
+      }
     },
     "Create New Database" : {
       "localizations" : {
@@ -1282,7 +1289,14 @@
       }
     },
     "Create Tag" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo thẻ"
+          }
+        }
+      }
     },
     "Database" : {
       "localizations" : {
@@ -1469,7 +1483,14 @@
       }
     },
     "Delete group" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa nhóm"
+          }
+        }
+      }
     },
     "Delete Group" : {
       "localizations" : {
@@ -1488,7 +1509,14 @@
       }
     },
     "Delete row" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa hàng"
+          }
+        }
+      }
     },
     "Delete Row" : {
       "localizations" : {
@@ -1507,7 +1535,14 @@
       }
     },
     "Delete tag" : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa thẻ"
+          }
+        }
+      }
     },
     "Descending" : {
       "localizations" : {
@@ -4226,7 +4261,14 @@
       }
     },
     "The query returned no rows." : {
-
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn không trả về hàng nào."
+          }
+        }
+      }
     },
     "The server is not responding. Check the host and port." : {
       "localizations" : {
@@ -4684,6 +4726,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编写SQL并点击运行按钮。"
+          }
+        }
+      }
+    },
+    "Hide query in Live Activities" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ẩn truy vấn trong Live Activity"
+          }
+        }
+      }
+    },
+    "When on, the lock screen and Dynamic Island show \"Running query\" instead of the SQL preview." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khi bật, màn hình khóa và Dynamic Island hiển thị \"Đang chạy truy vấn\" thay cho nội dung SQL."
+          }
+        }
+      }
+    },
+    "Running query" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang chạy truy vấn"
           }
         }
       }

--- a/TableProMobile/TableProMobile/Platform/AppPreferences.swift
+++ b/TableProMobile/TableProMobile/Platform/AppPreferences.swift
@@ -5,6 +5,7 @@ enum AppPreferences {
     static let cloudSyncEnabledKey = "com.TablePro.settings.cloudSyncEnabled"
     static let defaultPageSizeKey = "com.TablePro.settings.defaultPageSize"
     static let defaultSafeModeKey = "com.TablePro.settings.defaultSafeMode"
+    static let hideQueryPreviewInActivityKey = "com.TablePro.settings.hideQueryPreviewInActivity"
 
     static let pageSizeOptions: [Int] = [50, 100, 200, 500]
 
@@ -22,5 +23,9 @@ enum AppPreferences {
         guard let raw = UserDefaults.standard.string(forKey: defaultSafeModeKey),
               let level = SafeModeLevel(rawValue: raw) else { return .off }
         return level
+    }
+
+    static var hidesQueryPreviewInActivity: Bool {
+        UserDefaults.standard.bool(forKey: hideQueryPreviewInActivityKey)
     }
 }

--- a/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/SQLHighlightTextView.swift
@@ -87,9 +87,9 @@ struct SQLHighlightTextView: UIViewRepresentable {
         // MARK: - Keyboard Accessory Toolbar
 
         func makeAccessoryToolbar() -> UIView {
-            let toolbar = UIInputView(frame: CGRect(x: 0, y: 0, width: 0, height: 44), inputViewStyle: .keyboard)
+            let toolbar = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
             toolbar.autoresizingMask = .flexibleWidth
-            toolbar.allowsSelfSizing = true
+            toolbar.backgroundColor = .secondarySystemBackground
 
             let separator = UIView()
             separator.backgroundColor = .separator

--- a/TableProMobile/TableProMobile/Views/ConnectionListView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionListView.swift
@@ -7,7 +7,7 @@ struct ConnectionListView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showingAddConnection = false
     @State private var editingConnection: DatabaseConnection?
-    @AppStorage("lastConnectionId") private var selectedConnectionIdString: String?
+    @SceneStorage("lastConnectionId") private var selectedConnectionIdString: String?
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var showingGroupManagement = false
     @State private var showingTagManagement = false

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -398,7 +398,9 @@ struct QueryEditorView: View {
         let startedAt = Date()
         executionStartTime = startedAt
         let activity = startQueryActivity(trimmed: trimmed, startedAt: startedAt)
+        let progressUpdater = startActivityProgressUpdater(activity: activity, startedAt: startedAt)
         defer {
+            progressUpdater.cancel()
             isExecuting = false
             executionStartTime = nil
             endQueryActivity(activity, startedAt: startedAt)
@@ -442,6 +444,37 @@ struct QueryEditorView: View {
             attributes: attributes,
             content: .init(state: initialState, staleDate: startedAt.addingTimeInterval(5 * 60))
         )
+    }
+
+    /// Polls the streaming row count once per second while the query runs and pushes
+    /// `activity.update(state:)` only when the count changes. The system rate-limits
+    /// activity updates anyway, and the lock screen card just needs a fresh number
+    /// when the user wakes the device mid-query - it does not need real-time ticks
+    /// for the count (the elapsed time ticks itself via `Text(timerInterval:)`).
+    private func startActivityProgressUpdater(
+        activity: Activity<QueryActivityAttributes>?,
+        startedAt: Date
+    ) -> Task<Void, Never> {
+        Task { [weak viewModel] in
+            guard let activity else { return }
+            var lastReportedCount = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                if Task.isCancelled { return }
+                let count = viewModel?.legacyRows.count ?? 0
+                guard count != lastReportedCount else { continue }
+                lastReportedCount = count
+                let state = QueryActivityAttributes.ContentState(
+                    startedAt: startedAt,
+                    endedAt: nil,
+                    rowsStreamed: count
+                )
+                await activity.update(.init(
+                    state: state,
+                    staleDate: startedAt.addingTimeInterval(5 * 60)
+                ))
+            }
+        }
     }
 
     private func endQueryActivity(_ activity: Activity<QueryActivityAttributes>?, startedAt: Date) {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -1,3 +1,4 @@
+import ActivityKit
 import os
 import SwiftUI
 import TableProDatabase
@@ -394,10 +395,13 @@ struct QueryEditorView: View {
 
         editorFocused = false
         isExecuting = true
-        executionStartTime = Date()
+        let startedAt = Date()
+        executionStartTime = startedAt
+        let activity = startQueryActivity(trimmed: trimmed, startedAt: startedAt)
         defer {
             isExecuting = false
             executionStartTime = nil
+            endQueryActivity(activity)
         }
         appError = nil
 
@@ -416,5 +420,31 @@ struct QueryEditorView: View {
 
         let item = QueryHistoryItem(query: trimmed, connectionId: connectionId)
         coordinator.addHistoryItem(item)
+    }
+
+    // MARK: - Live Activity
+
+    private func startQueryActivity(trimmed: String, startedAt: Date) -> Activity<QueryActivityAttributes>? {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return nil }
+        let attributes = QueryActivityAttributes(
+            connectionName: coordinator.displayName,
+            queryPreview: String(trimmed.prefix(60))
+        )
+        let initialState = QueryActivityAttributes.ContentState(elapsed: 0, rowsStreamed: 0)
+        return try? Activity.request(
+            attributes: attributes,
+            content: .init(state: initialState, staleDate: startedAt.addingTimeInterval(60 * 60))
+        )
+    }
+
+    private func endQueryActivity(_ activity: Activity<QueryActivityAttributes>?) {
+        guard let activity else { return }
+        let final = QueryActivityAttributes.ContentState(
+            elapsed: viewModel.executionTime,
+            rowsStreamed: viewModel.legacyRows.count
+        )
+        Task {
+            await activity.end(.init(state: final, staleDate: nil), dismissalPolicy: .immediate)
+        }
     }
 }

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -401,7 +401,7 @@ struct QueryEditorView: View {
         defer {
             isExecuting = false
             executionStartTime = nil
-            endQueryActivity(activity)
+            endQueryActivity(activity, startedAt: startedAt)
         }
         appError = nil
 
@@ -430,17 +430,22 @@ struct QueryEditorView: View {
             connectionName: coordinator.displayName,
             queryPreview: String(trimmed.prefix(60))
         )
-        let initialState = QueryActivityAttributes.ContentState(elapsed: 0, rowsStreamed: 0)
+        let initialState = QueryActivityAttributes.ContentState(
+            startedAt: startedAt,
+            endedAt: nil,
+            rowsStreamed: 0
+        )
         return try? Activity.request(
             attributes: attributes,
             content: .init(state: initialState, staleDate: startedAt.addingTimeInterval(60 * 60))
         )
     }
 
-    private func endQueryActivity(_ activity: Activity<QueryActivityAttributes>?) {
+    private func endQueryActivity(_ activity: Activity<QueryActivityAttributes>?, startedAt: Date) {
         guard let activity else { return }
         let final = QueryActivityAttributes.ContentState(
-            elapsed: viewModel.executionTime,
+            startedAt: startedAt,
+            endedAt: Date(),
             rowsStreamed: viewModel.legacyRows.count
         )
         Task {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -428,10 +428,13 @@ struct QueryEditorView: View {
 
     private func startQueryActivity(trimmed: String, startedAt: Date) -> Activity<QueryActivityAttributes>? {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return nil }
+        let preview: String = AppPreferences.hidesQueryPreviewInActivity
+            ? String(localized: "Running query")
+            : String(trimmed.prefix(60))
         let attributes = QueryActivityAttributes(
             connectionId: coordinator.connection.id,
             connectionName: coordinator.displayName,
-            queryPreview: String(trimmed.prefix(60))
+            queryPreview: preview
         )
         let initialState = QueryActivityAttributes.ContentState(
             startedAt: startedAt,

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -427,6 +427,7 @@ struct QueryEditorView: View {
     private func startQueryActivity(trimmed: String, startedAt: Date) -> Activity<QueryActivityAttributes>? {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return nil }
         let attributes = QueryActivityAttributes(
+            connectionId: coordinator.connection.id,
             connectionName: coordinator.displayName,
             queryPreview: String(trimmed.prefix(60))
         )
@@ -435,9 +436,11 @@ struct QueryEditorView: View {
             endedAt: nil,
             rowsStreamed: 0
         )
+        // 5-minute stale window: if the app crashes mid-query, iOS marks the
+        // activity stale instead of showing a forever-ticking timer.
         return try? Activity.request(
             attributes: attributes,
-            content: .init(state: initialState, staleDate: startedAt.addingTimeInterval(60 * 60))
+            content: .init(state: initialState, staleDate: startedAt.addingTimeInterval(5 * 60))
         )
     }
 

--- a/TableProMobile/TableProMobile/Views/SettingsView.swift
+++ b/TableProMobile/TableProMobile/Views/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     @AppStorage(AppPreferences.cloudSyncEnabledKey) private var cloudSyncEnabled = true
     @AppStorage(AppPreferences.defaultPageSizeKey) private var defaultPageSize = 100
     @AppStorage(AppPreferences.defaultSafeModeKey) private var defaultSafeModeRaw = SafeModeLevel.off.rawValue
+    @AppStorage(AppPreferences.hideQueryPreviewInActivityKey) private var hideQueryPreviewInActivity = false
 
     private let auth = BiometricAuthService()
 
@@ -17,12 +18,18 @@ struct SettingsView: View {
             syncSection
             defaultsSection
 
-            Section("Privacy") {
+            Section {
                 Toggle(String(localized: "Share anonymous usage data"), isOn: $shareAnalytics)
 
                 Text("Help improve TablePro by sharing anonymous usage statistics (no personal data or queries).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Toggle(String(localized: "Hide query in Live Activities"), isOn: $hideQueryPreviewInActivity)
+            } header: {
+                Text("Privacy")
+            } footer: {
+                Text("When on, the lock screen and Dynamic Island show \"Running query\" instead of the SQL preview.")
             }
 
             Section("About") {

--- a/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
+++ b/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
@@ -15,7 +15,7 @@ struct QueryLiveActivityWidget: Widget {
                         .foregroundStyle(.tint)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(formatElapsed(context.state.elapsed))
+                    elapsedText(context.state)
                         .font(.body.monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
@@ -42,7 +42,7 @@ struct QueryLiveActivityWidget: Widget {
             } compactLeading: {
                 Image(systemName: "terminal.fill")
             } compactTrailing: {
-                Text(formatElapsed(context.state.elapsed))
+                elapsedText(context.state)
                     .monospacedDigit()
             } minimal: {
                 Image(systemName: "terminal.fill")
@@ -72,7 +72,7 @@ struct QueryLiveActivityWidget: Widget {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 2) {
-                Text(formatElapsed(context.state.elapsed))
+                elapsedText(context.state)
                     .font(.body.monospacedDigit())
                 if context.state.rowsStreamed > 0 {
                     Text("\(context.state.rowsStreamed) rows")
@@ -83,6 +83,16 @@ struct QueryLiveActivityWidget: Widget {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func elapsedText(_ state: QueryActivityAttributes.ContentState) -> some View {
+        if let ended = state.endedAt {
+            Text(formatElapsed(ended.timeIntervalSince(state.startedAt)))
+        } else {
+            // System ticks this label every second without app push updates.
+            Text(timerInterval: state.startedAt...Date.distantFuture, countsDown: false, showsHours: false)
+        }
     }
 
     private func formatElapsed(_ seconds: TimeInterval) -> String {

--- a/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
+++ b/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
@@ -9,10 +9,39 @@ struct QueryLiveActivityWidget: Widget {
                 .widgetURL(deepLink(connectionId: context.attributes.connectionId))
         } dynamicIsland: { context in
             DynamicIsland {
-                expandedLeading(context: context)
-                expandedTrailing(context: context)
-                expandedCenter(context: context)
-                expandedBottom(context: context)
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "terminal.fill")
+                        .font(.title3)
+                        .foregroundStyle(.tint)
+                        .frame(width: 32, height: 32)
+                        .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 7))
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    elapsedText(context.state)
+                        .font(.title3.monospacedDigit())
+                        .foregroundStyle(context.state.endedAt == nil ? .primary : .secondary)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.attributes.connectionName)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack {
+                        Text(context.attributes.queryPreview)
+                            .font(.system(.footnote, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Spacer()
+                        if context.state.rowsStreamed > 0 {
+                            Label("^[\(context.state.rowsStreamed) row](inflect: true)", systemImage: "list.bullet")
+                                .font(.caption)
+                                .labelStyle(.titleAndIcon)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
             } compactLeading: {
                 Image(systemName: "terminal.fill")
                     .foregroundStyle(.tint)
@@ -62,57 +91,6 @@ struct QueryLiveActivityWidget: Widget {
         .padding(.vertical, 10)
     }
 
-    // MARK: - Dynamic Island Expanded
-
-    @DynamicIslandExpandedContentBuilder
-    private func expandedLeading(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
-        DynamicIslandExpandedRegion(.leading) {
-            Image(systemName: "terminal.fill")
-                .font(.title3)
-                .foregroundStyle(.tint)
-                .frame(width: 32, height: 32)
-                .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 7))
-        }
-    }
-
-    @DynamicIslandExpandedContentBuilder
-    private func expandedTrailing(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
-        DynamicIslandExpandedRegion(.trailing) {
-            elapsedText(context.state)
-                .font(.title3.monospacedDigit())
-                .foregroundStyle(context.state.endedAt == nil ? .primary : .secondary)
-        }
-    }
-
-    @DynamicIslandExpandedContentBuilder
-    private func expandedCenter(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
-        DynamicIslandExpandedRegion(.center) {
-            Text(context.attributes.connectionName)
-                .font(.subheadline.weight(.medium))
-                .lineLimit(1)
-        }
-    }
-
-    @DynamicIslandExpandedContentBuilder
-    private func expandedBottom(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
-        DynamicIslandExpandedRegion(.bottom) {
-            HStack {
-                Text(context.attributes.queryPreview)
-                    .font(.system(.footnote, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer()
-                if context.state.rowsStreamed > 0 {
-                    Label("^[\(context.state.rowsStreamed) row](inflect: true)", systemImage: "list.bullet")
-                        .font(.caption)
-                        .labelStyle(.titleAndIcon)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-    }
-
     // MARK: - Compact / Minimal Status
 
     @ViewBuilder
@@ -124,7 +102,6 @@ struct QueryLiveActivityWidget: Widget {
             ProgressView()
                 .progressViewStyle(.circular)
                 .controlSize(.mini)
-                .tint(.tint)
         }
     }
 

--- a/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
+++ b/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
@@ -6,8 +6,7 @@ struct QueryLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: QueryActivityAttributes.self) { context in
             lockScreenView(context: context)
-                .activityBackgroundTint(Color.black.opacity(0.7))
-                .activitySystemActionForegroundColor(.white)
+                .widgetURL(deepLink(connectionId: context.attributes.connectionId))
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
@@ -93,6 +92,10 @@ struct QueryLiveActivityWidget: Widget {
             // System ticks this label every second without app push updates.
             Text(timerInterval: state.startedAt...Date.distantFuture, countsDown: false, showsHours: false)
         }
+    }
+
+    private func deepLink(connectionId: UUID) -> URL? {
+        URL(string: "tablepro://connect/\(connectionId.uuidString)")
     }
 
     private func formatElapsed(_ seconds: TimeInterval) -> String {

--- a/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
+++ b/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
@@ -1,0 +1,96 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct QueryLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: QueryActivityAttributes.self) { context in
+            lockScreenView(context: context)
+                .activityBackgroundTint(Color.black.opacity(0.7))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "terminal.fill")
+                        .foregroundStyle(.tint)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(formatElapsed(context.state.elapsed))
+                        .font(.body.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.attributes.connectionName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack {
+                        Text(context.attributes.queryPreview)
+                            .font(.system(.footnote, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Spacer()
+                        if context.state.rowsStreamed > 0 {
+                            Label("\(context.state.rowsStreamed)", systemImage: "list.bullet")
+                                .font(.caption)
+                                .labelStyle(.titleAndIcon)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: "terminal.fill")
+            } compactTrailing: {
+                Text(formatElapsed(context.state.elapsed))
+                    .monospacedDigit()
+            } minimal: {
+                Image(systemName: "terminal.fill")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<QueryActivityAttributes>) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "terminal.fill")
+                .font(.title2)
+                .foregroundStyle(.tint)
+                .frame(width: 36, height: 36)
+                .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(context.attributes.connectionName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(context.attributes.queryPreview)
+                    .font(.system(.subheadline, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formatElapsed(context.state.elapsed))
+                    .font(.body.monospacedDigit())
+                if context.state.rowsStreamed > 0 {
+                    Text("\(context.state.rowsStreamed) rows")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func formatElapsed(_ seconds: TimeInterval) -> String {
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let minutes = Int(seconds) / 60
+        let secs = Int(seconds) % 60
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}

--- a/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
+++ b/TableProMobile/TableProWidget/QueryLiveActivityWidget.swift
@@ -9,45 +9,23 @@ struct QueryLiveActivityWidget: Widget {
                 .widgetURL(deepLink(connectionId: context.attributes.connectionId))
         } dynamicIsland: { context in
             DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: "terminal.fill")
-                        .foregroundStyle(.tint)
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    elapsedText(context.state)
-                        .font(.body.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                }
-                DynamicIslandExpandedRegion(.center) {
-                    Text(context.attributes.connectionName)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    HStack {
-                        Text(context.attributes.queryPreview)
-                            .font(.system(.footnote, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        Spacer()
-                        if context.state.rowsStreamed > 0 {
-                            Label("\(context.state.rowsStreamed)", systemImage: "list.bullet")
-                                .font(.caption)
-                                .labelStyle(.titleAndIcon)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
+                expandedLeading(context: context)
+                expandedTrailing(context: context)
+                expandedCenter(context: context)
+                expandedBottom(context: context)
             } compactLeading: {
                 Image(systemName: "terminal.fill")
+                    .foregroundStyle(.tint)
             } compactTrailing: {
-                elapsedText(context.state)
-                    .monospacedDigit()
+                compactStatus(state: context.state)
             } minimal: {
-                Image(systemName: "terminal.fill")
+                compactStatus(state: context.state)
             }
+            .widgetURL(deepLink(connectionId: context.attributes.connectionId))
         }
     }
+
+    // MARK: - Lock Screen
 
     @ViewBuilder
     private func lockScreenView(context: ActivityViewContext<QueryActivityAttributes>) -> some View {
@@ -60,10 +38,10 @@ struct QueryLiveActivityWidget: Widget {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(context.attributes.connectionName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.subheadline.weight(.medium))
                 Text(context.attributes.queryPreview)
-                    .font(.system(.subheadline, design: .monospaced))
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -74,7 +52,7 @@ struct QueryLiveActivityWidget: Widget {
                 elapsedText(context.state)
                     .font(.body.monospacedDigit())
                 if context.state.rowsStreamed > 0 {
-                    Text("\(context.state.rowsStreamed) rows")
+                    Text("^[\(context.state.rowsStreamed) row](inflect: true)")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
@@ -84,12 +62,79 @@ struct QueryLiveActivityWidget: Widget {
         .padding(.vertical, 10)
     }
 
+    // MARK: - Dynamic Island Expanded
+
+    @DynamicIslandExpandedContentBuilder
+    private func expandedLeading(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
+        DynamicIslandExpandedRegion(.leading) {
+            Image(systemName: "terminal.fill")
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .frame(width: 32, height: 32)
+                .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 7))
+        }
+    }
+
+    @DynamicIslandExpandedContentBuilder
+    private func expandedTrailing(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
+        DynamicIslandExpandedRegion(.trailing) {
+            elapsedText(context.state)
+                .font(.title3.monospacedDigit())
+                .foregroundStyle(context.state.endedAt == nil ? .primary : .secondary)
+        }
+    }
+
+    @DynamicIslandExpandedContentBuilder
+    private func expandedCenter(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
+        DynamicIslandExpandedRegion(.center) {
+            Text(context.attributes.connectionName)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+        }
+    }
+
+    @DynamicIslandExpandedContentBuilder
+    private func expandedBottom(context: ActivityViewContext<QueryActivityAttributes>) -> DynamicIslandExpandedRegion<some View> {
+        DynamicIslandExpandedRegion(.bottom) {
+            HStack {
+                Text(context.attributes.queryPreview)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                if context.state.rowsStreamed > 0 {
+                    Label("^[\(context.state.rowsStreamed) row](inflect: true)", systemImage: "list.bullet")
+                        .font(.caption)
+                        .labelStyle(.titleAndIcon)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Compact / Minimal Status
+
+    @ViewBuilder
+    private func compactStatus(state: QueryActivityAttributes.ContentState) -> some View {
+        if state.endedAt != nil {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        } else {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.mini)
+                .tint(.tint)
+        }
+    }
+
+    // MARK: - Helpers
+
     @ViewBuilder
     private func elapsedText(_ state: QueryActivityAttributes.ContentState) -> some View {
         if let ended = state.endedAt {
             Text(formatElapsed(ended.timeIntervalSince(state.startedAt)))
         } else {
-            // System ticks this label every second without app push updates.
             Text(timerInterval: state.startedAt...Date.distantFuture, countsDown: false, showsHours: false)
         }
     }

--- a/TableProMobile/TableProWidget/QuickConnectWidget.swift
+++ b/TableProMobile/TableProWidget/QuickConnectWidget.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import WidgetKit
 
-@main
 struct QuickConnectWidget: Widget {
     let kind = "com.TablePro.QuickConnect"
 
@@ -13,5 +12,13 @@ struct QuickConnectWidget: Widget {
         .configurationDisplayName("Quick Connect")
         .description("Quickly connect to your databases.")
         .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+@main
+struct TableProWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        QuickConnectWidget()
+        QueryLiveActivityWidget()
     }
 }

--- a/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
+++ b/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
@@ -1,0 +1,12 @@
+import ActivityKit
+import Foundation
+
+struct QueryActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var elapsed: TimeInterval
+        var rowsStreamed: Int
+    }
+
+    let connectionName: String
+    let queryPreview: String
+}

--- a/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
+++ b/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
@@ -8,6 +8,7 @@ struct QueryActivityAttributes: ActivityAttributes {
         var rowsStreamed: Int
     }
 
+    let connectionId: UUID
     let connectionName: String
     let queryPreview: String
 }

--- a/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
+++ b/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
@@ -3,7 +3,8 @@ import Foundation
 
 struct QueryActivityAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
-        var elapsed: TimeInterval
+        var startedAt: Date
+        var endedAt: Date?
         var rowsStreamed: Int
     }
 


### PR DESCRIPTION
## Summary

Two iOS-first features bundled because they share Info.plist edits and target a common goal of bringing the app onto more iPad surfaces.

### Live Activity (iOS 16.1+)

Long-running queries now surface on the Lock Screen and Dynamic Island via ActivityKit:

- **Lock Screen**: terminal icon, connection name, query preview (first 60 chars, monospaced), elapsed time, and streamed row count
- **Dynamic Island compact**: terminal icon + elapsed time
- **Dynamic Island expanded**: leading icon, trailing elapsed, center connection name, bottom row with query preview + row count

`TableProWidget` extension converts from a single `@main Widget` to `@main WidgetBundle` so it can ship both `QuickConnectWidget` and the new `QueryLiveActivityWidget`.

`QueryActivityAttributes` lives in `TableProWidget/Shared/` and is in both the app target (to start/end the activity) and the widget target (to render). The pbxproj `membershipExceptions` for the app target gains the new file alongside the existing two shared files.

`QueryEditorView.executeQueryDirect` calls `Activity.request(...)` when execution starts and `activity.end(...)` in the `defer` block. When the user has Live Activities disabled in Settings the request silently no-ops via `ActivityAuthorizationInfo().areActivitiesEnabled`.

`Info.plist` gains `NSSupportsLiveActivities = true`.

**Privacy toggle:** Settings → Privacy adds "Hide query in Live Activities". When on, the lock screen and Dynamic Island show "Running query" instead of the SQL preview. Off by default.

### iPad multi-window

`Info.plist` gains `UIApplicationSceneManifest.UIApplicationSupportsMultipleScenes = true`.

`ConnectionListView.selectedConnectionIdString` switches from `@AppStorage` to `@SceneStorage` so each window remembers its own selected connection across cold launches and Stage Manager rearrangement. The two preference flags `lastFilterTagId` and `groupByGroup` stay `@AppStorage` because tag filter and grouping are global preferences, not per-window state. The `searchText` keys in the Data Browser and Table List are already `@SceneStorage`.

`AppState`, `coordinatorCache`, and the `appState.connections` array are shared across windows by design - users want the same list of connections in every window.

### Side fixes

- `SQLHighlightTextView` keyboard accessory toolbar: revert from `UIInputView` back to plain `UIView` with `.secondarySystemBackground`, which resolves the keyboard layout constraint conflict logged on iOS 26.
- `ConnectionCoordinator.reconnectIfNeeded()`: only set `isReconnecting = true` after the ping health check fails, so the "Reconnecting" chip no longer flashes during routine ping checks (e.g., after tapping a Live Activity).

## Test plan

- [ ] Run a SELECT that takes 5+ seconds: lock screen shows the activity, Dynamic Island shows compact + expanded states, query preview matches, elapsed time advances
- [ ] Cancel via Stop button: activity dismisses immediately
- [ ] Toggle off Live Activities in Settings → Notifications → TablePro: query runs without surfacing the activity, no crash
- [ ] Toggle "Hide query in Live Activities" on, run a query: lock screen shows "Running query" instead of the SQL
- [ ] iPad: drag a tab off the title bar to create a second window, pick a different connection in each window, both selections survive a relaunch (`@SceneStorage` per scene)
- [ ] Stage Manager: arrange three TablePro windows side by side, each operates on its own connection independently
- [ ] iPhone: behavior unchanged (single scene, full-screen)