### PR TITLE
perf(sidebar): memoize filteredTables on the view model

### DIFF
--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -15,7 +15,9 @@ import SwiftUI
 final class SidebarViewModel {
     // MARK: - Published State
 
-    var searchText = ""
+    var searchText = "" {
+        didSet { invalidateFilteredTablesCache() }
+    }
     var isTablesExpanded: Bool = {
         let key = "sidebar.isTablesExpanded"
         if UserDefaults.standard.object(forKey: key) != nil {
@@ -175,5 +177,34 @@ final class SidebarViewModel {
         guard !selectedTables.isEmpty else { return }
         let names = selectedTables.map { $0.name }.sorted()
         ClipboardService.shared.writeText(names.joined(separator: ","))
+    }
+
+    // MARK: - Filtering
+
+    @ObservationIgnored private var cachedFilteredTables: [TableInfo]?
+    @ObservationIgnored private var cachedFilterInputs: (count: Int, hash: Int, query: String)?
+
+    func filteredTables(from tables: [TableInfo]) -> [TableInfo] {
+        let query = searchText
+        let fingerprint = (count: tables.count, hash: tables.hashValue, query: query)
+        if let cache = cachedFilteredTables,
+           let inputs = cachedFilterInputs,
+           inputs == fingerprint {
+            return cache
+        }
+        let result: [TableInfo]
+        if query.isEmpty {
+            result = tables
+        } else {
+            result = tables.filter { $0.name.localizedCaseInsensitiveContains(query) }
+        }
+        cachedFilteredTables = result
+        cachedFilterInputs = fingerprint
+        return result
+    }
+
+    private func invalidateFilteredTablesCache() {
+        cachedFilteredTables = nil
+        cachedFilterInputs = nil
     }
 }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -27,8 +27,7 @@ struct SidebarView: View {
     }
 
     private var filteredTables: [TableInfo] {
-        guard !viewModel.searchText.isEmpty else { return tables }
-        return tables.filter { $0.name.localizedCaseInsensitiveContains(viewModel.searchText) }
+        viewModel.filteredTables(from: tables)
     }
 
     private var selectedTablesBinding: Binding<Set<TableInfo>> {


### PR DESCRIPTION
## What

Moves the `filteredTables` filter into `SidebarViewModel.filteredTables(from:)` with a cache keyed on the input `(count, hashValue, searchText)`. View now calls the VM method; output is identical for identical inputs.

## Why

The plain computed `filteredTables` in `SidebarView` ran the filter on every body access. Once #1038 adds 5 more sidebar sections, that work multiplies. The cache makes repeated renders during scroll/typing return in O(1) when nothing has changed.

## Not in scope

- Adding new sections (lands in #1038)
- Refactoring `tables` source to push from `SchemaService` instead of pulling

## Test plan

- [x] swiftlint clean
- [ ] Manual: type into search, confirm filtered results match prior behavior
- [ ] Manual: refresh schema, confirm the new table list flushes the cache