### PR TITLE
refactor(plugins): normalize fetchTables type strings in adapter

### DIFF
--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -162,8 +162,9 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         let pluginTables = try await pluginDriver.fetchTables(schema: pluginDriver.currentSchema)
         return pluginTables.map { table in
             let tableType: TableInfo.TableType = switch table.type.lowercased() {
+            case "table", "base table", "prefix": .table
             case "view": .view
-            case "system table": .systemTable
+            case "system table", "system base table", "system view": .systemTable
             default: .table
             }
             return TableInfo(name: table.name, type: tableType, rowCount: table.rowCount)


### PR DESCRIPTION
## What

Extends the `switch table.type.lowercased()` in `PluginDriverAdapter.fetchTables` to recognize the variants different plugins return today: Oracle/MSSQL return \"BASE TABLE\", Etcd returns \"PREFIX\", and some return \"SYSTEM VIEW\". Adapter is now permissive about the canonical strings.

## Why

Plugin fetchTables impls are inconsistent (audit: `/tmp/issue-1038/prerefactor/plugin-fetch.md`). Centralizing the normalization in the adapter lets plugins keep their existing strings while the app sees a clean enum mapping. Required before #1038 maps matviews and foreign tables.

## Not in scope

- Modifying individual plugin fetchTables impls
- Adding a new `materializedView` case to `TableInfo.TableType` (lands in #1038)
- Logging unknown types (separate PR)

## Test plan

- [x] swiftlint clean
- [ ] No regression: previously known cases (\"view\", \"system table\") still map identically