### PR TITLE
perf(datagrid): cut scroll CPU via CTLine and snapshot gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Data grid: skip the structural update pipeline when the inputs to `updateNSView` are unchanged, and pull binding and selection synchronization out so they always run cheaply
+- Data grid: theme changes now reload visible rows so the direct-draw cell picks up the new palette; the legacy `updateVisibleCellFonts` path is removed
+- Data grid: background prewarm fills the display cache in frame-budgeted batches after each structural reload, so scrolling stays a cache hit instead of running the date formatter on the main thread
+- Data grid: display cache bumped to 50,000 rows / 64 MB and date format cache to 100,000 entries to cover larger result sets without eviction churn
+- Data grid: per-cell accessibility label now resolves lazily through `accessibilityLabel()` so VoiceOver-only work no longer runs in the scroll hot path
+- Data grid: cell text rendering switched from `NSAttributedString.draw(with:options:)` to `CTLineDraw`, dropping the truncation and justification engines from the scroll redraw path
+- Data grid: cell accessory icons (chevron, foreign-key arrow) are pre-resolved to `CGImage` at startup and drawn via `CGContext.draw(_:in:)`, skipping per-draw representation selection and hint validation
+- Data grid: row view pushes emphasized-selection state directly into cells via `didAddSubview` and selection setters, so cells no longer walk the superview chain in `viewWillDraw`
+- Data grid: background prewarm pauses while the user is actively scrolling and resumes 300 ms after `didEndLiveScroll`, and the per-batch frame budget drops from 8 ms to 2 ms so prewarm work cannot crowd the scroll frame
 - iOS: drop the centered navigation title on the four connection tabs (Tables, Query, History, Info). The bottom tab bar already labels the active tab, so the centered title was redundant; removing it frees room for the database picker, schema picker, and edit button on iPhone widths.
 - iOS: Vietnamese localization completed for the iOS strings catalog (312/312 keys)
 - Internal: GitHub Actions workflow `ios-tests.yml` runs the iOS unit tests on every PR and main push that touches mobile code or shared packages

--- a/TablePro/Core/Services/Formatting/DateFormattingService.swift
+++ b/TablePro/Core/Services/Formatting/DateFormattingService.swift
@@ -35,8 +35,7 @@ final class DateFormattingService {
         self.currentFormat = .iso8601
         self.formatter = Self.createFormatter(for: .iso8601)
         self.parsers = Self.createParsers()
-        // Limit cache to 10,000 entries to bound memory usage
-        formatCache.countLimit = 10_000
+        formatCache.countLimit = 100_000
     }
 
     // MARK: - Public Methods

