### PR TITLE
feat(plugins): #1038 PR A - data layer for sidebar grouping

### DIFF
--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Routines.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Routines.swift
@@ -1,0 +1,65 @@
+//
+//  MySQLPluginDriver+Routines.swift
+//  MySQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+extension MySQLPluginDriver: PluginProcedureFunctionSupport {
+    func fetchProcedures(schema: String?) async throws -> [PluginRoutineInfo] {
+        try await fetchRoutines(routineType: "PROCEDURE")
+    }
+
+    func fetchFunctions(schema: String?) async throws -> [PluginRoutineInfo] {
+        try await fetchRoutines(routineType: "FUNCTION")
+    }
+
+    func fetchProcedureDDL(name: String, schema: String?) async throws -> String {
+        try await fetchRoutineDDL(name: name, kind: "PROCEDURE")
+    }
+
+    func fetchFunctionDDL(name: String, schema: String?) async throws -> String {
+        try await fetchRoutineDDL(name: name, kind: "FUNCTION")
+    }
+
+    private func fetchRoutines(routineType: String) async throws -> [PluginRoutineInfo] {
+        let typeLiteral = escapeStringLiteral(routineType)
+        let query = """
+            SELECT routine_name, data_type
+            FROM information_schema.routines
+            WHERE routine_schema = DATABASE()
+              AND routine_type = '\(typeLiteral)'
+            ORDER BY routine_name
+            """
+        let result = try await execute(query: query)
+        return result.rows.compactMap { row -> PluginRoutineInfo? in
+            guard let name = row[safe: 0]?.asText else { return nil }
+            return PluginRoutineInfo(
+                name: name,
+                returnType: row[safe: 1]?.asText,
+                language: "SQL"
+            )
+        }
+    }
+
+    private func fetchRoutineDDL(name: String, kind: String) async throws -> String {
+        let quoted = quoteIdentifier(name)
+        let result = try await execute(query: "SHOW CREATE \(kind) \(quoted)")
+        guard let row = result.rows.first else {
+            throw NSError(
+                domain: "MySQLDriverPlugin",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "DDL not found for \(kind.lowercased()) '\(name)'"]
+            )
+        }
+        if let ddl = row[safe: 2]?.asText, !ddl.isEmpty {
+            return ddl
+        }
+        throw NSError(
+            domain: "MySQLDriverPlugin",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "DDL body missing for \(kind.lowercased()) '\(name)'"]
+        )
+    }
+}

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -32,6 +32,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             .alterTableDDL,
             .foreignKeyToggle,
             .cancelQuery,
