### PR TITLE
fix(plugin-bigquery): declare materializedViews capability

### DIFF
--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -57,6 +57,7 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
             .truncateTable,
             .multiSchema,
             .cancelQuery,
+            .materializedViews,
         ]
     }
 


### PR DESCRIPTION
## What

Adds `.materializedViews` to `BigQueryPluginDriver.capabilities`.

## Why

`fetchTables` already returns `\"MATERIALIZED_VIEW\"` for matviews (see `BigQueryPluginDriver.swift:282`) but the capability flag did not declare it. Once #1038 reads the flag to decide which sidebar sections to render, BigQuery would be silently excluded.

## Not in scope

- New plugin output (matview support is already there)
- UI changes (lands in #1038)

## Test plan

- [x] swiftlint clean (no new warnings)
- [ ] Manual: open a BigQuery dataset with a matview; after #1038, confirm matview section appears