### PR TITLE
refactor(sidebar): centralize sidebar UserDefaults keys

### DIFF
--- a/TablePro/Models/UI/SharedSidebarState.swift
+++ b/TablePro/Models/UI/SharedSidebarState.swift
@@ -24,7 +24,7 @@ final class SharedSidebarState {
         didSet {
             UserDefaults.standard.set(
                 selectedSidebarTab.rawValue,
-                forKey: "sidebar.selectedTab.\(connectionId.uuidString)"
+                forKey: SidebarPersistenceKey.selectedTab(connectionId: connectionId)
             )
         }
     }
@@ -33,7 +33,7 @@ final class SharedSidebarState {
 
     private init(connectionId: UUID) {
         self.connectionId = connectionId
-        let key = "sidebar.selectedTab.\(connectionId.uuidString)"
+        let key = SidebarPersistenceKey.selectedTab(connectionId: connectionId)
         if let raw = UserDefaults.standard.string(forKey: key),
            let tab = SidebarTab(rawValue: raw) {
             self.selectedSidebarTab = tab

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -17,22 +17,26 @@ final class SidebarViewModel {
 
     var searchText = ""
     var isTablesExpanded: Bool = {
-        let key = "sidebar.isTablesExpanded"
+        let key = SidebarPersistenceKey.isTablesExpanded
         if UserDefaults.standard.object(forKey: key) != nil {
             return UserDefaults.standard.bool(forKey: key)
         }
         return true
     }() {
-        didSet { UserDefaults.standard.set(isTablesExpanded, forKey: "sidebar.isTablesExpanded") }
+        didSet {
+            UserDefaults.standard.set(isTablesExpanded, forKey: SidebarPersistenceKey.isTablesExpanded)
+        }
     }
     var isRedisKeysExpanded: Bool = {
-        let key = "sidebar.isRedisKeysExpanded"
+        let key = SidebarPersistenceKey.isRedisKeysExpanded
         if UserDefaults.standard.object(forKey: key) != nil {
             return UserDefaults.standard.bool(forKey: key)
         }
         return true
     }() {
-        didSet { UserDefaults.standard.set(isRedisKeysExpanded, forKey: "sidebar.isRedisKeysExpanded") }
+        didSet {
+            UserDefaults.standard.set(isRedisKeysExpanded, forKey: SidebarPersistenceKey.isRedisKeysExpanded)
+        }
     }
     var redisKeyTreeViewModel: RedisKeyTreeViewModel?
     var showOperationDialog = false

--- a/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
+++ b/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum SidebarPersistenceKey {
+    static let isTablesExpanded = "sidebar.isTablesExpanded"
+    static let isRedisKeysExpanded = "sidebar.isRedisKeysExpanded"
+
+    static func selectedTab(connectionId: UUID) -> String {
+        "sidebar.selectedTab.\(connectionId.uuidString)"
+    }
+}


### PR DESCRIPTION
## What

Adds `SidebarPersistenceKey` enum collecting the sidebar UserDefaults keys (`isTablesExpanded`, `isRedisKeysExpanded`, `selectedTab.<connectionId>`). Migrates `SidebarViewModel` and `SharedSidebarState` to read/write through it. Behavior unchanged: same keys, same values.

## Why

Hardcoded string keys are scattered across files. Once #1038 adds expansion flags for views, matviews, foreign tables, etc., we want one place to keep them in sync. A central type also catches typos at compile time.

## Not in scope

- Migrating these keys to per-connection (separate PR)
- Adding new keys for #1038's sections

## Test plan

- [x] swiftlint clean
- [ ] Manual: confirm expansion state persists across relaunch on the same key as before