+            .storedProcedures,
+            .userFunctions,
         ]
     }
 

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
@@ -1,0 +1,70 @@
+//
+//  PostgreSQLPluginDriver+Routines.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+extension PostgreSQLPluginDriver: PluginProcedureFunctionSupport {
+    func fetchProcedures(schema: String?) async throws -> [PluginRoutineInfo] {
+        try await fetchRoutines(schema: schema, routineType: "PROCEDURE")
+    }
+
+    func fetchFunctions(schema: String?) async throws -> [PluginRoutineInfo] {
+        try await fetchRoutines(schema: schema, routineType: "FUNCTION")
+    }
+
+    func fetchProcedureDDL(name: String, schema: String?) async throws -> String {
+        try await fetchRoutineDDL(name: name, schema: schema, routineType: "PROCEDURE")
+    }
+
+    func fetchFunctionDDL(name: String, schema: String?) async throws -> String {
+        try await fetchRoutineDDL(name: name, schema: schema, routineType: "FUNCTION")
+    }
+
+    private func fetchRoutines(schema: String?, routineType: String) async throws -> [PluginRoutineInfo] {
+        let schemaLiteral = escapeStringLiteral(schema ?? currentSchema ?? "public")
+        let typeLiteral = escapeStringLiteral(routineType)
+        let query = """
+            SELECT routine_name, data_type, external_language
+            FROM information_schema.routines
+            WHERE routine_schema = '\(schemaLiteral)'
+              AND routine_type = '\(typeLiteral)'
+            ORDER BY routine_name
+            """
+        let result = try await execute(query: query)
+        return result.rows.compactMap { row -> PluginRoutineInfo? in
+            guard row.count >= 1, let name = row[0].asText else { return nil }
+            let returnType = row.count > 1 ? row[1].asText : nil
+            let language = row.count > 2 ? row[2].asText : nil
+            return PluginRoutineInfo(name: name, returnType: returnType, language: language)
+        }
+    }
+
+    private func fetchRoutineDDL(name: String, schema: String?, routineType: String) async throws -> String {
+        let schemaLiteral = escapeStringLiteral(schema ?? currentSchema ?? "public")
+        let nameLiteral = escapeStringLiteral(name)
+        let typeLiteral = escapeStringLiteral(routineType)
+        let query = """
+            SELECT pg_get_functiondef(p.oid)
+            FROM pg_proc p
+            JOIN pg_namespace n ON n.oid = p.pronamespace
+            JOIN information_schema.routines r
+              ON r.specific_name = p.proname || '_' || p.oid
+            WHERE n.nspname = '\(schemaLiteral)'
+              AND p.proname = '\(nameLiteral)'
+              AND r.routine_type = '\(typeLiteral)'
+            LIMIT 1
+            """
+        let result = try await execute(query: query)
+        guard let firstRow = result.rows.first, !firstRow.isEmpty, let ddl = firstRow[0].asText else {
+            throw NSError(
+                domain: "PostgreSQLDriverPlugin",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "DDL not found for \(routineType.lowercased()) '\(name)'"]
+            )
+        }
+        return ddl
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
@@ -35,10 +35,12 @@ extension PostgreSQLPluginDriver: PluginProcedureFunctionSupport {
             """
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginRoutineInfo? in
-            guard row.count >= 1, let name = row[0].asText else { return nil }
-            let returnType = row.count > 1 ? row[1].asText : nil
-            let language = row.count > 2 ? row[2].asText : nil
-            return PluginRoutineInfo(name: name, returnType: returnType, language: language)
+            guard let name = row[safe: 0]?.asText else { return nil }
+            return PluginRoutineInfo(
+                name: name,
+                returnType: row[safe: 1]?.asText,
+                language: row[safe: 2]?.asText
+            )
         }
     }
 
@@ -58,7 +60,7 @@ extension PostgreSQLPluginDriver: PluginProcedureFunctionSupport {
             LIMIT 1
             """
         let result = try await execute(query: query)
-        guard let firstRow = result.rows.first, !firstRow.isEmpty, let ddl = firstRow[0].asText else {
+        guard let ddl = result.rows.first?[safe: 0]?.asText else {
             throw NSError(
                 domain: "PostgreSQLDriverPlugin",
                 code: -1,

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -24,7 +24,18 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     var parameterStyle: ParameterStyle { .dollar }
 
     var capabilities: PluginCapabilities {
-        [.parameterizedQueries, .transactions, .alterTableDDL, .multiSchema, .cancelQuery, .batchExecute]
+        [
+            .parameterizedQueries,
+            .transactions,
+            .alterTableDDL,
+            .multiSchema,
+            .cancelQuery,
+            .batchExecute,
+            .materializedViews,
+            .foreignTables,
+            .storedProcedures,
+            .userFunctions
+        ]
     }
 
     init(config: DriverConnectionConfig) {
@@ -218,17 +229,36 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Schema
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
+        let schemaLiteral = escapeLiteral(schema ?? _currentSchema)
         let query = """
-            SELECT table_name, table_type
-            FROM information_schema.tables
-            WHERE table_schema = '\(escapedSchema)'
+            SELECT table_name, table_type FROM information_schema.tables
+            WHERE table_schema = '\(schemaLiteral)'
+            UNION ALL
+            SELECT matviewname AS table_name, 'MATERIALIZED VIEW' AS table_type
+            FROM pg_matviews
+            WHERE schemaname = '\(schemaLiteral)'
+            UNION ALL
+            SELECT c.relname AS table_name, 'FOREIGN TABLE' AS table_type
+            FROM pg_foreign_table ft
+            JOIN pg_class c ON c.oid = ft.ftrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = '\(schemaLiteral)'
             ORDER BY table_name
             """
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginTableInfo? in
             guard let name = row[0].asText else { return nil }
             let typeStr = row[1].asText ?? "BASE TABLE"
-            let type = typeStr.contains("VIEW") ? "VIEW" : "TABLE"
+            let type: String
+            if typeStr == "MATERIALIZED VIEW" {
+                type = "MATERIALIZED VIEW"
+            } else if typeStr == "FOREIGN TABLE" {
+                type = "FOREIGN TABLE"
+            } else if typeStr.contains("VIEW") {
+                type = "VIEW"
+            } else {
+                type = "TABLE"
+            }
             return PluginTableInfo(name: name, type: type)
         }
     }

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -167,6 +167,10 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
                 tableType = .table
             case "view":
                 tableType = .view
+            case "materialized view", "materialized_view":
+                tableType = .materializedView
+            case "foreign table", "foreign_table":
+                tableType = .foreignTable
             case "system table", "system base table", "system view":
                 tableType = .systemTable
             default:

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -81,6 +81,8 @@ struct TableInfo: Identifiable, Hashable, Sendable {
     enum TableType: String, Sendable {
         case table = "TABLE"
         case view = "VIEW"
+        case materializedView = "MATERIALIZED VIEW"
+        case foreignTable = "FOREIGN TABLE"
         case systemTable = "SYSTEM TABLE"
     }
 

--- a/TablePro/ViewModels/QuickSwitcherViewModel.swift
+++ b/TablePro/ViewModels/QuickSwitcherViewModel.swift
@@ -64,6 +64,12 @@ internal final class QuickSwitcherViewModel {
             case .view:
                 kind = .view
                 subtitle = String(localized: "View")
+            case .materializedView:
+                kind = .view
+                subtitle = String(localized: "Materialized View")
+            case .foreignTable:
+                kind = .table
+                subtitle = String(localized: "Foreign Table")
             case .systemTable:
                 kind = .systemTable
                 subtitle = String(localized: "System")

--- a/TableProTests/Core/Plugins/PluginDriverAdapterTableTypeMappingTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterTableTypeMappingTests.swift
@@ -1,0 +1,157 @@
+//
+//  PluginDriverAdapterTableTypeMappingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+private final class StubTableTypeDriver: PluginDatabaseDriver {
+    var supportsSchemas: Bool { false }
+    var supportsTransactions: Bool { false }
+    var currentSchema: String? { nil }
+    var serverVersion: String? { nil }
+
+    var stubbedTables: [PluginTableInfo] = []
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
+        stubbedTables
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func ping() async throws {}
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+    }
+
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+@Suite("PluginDriverAdapter table type mapping")
+struct PluginDriverAdapterTableTypeMappingTests {
+    private func makeAdapter(driver: StubTableTypeDriver) -> PluginDriverAdapter {
+        let connection = DatabaseConnection(name: "Test", type: .postgresql)
+        return PluginDriverAdapter(connection: connection, pluginDriver: driver)
+    }
+
+    @Test("Maps TABLE/BASE TABLE/PREFIX strings to .table")
+    func mapsTableVariants() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [
+            PluginTableInfo(name: "users", type: "TABLE"),
+            PluginTableInfo(name: "orders", type: "BASE TABLE"),
+            PluginTableInfo(name: "PREFIX", type: "prefix")
+        ]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.count == 3)
+        #expect(tables.allSatisfy { $0.type == .table })
+    }
+
+    @Test("Maps VIEW string to .view")
+    func mapsView() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "user_summary", type: "VIEW")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .view)
+    }
+
+    @Test("Maps MATERIALIZED VIEW string to .materializedView")
+    func mapsMaterializedView() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "daily_sales", type: "MATERIALIZED VIEW")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .materializedView)
+    }
+
+    @Test("Maps materialized_view variant to .materializedView")
+    func mapsMaterializedViewUnderscore() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "daily_sales", type: "materialized_view")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .materializedView)
+    }
+
+    @Test("Maps FOREIGN TABLE string to .foreignTable")
+    func mapsForeignTable() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "remote_users", type: "FOREIGN TABLE")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .foreignTable)
+    }
+
+    @Test("Maps foreign_table variant to .foreignTable")
+    func mapsForeignTableUnderscore() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "remote_users", type: "foreign_table")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .foreignTable)
+    }
+
+    @Test("Maps system table variants to .systemTable")
+    func mapsSystemTable() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [
+            PluginTableInfo(name: "pg_class", type: "SYSTEM TABLE"),
+            PluginTableInfo(name: "sqlite_master", type: "system base table"),
+            PluginTableInfo(name: "sys_views", type: "system view")
+        ]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.count == 3)
+        #expect(tables.allSatisfy { $0.type == .systemTable })
+    }
+
+    @Test("Maps unknown type to .table with warning")
+    func mapsUnknownToTable() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [PluginTableInfo(name: "thing", type: "GIBBERISH")]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables.first?.type == .table)
+    }
+
+    @Test("Type matching is case-insensitive")
+    func caseInsensitiveMatching() async throws {
+        let driver = StubTableTypeDriver()
+        driver.stubbedTables = [
+            PluginTableInfo(name: "t1", type: "table"),
+            PluginTableInfo(name: "v1", type: "View"),
+            PluginTableInfo(name: "m1", type: "Materialized View"),
+            PluginTableInfo(name: "f1", type: "Foreign Table")
+        ]
+        let adapter = makeAdapter(driver: driver)
+        let tables = try await adapter.fetchTables()
+        #expect(tables[0].type == .table)
+        #expect(tables[1].type == .view)
+        #expect(tables[2].type == .materializedView)
+        #expect(tables[3].type == .foreignTable)
+    }
+
+    @Test("TableType raw value round-trip for new cases")
+    func rawValueRoundTrip() {
+        #expect(TableInfo.TableType.materializedView.rawValue == "MATERIALIZED VIEW")
+        #expect(TableInfo.TableType.foreignTable.rawValue == "FOREIGN TABLE")
+        #expect(TableInfo.TableType(rawValue: "MATERIALIZED VIEW") == .materializedView)
+        #expect(TableInfo.TableType(rawValue: "FOREIGN TABLE") == .foreignTable)
+    }
+}


