### PR TITLE
fix(plugin-cassandra): exclude materialized views from fetchTables

### DIFF
--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -991,27 +991,14 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let ks = resolveKeyspace(schema)
 
-        // Fetch tables
         let tablesQuery = """
             SELECT table_name FROM system_schema.tables WHERE keyspace_name = '\(escapeSingleQuote(ks))'
         """
         let tablesResult = try await execute(query: tablesQuery)
 
-        var tables = tablesResult.rows.compactMap { row -> PluginTableInfo? in
+        let tables = tablesResult.rows.compactMap { row -> PluginTableInfo? in
             guard let name = row[safe: 0] ?? nil else { return nil }
             return PluginTableInfo(name: name, type: "TABLE")
-        }
-
-        // Fetch materialized views
-        let viewsQuery = """
-            SELECT view_name FROM system_schema.views WHERE keyspace_name = '\(escapeSingleQuote(ks))'
-        """
-        if let viewsResult = try? await execute(query: viewsQuery) {
-            let views = viewsResult.rows.compactMap { row -> PluginTableInfo? in
-                guard let name = row[safe: 0] ?? nil else { return nil }
-                return PluginTableInfo(name: name, type: "VIEW")
-            }
-            tables.append(contentsOf: views)
         }
 
         return tables.sorted { $0.name < $1.name }


### PR DESCRIPTION
## What

`CassandraPlugin.fetchTables` was returning materialized views from `system_schema.views` merged into the table list with type \"VIEW\". This PR drops that second query so `fetchTables` returns only true tables.

## Why

The driver declares the `.materializedViews` capability but the implementation hides matviews behind a generic \"VIEW\" string. Once #1038 surfaces views and matviews as their own sidebar sections, mixing them at the fetch layer would double-list every matview. Keeping `fetchTables` table-only now lets #1038 add a dedicated fetch path cleanly.

## Not in scope

- A new `fetchMaterializedViews` method (lands in #1038)
- Re-surfacing views/matviews in the sidebar (lands in #1038)

## Test plan

- [x] swiftlint clean on touched file (no new warnings)
- [ ] Manual: open a Cassandra keyspace with a matview; confirm sidebar lists only tables