### PR TITLE
fix(ios): restore IndexedRow wrapping in row detail pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- iOS: row detail pager no longer carries the index-based row iteration that caused the build 11 filter crash. A recent refactor reintroduced the pattern; row detail now uses the same identity-based row wrapping the data browser does.
 - Tables in the sidebar now load automatically after a slow connect. SQL Server connections previously showed "No Tables" until the user manually picked a schema; the same race could affect other engines on slow networks. The post-connect listener now triggers the schema load once the driver is bound.
 - SQL Server `switchDatabase` now actually switches the database (`USE <database>`) instead of being routed through a schema switch. Switching from a saved tab pointing at a different database used to overwrite the current schema with the database name and leave the table list empty until the user manually re-picked a schema.
 - SQL Server cell edits now save without "Conversion failed when converting date and/or time from character string." Tables with primary keys use a PK-only WHERE clause (no longer including every column), and DATETIME / DATETIME2 / SMALLDATETIME values round-trip as ISO 8601 instead of FreeTDS's `MMM d yyyy h:mm:ss:fffAM` format that SQL Server's parser rejects.

--- a/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
+++ b/TableProMobile/TableProMobile/Helpers/IndexedRow.swift
@@ -3,13 +3,13 @@ import Foundation
 /// Identifiable wrapper used by iOS lists that need both the row payload and
 /// its position index. Iterating over `[IndexedRow]` instead of
 /// `rows.indices` keeps SwiftUI's `ForEach` diff stable when the underlying
-/// `[[String?]]` shrinks mid-render — the pattern that caused the
-/// `Array._checkSubscript` crashes in release 1.0 (build 11).
-struct IndexedRow: Identifiable {
+/// row collection shrinks mid-render. This is the pattern that prevents the
+/// `Array._checkSubscript` crashes seen in release 1.0 (build 11).
+struct IndexedRow<Element>: Identifiable {
     let id: Int
-    let values: [String?]
+    let values: Element
 
-    static func wrap(_ rows: [[String?]]) -> [IndexedRow] {
+    static func wrap(_ rows: [Element]) -> [IndexedRow<Element>] {
         rows.enumerated().map { IndexedRow(id: $0.offset, values: $0.element) }
     }
 }

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -46,9 +46,9 @@ struct RowDetailView: View {
                 rowContent(at: viewModel.currentIndex)
             } else {
                 TabView(selection: $viewModel.currentIndex) {
-                    ForEach(viewModel.rows.indices, id: \.self) { index in
-                        rowContent(at: index)
-                            .tag(index)
+                    ForEach(IndexedRow.wrap(viewModel.rows)) { item in
+                        rowContent(at: item.id)
+                            .tag(item.id)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))


### PR DESCRIPTION
## Summary

- Restores the `IndexedRow.wrap(...)` wrapping in `RowDetailView`'s pager that PR #1166 silently reverted while extracting `RowDetailViewModel`. The `ForEach(viewModel.rows.indices, id: \.self)` pattern is the same shape that caused the build 11 PostgreSQL filter crash (`Array._checkSubscript`, TestFlight feedback `AOsWBxPNuHp_NmN0QIclyc8`) and that PR #1094 (`f7ed420e`) originally fixed.
- Generalizes `IndexedRow` to `IndexedRow<Element>` so the helper covers both flat `[[String?]]` rows (data browser, query editor) and the richer `[Row]` payload the row detail view model holds.
- CHANGELOG entry added under Unreleased Fixed.

The detail view model already guards `row(at:)` and `cells(at:)` against out-of-range indices, so this regression doesn't crash today the way the data browser one did. Restoring the wrapping puts identity-based diffing back in place and keeps the three iOS row lists on the same pattern.

## Test plan

- [ ] Build TableProMobile on the iOS scheme; SwiftLint passes (`swiftlint lint --strict` on touched files).
- [ ] In the iOS app, open a row detail view, swipe the pager left/right, then trigger a list refresh that shrinks `rows` while the pager is mounted; confirm no `Array._checkSubscript` trap and that the pager re-anchors on the surviving rows.
- [ ] Apply a filter on a PostgreSQL table on iOS (the build 11 repro from `rcuni8@gmail.com`) and confirm the data browser + row detail flow still works end to end.