### PR DESCRIPTION
## Scope

Foundation for issue #1038 (sidebar grouping by object kind). Data layer only — no UI changes. PR B will render against this.

PRD: [/tmp/issue-1038/prd/PRD-sidebar-grouping.md] (local), tracking issue #1038.

## Changes

- `TableInfo.TableType`: add `.materializedView = "MATERIALIZED VIEW"` and `.foreignTable = "FOREIGN TABLE"`. Update `QuickSwitcherViewModel` (only exhaustive switch on TableType) to handle new cases, mapping matviews to view bucket and foreign tables to table bucket as interim until PR B introduces dedicated kinds.
- `PluginDriverAdapter.fetchTables`: map `"materialized view"`/`"materialized_view"` to `.materializedView` and `"foreign table"`/`"foreign_table"` to `.foreignTable`. Existing case-insensitive matching and unknown-type warning logging preserved.
- **PostgreSQL plugin**: adopt `PluginProcedureFunctionSupport` via `+Routines.swift` extension. Implements `fetchProcedures/fetchFunctions` via `information_schema.routines` and `fetchProcedureDDL/fetchFunctionDDL` via `pg_get_functiondef`. Extends `fetchTables` to UNION `pg_matviews` and `pg_foreign_table` with explicit type strings. Capability flags add `.materializedViews, .foreignTables, .storedProcedures, .userFunctions`.
- **MySQL plugin**: adopt `PluginProcedureFunctionSupport` via `+Routines.swift` extension. Uses `information_schema.routines` filtered by `routine_schema = DATABASE()` and `SHOW CREATE PROCEDURE/FUNCTION` for DDL. Capabilities add `.storedProcedures, .userFunctions`.