--- a/TablePro/Views/Results/Cells/DataGridCellContent.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellContent.swift
@@ -15,7 +15,6 @@ struct DataGridCellContent {
     let displayText: String
     let rawValue: String?
     let placeholder: DataGridCellPlaceholder?
-    let accessibilityLabel: String
 }
 
 struct DataGridCellState {

--- a/TablePro/Views/Results/Cells/DataGridCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellView.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import CoreText
 
 @MainActor
 final class DataGridCellView: NSView {
@@ -22,7 +23,7 @@ final class DataGridCellView: NSView {
     private var isLargeDataset: Bool = false
     private var isEditableCell: Bool = false
 
-    private var textFont: NSFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+    private var textFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
     private var textColor: NSColor = .labelColor
     private var modifiedColumnTint: NSColor?
 
@@ -30,28 +31,24 @@ final class DataGridCellView: NSView {
     private var isFocusedCell: Bool = false
     private var onEmphasizedSelection: Bool = false
 
-    private var attributedCache: NSAttributedString?
+    private var cachedLine: CTLine?
 
     private var accessoryHitRect: NSRect = .zero
 
-    private static let chevronNormal = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .secondaryLabelColor)
-    private static let chevronEmphasized = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .alternateSelectedControlTextColor)
-    private static let chevronDisabled = makeAccessoryImage("chevron.up.chevron.down", pointSize: 10, color: .tertiaryLabelColor)
-    private static let fkArrowNormal = makeAccessoryImage("arrow.right.circle.fill", pointSize: 14, color: .secondaryLabelColor)
-    private static let fkArrowEmphasized = makeAccessoryImage("arrow.right.circle.fill", pointSize: 14, color: .alternateSelectedControlTextColor)
+    private static let chevronNormal = makeAccessoryCGImage("chevron.up.chevron.down", pointSize: 10, color: .secondaryLabelColor)
+    private static let chevronEmphasized = makeAccessoryCGImage("chevron.up.chevron.down", pointSize: 10, color: .alternateSelectedControlTextColor)
+    private static let chevronDisabled = makeAccessoryCGImage("chevron.up.chevron.down", pointSize: 10, color: .tertiaryLabelColor)
+    private static let fkArrowNormal = makeAccessoryCGImage("arrow.right.circle.fill", pointSize: 14, color: .secondaryLabelColor)
+    private static let fkArrowEmphasized = makeAccessoryCGImage("arrow.right.circle.fill", pointSize: 14, color: .alternateSelectedControlTextColor)
 
-    private static func makeAccessoryImage(_ name: String, pointSize: CGFloat, color: NSColor) -> NSImage {
+    private static func makeAccessoryCGImage(_ name: String, pointSize: CGFloat, color: NSColor) -> CGImage? {
         let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
             .applying(.init(hierarchicalColor: color))
-        return NSImage(systemSymbolName: name, accessibilityDescription: nil)?
-            .withSymbolConfiguration(config) ?? NSImage()
+        guard let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(config) else { return nil }
+        var rect = CGRect(origin: .zero, size: image.size)
+        return image.cgImage(forProposedRect: &rect, context: nil, hints: nil)
     }
-
-    private static let placeholderParagraph: NSParagraphStyle = {
-        let p = NSMutableParagraphStyle()
-        p.lineBreakMode = .byTruncatingTail
-        return p
-    }()
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -128,7 +125,7 @@ final class DataGridCellView: NSView {
             displayText = nextDisplayText
             textFont = nextFont
             textColor = nextColor
-            attributedCache = nil
+            cachedLine = nil
         }
 
         rawValue = content.rawValue
@@ -154,30 +151,26 @@ final class DataGridCellView: NSView {
             updateFocusPresentation()
         }
 
-        setAccessibilityLabel(content.accessibilityLabel)
         setAccessibilityRowIndexRange(NSRange(location: state.row, length: 1))
         setAccessibilityColumnIndexRange(NSRange(location: state.columnIndex, length: 1))
 
         needsDisplay = true
     }
 
-    private func currentEmphasizedSelection() -> Bool {
-        var view: NSView? = superview
-        while let candidate = view {
-            if let row = candidate as? NSTableRowView {
-                return row.isSelected && row.isEmphasized
-            }
-            view = candidate.superview
-        }
-        return false
+    override func accessibilityLabel() -> String? {
+        let value = rawValue ?? String(localized: "NULL")
+        return String(
+            format: String(localized: "Row %d, column %d: %@"),
+            cellRow + 1,
+            cellColumnIndex + 1,
+            value
+        )
     }
 
-    override func viewWillDraw() {
-        super.viewWillDraw()
-        let nextEmphasized = currentEmphasizedSelection()
-        guard nextEmphasized != onEmphasizedSelection else { return }
-        onEmphasizedSelection = nextEmphasized
-        attributedCache = nil
+    func applyEmphasizedSelection(_ value: Bool) {
+        guard onEmphasizedSelection != value else { return }
+        onEmphasizedSelection = value
+        cachedLine = nil
         updateFocusPresentation()
     }
 
@@ -220,22 +213,35 @@ final class DataGridCellView: NSView {
 
     private func drawText(reservingTrailingWidth trailing: CGFloat) {
         guard !displayText.isEmpty else { return }
-        let attr = cachedAttributedString()
-        var rect = bounds.insetBy(dx: DataGridMetrics.cellHorizontalInset, dy: 0)
-        rect.size.width -= trailing
-        guard rect.width > 0 else { return }
-        let lineHeight = textFont.ascender - textFont.descender + textFont.leading
-        rect.origin.y = max(0, (bounds.height - lineHeight) / 2)
-        rect.size.height = lineHeight + 2
-        attr.draw(with: rect, options: [.truncatesLastVisibleLine, .usesLineFragmentOrigin], context: nil)
+        let availableWidth = bounds.width - 2 * DataGridMetrics.cellHorizontalInset - trailing
+        guard availableWidth > 0 else { return }
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+
+        let fullLine = cachedCTLine()
+        let lineToDraw: CTLine
+        let typographicWidth = CTLineGetTypographicBounds(fullLine, nil, nil, nil)
+        if typographicWidth > Double(availableWidth) {
+            let ellipsis = makeEllipsisLine()
+            lineToDraw = CTLineCreateTruncatedLine(fullLine, Double(availableWidth), .end, ellipsis) ?? fullLine
+        } else {
+            lineToDraw = fullLine
+        }
+
+        let baselineY = (bounds.height - textFont.ascender + textFont.descender - textFont.leading) / 2 + textFont.ascender
+
+        context.saveGState()
+        context.textMatrix = CGAffineTransform(scaleX: 1, y: -1)
+        context.textPosition = CGPoint(x: DataGridMetrics.cellHorizontalInset, y: baselineY)
+        CTLineDraw(lineToDraw, context)
+        context.restoreGState()
     }
 
     private func resolvedTextColor() -> NSColor {
         onEmphasizedSelection ? .alternateSelectedControlTextColor : textColor
     }
 
-    private func cachedAttributedString() -> NSAttributedString {
-        if let cached = attributedCache { return cached }
+    private func cachedCTLine() -> CTLine {
+        if let cached = cachedLine { return cached }
         let textNS = displayText as NSString
         let truncated: String
         if textNS.length > 300 {
@@ -243,14 +249,27 @@ final class DataGridCellView: NSView {
         } else {
             truncated = displayText
         }
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: textFont,
-            .foregroundColor: resolvedTextColor(),
-            .paragraphStyle: Self.placeholderParagraph
-        ]
-        let str = NSAttributedString(string: truncated, attributes: attrs)
-        attributedCache = str
-        return str
+        let attr = NSAttributedString(
+            string: truncated,
+            attributes: [
+                .font: textFont,
+                .foregroundColor: resolvedTextColor()
+            ]
+        )
+        let line = CTLineCreateWithAttributedString(attr as CFAttributedString)
+        cachedLine = line
+        return line
+    }
+
+    private func makeEllipsisLine() -> CTLine {
+        let attr = NSAttributedString(
+            string: "\u{2026}",
+            attributes: [
+                .font: textFont,
+                .foregroundColor: resolvedTextColor()
+            ]
+        )
+        return CTLineCreateWithAttributedString(attr as CFAttributedString)
     }
 
     private func computeAccessoryRect() -> NSRect {
@@ -274,7 +293,7 @@ final class DataGridCellView: NSView {
 
     private func drawAccessory(in rect: NSRect) {
         guard !rect.isEmpty else { return }
-        let image: NSImage
+        let image: CGImage?
         switch kind {
         case .text:
             return
@@ -289,7 +308,12 @@ final class DataGridCellView: NSView {
                 image = Self.chevronNormal
             }
         }
-        image.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0, respectFlipped: true, hints: nil)
+        guard let cgImage = image, let context = NSGraphicsContext.current?.cgContext else { return }
+        context.saveGState()
+        context.translateBy(x: rect.minX, y: rect.maxY)
+        context.scaleBy(x: 1, y: -1)
+        context.draw(cgImage, in: CGRect(origin: .zero, size: rect.size))
+        context.restoreGState()
     }
 
     private func drawFocusBorder() {

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -17,8 +17,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     private(set) var columnDisplayFormats: [ValueDisplayFormat?] = []
     private let displayCache: NSCache<RowIDKey, RowDisplayBox> = {
         let cache = NSCache<RowIDKey, RowDisplayBox>()
-        cache.countLimit = 5_000
-        cache.totalCostLimit = 32 * 1024 * 1024
+        cache.countLimit = 50_000
+        cache.totalCostLimit = 64 * 1_024 * 1_024
         cache.name = "TablePro.DataGrid.displayCache"
         return cache
     }()
@@ -114,6 +114,13 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var isEscapeCancelling = false
     var isCommittingCellEdit = false
     var layoutPersistTask: Task<Void, Never>?
+    var lastUpdateSnapshot: DataGridUpdateSnapshot?
+    private var lastColumnMetadataFingerprint = ColumnMetadataFingerprint.empty
+    private var prewarmTask: Task<Void, Never>?
+    private var prewarmResumeTask: Task<Void, Never>?
+    private var scrollObservers: [NSObjectProtocol] = []
+    private static let prewarmFrameBudgetMs: Int = 2
+    private static let prewarmResumeDelayMs: Int = 300
 
     static let rowViewIdentifier = NSUserInterfaceItemIdentifier("TableRowView")
     let visualIndex = RowVisualIndex()
@@ -182,12 +189,16 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         themeCancellable = AppEvents.shared.themeChanged
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                guard let self, let tableView = self.tableView else { return }
-                Self.updateVisibleCellFonts(tableView: tableView)
+                self?.reloadVisibleRowsAndStates()
             }
     }
 
     func releaseData() {
+        prewarmTask?.cancel()
+        prewarmTask = nil
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = nil
+        detachScrollObservers()
         overlayEditor?.dismiss(commit: false)
         settingsCancellable?.cancel()
         settingsCancellable = nil
@@ -199,6 +210,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         cachedRowCount = 0
         cachedColumnCount = 0
         sortedIDs = nil
+        lastUpdateSnapshot = nil
+        lastColumnMetadataFingerprint = .empty
         columnPool.detachFromTableView()
         if let tableView {
             while let col = tableView.tableColumns.last {
@@ -237,10 +250,14 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         invalidateAllDisplayCaches()
         updateCache()
         tableView.reloadData()
+        startBackgroundPrewarm()
     }
 
     func displayRow(at displayIndex: Int) -> Row? {
-        let tableRows = tableRowsProvider()
+        displayRow(at: displayIndex, in: tableRowsProvider())
+    }
+
+    func displayRow(at displayIndex: Int, in tableRows: TableRows) -> Row? {
         if let sorted = sortedIDs {
             guard displayIndex >= 0, displayIndex < sorted.count else { return nil }
             return tableRows.row(withID: sorted[displayIndex])
@@ -315,26 +332,114 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         let displayCount = sortedIDs?.count ?? tableRows.count
         let count = min(rowCount, displayCount)
         guard count > 0 else { return }
-        let columnCount = tableRows.columns.count
         for displayIndex in 0..<count {
-            guard let row = displayRow(at: displayIndex) else { continue }
-            let key = RowIDKey(row.id)
-            guard displayCache.object(forKey: key) == nil else { continue }
-            var values = ContiguousArray<String?>()
-            values.reserveCapacity(columnCount)
-            for _ in 0..<columnCount { values.append(nil) }
-            for col in 0..<min(row.values.count, columnCount) {
-                let columnType = col < tableRows.columnTypes.count ? tableRows.columnTypes[col] : nil
-                let format = col < columnDisplayFormats.count ? columnDisplayFormats[col] : nil
-                values[col] = CellDisplayFormatter.format(
-                    row.values[col],
-                    columnType: columnType,
-                    displayFormat: format
-                ) ?? row.values[col].asText
-            }
-            let box = RowDisplayBox(values)
-            displayCache.setObject(box, forKey: key, cost: displayCacheCost(values))
+            cacheDisplayRow(at: displayIndex, in: tableRows)
         }
+    }
+
+    /// Populates the entire display cache off the scroll hot path by iterating all
+    /// rows in frame-budgeted batches and yielding between batches. Subsequent
+    /// `tableView(_:viewFor:row:)` calls then hit the cache instead of running
+    /// `CellDisplayFormatter.format` (and its `NSDateFormatter` parse) on the main
+    /// thread during scroll. Replaces any in-flight prewarm task.
+    func startBackgroundPrewarm() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = nil
+        prewarmTask?.cancel()
+        prewarmTask = Task { @MainActor [weak self] in
+            await self?.runBackgroundPrewarm()
+        }
+    }
+
+    /// Subscribes to the scroll view's live-scroll notifications so the prewarm
+    /// task can be paused while the user is actively scrolling. The task resumes
+    /// after a short debounce so quick successive scrolls do not restart and
+    /// cancel the work repeatedly.
+    func attachScrollObservers(scrollView: NSScrollView) {
+        detachScrollObservers()
+        let start = NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.pausePrewarmForScroll()
+            }
+        }
+        let end = NotificationCenter.default.addObserver(
+            forName: NSScrollView.didEndLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.schedulePrewarmResume()
+            }
+        }
+        scrollObservers = [start, end]
+    }
+
+    private func detachScrollObservers() {
+        for observer in scrollObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        scrollObservers.removeAll()
+    }
+
+    private func pausePrewarmForScroll() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = nil
+        prewarmTask?.cancel()
+        prewarmTask = nil
+    }
+
+    private func schedulePrewarmResume() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(Self.prewarmResumeDelayMs))
+            guard !Task.isCancelled, let self else { return }
+            self.startBackgroundPrewarm()
+        }
+    }
+
+    private func runBackgroundPrewarm() async {
+        var nextIndex = 0
+        while !Task.isCancelled {
+            let tableRows = tableRowsProvider()
+            let displayCount = sortedIDs?.count ?? tableRows.count
+            guard nextIndex < displayCount else { return }
+
+            let frameBudget = ContinuousClock.Instant.Duration.milliseconds(Self.prewarmFrameBudgetMs)
+            let deadline = ContinuousClock.now.advanced(by: frameBudget)
+            while nextIndex < displayCount {
+                if Task.isCancelled { return }
+                cacheDisplayRow(at: nextIndex, in: tableRows)
+                nextIndex += 1
+                if ContinuousClock.now >= deadline { break }
+            }
+            await Task.yield()
+        }
+    }
+
+    private func cacheDisplayRow(at displayIndex: Int, in tableRows: TableRows) {
+        guard let row = displayRow(at: displayIndex, in: tableRows) else { return }
+        let key = RowIDKey(row.id)
+        guard displayCache.object(forKey: key) == nil else { return }
+
+        let columnCount = tableRows.columns.count
+        var values = ContiguousArray<String?>()
+        values.reserveCapacity(columnCount)
+        for _ in 0..<columnCount { values.append(nil) }
+        for col in 0..<min(row.values.count, columnCount) {
+            let columnType = col < tableRows.columnTypes.count ? tableRows.columnTypes[col] : nil
+            let format = col < columnDisplayFormats.count ? columnDisplayFormats[col] : nil
+            values[col] = CellDisplayFormatter.format(
+                row.values[col],
+                columnType: columnType,
+                displayFormat: format
+            ) ?? row.values[col].asText
+        }
+        let box = RowDisplayBox(values)
+        displayCache.setObject(box, forKey: key, cost: displayCacheCost(values))
     }
 
     private func displayCacheCost(_ values: ContiguousArray<String?>) -> Int {
@@ -519,6 +624,29 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
     @discardableResult
     func rebuildColumnMetadataCache(from tableRows: TableRows) -> Bool {
+        let columns = tableRows.columns
+        let nextSchema = ColumnIdentitySchema(columns: columns)
+        let schemaChanged = nextSchema != identitySchema
+
+        let fingerprint = ColumnMetadataFingerprint(
+            columnsCount: columns.count,
+            columnTypesCount: tableRows.columnTypes.count,
+            foreignKeyKeysCount: tableRows.columnForeignKeys.count,
+            enumValuesKeysCount: tableRows.columnEnumValues.count
+        )
+        let metadataChanged = schemaChanged || fingerprint != lastColumnMetadataFingerprint
+        if metadataChanged {
+            rebuildKindSets(from: tableRows)
+            lastColumnMetadataFingerprint = fingerprint
+        }
+
+        guard schemaChanged else { return false }
+        identitySchema = nextSchema
+        displayCache.removeAllObjects()
+        return true
+    }
+
+    private func rebuildKindSets(from tableRows: TableRows) {
         var enumSet = Set<Int>()
         var fkSet = Set<Int>()
         let columns = tableRows.columns
@@ -540,40 +668,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
         enumOrSetColumns = enumSet
         fkColumns = fkSet
-
-        let nextSchema = ColumnIdentitySchema(columns: columns)
-        guard nextSchema != identitySchema else { return false }
-        identitySchema = nextSchema
-        displayCache.removeAllObjects()
-        return true
-    }
-
-    // MARK: - Font Updates
-
-    @MainActor
-    static func updateVisibleCellFonts(tableView: NSTableView) {
-        let visibleRect = tableView.visibleRect
-        let visibleRange = tableView.rows(in: visibleRect)
-        guard visibleRange.length > 0 else { return }
-
-        let columnCount = tableView.numberOfColumns
-        for row in visibleRange.location..<(visibleRange.location + visibleRange.length) {
-            for col in 0..<columnCount {
-                guard let cellView = tableView.view(atColumn: col, row: row, makeIfNecessary: false) as? NSTableCellView,
-                      let textField = cellView.textField else { continue }
-
-                switch textField.tag {
-                case DataGridFontVariant.rowNumber:
-                    textField.font = ThemeEngine.shared.dataGridFonts.rowNumber
-                case DataGridFontVariant.italic:
-                    textField.font = ThemeEngine.shared.dataGridFonts.italic
-                case DataGridFontVariant.medium:
-                    textField.font = ThemeEngine.shared.dataGridFonts.medium
-                default:
-                    textField.font = ThemeEngine.shared.dataGridFonts.regular
-                }
-            }
-        }
     }
 
     // MARK: - Row Visual State

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -115,12 +115,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var isCommittingCellEdit = false
     var layoutPersistTask: Task<Void, Never>?
     var lastUpdateSnapshot: DataGridUpdateSnapshot?
-    private var lastColumnMetadataFingerprint = ColumnMetadataFingerprint.empty
     private var prewarmTask: Task<Void, Never>?
     private var prewarmResumeTask: Task<Void, Never>?
     private var scrollObservers: [NSObjectProtocol] = []
-    private static let prewarmFrameBudgetMs: Int = 2
-    private static let prewarmResumeDelayMs: Int = 300
+    private static let prewarmFrameBudget: Duration = .milliseconds(2)
+    private static let prewarmResumeDelay: Duration = .milliseconds(300)
 
     static let rowViewIdentifier = NSUserInterfaceItemIdentifier("TableRowView")
     let visualIndex = RowVisualIndex()
@@ -211,7 +210,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         cachedColumnCount = 0
         sortedIDs = nil
         lastUpdateSnapshot = nil
-        lastColumnMetadataFingerprint = .empty
         columnPool.detachFromTableView()
         if let tableView {
             while let col = tableView.tableColumns.last {
@@ -337,11 +335,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
     }
 
-    /// Populates the entire display cache off the scroll hot path by iterating all
-    /// rows in frame-budgeted batches and yielding between batches. Subsequent
-    /// `tableView(_:viewFor:row:)` calls then hit the cache instead of running
-    /// `CellDisplayFormatter.format` (and its `NSDateFormatter` parse) on the main
-    /// thread during scroll. Replaces any in-flight prewarm task.
+    /// Fills displayCache off the scroll hot path so viewFor:row: stays a cache hit.
     func startBackgroundPrewarm() {
         prewarmResumeTask?.cancel()
         prewarmResumeTask = nil
@@ -351,10 +345,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
     }
 
-    /// Subscribes to the scroll view's live-scroll notifications so the prewarm
-    /// task can be paused while the user is actively scrolling. The task resumes
-    /// after a short debounce so quick successive scrolls do not restart and
-    /// cancel the work repeatedly.
+    /// Pauses prewarm during live scroll; resumes after a debounce so rapid scrolls do not restart it repeatedly.
     func attachScrollObservers(scrollView: NSScrollView) {
         detachScrollObservers()
         let start = NotificationCenter.default.addObserver(
@@ -362,7 +353,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             object: scrollView,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.pausePrewarmForScroll()
             }
         }
@@ -371,7 +362,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             object: scrollView,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.schedulePrewarmResume()
             }
         }
@@ -395,7 +386,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     private func schedulePrewarmResume() {
         prewarmResumeTask?.cancel()
         prewarmResumeTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(Self.prewarmResumeDelayMs))
+            try? await Task.sleep(for: Self.prewarmResumeDelay)
             guard !Task.isCancelled, let self else { return }
             self.startBackgroundPrewarm()
         }
