### PR TITLE
feat(sidebar): wire routines end-to-end (#1038 PR C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sidebar groups database objects into Tables, Views, Materialized Views, Foreign Tables, Procedures, and Functions sections; routines load automatically on connect for Postgres and MySQL, and each section header has its own Refresh action (#1038)
 - iOS: Live Activity for running queries shows query preview, elapsed time, and row count on the lock screen and Dynamic Island
 - iOS: multi-window support on iPad - drag a tab off to open a second window, each window remembers its own selected connection across launches
 - iOS: VoiceOver "Delete row" / "Delete group" / "Delete tag" custom actions on rows whose only deletion path was a swipe gesture

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -116,6 +116,14 @@ protocol DatabaseDriver: AnyObject {
     /// Fetch list of schemas in the current database (PostgreSQL only)
     func fetchSchemas() async throws -> [String]
 
+    /// Fetch stored procedures for the given schema (or current schema if nil).
+    /// Default implementation returns an empty list; drivers that support routines override.
+    func fetchProcedures(schema: String?) async throws -> [RoutineInfo]
+
+    /// Fetch user-defined functions for the given schema (or current schema if nil).
+    /// Default implementation returns an empty list; drivers that support routines override.
+    func fetchFunctions(schema: String?) async throws -> [RoutineInfo]
+
     /// Fetch metadata for a specific database (table count, size, etc.)
     func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata
 
@@ -350,6 +358,10 @@ extension DatabaseDriver {
 
     /// Default: no schema support (MySQL/SQLite don't use schemas in the same way)
     func fetchSchemas() async throws -> [String] { [] }
+
+    func fetchProcedures(schema: String?) async throws -> [RoutineInfo] { [] }
+
+    func fetchFunctions(schema: String?) async throws -> [RoutineInfo] { [] }
 
     var supportsTransactions: Bool { true }
 

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -285,6 +285,44 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         try await pluginDriver.fetchSchemas()
     }
 
+    func fetchProcedures(schema: String?) async throws -> [RoutineInfo] {
+        guard let support = pluginDriver as? PluginProcedureFunctionSupport else { return [] }
+        let resolvedSchema = schema ?? pluginDriver.currentSchema
+        do {
+            let pluginRoutines = try await support.fetchProcedures(schema: resolvedSchema)
+            return pluginRoutines.map { routine in
+                RoutineInfo(
+                    name: routine.name,
+                    schema: resolvedSchema,
+                    kind: .procedure,
+                    signature: routine.returnType
+                )
+            }
+        } catch {
+            Self.logger.warning("fetchProcedures failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    func fetchFunctions(schema: String?) async throws -> [RoutineInfo] {
+        guard let support = pluginDriver as? PluginProcedureFunctionSupport else { return [] }
+        let resolvedSchema = schema ?? pluginDriver.currentSchema
+        do {
+            let pluginRoutines = try await support.fetchFunctions(schema: resolvedSchema)
+            return pluginRoutines.map { routine in
+                RoutineInfo(
+                    name: routine.name,
+                    schema: resolvedSchema,
+                    kind: .function,
+                    signature: routine.returnType
+                )
+            }
+        } catch {
+            Self.logger.warning("fetchFunctions failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
     func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata {
         let pluginMeta = try await pluginDriver.fetchDatabaseMetadata(database)
         return DatabaseMetadata(

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -12,9 +12,13 @@ final class SchemaService {
     static let shared = SchemaService()
 
     private(set) var states: [UUID: SchemaState] = [:]
+    private(set) var procedures: [UUID: [RoutineInfo]] = [:]
+    private(set) var functions: [UUID: [RoutineInfo]] = [:]
 
     @ObservationIgnored private var lastLoadDates: [UUID: Date] = [:]
     @ObservationIgnored private let loadDedup = OnceTask<UUID, [TableInfo]>()
+    @ObservationIgnored private let procedureDedup = OnceTask<UUID, [RoutineInfo]>()
+    @ObservationIgnored private let functionDedup = OnceTask<UUID, [RoutineInfo]>()
     @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaService")
 
     init() {}
@@ -28,6 +32,18 @@ final class SchemaService {
             return tables
         }
         return []
+    }
+
+    func procedures(for connectionId: UUID) -> [RoutineInfo] {
+        procedures[connectionId] ?? []
+    }
+
+    func functions(for connectionId: UUID) -> [RoutineInfo] {
+        functions[connectionId] ?? []
+    }
+
+    func routines(for connectionId: UUID) -> [RoutineInfo] {
+        procedures(for: connectionId) + functions(for: connectionId)
     }
 
     func load(connectionId: UUID, driver: DatabaseDriver, connection: DatabaseConnection) async {
@@ -57,9 +73,43 @@ final class SchemaService {
         await reload(connectionId: connectionId, driver: driver, connection: connection)
     }
 
+    func reloadProcedures(connectionId: UUID, driver: DatabaseDriver) async {
+        do {
+            let routines = try await procedureDedup.execute(key: connectionId) {
+                try await driver.fetchProcedures(schema: nil)
+            }
+            procedures[connectionId] = routines
+        } catch is CancellationError {
+            return
+        } catch {
+            Self.logger.warning(
+                "[schema] procedures reload failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    func reloadFunctions(connectionId: UUID, driver: DatabaseDriver) async {
+        do {
+            let routines = try await functionDedup.execute(key: connectionId) {
+                try await driver.fetchFunctions(schema: nil)
+            }
+            functions[connectionId] = routines
+        } catch is CancellationError {
+            return
+        } catch {
+            Self.logger.warning(
+                "[schema] functions reload failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
     func invalidate(connectionId: UUID) async {
         await loadDedup.cancel(key: connectionId)
+        await procedureDedup.cancel(key: connectionId)
+        await functionDedup.cancel(key: connectionId)
         states.removeValue(forKey: connectionId)
+        procedures.removeValue(forKey: connectionId)
+        functions.removeValue(forKey: connectionId)
         lastLoadDates.removeValue(forKey: connectionId)
     }
 
@@ -69,11 +119,31 @@ final class SchemaService {
         connection: DatabaseConnection
     ) async {
         states[connectionId] = .loading
+
+        async let tablesTask: [TableInfo] = loadDedup.execute(key: connectionId) {
+            try await driver.fetchTables()
+        }
+        async let proceduresTask: [RoutineInfo] = Self.fetchRoutinesSafely(
+            connectionId: connectionId,
+            kind: .procedure,
+            dedup: procedureDedup,
+            fetch: { try await driver.fetchProcedures(schema: nil) }
+        )
+        async let functionsTask: [RoutineInfo] = Self.fetchRoutinesSafely(
+            connectionId: connectionId,
+            kind: .function,
+            dedup: functionDedup,
+            fetch: { try await driver.fetchFunctions(schema: nil) }
+        )
+
+        let loadedProcedures = await proceduresTask
+        let loadedFunctions = await functionsTask
+
         do {
-            let tables = try await loadDedup.execute(key: connectionId) {
-                try await driver.fetchTables()
-            }
+            let tables = try await tablesTask
             states[connectionId] = .loaded(tables)
+            procedures[connectionId] = loadedProcedures
+            functions[connectionId] = loadedFunctions
             lastLoadDates[connectionId] = Date()
         } catch is CancellationError {
             return
@@ -82,6 +152,24 @@ final class SchemaService {
                 "[schema] load failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
             )
             states[connectionId] = .failed(error.localizedDescription)
+        }
+    }
+
+    private static func fetchRoutinesSafely(
+        connectionId: UUID,
+        kind: RoutineInfo.Kind,
+        dedup: OnceTask<UUID, [RoutineInfo]>,
+        fetch: @Sendable @escaping () async throws -> [RoutineInfo]
+    ) async -> [RoutineInfo] {
+        do {
+            return try await dedup.execute(key: connectionId, work: fetch)
+        } catch is CancellationError {
+            return []
+        } catch {
+            logger.warning(
+                "[schema] \(kind.rawValue, privacy: .public) load failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+            return []
         }
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -513,6 +513,16 @@ final class MainContentCoordinator {
         await reconcilePostSchemaLoad()
     }
 
+    func refreshProcedures() async {
+        guard let driver = services.databaseManager.driver(for: connectionId) else { return }
+        await services.schemaService.reloadProcedures(connectionId: connectionId, driver: driver)
+    }
+
+    func refreshFunctions() async {
+        guard let driver = services.databaseManager.driver(for: connectionId) else { return }
+        await services.schemaService.reloadFunctions(connectionId: connectionId, driver: driver)
+    }
+
     /// Push the SchemaService table list into the autocomplete provider and prune sidebar
     /// state for tables that no longer exist.
     private func reconcilePostSchemaLoad() async {

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -28,7 +28,7 @@ struct SidebarView: View {
     }
 
     private var routines: [RoutineInfo] {
-        []
+        schemaService.routines(for: connectionId)
     }
 
     private var pluginCapabilities: PluginCapabilities {

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -321,7 +321,14 @@ struct SidebarView: View {
             .disabled(kind != .table)
         }
         Button(String(localized: "Refresh")) {
-            Task { await coordinator?.refreshTables() }
+            switch kind {
+            case .procedure:
+                Task { await coordinator?.refreshProcedures() }
+            case .function:
+                Task { await coordinator?.refreshFunctions() }
+            default:
+                Task { await coordinator?.refreshTables() }
+            }
         }
     }
 

--- a/TableProTests/Services/SchemaServiceRoutinesTests.swift
+++ b/TableProTests/Services/SchemaServiceRoutinesTests.swift
@@ -1,0 +1,266 @@
+//
+//  SchemaServiceRoutinesTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+private final class RoutineMockDriver: DatabaseDriver, @unchecked Sendable {
+    let connection: DatabaseConnection
+    var status: ConnectionStatus = .connected
+    var serverVersion: String? { nil }
+
+    var tablesToReturn: [TableInfo] = []
+    var proceduresToReturn: [RoutineInfo] = []
+    var functionsToReturn: [RoutineInfo] = []
+
+    var proceduresCallCount = 0
+    var functionsCallCount = 0
+    var tablesCallCount = 0
+
+    init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
+        self.connection = connection
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func testConnection() async throws -> Bool { true }
+    func applyQueryTimeout(_ seconds: Int) async throws {}
+
+    func execute(query: String) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeParameterized(query: String, parameters: [Any?]) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeUserQuery(query: String, rowCap: Int?, parameters: [Any?]?) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func fetchTables() async throws -> [TableInfo] {
+        tablesCallCount += 1
+        return tablesToReturn
+    }
+
+    func fetchColumns(table: String) async throws -> [ColumnInfo] { [] }
+    func fetchIndexes(table: String) async throws -> [IndexInfo] { [] }
+    func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo] { [] }
+    func fetchApproximateRowCount(table: String) async throws -> Int? { nil }
+    func fetchTableDDL(table: String) async throws -> String { "" }
+    func fetchViewDefinition(view: String) async throws -> String { "" }
+
+    func fetchTableMetadata(tableName: String) async throws -> TableMetadata {
+        TableMetadata(
+            tableName: tableName, dataSize: nil, indexSize: nil, totalSize: nil,
+            avgRowLength: nil, rowCount: nil, comment: nil, engine: nil,
+            collation: nil, createTime: nil, updateTime: nil
+        )
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata {
+        DatabaseMetadata(
+            id: database, name: database, tableCount: nil, sizeBytes: nil,
+            lastAccessed: nil, isSystemDatabase: false, icon: "cylinder"
+        )
+    }
+
+    func cancelQuery() throws {}
+    func beginTransaction() async throws {}
+    func commitTransaction() async throws {}
+    func rollbackTransaction() async throws {}
+
+    func fetchProcedures(schema: String?) async throws -> [RoutineInfo] {
+        proceduresCallCount += 1
+        return proceduresToReturn
+    }
+
+    func fetchFunctions(schema: String?) async throws -> [RoutineInfo] {
+        functionsCallCount += 1
+        return functionsToReturn
+    }
+}
+
+private final class FailingRoutineDriver: DatabaseDriver, @unchecked Sendable {
+    let connection: DatabaseConnection
+    var status: ConnectionStatus = .connected
+    var serverVersion: String? { nil }
+
+    init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
+        self.connection = connection
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func testConnection() async throws -> Bool { true }
+    func applyQueryTimeout(_ seconds: Int) async throws {}
+
+    func execute(query: String) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeParameterized(query: String, parameters: [Any?]) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeUserQuery(query: String, rowCap: Int?, parameters: [Any?]?) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func fetchTables() async throws -> [TableInfo] {
+        [TestFixtures.makeTableInfo(name: "users")]
+    }
+
+    func fetchColumns(table: String) async throws -> [ColumnInfo] { [] }
+    func fetchIndexes(table: String) async throws -> [IndexInfo] { [] }
+    func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo] { [] }
+    func fetchApproximateRowCount(table: String) async throws -> Int? { nil }
+    func fetchTableDDL(table: String) async throws -> String { "" }
+    func fetchViewDefinition(view: String) async throws -> String { "" }
+
+    func fetchTableMetadata(tableName: String) async throws -> TableMetadata {
+        TableMetadata(
+            tableName: tableName, dataSize: nil, indexSize: nil, totalSize: nil,
+            avgRowLength: nil, rowCount: nil, comment: nil, engine: nil,
+            collation: nil, createTime: nil, updateTime: nil
+        )
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata {
+        DatabaseMetadata(
+            id: database, name: database, tableCount: nil, sizeBytes: nil,
+            lastAccessed: nil, isSystemDatabase: false, icon: "cylinder"
+        )
+    }
+
+    func cancelQuery() throws {}
+    func beginTransaction() async throws {}
+    func commitTransaction() async throws {}
+    func rollbackTransaction() async throws {}
+
+    func fetchProcedures(schema: String?) async throws -> [RoutineInfo] {
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])
+    }
+
+    func fetchFunctions(schema: String?) async throws -> [RoutineInfo] {
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])
+    }
+}
+
+@Suite("SchemaService routines")
+@MainActor
+struct SchemaServiceRoutinesTests {
+    @Test("load caches procedures and functions alongside tables")
+    func loadCachesRoutines() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = RoutineMockDriver(connection: connection)
+        driver.tablesToReturn = [TestFixtures.makeTableInfo(name: "users")]
+        driver.proceduresToReturn = [
+            RoutineInfo(name: "add_user", schema: "public", kind: .procedure, signature: nil)
+        ]
+        driver.functionsToReturn = [
+            RoutineInfo(name: "user_count", schema: "public", kind: .function, signature: "int")
+        ]
+
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+
+        #expect(service.tables(for: connectionId).map(\.name) == ["users"])
+        #expect(service.procedures(for: connectionId).map(\.name) == ["add_user"])
+        #expect(service.functions(for: connectionId).map(\.name) == ["user_count"])
+        #expect(driver.tablesCallCount == 1)
+        #expect(driver.proceduresCallCount == 1)
+        #expect(driver.functionsCallCount == 1)
+    }
+
+    @Test("routines() concatenates procedures then functions")
+    func routinesConcatenation() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = RoutineMockDriver(connection: connection)
+        driver.proceduresToReturn = [
+            RoutineInfo(name: "p1", schema: nil, kind: .procedure, signature: nil)
+        ]
+        driver.functionsToReturn = [
+            RoutineInfo(name: "f1", schema: nil, kind: .function, signature: nil)
+        ]
+
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+
+        let combined = service.routines(for: connectionId)
+        #expect(combined.map(\.name) == ["p1", "f1"])
+        #expect(combined.map(\.kind) == [.procedure, .function])
+    }
+
+    @Test("failing routine fetches leave tables loaded and routines empty")
+    func failingRoutinesDoNotBlockTables() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = FailingRoutineDriver(connection: connection)
+
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+
+        #expect(service.tables(for: connectionId).map(\.name) == ["users"])
+        #expect(service.procedures(for: connectionId).isEmpty)
+        #expect(service.functions(for: connectionId).isEmpty)
+        if case .loaded = service.state(for: connectionId) {
+            // success: state is loaded even though routines failed
+        } else {
+            Issue.record("expected loaded state when only routine fetches fail")
+        }
+    }
+
+    @Test("invalidate clears tables and routine caches")
+    func invalidateClearsAll() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = RoutineMockDriver(connection: connection)
+        driver.tablesToReturn = [TestFixtures.makeTableInfo(name: "t")]
+        driver.proceduresToReturn = [
+            RoutineInfo(name: "p", schema: nil, kind: .procedure, signature: nil)
+        ]
+
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+        #expect(!service.procedures(for: connectionId).isEmpty)
+
+        await service.invalidate(connectionId: connectionId)
+
+        #expect(service.tables(for: connectionId).isEmpty)
+        #expect(service.procedures(for: connectionId).isEmpty)
+        #expect(service.functions(for: connectionId).isEmpty)
+    }
+
+    @Test("reloadProcedures refreshes only procedures")
+    func reloadProceduresOnly() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = RoutineMockDriver(connection: connection)
+        driver.proceduresToReturn = [
+            RoutineInfo(name: "p1", schema: nil, kind: .procedure, signature: nil)
+        ]
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+        let firstProcCount = driver.proceduresCallCount
+        let firstFuncCount = driver.functionsCallCount
+
+        driver.proceduresToReturn = [
+            RoutineInfo(name: "p1", schema: nil, kind: .procedure, signature: nil),
+            RoutineInfo(name: "p2", schema: nil, kind: .procedure, signature: nil)
+        ]
+        await service.reloadProcedures(connectionId: connectionId, driver: driver)
+
+        #expect(driver.proceduresCallCount == firstProcCount + 1)
+        #expect(driver.functionsCallCount == firstFuncCount)
+        #expect(service.procedures(for: connectionId).map(\.name) == ["p1", "p2"])
+    }
+}


### PR DESCRIPTION
## Summary

Wires the routines pipeline added in PRs A and B end-to-end. After this PR, opening a Postgres or MySQL connection automatically shows actual procedures and functions in the sidebar with their own Refresh actions; other engines surface an empty (hidden) routine section until they adopt `PluginProcedureFunctionSupport`.

- `PluginDriverAdapter` downcasts to `PluginProcedureFunctionSupport` and maps `PluginRoutineInfo` to the app's `RoutineInfo`. Drivers without the protocol return an empty list, so unsupported engines no-op safely.
- `DatabaseDriver` gains `fetchProcedures(schema:)` and `fetchFunctions(schema:)` with default `[]` implementations, keeping every existing driver source compiling untouched.
- `SchemaService` caches `procedures` and `functions` per connection. `load()` fetches them in parallel with tables via `async let`; routine errors are logged and leave the slot empty without blocking the table load or flipping the state to `.failed`.
- `SidebarView` reads routines from the same `SchemaService` it already uses for tables. The section header "Refresh" action dispatches to the matching coordinator method per kind.

Scope is wire-up only: no plugin changes, no `PluginKit` ABI version bump, no `TableInfo.TableType` changes.

## Test plan

- [x] `xcodebuild ... test -only-testing:TableProTests/SchemaServiceRoutinesTests` (5 tests pass): caches procedures and functions on load, concatenates routines in `routines(for:)`, routine fetch failures do not block table loading, `invalidate()` clears all caches, `reloadProcedures()` refreshes only procedures.
- [x] `xcodebuild ... test -only-testing:TableProTests/SidebarViewModelMultiSectionTests` still passes (existing `filteredRoutines` coverage from PR B).
- [x] `swiftlint --strict` clean on every touched source file.
- [x] Full build succeeds.
- [ ] Manual: connect to Postgres, confirm Procedures and Functions sections render with item counts and survive search filtering, right-click the section headers and confirm Refresh updates each kind in isolation.
- [ ] Manual: connect to MySQL, same checks.
- [ ] Manual: connect to SQLite/Redis, confirm the routine sections stay hidden (capability gate plus empty list).