### PR TITLE
refactor(sidebar): per-connection expansion state

### DIFF
--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -16,28 +16,48 @@ final class SidebarViewModel {
     // MARK: - Published State
 
     var searchText = ""
-    var isTablesExpanded: Bool = {
-        let key = "sidebar.isTablesExpanded"
-        if UserDefaults.standard.object(forKey: key) != nil {
-            return UserDefaults.standard.bool(forKey: key)
+    var isTablesExpanded: Bool {
+        didSet {
+            UserDefaults.standard.set(isTablesExpanded, forKey: Self.tablesExpandedKey(connectionId: connectionId))
         }
-        return true
-    }() {
-        didSet { UserDefaults.standard.set(isTablesExpanded, forKey: "sidebar.isTablesExpanded") }
     }
-    var isRedisKeysExpanded: Bool = {
-        let key = "sidebar.isRedisKeysExpanded"
-        if UserDefaults.standard.object(forKey: key) != nil {
-            return UserDefaults.standard.bool(forKey: key)
+    var isRedisKeysExpanded: Bool {
+        didSet {
+            UserDefaults.standard.set(isRedisKeysExpanded, forKey: Self.redisKeysExpandedKey(connectionId: connectionId))
         }
-        return true
-    }() {
-        didSet { UserDefaults.standard.set(isRedisKeysExpanded, forKey: "sidebar.isRedisKeysExpanded") }
     }
     var redisKeyTreeViewModel: RedisKeyTreeViewModel?
     var showOperationDialog = false
     var pendingOperationType: TableOperationType?
     var pendingOperationTables: [String] = []
+
+    private static let legacyTablesExpandedKey = "sidebar.isTablesExpanded"
+    private static let legacyRedisKeysExpandedKey = "sidebar.isRedisKeysExpanded"
+
+    private static func tablesExpandedKey(connectionId: UUID) -> String {
+        "sidebar.\(connectionId.uuidString).tables.expanded"
+    }
+
+    private static func redisKeysExpandedKey(connectionId: UUID) -> String {
+        "sidebar.\(connectionId.uuidString).redisKeys.expanded"
+    }
+
+    private static func loadExpansion(
+        perConnectionKey: String,
+        legacyKey: String,
+        defaultValue: Bool
+    ) -> Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: perConnectionKey) != nil {
+            return defaults.bool(forKey: perConnectionKey)
+        }
+        if defaults.object(forKey: legacyKey) != nil {
+            let seeded = defaults.bool(forKey: legacyKey)
+            defaults.set(seeded, forKey: perConnectionKey)
+            return seeded
+        }
+        return defaultValue
+    }
 
     // MARK: - Binding Storage
 
@@ -89,6 +109,16 @@ final class SidebarViewModel {
         self.tableOperationOptionsBinding = tableOperationOptions
         self.databaseType = databaseType
         self.connectionId = connectionId
+        self.isTablesExpanded = Self.loadExpansion(
+            perConnectionKey: Self.tablesExpandedKey(connectionId: connectionId),
+            legacyKey: Self.legacyTablesExpandedKey,
+            defaultValue: true
+        )
+        self.isRedisKeysExpanded = Self.loadExpansion(
+            perConnectionKey: Self.redisKeysExpandedKey(connectionId: connectionId),
+            legacyKey: Self.legacyRedisKeysExpandedKey,
+            defaultValue: true
+        )
     }
 
     // MARK: - Batch Operations


### PR DESCRIPTION
## What

Reworks sidebar expansion persistence so each connection has its own `tables.expanded` and `redisKeys.expanded` flag. Key shape: `sidebar.<connectionId>.tables.expanded`. The old global key is read once and seeded into the connection-specific key on first load; the legacy key is left in place (harmless).

## Why

`isTablesExpanded` and `isRedisKeysExpanded` lived under a single global key. Two open connections shared one bit, so expanding tables on connection A flipped the state on connection B. Once #1038 adds 5+ more flags, that collision compounds. Per-connection keys isolate state.

## Optional dependency

PR #1199 (`chore/sidebar-userdefaults-keys`) centralizes sidebar UserDefaults keys into `SidebarPersistenceKey`. This PR inlines key building to stay independent; once #1199 lands, the inline helpers can move into `SidebarPersistenceKey`.

## Not in scope

- New expansion flags for #1038's matview / foreign table sections
- Touching `selectedSidebarTab` persistence (already per-connection)
- Deleting the legacy global keys (left in place to avoid losing state for users who roll back)

## Test plan

- [x] swiftlint clean
- [ ] Manual: open two connections, toggle Tables on each, relaunch; each preserves its own state
- [ ] Migration: a user with the legacy `sidebar.isTablesExpanded` key set to false sees the first connection load collapsed, the global key still present