### PR TITLE
fix(plugins): log unknown plugin table type strings

### DIFF
--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -161,10 +161,17 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     func fetchTables() async throws -> [TableInfo] {
         let pluginTables = try await pluginDriver.fetchTables(schema: pluginDriver.currentSchema)
         return pluginTables.map { table in
-            let tableType: TableInfo.TableType = switch table.type.lowercased() {
-            case "view": .view
-            case "system table": .systemTable
-            default: .table
+            let tableType: TableInfo.TableType
+            switch table.type.lowercased() {
+            case "table":
+                tableType = .table
+            case "view":
+                tableType = .view
+            case "system table":
+                tableType = .systemTable
+            default:
+                Self.logger.warning("Unknown plugin table type \"\(table.type, privacy: .public)\" for \"\(table.name, privacy: .public)\"; defaulting to .table")
+                tableType = .table
             }
             return TableInfo(name: table.name, type: tableType, rowCount: table.rowCount)
         }


### PR DESCRIPTION
## What

In `PluginDriverAdapter.fetchTables`, the `switch table.type.lowercased()` had a silent `default: .table` fallback. Unknown type strings like \"MATERIALIZED VIEW\" or \"FOREIGN TABLE\" were collapsed to `.table` with no signal.

## Why

Prepares the surface for issue #1038 (sidebar grouping). With matviews/foreign tables landing soon, silent fallback would misclassify objects. Logging makes the misclassification visible in console during dev so we catch it before it ships.

## Not in scope

- New type cases on `TableInfo.TableType` (lands in #1038)
- Adapter normalization of \"base table\", \"prefix\", etc. (separate PR)

## Test plan

- [x] swiftlint clean on touched files
- [ ] Reviewer can grep `category: \"PluginDriverAdapter\"` to confirm logger reuse