### PR TITLE
feat(sidebar): group objects into 6 kind-based sections (#1038)

### DIFF
--- a/TablePro/Models/Query/RoutineInfo.swift
+++ b/TablePro/Models/Query/RoutineInfo.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct RoutineInfo: Identifiable, Hashable, Sendable {
+    var id: String { "\(kind.rawValue)_\(qualifiedName)" }
+    let name: String
+    let schema: String?
+    let kind: Kind
+    let signature: String?
+
+    enum Kind: String, Sendable {
+        case procedure = "PROCEDURE"
+        case function = "FUNCTION"
+
+        var sidebarObjectKind: SidebarObjectKind {
+            switch self {
+            case .procedure: return .procedure
+            case .function:  return .function
+            }
+        }
+    }
+
+    var qualifiedName: String {
+        if let schema, !schema.isEmpty {
+            return "\(schema).\(name)"
+        }
+        return name
+    }
+
+    static func == (lhs: RoutineInfo, rhs: RoutineInfo) -> Bool {
+        lhs.kind == rhs.kind && lhs.schema == rhs.schema && lhs.name == rhs.name
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(schema)
+        hasher.combine(name)
+    }
+}

--- a/TablePro/Models/Sidebar/SidebarObjectKind.swift
+++ b/TablePro/Models/Sidebar/SidebarObjectKind.swift
@@ -1,0 +1,58 @@
+import Foundation
+import TableProPluginKit
+
+enum SidebarObjectKind: String, CaseIterable, Sendable, Hashable {
+    case table
+    case view
+    case materializedView
+    case foreignTable
+    case procedure
+    case function
+
+    var displayName: String {
+        switch self {
+        case .table:            return String(localized: "Table")
+        case .view:             return String(localized: "View")
+        case .materializedView: return String(localized: "Materialized View")
+        case .foreignTable:     return String(localized: "Foreign Table")
+        case .procedure:        return String(localized: "Procedure")
+        case .function:         return String(localized: "Function")
+        }
+    }
+
+    var pluralDisplayName: String {
+        switch self {
+        case .table:            return String(localized: "Tables")
+        case .view:             return String(localized: "Views")
+        case .materializedView: return String(localized: "Materialized Views")
+        case .foreignTable:     return String(localized: "Foreign Tables")
+        case .procedure:        return String(localized: "Procedures")
+        case .function:         return String(localized: "Functions")
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .table:            return "tablecells"
+        case .view:             return "eye"
+        case .materializedView: return "square.stack.3d.up"
+        case .foreignTable:     return "link"
+        case .procedure:        return "curlybraces.square"
+        case .function:         return "function"
+        }
+    }
+
+    var capabilityFlag: PluginCapabilities? {
+        switch self {
+        case .table, .view:     return nil
+        case .materializedView: return .materializedViews
+        case .foreignTable:     return .foreignTables
+        case .procedure:        return .storedProcedures
+        case .function:         return .userFunctions
+        }
+    }
+
+    var isRoutine: Bool {
+        self == .procedure || self == .function
+    }
+}

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -8,23 +8,38 @@
 
 import Observation
 import SwiftUI
+import TableProPluginKit
 
 // MARK: - SidebarViewModel
 
 @MainActor @Observable
 final class SidebarViewModel {
+    // MARK: - Expansion State
+
+    struct ExpansionState: Sendable {
+        var values: [SidebarObjectKind: Bool]
+
+        init(values: [SidebarObjectKind: Bool] = [:]) {
+            self.values = values
+        }
+
+        subscript(kind: SidebarObjectKind) -> Bool {
+            get { values[kind] ?? Self.defaultValue(for: kind) }
+            set { values[kind] = newValue }
+        }
+
+        static func defaultValue(for kind: SidebarObjectKind) -> Bool {
+            kind == .table
+        }
+    }
+
     // MARK: - Published State
 
     var searchText = "" {
-        didSet { invalidateFilteredTablesCache() }
+        didSet { invalidateFilterCaches() }
     }
-    var isTablesExpanded: Bool {
-        didSet {
-            UserDefaults.standard.set(
-                isTablesExpanded,
-                forKey: SidebarPersistenceKey.tablesExpanded(connectionId: connectionId)
-            )
-        }
+    var expanded: ExpansionState {
+        didSet { persistExpansion(oldValue: oldValue) }
     }
     var isRedisKeysExpanded: Bool {
         didSet {
@@ -73,6 +88,12 @@ final class SidebarViewModel {
         set { tableOperationOptionsBinding.wrappedValue = newValue }
     }
 
+    // Maintained for backwards compatibility with call sites that read/write a single boolean.
+    var isTablesExpanded: Bool {
+        get { expanded[.table] }
+        set { expanded[.table] = newValue }
+    }
+
     // MARK: - Initialization
 
     init(
@@ -89,16 +110,42 @@ final class SidebarViewModel {
         self.tableOperationOptionsBinding = tableOperationOptions
         self.databaseType = databaseType
         self.connectionId = connectionId
-        self.isTablesExpanded = Self.loadExpansion(
-            perConnectionKey: SidebarPersistenceKey.tablesExpanded(connectionId: connectionId),
-            legacyKey: SidebarPersistenceKey.legacyTablesExpanded,
-            defaultValue: true
-        )
+        self.expanded = Self.loadInitialExpansion(connectionId: connectionId)
         self.isRedisKeysExpanded = Self.loadExpansion(
             perConnectionKey: SidebarPersistenceKey.redisKeysExpanded(connectionId: connectionId),
             legacyKey: SidebarPersistenceKey.legacyRedisKeysExpanded,
             defaultValue: true
         )
+    }
+
+    private static func loadInitialExpansion(connectionId: UUID) -> ExpansionState {
+        var values: [SidebarObjectKind: Bool] = [:]
+        for kind in SidebarObjectKind.allCases {
+            values[kind] = loadKindExpansion(connectionId: connectionId, kind: kind)
+        }
+        return ExpansionState(values: values)
+    }
+
+    private static func loadKindExpansion(connectionId: UUID, kind: SidebarObjectKind) -> Bool {
+        let defaults = UserDefaults.standard
+        let perKindKey = SidebarPersistenceKey.expanded(connectionId: connectionId, kind: kind)
+        if defaults.object(forKey: perKindKey) != nil {
+            return defaults.bool(forKey: perKindKey)
+        }
+        if kind == .table {
+            let legacyPerConnection = SidebarPersistenceKey.tablesExpanded(connectionId: connectionId)
+            if defaults.object(forKey: legacyPerConnection) != nil {
+                let seeded = defaults.bool(forKey: legacyPerConnection)
+                defaults.set(seeded, forKey: perKindKey)
+                return seeded
+            }
+            if defaults.object(forKey: SidebarPersistenceKey.legacyTablesExpanded) != nil {
+                let seeded = defaults.bool(forKey: SidebarPersistenceKey.legacyTablesExpanded)
+                defaults.set(seeded, forKey: perKindKey)
+                return seeded
+            }
+        }
+        return ExpansionState.defaultValue(for: kind)
     }
 
     private static func loadExpansion(
@@ -116,6 +163,36 @@ final class SidebarViewModel {
             return seeded
         }
         return defaultValue
+    }
+
+    private func persistExpansion(oldValue: ExpansionState) {
+        let defaults = UserDefaults.standard
+        for kind in SidebarObjectKind.allCases where oldValue[kind] != expanded[kind] {
+            defaults.set(
+                expanded[kind],
+                forKey: SidebarPersistenceKey.expanded(connectionId: connectionId, kind: kind)
+            )
+        }
+    }
+
+    // MARK: - Capability Gating
+
+    func capabilities(for connectionId: UUID) -> PluginCapabilities {
+        guard let adapter = DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter else {
+            return []
+        }
+        return adapter.schemaPluginDriver.capabilities
+    }
+
+    func sectionShouldRender(
+        kind: SidebarObjectKind,
+        itemCount: Int,
+        capabilities: PluginCapabilities
+    ) -> Bool {
+        if kind == .table { return true }
+        if let flag = kind.capabilityFlag, !capabilities.contains(flag) { return false }
+        if itemCount > 0 { return true }
+        return false
     }
 
     // MARK: - Batch Operations
@@ -197,6 +274,15 @@ final class SidebarViewModel {
     @ObservationIgnored private var cachedFilteredTables: [TableInfo]?
     @ObservationIgnored private var cachedFilterInputs: (count: Int, hash: Int, query: String)?
 
+    @ObservationIgnored private var cachedKindBuckets: [SidebarObjectKind: [TableInfo]] = [:]
+    @ObservationIgnored private var cachedKindFingerprint: (count: Int, hash: Int)?
+
+    @ObservationIgnored private var cachedFilteredByKind: [SidebarObjectKind: [TableInfo]] = [:]
+    @ObservationIgnored private var cachedFilteredByKindFingerprint: (count: Int, hash: Int, query: String)?
+
+    @ObservationIgnored private var cachedFilteredRoutines: [SidebarObjectKind: [RoutineInfo]] = [:]
+    @ObservationIgnored private var cachedFilteredRoutinesFingerprint: (count: Int, hash: Int, query: String)?
+
     func filteredTables(from tables: [TableInfo]) -> [TableInfo] {
         let query = searchText
         let fingerprint = (count: tables.count, hash: tables.hashValue, query: query)
@@ -216,8 +302,93 @@ final class SidebarViewModel {
         return result
     }
 
-    private func invalidateFilteredTablesCache() {
+    func tables(of kind: SidebarObjectKind, from tables: [TableInfo]) -> [TableInfo] {
+        guard !kind.isRoutine else { return [] }
+        let fingerprint = (count: tables.count, hash: tables.hashValue)
+        if cachedKindFingerprint?.count != fingerprint.count
+            || cachedKindFingerprint?.hash != fingerprint.hash {
+            rebuildKindBuckets(from: tables)
+            cachedKindFingerprint = fingerprint
+        }
+        return cachedKindBuckets[kind] ?? []
+    }
+
+    func filteredTables(of kind: SidebarObjectKind, from tables: [TableInfo]) -> [TableInfo] {
+        let query = searchText
+        let fingerprint = (count: tables.count, hash: tables.hashValue, query: query)
+        if cachedFilteredByKindFingerprint?.count != fingerprint.count
+            || cachedFilteredByKindFingerprint?.hash != fingerprint.hash
+            || cachedFilteredByKindFingerprint?.query != fingerprint.query {
+            let bucket = self.tables(of: .table, from: tables)
+            let bucketView = self.tables(of: .view, from: tables)
+            let bucketMat = self.tables(of: .materializedView, from: tables)
+            let bucketForeign = self.tables(of: .foreignTable, from: tables)
+            cachedFilteredByKind[.table] = applyQuery(query, to: bucket)
+            cachedFilteredByKind[.view] = applyQuery(query, to: bucketView)
+            cachedFilteredByKind[.materializedView] = applyQuery(query, to: bucketMat)
+            cachedFilteredByKind[.foreignTable] = applyQuery(query, to: bucketForeign)
+            cachedFilteredByKindFingerprint = fingerprint
+        }
+        return cachedFilteredByKind[kind] ?? []
+    }
+
+    func filteredRoutines(of kind: SidebarObjectKind, from routines: [RoutineInfo]) -> [RoutineInfo] {
+        let query = searchText
+        let fingerprint = (count: routines.count, hash: routines.hashValue, query: query)
+        if cachedFilteredRoutinesFingerprint?.count != fingerprint.count
+            || cachedFilteredRoutinesFingerprint?.hash != fingerprint.hash
+            || cachedFilteredRoutinesFingerprint?.query != fingerprint.query {
+            let procs = routines.filter { $0.kind == .procedure }
+            let funcs = routines.filter { $0.kind == .function }
+            cachedFilteredRoutines[.procedure] = applyRoutineQuery(query, to: procs)
+            cachedFilteredRoutines[.function] = applyRoutineQuery(query, to: funcs)
+            cachedFilteredRoutinesFingerprint = fingerprint
+        }
+        return cachedFilteredRoutines[kind] ?? []
+    }
+
+    func effectiveExpanded(kind: SidebarObjectKind, hasMatches: Bool) -> Bool {
+        if !searchText.isEmpty && hasMatches { return true }
+        return expanded[kind]
+    }
+
+    private func applyQuery(_ query: String, to tables: [TableInfo]) -> [TableInfo] {
+        guard !query.isEmpty else { return tables }
+        return tables.filter { $0.name.localizedCaseInsensitiveContains(query) }
+    }
+
+    private func applyRoutineQuery(_ query: String, to routines: [RoutineInfo]) -> [RoutineInfo] {
+        guard !query.isEmpty else { return routines }
+        return routines.filter { $0.name.localizedCaseInsensitiveContains(query) }
+    }
+
+    private func rebuildKindBuckets(from tables: [TableInfo]) {
+        var buckets: [SidebarObjectKind: [TableInfo]] = [:]
+        for kind in SidebarObjectKind.allCases {
+            buckets[kind] = []
+        }
+        for table in tables {
+            let kind = Self.sidebarObjectKind(for: table.type)
+            buckets[kind, default: []].append(table)
+        }
+        cachedKindBuckets = buckets
+    }
+
+    private static func sidebarObjectKind(for tableType: TableInfo.TableType) -> SidebarObjectKind {
+        switch tableType.rawValue {
+        case "VIEW":               return .view
+        case "MATERIALIZED VIEW":  return .materializedView
+        case "FOREIGN TABLE":      return .foreignTable
+        default:                   return .table
+        }
+    }
+
+    private func invalidateFilterCaches() {
         cachedFilteredTables = nil
         cachedFilterInputs = nil
+        cachedFilteredByKind = [:]
+        cachedFilteredByKindFingerprint = nil
+        cachedFilteredRoutines = [:]
+        cachedFilteredRoutinesFingerprint = nil
     }
 }

--- a/TablePro/Views/Sidebar/RoutineRowView.swift
+++ b/TablePro/Views/Sidebar/RoutineRowView.swift
@@ -1,0 +1,79 @@
+//
+//  RoutineRowView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+enum RoutineRowLogic {
+    static func accessibilityLabel(for routine: RoutineInfo) -> String {
+        let kindLabel: String = routine.kind == .procedure
+            ? String(localized: "Procedure")
+            : String(localized: "Function")
+        let baseLabel = "\(kindLabel): \(routine.name)"
+        if let signature = routine.signature, !signature.isEmpty {
+            return "\(baseLabel), \(signature)"
+        }
+        return baseLabel
+    }
+
+    static func iconName(for kind: RoutineInfo.Kind) -> String {
+        switch kind {
+        case .procedure: return "curlybraces.square"
+        case .function:  return "function"
+        }
+    }
+
+    static func iconColor(for kind: RoutineInfo.Kind) -> Color {
+        switch kind {
+        case .procedure: return Color(nsColor: .systemTeal)
+        case .function:  return Color(nsColor: .systemCyan)
+        }
+    }
+
+    static func tooltip(for routine: RoutineInfo) -> String? {
+        guard let signature = routine.signature, !signature.isEmpty else { return nil }
+        return signature
+    }
+}
+
+struct RoutineRowView: View {
+    let routine: RoutineInfo
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: RoutineRowLogic.iconName(for: routine.kind))
+                .foregroundStyle(RoutineRowLogic.iconColor(for: routine.kind))
+                .frame(width: 14)
+
+            Text(routine.name)
+                .font(.system(.callout, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(RoutineRowLogic.accessibilityLabel(for: routine))
+        .help(RoutineRowLogic.tooltip(for: routine) ?? routine.name)
+    }
+}
+
+struct RoutineContextMenu: View {
+    let routine: RoutineInfo
+    let onShowDDL: (RoutineInfo) -> Void
+
+    var body: some View {
+        Button(String(localized: "Copy Name")) {
+            ClipboardService.shared.writeText(routine.name)
+        }
+        if let signature = routine.signature, !signature.isEmpty {
+            Button(String(localized: "Copy with Signature")) {
+                ClipboardService.shared.writeText("\(routine.name)\(signature)")
+            }
+        }
+        Divider()
+        Button(String(localized: "Show DDL")) {
+            onShowDDL(routine)
+        }
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
+++ b/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
@@ -15,4 +15,8 @@ enum SidebarPersistenceKey {
     static func selectedTab(connectionId: UUID) -> String {
         "sidebar.selectedTab.\(connectionId.uuidString)"
     }
+
+    static func expanded(connectionId: UUID, kind: SidebarObjectKind) -> String {
+        "sidebar.\(connectionId.uuidString).\(kind.rawValue).expanded"
+    }
 }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TableProPluginKit
 
 // MARK: - SidebarView
 
@@ -26,8 +27,18 @@ struct SidebarView: View {
         schemaService.tables(for: connectionId)
     }
 
-    private var filteredTables: [TableInfo] {
-        viewModel.filteredTables(from: tables)
+    private var routines: [RoutineInfo] {
+        []
+    }
+
+    private var pluginCapabilities: PluginCapabilities {
+        viewModel.capabilities(for: connectionId)
+    }
+
+    private var hasAnyMatch: Bool {
+        SidebarObjectKind.allCases.contains { kind in
+            countFor(kind: kind) > 0
+        }
     }
 
     private var selectedTablesBinding: Binding<Set<TableInfo>> {
@@ -96,7 +107,6 @@ struct SidebarView: View {
         }
         .onAppear {
             coordinator?.sidebarViewModel = viewModel
-            // Update toolbar version if driver connected before this window's observer was set up
             if let driver = DatabaseManager.shared.driver(for: connectionId),
                coordinator?.toolbarState.databaseVersion == nil {
                 coordinator?.toolbarState.databaseVersion = driver.serverVersion
@@ -129,9 +139,9 @@ struct SidebarView: View {
             loadingState
         case .failed(let message):
             errorState(message: message)
-        case .loaded where !viewModel.searchText.isEmpty && filteredTables.isEmpty:
+        case .loaded where !viewModel.searchText.isEmpty && !hasAnyMatch:
             noMatchState
-        case .loaded(let allTables) where allTables.isEmpty:
+        case .loaded(let allTables) where allTables.isEmpty && routines.isEmpty:
             emptyState
         case .loaded, .loading:
             tableList
@@ -179,42 +189,9 @@ struct SidebarView: View {
     // MARK: - Table List
 
     private var tableList: some View {
-        let entityLabel = PluginManager.shared.tableEntityName(for: viewModel.databaseType)
-        let helpLabel = String(format: String(localized: "Right-click to show all %@"), entityLabel.lowercased())
-        let showAllLabel = String(format: String(localized: "Show All %@"), entityLabel)
-        return List(selection: selectedTablesBinding) {
-            Section(isExpanded: $viewModel.isTablesExpanded) {
-                ForEach(filteredTables) { table in
-                    TableRow(
-                        table: table,
-                        isPendingTruncate: pendingTruncates.contains(table.name),
-                        isPendingDelete: pendingDeletes.contains(table.name)
-                    )
-                    .tag(table)
-                    .overlay {
-                        DoubleClickDetector {
-                            onDoubleClick?(table)
-                        }
-                    }
-                    .contextMenu {
-                        SidebarContextMenu(
-                            clickedTable: table,
-                            selectedTables: sidebarState.selectedTables,
-                            isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
-                            onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
-                            onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
-                            coordinator: coordinator
-                        )
-                    }
-                }
-            } header: {
-                Text(entityLabel)
-                    .help(helpLabel)
-                    .contextMenu {
-                        Button(showAllLabel) {
-                            coordinator?.showAllTablesMetadata()
-                        }
-                    }
+        List(selection: selectedTablesBinding) {
+            ForEach(SidebarObjectKind.allCases, id: \.self) { kind in
+                sectionView(for: kind)
             }
 
             if viewModel.databaseType == .redis, let keyTreeVM = sidebarState.redisKeyTreeViewModel {
@@ -250,6 +227,116 @@ struct SidebarView: View {
         .onExitCommand {
             sidebarState.selectedTables.removeAll()
         }
+    }
+
+    // MARK: - Section View
+
+    @ViewBuilder
+    private func sectionView(for kind: SidebarObjectKind) -> some View {
+        let count = countFor(kind: kind)
+        if viewModel.sectionShouldRender(kind: kind, itemCount: count, capabilities: pluginCapabilities) {
+            let isExpanded = sectionExpandedBinding(kind: kind, hasMatches: count > 0)
+            Section(isExpanded: isExpanded) {
+                sectionRows(for: kind)
+            } header: {
+                sectionHeader(for: kind, count: count)
+            }
+        }
+    }
+
+    private func sectionExpandedBinding(kind: SidebarObjectKind, hasMatches: Bool) -> Binding<Bool> {
+        Binding(
+            get: { viewModel.effectiveExpanded(kind: kind, hasMatches: hasMatches) },
+            set: { viewModel.expanded[kind] = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private func sectionRows(for kind: SidebarObjectKind) -> some View {
+        if kind.isRoutine {
+            ForEach(viewModel.filteredRoutines(of: kind, from: routines)) { routine in
+                RoutineRowView(routine: routine)
+                    .tag(routine)
+                    .contextMenu {
+                        RoutineContextMenu(routine: routine) { _ in }
+                    }
+            }
+        } else {
+            ForEach(viewModel.filteredTables(of: kind, from: tables)) { table in
+                TableRow(
+                    table: table,
+                    isPendingTruncate: pendingTruncates.contains(table.name),
+                    isPendingDelete: pendingDeletes.contains(table.name)
+                )
+                .tag(table)
+                .overlay {
+                    DoubleClickDetector {
+                        onDoubleClick?(table)
+                    }
+                }
+                .contextMenu {
+                    SidebarContextMenu(
+                        clickedTable: table,
+                        selectedTables: sidebarState.selectedTables,
+                        isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
+                        onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
+                        onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
+                        coordinator: coordinator
+                    )
+                }
+            }
+        }
+    }
+
+    private func sectionHeader(for kind: SidebarObjectKind, count: Int) -> some View {
+        let title = sectionTitle(for: kind)
+        let helpLabel = String(
+            format: String(localized: "Right-click to show all %@"),
+            title.lowercased()
+        )
+        return HStack(spacing: 8) {
+            Text(title)
+            Spacer()
+            if count > 0 {
+                Text("\(count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+        }
+        .help(helpLabel)
+        .contextMenu {
+            sectionHeaderMenu(for: kind, title: title)
+        }
+    }
+
+    @ViewBuilder
+    private func sectionHeaderMenu(for kind: SidebarObjectKind, title: String) -> some View {
+        if !kind.isRoutine {
+            Button(String(format: String(localized: "Show All %@"), title)) {
+                if kind == .table {
+                    coordinator?.showAllTablesMetadata()
+                }
+            }
+            .disabled(kind != .table)
+        }
+        Button(String(localized: "Refresh")) {
+            Task { await coordinator?.refreshTables() }
+        }
+    }
+
+    private func sectionTitle(for kind: SidebarObjectKind) -> String {
+        if kind == .table {
+            return PluginManager.shared.tableEntityName(for: viewModel.databaseType)
+        }
+        return kind.pluralDisplayName
+    }
+
+    private func countFor(kind: SidebarObjectKind) -> Int {
+        if kind.isRoutine {
+            return viewModel.filteredRoutines(of: kind, from: routines).count
+        }
+        return viewModel.filteredTables(of: kind, from: tables).count
     }
 }
 

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -247,3 +247,256 @@ struct SidebarViewModelTests {
         }
     }
 }
+
+// MARK: - Multi-Section Sidebar
+
+@MainActor
+private func makeViewModel(
+    connectionId: UUID = UUID(),
+    databaseType: DatabaseType = .postgresql
+) -> SidebarViewModel {
+    var selectedState: Set<TableInfo> = []
+    var truncates: Set<String> = []
+    var deletes: Set<String> = []
+    var options: [String: TableOperationOptions] = [:]
+    let selectedBinding = Binding(get: { selectedState }, set: { selectedState = $0 })
+    let truncatesBinding = Binding(get: { truncates }, set: { truncates = $0 })
+    let deletesBinding = Binding(get: { deletes }, set: { deletes = $0 })
+    let optionsBinding = Binding(get: { options }, set: { options = $0 })
+    return SidebarViewModel(
+        selectedTables: selectedBinding,
+        pendingTruncates: truncatesBinding,
+        pendingDeletes: deletesBinding,
+        tableOperationOptions: optionsBinding,
+        databaseType: databaseType,
+        connectionId: connectionId
+    )
+}
+
+@Suite("SidebarViewModel multi-section")
+struct SidebarViewModelMultiSectionTests {
+    @Test("tables of kind splits by TableType raw value")
+    @MainActor
+    func splitsTablesByKind() {
+        let vm = makeViewModel()
+        let userTable = TestFixtures.makeTableInfo(name: "users", type: .table)
+        let profileView = TestFixtures.makeTableInfo(name: "profiles", type: .view)
+        let mixed = [userTable, profileView]
+
+        let tablesOnly = vm.tables(of: .table, from: mixed)
+        let viewsOnly = vm.tables(of: .view, from: mixed)
+        let matviews = vm.tables(of: .materializedView, from: mixed)
+
+        #expect(tablesOnly.map(\.name) == ["users"])
+        #expect(viewsOnly.map(\.name) == ["profiles"])
+        #expect(matviews.isEmpty)
+    }
+
+    @Test("system tables fall into the table bucket")
+    @MainActor
+    func systemTablesBucketAsTables() {
+        let vm = makeViewModel()
+        let sysTable = TestFixtures.makeTableInfo(name: "pg_stat_user_tables", type: .systemTable)
+
+        let tablesOnly = vm.tables(of: .table, from: [sysTable])
+        let viewsOnly = vm.tables(of: .view, from: [sysTable])
+
+        #expect(tablesOnly.map(\.name) == ["pg_stat_user_tables"])
+        #expect(viewsOnly.isEmpty)
+    }
+
+    @Test("routine kinds return empty when querying tables(of:)")
+    @MainActor
+    func routinesEmptyInTablesOf() {
+        let vm = makeViewModel()
+        let table = TestFixtures.makeTableInfo(name: "users", type: .table)
+
+        #expect(vm.tables(of: .procedure, from: [table]).isEmpty)
+        #expect(vm.tables(of: .function, from: [table]).isEmpty)
+    }
+
+    @Test("filteredTables(of:) honors search across kinds")
+    @MainActor
+    func filteredTablesAcrossKinds() {
+        let vm = makeViewModel()
+        let users = TestFixtures.makeTableInfo(name: "users", type: .table)
+        let userView = TestFixtures.makeTableInfo(name: "user_profile_view", type: .view)
+        let orders = TestFixtures.makeTableInfo(name: "orders", type: .table)
+        let mixed = [users, userView, orders]
+        vm.searchText = "user"
+
+        let tableMatches = vm.filteredTables(of: .table, from: mixed)
+        let viewMatches = vm.filteredTables(of: .view, from: mixed)
+
+        #expect(tableMatches.map(\.name) == ["users"])
+        #expect(viewMatches.map(\.name) == ["user_profile_view"])
+    }
+
+    @Test("filteredRoutines filters by name across kinds")
+    @MainActor
+    func filteredRoutinesByKind() {
+        let vm = makeViewModel()
+        let getUser = RoutineInfo(name: "get_user_by_id", schema: "public", kind: .procedure, signature: nil)
+        let calcAge = RoutineInfo(name: "calculate_age", schema: "public", kind: .function, signature: nil)
+        let mixed = [getUser, calcAge]
+
+        let procs = vm.filteredRoutines(of: .procedure, from: mixed)
+        let funcs = vm.filteredRoutines(of: .function, from: mixed)
+
+        #expect(procs.map(\.name) == ["get_user_by_id"])
+        #expect(funcs.map(\.name) == ["calculate_age"])
+    }
+
+    @Test("filteredRoutines search matches name case insensitively")
+    @MainActor
+    func filteredRoutinesSearch() {
+        let vm = makeViewModel()
+        let getUser = RoutineInfo(name: "GET_USER_BY_ID", schema: nil, kind: .procedure, signature: nil)
+        let other = RoutineInfo(name: "log_event", schema: nil, kind: .procedure, signature: nil)
+        vm.searchText = "user"
+
+        let procs = vm.filteredRoutines(of: .procedure, from: [getUser, other])
+
+        #expect(procs.map(\.name) == ["GET_USER_BY_ID"])
+    }
+
+    @Test("effectiveExpanded honors stored state when search empty")
+    @MainActor
+    func effectiveExpandedRespectsStored() {
+        let vm = makeViewModel()
+        vm.expanded[.view] = false
+
+        #expect(vm.effectiveExpanded(kind: .view, hasMatches: false) == false)
+        #expect(vm.effectiveExpanded(kind: .table, hasMatches: false) == true)
+    }
+
+    @Test("effectiveExpanded auto-expands when search has matches")
+    @MainActor
+    func effectiveExpandedAutoExpandsOnSearch() {
+        let vm = makeViewModel()
+        vm.expanded[.procedure] = false
+        vm.searchText = "user"
+
+        let result = vm.effectiveExpanded(kind: .procedure, hasMatches: true)
+
+        #expect(result == true)
+    }
+
+    @Test("effectiveExpanded stays collapsed when search has no matches")
+    @MainActor
+    func effectiveExpandedStaysCollapsedWithoutMatches() {
+        let vm = makeViewModel()
+        vm.expanded[.function] = false
+        vm.searchText = "nonexistent"
+
+        let result = vm.effectiveExpanded(kind: .function, hasMatches: false)
+
+        #expect(result == false)
+    }
+
+    @Test("sectionShouldRender always shows tables")
+    @MainActor
+    func tablesAlwaysShown() {
+        let vm = makeViewModel()
+        let empty: PluginCapabilities = []
+
+        #expect(vm.sectionShouldRender(kind: .table, itemCount: 0, capabilities: empty))
+        #expect(vm.sectionShouldRender(kind: .table, itemCount: 5, capabilities: empty))
+    }
+
+    @Test("sectionShouldRender hides matview when capability missing")
+    @MainActor
+    func hidesMatviewWithoutCapability() {
+        let vm = makeViewModel()
+        let result = vm.sectionShouldRender(
+            kind: .materializedView,
+            itemCount: 10,
+            capabilities: []
+        )
+        #expect(result == false)
+    }
+
+    @Test("sectionShouldRender shows matview when capability present and items exist")
+    @MainActor
+    func showsMatviewWithCapability() {
+        let vm = makeViewModel()
+        let result = vm.sectionShouldRender(
+            kind: .materializedView,
+            itemCount: 3,
+            capabilities: [.materializedViews]
+        )
+        #expect(result == true)
+    }
+
+    @Test("sectionShouldRender hides matview when no items even with capability")
+    @MainActor
+    func hidesEmptyMatviewWithCapability() {
+        let vm = makeViewModel()
+        let result = vm.sectionShouldRender(
+            kind: .materializedView,
+            itemCount: 0,
+            capabilities: [.materializedViews]
+        )
+        #expect(result == false)
+    }
+
+    @Test("default expansion is true for tables only")
+    @MainActor
+    func defaultExpansionTablesOnly() {
+        let vm = makeViewModel()
+
+        #expect(vm.expanded[.table] == true)
+        #expect(vm.expanded[.view] == false)
+        #expect(vm.expanded[.materializedView] == false)
+        #expect(vm.expanded[.foreignTable] == false)
+        #expect(vm.expanded[.procedure] == false)
+        #expect(vm.expanded[.function] == false)
+    }
+
+    @Test("expansion writes persist to per-kind UserDefaults keys")
+    @MainActor
+    func expansionWritesPersist() {
+        let connectionId = UUID()
+        let vm = makeViewModel(connectionId: connectionId)
+        let key = SidebarPersistenceKey.expanded(connectionId: connectionId, kind: .procedure)
+        UserDefaults.standard.removeObject(forKey: key)
+
+        vm.expanded[.procedure] = true
+
+        #expect(UserDefaults.standard.bool(forKey: key) == true)
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    @Test("expansion seeds .table from legacy per-connection key on first init")
+    @MainActor
+    func legacyMigrationFromPerConnectionKey() {
+        let connectionId = UUID()
+        let perKindKey = SidebarPersistenceKey.expanded(connectionId: connectionId, kind: .table)
+        let legacyKey = SidebarPersistenceKey.tablesExpanded(connectionId: connectionId)
+        UserDefaults.standard.removeObject(forKey: perKindKey)
+        UserDefaults.standard.set(false, forKey: legacyKey)
+
+        let vm = makeViewModel(connectionId: connectionId)
+
+        #expect(vm.expanded[.table] == false)
+        UserDefaults.standard.removeObject(forKey: perKindKey)
+        UserDefaults.standard.removeObject(forKey: legacyKey)
+    }
+
+    @Test("expansion seeds .table from global legacy key when no per-connection key set")
+    @MainActor
+    func legacyMigrationFromGlobalKey() {
+        let connectionId = UUID()
+        let perKindKey = SidebarPersistenceKey.expanded(connectionId: connectionId, kind: .table)
+        let perConnLegacy = SidebarPersistenceKey.tablesExpanded(connectionId: connectionId)
+        UserDefaults.standard.removeObject(forKey: perKindKey)
+        UserDefaults.standard.removeObject(forKey: perConnLegacy)
+        UserDefaults.standard.set(false, forKey: SidebarPersistenceKey.legacyTablesExpanded)
+
+        let vm = makeViewModel(connectionId: connectionId)
+
+        #expect(vm.expanded[.table] == false)
+        UserDefaults.standard.removeObject(forKey: perKindKey)
+        UserDefaults.standard.removeObject(forKey: SidebarPersistenceKey.legacyTablesExpanded)
+    }
+}


### PR DESCRIPTION
PR B for #1038. UI layer only.

Replaces the single Tables section in the sidebar with 6 collapsible sections (Tables, Views, Materialized Views, Foreign Tables, Procedures, Functions). Sections are gated by plugin capability flags and hide when empty (Tables always renders).

## Summary
- Add `SidebarObjectKind` and `RoutineInfo` domain types.
- Replace `isTablesExpanded` boolean with a per-kind `ExpansionState`. Old per-connection and global legacy keys seed the new `.table` flag on first init.
- `SidebarViewModel` exposes per-kind table/routine filtering with memoization fingerprints (count/hash/query).
- `SidebarView` renders the six sections from a single `ForEach` over `SidebarObjectKind.allCases`. Tables always shows, others gate on `PluginCapabilities` (`.materializedViews`, `.foreignTables`, `.storedProcedures`, `.userFunctions`) and on item count.
- Search auto-expands sections with matches via `effectiveExpanded(kind:hasMatches:)` and hides empty sections (except Tables).
- New `RoutineRowView` thinner row variant (SF Symbol + name, no row-count badge, no truncate/delete toggles). Context menu: Copy Name, Copy with Signature (if available), Show DDL.
- Per-section header context menu: "Show All <Kind>" for tables/views/matviews/foreign (only Tables wired today via existing `showAllTablesMetadata`); "Refresh" for all sections via `coordinator.refreshTables()`.
- Tests: 18 new cases covering per-kind splitter, search filtering, auto-expand, capability gating, default expansion, and legacy expansion key migration.

## Dependencies
- Depends on PR A (feat/1038-data-layer) for `TableInfo.TableType.materializedView` and `.foreignTable` cases. The bucket splitter uses raw-value matching (`"MATERIALIZED VIEW"` / `"FOREIGN TABLE"`) so this branch compiles independently against the current enum, but matview / foreign-table buckets stay empty until PR A merges and the schema layer returns those rows.
- Routines are wired empty (`let routines: [RoutineInfo] = []`) in `SidebarView`. PR A will land `PluginProcedureFunctionSupport` on `PluginDriverAdapter`; once merged this branch rebases and the coordinator wires the actual array.
- Capabilities are read via `PluginDriverAdapter.schemaPluginDriver.capabilities` (already public on the adapter), so no changes to plugin protocol or `PluginDriverAdapter` are required from this PR.

## Test plan
- [ ] Postgres connection: 6 sections render once PR A lands; Tables expanded, others collapsed.
- [ ] SQLite connection: Tables + Views only, others hidden (no capability).
- [ ] Redis connection: Keys section renders, SQL-object sections hidden when empty (Tables always shows; will be empty for Redis).
- [ ] Type "user" in search: matching sections auto-expand, sections with no matches hide.
- [ ] Toggle a section's chevron, restart the app: state persists per connection.
- [ ] Existing Tables legacy per-connection key (`sidebar.<uuid>.tables.expanded`) seeds new per-kind key without losing user preference.
- [ ] Right-click section header shows "Show All <Kind>" and "Refresh"; clicking Refresh reloads schema.
- [ ] Routine row context menu (after PR A wiring): Copy Name, Copy with Signature, Show DDL.

Closes part of #1038 (UI half).