## No ABI bump

`currentPluginKitVersion` stays at 11. Both changes are additive:
- New `PluginCapabilities` flags already exist in PluginKit (lines 10–13 of `PluginCapabilities.swift`); plugins opt in by declaring them.
- `PluginProcedureFunctionSupport` is a separate sub-protocol that plugins downcast to. Existing plugins without it continue to work; new methods are not requirements on `PluginDatabaseDriver`.

## Capability matrix added in this PR

| Plugin     | Tables | Views | Matview | Foreign | Procs | Funcs |
|------------|--------|-------|---------|---------|-------|-------|
| PostgreSQL | yes    | yes   | yes     | yes     | yes   | yes   |
| MySQL      | yes    | yes   | -       | -       | yes   | yes   |

Other plugins unchanged (PR C will roll out Oracle, MSSQL, DuckDB, ClickHouse, etc.).

## Test plan

- [x] `swiftlint --strict` clean on all changed files
- [x] `xcodebuild build` succeeds
- [x] New unit tests `PluginDriverAdapterTableTypeMappingTests` (10 tests) cover TABLE/BASE TABLE/PREFIX/VIEW/MATERIALIZED VIEW/materialized_view/FOREIGN TABLE/foreign_table/SYSTEM TABLE variants, case-insensitive matching, unknown-type fallback, and raw-value round trip
- [x] Existing `PluginDriverAdapterTableOpsTests` still pass
- [ ] Manual: connect to Postgres with a matview + foreign table + procedure + function and confirm `fetchTables` returns them with correct types and `PluginProcedureFunctionSupport` downcast yields the routines (deferred to PR B integration)
- [ ] Manual: MySQL connection with a stored procedure and function; confirm same (deferred to PR B integration)