### PR TITLE
polish(ios): drop redundant centered title on connection tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- iOS: drop the centered navigation title on the four connection tabs (Tables, Query, History, Info). The bottom tab bar already labels the active tab, so the centered title was redundant; removing it frees room for the database picker, schema picker, and edit button on iPhone widths.
 - iOS: Vietnamese localization completed for the iOS strings catalog (312/312 keys)
 - Internal: GitHub Actions workflow `ios-tests.yml` runs the iOS unit tests on every PR and main push that touches mobile code or shared packages
 - Internal: Swift Testing tests for `DataBrowserViewModel`, `ConnectionFormViewModel`, and `RowDetailViewModel` covering load lifecycle, pagination, sort/filter/search, delete, hydration, validation, edit lifecycle, save paths, and lazy cell load. Runs against in-memory `DatabaseDriver` and `SecureStore` mocks. `loadStoredCredentials`, `testConnection`, `save` on `ConnectionFormViewModel` now accept `any SecureStore` so the keychain backend can be substituted under test

--- a/TableProMobile/TableProMobile/Views/ConnectedView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectedView.swift
@@ -113,7 +113,6 @@ struct ConnectedView: View {
                         .environment(coordinator)
                 }
             }
-            .navigationTitle(tabTitle(coordinator))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { connectionToolbar(coordinator) }
             .navigationDestination(for: TableInfo.self) { table in
@@ -178,14 +177,6 @@ struct ConnectedView: View {
             activity.title = connection.name.isEmpty ? connection.host : connection.name
             activity.isEligibleForHandoff = true
             activity.userInfo = ["connectionId": connection.id.uuidString]
-        }
-    }
-
-    private func tabTitle(_ coordinator: ConnectionCoordinator) -> String {
-        switch coordinator.selectedTab {
-        case .tables, .query: coordinator.displayName
-        case .history: String(localized: "History")
-        case .info: String(localized: "Info")
         }
     }
 


### PR DESCRIPTION
## Summary

- Drops the centered navigation title on the four connection tabs (Tables, Query, History, Info). The bottom tab bar already labels the active tab, so the centered title was redundant.
- On Tables and Query the title was the connection name (`TablePro`); on History and Info it was just the tab name (`History`, `Info`). All four now show no centered title.
- Frees toolbar room for the database picker, schema picker, and edit button — noticeable on iPhone widths where the Info tab previously had 5 toolbar items competing for space.
- Outer `.navigationTitle(connection.name)` on `ConnectedView.swift:35` kept intact for VoiceOver screen identification when entering from the connection list; doesn't show in the inner tab toolbar.
- `tabTitle(_:)` helper removed (was only called from the line being deleted).

## Test plan

- [ ] Open a connection, switch through Tables / Query / History / Info — no centered title appears in any tab toolbar.
- [ ] Database picker and schema picker still render and function on tabs that have multiple databases / schemas.
- [ ] Info tab still shows the pencil edit button.
- [ ] Push into a table from Tables tab — the table name still shows as the title on the data browser screen.
- [ ] VoiceOver: enter a connection from the list, confirm the connection name is announced once on entry.