@@ -408,8 +399,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             let displayCount = sortedIDs?.count ?? tableRows.count
             guard nextIndex < displayCount else { return }
 
-            let frameBudget = ContinuousClock.Instant.Duration.milliseconds(Self.prewarmFrameBudgetMs)
-            let deadline = ContinuousClock.now.advanced(by: frameBudget)
+            let deadline = ContinuousClock.now.advanced(by: Self.prewarmFrameBudget)
             while nextIndex < displayCount {
                 if Task.isCancelled { return }
                 cacheDisplayRow(at: nextIndex, in: tableRows)
@@ -628,17 +618,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         let nextSchema = ColumnIdentitySchema(columns: columns)
         let schemaChanged = nextSchema != identitySchema
 
-        let fingerprint = ColumnMetadataFingerprint(
-            columnsCount: columns.count,
-            columnTypesCount: tableRows.columnTypes.count,
-            foreignKeyKeysCount: tableRows.columnForeignKeys.count,
-            enumValuesKeysCount: tableRows.columnEnumValues.count
-        )
-        let metadataChanged = schemaChanged || fingerprint != lastColumnMetadataFingerprint
-        if metadataChanged {
-            rebuildKindSets(from: tableRows)
-            lastColumnMetadataFingerprint = fingerprint
-        }
+        rebuildKindSets(from: tableRows)
 
         guard schemaChanged else { return false }
         identitySchema = nextSchema

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -57,20 +57,29 @@ class DataGridRowView: NSTableRowView {
     override var isSelected: Bool {
         didSet {
             guard isSelected != oldValue else { return }
-            invalidateCellSubviews()
+            propagateEmphasisToCells()
         }
     }
 
     override var isEmphasized: Bool {
         didSet {
             guard isEmphasized != oldValue else { return }
-            invalidateCellSubviews()
+            propagateEmphasisToCells()
         }
     }
 
-    private func invalidateCellSubviews() {
-        for subview in subviews where subview is DataGridCellView {
-            subview.needsDisplay = true
+    override func didAddSubview(_ subview: NSView) {
+        super.didAddSubview(subview)
+        guard let cell = subview as? DataGridCellView else { return }
+        cell.applyEmphasizedSelection(isSelected && isEmphasized)
+    }
+
+    private func propagateEmphasisToCells() {
+        let emphasized = isSelected && isEmphasized
+        for subview in subviews {
+            guard let cell = subview as? DataGridCellView else { continue }
+            cell.applyEmphasizedSelection(emphasized)
+            cell.needsDisplay = true
         }
     }
 

--- a/TablePro/Views/Results/DataGridUpdateSnapshot.swift
+++ b/TablePro/Views/Results/DataGridUpdateSnapshot.swift
@@ -1,0 +1,41 @@
+//
+//  DataGridUpdateSnapshot.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+
+/// Captures the inputs `DataGridView.updateNSView(_:context:)` cares about so the
+/// coordinator can skip the heavy reconciliation pipeline when SwiftUI re-evaluates
+/// the parent view without any data, configuration, or layout change.
+@MainActor
+struct DataGridUpdateSnapshot: Equatable {
+    let rowDisplayCount: Int
+    let columnCount: Int
+    let columns: [String]
+    let sortedIDsCount: Int?
+    let displayFormats: [ValueDisplayFormat?]
+    let configuration: DataGridConfiguration
+    let isEditable: Bool
+    let hasMoveDelegate: Bool
+    let rowHeight: CGFloat
+    let alternatingRows: Bool
+}
+
+/// Lightweight fingerprint for column metadata sets (FK / enum). Catches the common
+/// cases where columns are added, removed, or have their metadata replaced. Identical
+/// fingerprints with the same schema mean the kind sets do not need to be rebuilt.
+struct ColumnMetadataFingerprint: Equatable {
+    let columnsCount: Int
+    let columnTypesCount: Int
+    let foreignKeyKeysCount: Int
+    let enumValuesKeysCount: Int
+
+    static let empty = ColumnMetadataFingerprint(
+        columnsCount: 0,
+        columnTypesCount: 0,
+        foreignKeyKeysCount: 0,
+        enumValuesKeysCount: 0
+    )
+}

--- a/TablePro/Views/Results/DataGridUpdateSnapshot.swift
+++ b/TablePro/Views/Results/DataGridUpdateSnapshot.swift
@@ -6,10 +6,7 @@
 import AppKit
 import Foundation
 
-/// Captures the inputs `DataGridView.updateNSView(_:context:)` cares about so the
-/// coordinator can skip the heavy reconciliation pipeline when SwiftUI re-evaluates
-/// the parent view without any data, configuration, or layout change.
-@MainActor
+/// Equatable input signature; coordinator bails the updateNSView pipeline when unchanged.
 struct DataGridUpdateSnapshot: Equatable {
     let rowDisplayCount: Int
     let columnCount: Int
@@ -21,21 +18,4 @@ struct DataGridUpdateSnapshot: Equatable {
     let hasMoveDelegate: Bool
     let rowHeight: CGFloat
     let alternatingRows: Bool
-}
-
-/// Lightweight fingerprint for column metadata sets (FK / enum). Catches the common
-/// cases where columns are added, removed, or have their metadata replaced. Identical
-/// fingerprints with the same schema mean the kind sets do not need to be rebuilt.
-struct ColumnMetadataFingerprint: Equatable {
-    let columnsCount: Int
-    let columnTypesCount: Int
-    let foreignKeyKeysCount: Int
-    let enumValuesKeysCount: Int
-
-    static let empty = ColumnMetadataFingerprint(
-        columnsCount: 0,
-        columnTypesCount: 0,
-        foreignKeyKeysCount: 0,
-        enumValuesKeysCount: 0
-    )
 }

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -108,6 +108,7 @@ struct DataGridView: NSViewRepresentable {
 
         scrollView.documentView = tableView
         context.coordinator.tableView = tableView
+        context.coordinator.attachScrollObservers(scrollView: scrollView)
         context.coordinator.tableRowsController.attach(tableView)
         context.coordinator.tableRowsProvider = tableRowsProvider
         context.coordinator.tableRowsMutator = tableRowsMutator
@@ -135,12 +136,63 @@ struct DataGridView: NSViewRepresentable {
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let tableView = scrollView.documentView as? NSTableView else { return }
-
         let coordinator = context.coordinator
 
         if tableView.editedRow >= 0 { return }
-        if let editor = context.coordinator.overlayEditor, editor.isActive { return }
+        if let editor = coordinator.overlayEditor, editor.isActive { return }
 
+        coordinator.tableRowsProvider = tableRowsProvider
+        coordinator.tableRowsMutator = tableRowsMutator
+        coordinator.changeManager = changeManager
+
+        let latestRows = tableRowsProvider()
+        let rowDisplayCount = sortedIDs?.count ?? latestRows.count
+        let columnCount = latestRows.columns.count
+        let settings = AppSettingsManager.shared.dataGrid
+        let rowHeight = CGFloat(settings.rowHeight.rawValue)
+        let alternatingRows = settings.showAlternateRows
+
+        let snapshot = DataGridUpdateSnapshot(
+            rowDisplayCount: rowDisplayCount,
+            columnCount: columnCount,
+            columns: latestRows.columns,
+            sortedIDsCount: sortedIDs?.count,
+            displayFormats: displayFormats,
+            configuration: configuration,
+            isEditable: isEditable,
+            hasMoveDelegate: delegate != nil,
+            rowHeight: rowHeight,
+            alternatingRows: alternatingRows
+        )
+
+        if snapshot != coordinator.lastUpdateSnapshot {
+            applyStructuralUpdate(
+                tableView: tableView,
+                coordinator: coordinator,
+                latestRows: latestRows,
+                rowDisplayCount: rowDisplayCount,
+                columnCount: columnCount,
+                rowHeight: rowHeight,
+                alternatingRows: alternatingRows,
+                hasMoveDelegate: snapshot.hasMoveDelegate
+            )
+            coordinator.lastUpdateSnapshot = snapshot
+        }
+
+        syncSortDescriptors(tableView: tableView, coordinator: coordinator, columns: latestRows.columns)
+        syncSelection(tableView: tableView, coordinator: coordinator)
+    }
+
+    private func applyStructuralUpdate(
+        tableView: NSTableView,
+        coordinator: TableViewCoordinator,
+        latestRows: TableRows,
+        rowDisplayCount: Int,
+        columnCount: Int,
+        rowHeight: CGFloat,
+        alternatingRows: Bool,
+        hasMoveDelegate: Bool
+    ) {
         if let rowNumCol = tableView.tableColumns.first(where: { $0.identifier == ColumnIdentitySchema.rowNumberIdentifier }) {
             let shouldHide = !configuration.showRowNumbers
             if rowNumCol.isHidden != shouldHide {
@@ -150,11 +202,10 @@ struct DataGridView: NSViewRepresentable {
 
         let rowDragType = NSPasteboard.PasteboardType("com.TablePro.rowDrag")
         let hasDragRegistered = tableView.registeredDraggedTypes.contains(rowDragType)
-        let hasMoveRow = delegate != nil
-        if hasMoveRow && !hasDragRegistered {
+        if hasMoveDelegate && !hasDragRegistered {
             tableView.registerForDraggedTypes([rowDragType])
             tableView.draggingDestinationFeedbackStyle = .gap
-        } else if !hasMoveRow && hasDragRegistered {
+        } else if !hasMoveDelegate && hasDragRegistered {
             let remaining = tableView.registeredDraggedTypes.filter { $0 != rowDragType }
             tableView.unregisterDraggedTypes()
             if !remaining.isEmpty {
@@ -162,39 +213,26 @@ struct DataGridView: NSViewRepresentable {
             }
         }
 
-        let latestRows = tableRowsProvider()
-        let rowDisplayCount = sortedIDs?.count ?? latestRows.count
-        let columnCount = latestRows.columns.count
-
-        let settings = AppSettingsManager.shared.dataGrid
-        if tableView.rowHeight != CGFloat(settings.rowHeight.rawValue) {
-            tableView.rowHeight = CGFloat(settings.rowHeight.rawValue)
+        if tableView.rowHeight != rowHeight {
+            tableView.rowHeight = rowHeight
         }
-        if tableView.usesAlternatingRowBackgroundColors != settings.showAlternateRows {
-            tableView.usesAlternatingRowBackgroundColors = settings.showAlternateRows
+        if tableView.usesAlternatingRowBackgroundColors != alternatingRows {
+            tableView.usesAlternatingRowBackgroundColors = alternatingRows
         }
 
         let oldRowCount = coordinator.cachedRowCount
         let oldColumnCount = coordinator.cachedColumnCount
-
         let structureChanged = oldRowCount != rowDisplayCount || oldColumnCount != columnCount
 
-        coordinator.updateCache()
         let schemaChanged = coordinator.rebuildColumnMetadataCache(from: latestRows)
         let needsFullReload = structureChanged || schemaChanged
 
-        if oldRowCount == 0, rowDisplayCount > 0 {
-            let rowH = tableView.rowHeight
-            if rowH > 0 {
-                let visibleRows = Int(tableView.visibleRect.height / rowH) + 5
-                coordinator.preWarmDisplayCache(upTo: visibleRows)
-            }
+        if oldRowCount == 0, rowDisplayCount > 0, rowHeight > 0 {
+            let visibleRows = Int(tableView.visibleRect.height / rowHeight) + 5
+            coordinator.preWarmDisplayCache(upTo: visibleRows)
         }
 
-        coordinator.changeManager = changeManager
         coordinator.isEditable = isEditable
-        coordinator.tableRowsProvider = tableRowsProvider
-        coordinator.tableRowsMutator = tableRowsMutator
         coordinator.sortedIDs = sortedIDs
         coordinator.updateCache()
         coordinator.syncDisplayFormats(displayFormats)
@@ -227,13 +265,19 @@ struct DataGridView: NSViewRepresentable {
             }
         }
 
-        syncSortDescriptors(tableView: tableView, coordinator: coordinator, columns: latestRows.columns)
+        if needsFullReload {
+            tableView.reloadData()
+            coordinator.startBackgroundPrewarm()
+        }
+    }
 
-        reloadAndSyncSelection(
-            tableView: tableView,
-            coordinator: coordinator,
-            needsFullReload: needsFullReload
-        )
+    private func syncSelection(tableView: NSTableView, coordinator: TableViewCoordinator) {
+        let currentSelection = tableView.selectedRowIndexes
+        let targetSelection = IndexSet(selectedRowIndices)
+        guard currentSelection != targetSelection else { return }
+        coordinator.isSyncingSelection = true
+        tableView.selectRowIndexes(targetSelection, byExtendingSelection: false)
+        coordinator.isSyncingSelection = false
     }
 
     private func reconcileColumnPool(
@@ -291,24 +335,6 @@ struct DataGridView: NSViewRepresentable {
 
         if let header = tableView.headerView as? SortableHeaderView {
             header.updateSortIndicators(state: sortState, schema: schema)
-        }
-    }
-
-    private func reloadAndSyncSelection(
-        tableView: NSTableView,
-        coordinator: TableViewCoordinator,
-        needsFullReload: Bool
-    ) {
-        if needsFullReload {
-            tableView.reloadData()
-        }
-
-        let currentSelection = tableView.selectedRowIndexes
-        let targetSelection = IndexSet(selectedRowIndices)
-        if currentSelection != targetSelection {
-            coordinator.isSyncingSelection = true
-            tableView.selectRowIndexes(targetSelection, byExtendingSelection: false)
-            coordinator.isSyncingSelection = false
         }
     }
 

--- a/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
@@ -32,7 +32,7 @@ extension TableViewCoordinator {
             return nil
         }
 
-        guard let displayRow = displayRow(at: row),
+        guard let displayRow = displayRow(at: row, in: tableRows),
               columnIndex < displayRow.values.count else {
             return nil
         }
@@ -74,18 +74,10 @@ extension TableViewCoordinator {
             isDropdownColumn: resolvedDropdown
         )
 
-        let rawText = rawValue.asText
-        let accessibilityValue = rawText ?? String(localized: "NULL")
         let content = DataGridCellContent(
             displayText: formattedValue ?? "",
-            rawValue: rawText,
-            placeholder: placeholderKind(for: rawValue),
-            accessibilityLabel: String(
-                format: String(localized: "Row %d, column %d: %@"),
-                row + 1,
-                columnIndex + 1,
-                accessibilityValue
-            )
+            rawValue: rawValue.asText,
+            placeholder: placeholderKind(for: rawValue)
         )
         let cellState = DataGridCellState(
             visualState: state,


### PR DESCRIPTION
## Summary

- Direct-draw cell text via `CTLineDraw` (replaces `NSAttributedString.draw(with:options:)`) — drops `NSStringDrawing` + justification engine from the scroll redraw path
- Pre-resolved `CGImage` for chevron / FK arrow accessories — skips `NSImage._usingBestRepresentationForRect` and hint validation per cell
- `DataGridUpdateSnapshot` Equatable input fingerprint at the top of `updateNSView` — skips rebuild, reconcile, visualIndex when SwiftUI re-evaluates with no real change
- Background display-cache prewarm via `Task` + `Task.yield()` with a 2 ms per-batch budget, paused on `NSScrollView.willStartLiveScrollNotification` and resumed 300 ms after `didEndLiveScrollNotification`
- Lazy `accessibilityLabel()` override on cell — string only built when VoiceOver requests it
- Row view pushes emphasized-selection state to cell subviews via `didAddSubview` and setter `didSet`, cell no longer walks the superview chain in `viewWillDraw`
- Theme changes reload visible rows so the direct-draw cell picks up the new palette (legacy `updateVisibleCellFonts` removed)
- `DateFormattingService` cache bumped 10k → 100k, `displayCache` bumped 5k → 50k rows / 32 MB → 64 MB

## Test plan

- [ ] Open a MySQL or PostgreSQL table with 10k+ rows, scroll continuously with trackpad and scrollbar — verify no visible jank
- [ ] Open the same table, switch app theme — verify visible cell fonts and colors update without reloading the tab
- [ ] Click a cell, edit value, press enter — verify field editor opens and commits the change
- [ ] Click chevron in date / json / blob cell — verify popover opens
- [ ] Click FK arrow — verify FK preview popover opens
- [ ] Select a range of rows (Cmd+click, Shift+click) — verify selection highlight on cells
- [ ] Right-click a row — verify context menu items work (Copy, Copy as JSON, Set Value > NULL, etc.)
- [ ] Filter by typing in the filter bar — verify rows filter and prewarm resumes after filter settles
- [ ] Sort by clicking a column header — verify rows reorder and selection follows
- [ ] Resize a column — verify column width persists across reopening the tab
- [ ] Toggle a column visible / hidden from the column visibility popover — verify the grid reflows
- [ ] Scroll to a row, edit a cell, undo (Cmd+Z) — verify cell content reverts and visual state clears
- [ ] Run `swiftlint lint --strict` — no new warnings