### PR TITLE
refactor(plugins): add schema/owner/comment metadata to PluginTableInfo

### DIFF
--- a/Plugins/TableProPluginKit/PluginTableInfo.swift
+++ b/Plugins/TableProPluginKit/PluginTableInfo.swift
@@ -4,10 +4,23 @@ public struct PluginTableInfo: Codable, Sendable {
     public let name: String
     public let type: String
     public let rowCount: Int?
+    public let schema: String?
+    public let owner: String?
+    public let comment: String?
 
-    public init(name: String, type: String = "TABLE", rowCount: Int? = nil) {
+    public init(
+        name: String,
+        type: String = "TABLE",
+        rowCount: Int? = nil,
+        schema: String? = nil,
+        owner: String? = nil,
+        comment: String? = nil
+    ) {
         self.name = name
         self.type = type
         self.rowCount = rowCount
+        self.schema = schema
+        self.owner = owner
+        self.comment = comment
     }
 }


### PR DESCRIPTION
## What

Adds three optional public fields to `PluginTableInfo`: `schema`, `owner`, `comment`. Public init now takes them with `nil` defaults. Existing plugin call sites compile unchanged.

## Why

Prepares the surface for issue #1038 (sidebar grouping). After #1038, the sidebar needs schema/owner to group and filter tables. Adding optional fields now avoids wire-format churn when individual plugins start populating them.

## Not in scope

- Updating individual plugin `fetchTables` to populate the new fields
- Surfacing these fields in `TableInfo` or the sidebar UI

## Test plan

- [x] swiftlint clean
- [x] All existing call sites use positional or labeled args that still resolve (new fields default to nil)
- [ ] Decodable synthesis: optional fields tolerate missing keys in old persisted JSON