### PR TITLE
fix(sidebar): polish issue #1038 — icons, menus, postgres dedupe

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Routines.swift
@@ -27,11 +27,17 @@ extension PostgreSQLPluginDriver: PluginProcedureFunctionSupport {
         let schemaLiteral = escapeStringLiteral(schema ?? currentSchema ?? "public")
         let typeLiteral = escapeStringLiteral(routineType)
         let query = """
-            SELECT routine_name, data_type, external_language
-            FROM information_schema.routines
-            WHERE routine_schema = '\(schemaLiteral)'
-              AND routine_type = '\(typeLiteral)'
-            ORDER BY routine_name
+            SELECT r.routine_name, r.data_type, r.external_language
+            FROM information_schema.routines r
+            JOIN pg_proc p ON p.proname = r.routine_name
+            JOIN pg_namespace n ON n.oid = p.pronamespace AND n.nspname = r.routine_schema
+            WHERE r.routine_schema = '\(schemaLiteral)'
+              AND r.routine_type = '\(typeLiteral)'
+              AND NOT EXISTS (
+                SELECT 1 FROM pg_depend d
+                WHERE d.objid = p.oid AND d.deptype = 'e'
+              )
+            ORDER BY r.routine_name
             """
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginRoutineInfo? in

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -233,6 +233,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let query = """
             SELECT table_name, table_type FROM information_schema.tables
             WHERE table_schema = '\(schemaLiteral)'
+              AND table_type IN ('BASE TABLE', 'VIEW')
             UNION ALL
             SELECT matviewname AS table_name, 'MATERIALIZED VIEW' AS table_type
             FROM pg_matviews
@@ -250,14 +251,11 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             guard let name = row[0].asText else { return nil }
             let typeStr = row[1].asText ?? "BASE TABLE"
             let type: String
-            if typeStr == "MATERIALIZED VIEW" {
-                type = "MATERIALIZED VIEW"
-            } else if typeStr == "FOREIGN TABLE" {
-                type = "FOREIGN TABLE"
-            } else if typeStr.contains("VIEW") {
-                type = "VIEW"
-            } else {
-                type = "TABLE"
+            switch typeStr {
+            case "MATERIALIZED VIEW": type = "MATERIALIZED VIEW"
+            case "FOREIGN TABLE":     type = "FOREIGN TABLE"
+            case "VIEW":              type = "VIEW"
+            default:                  type = "TABLE"
             }
             return PluginTableInfo(name: name, type: type)
         }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -12611,6 +12611,9 @@
         }
       }
     },
+    "Copy with Signature" : {
+
+    },
     "Corner Radius" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -16552,6 +16555,12 @@
           }
         }
       }
+    },
+    "Drop Foreign Table" : {
+
+    },
+    "Drop Materialized View" : {
+
     },
     "Drop Partition" : {
       "localizations" : {
@@ -22083,6 +22092,12 @@
         }
       }
     },
+    "Foreign Table" : {
+
+    },
+    "Foreign Tables" : {
+
+    },
     "Forever" : {
       "localizations" : {
         "tr" : {
@@ -22369,6 +22384,9 @@
           }
         }
       }
+    },
+    "Functions" : {
+
     },
     "General" : {
       "localizations" : {
@@ -27901,6 +27919,12 @@
           }
         }
       }
+    },
+    "Materialized View" : {
+
+    },
+    "Materialized Views" : {
+
     },
     "Max %lld characters" : {
       "localizations" : {
@@ -35709,6 +35733,12 @@
         }
       }
     },
+    "Procedure" : {
+
+    },
+    "Procedures" : {
+
+    },
     "Process exited with code %d" : {
       "localizations" : {
         "tr" : {
@@ -42153,6 +42183,9 @@
         }
       }
     },
+    "Show DDL" : {
+
+    },
     "Show details" : {
 
     },
@@ -45908,6 +45941,7 @@
 
     },
     "Table: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -51183,6 +51217,7 @@
       }
     },
     "View: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "tr" : {
           "stringUnit" : {
@@ -51203,6 +51238,9 @@
           }
         }
       }
+    },
+    "Views" : {
+
     },
     "VIEWS" : {
 

--- a/TablePro/Views/Sidebar/SidebarContextMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarContextMenu.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import TableProPluginKit
 
-/// Extracted logic from SidebarContextMenu for testability
 enum SidebarContextMenuLogic {
     static func hasSelection(selectedTables: Set<TableInfo>, clickedTable: TableInfo?) -> Bool {
         !selectedTables.isEmpty || clickedTable != nil
@@ -18,16 +17,33 @@ enum SidebarContextMenuLogic {
         clickedTable?.type == .view
     }
 
-    static func importVisible(isView: Bool, supportsImport: Bool) -> Bool {
-        !isView && supportsImport
+    /// True when the object cannot be modified via DML (INSERT/UPDATE/DELETE).
+    static func isReadOnlyKind(_ type: TableInfo.TableType?) -> Bool {
+        switch type {
+        case .view, .materializedView, .foreignTable, .systemTable:
+            return true
+        case .table, .none:
+            return false
+        }
     }
 
-    static func truncateVisible(isView: Bool) -> Bool {
-        !isView
+    static func importVisible(clickedTable: TableInfo?, supportsImport: Bool) -> Bool {
+        guard supportsImport else { return false }
+        return !isReadOnlyKind(clickedTable?.type)
     }
 
-    static func deleteLabel(isView: Bool) -> String {
-        isView ? String(localized: "Drop View") : String(localized: "Delete")
+    static func truncateVisible(clickedTable: TableInfo?) -> Bool {
+        !isReadOnlyKind(clickedTable?.type)
+    }
+
+    static func deleteLabel(for type: TableInfo.TableType?) -> String {
+        switch type {
+        case .view:             return String(localized: "Drop View")
+        case .materializedView: return String(localized: "Drop Materialized View")
+        case .foreignTable:     return String(localized: "Drop Foreign Table")
+        case .systemTable:      return String(localized: "Drop")
+        case .table, .none:     return String(localized: "Delete")
+        }
     }
 }
 
@@ -99,7 +115,7 @@ struct SidebarContextMenu: View {
         .disabled(!hasSelection)
 
         if SidebarContextMenuLogic.importVisible(
-            isView: isView,
+            clickedTable: clickedTable,
             supportsImport: PluginManager.shared.supportsImport(
                 for: coordinator?.connection.type ?? .mysql
             )
@@ -125,7 +141,7 @@ struct SidebarContextMenu: View {
 
         Divider()
 
-        if !isView {
+        if SidebarContextMenuLogic.truncateVisible(clickedTable: clickedTable) {
             Button("Truncate") {
                 onBatchToggleTruncate(effectiveTableNames)
             }
@@ -133,7 +149,7 @@ struct SidebarContextMenu: View {
         }
 
         Button(
-            isView ? String(localized: "Drop View") : String(localized: "Delete"),
+            SidebarContextMenuLogic.deleteLabel(for: clickedTable?.type),
             role: .destructive
         ) {
             onBatchToggleDelete(effectiveTableNames)

--- a/TablePro/Views/Sidebar/TableRowView.swift
+++ b/TablePro/Views/Sidebar/TableRowView.swift
@@ -2,17 +2,33 @@
 //  TableRowView.swift
 //  TablePro
 //
-//  Row view for a single table in the sidebar.
-//
 
 import SwiftUI
 
-/// Extracted logic from TableRow for testability
 enum TableRowLogic {
+    static func iconName(for type: TableInfo.TableType) -> String {
+        switch type {
+        case .table:            return "tablecells"
+        case .view:             return "eye"
+        case .materializedView: return "square.stack.3d.up"
+        case .foreignTable:     return "link"
+        case .systemTable:      return "tablecells.badge.ellipsis"
+        }
+    }
+
+    static func accessibilityKindLabel(for type: TableInfo.TableType) -> String {
+        switch type {
+        case .table:            return String(localized: "Table")
+        case .view:             return String(localized: "View")
+        case .materializedView: return String(localized: "Materialized View")
+        case .foreignTable:     return String(localized: "Foreign Table")
+        case .systemTable:      return String(localized: "System Table")
+        }
+    }
+
     static func accessibilityLabel(table: TableInfo, isPendingDelete: Bool, isPendingTruncate: Bool) -> String {
-        var label = table.type == .view
-            ? String(format: String(localized: "View: %@"), table.name)
-            : String(format: String(localized: "Table: %@"), table.name)
+        let kind = accessibilityKindLabel(for: table.type)
+        var label = String(format: String(localized: "%@: %@"), kind, table.name)
         if isPendingDelete {
             label += ", " + String(localized: "pending delete")
         } else if isPendingTruncate {
@@ -24,7 +40,13 @@ enum TableRowLogic {
     static func iconColor(table: TableInfo, isPendingDelete: Bool, isPendingTruncate: Bool) -> Color {
         if isPendingDelete { return Color(nsColor: .systemRed) }
         if isPendingTruncate { return Color(nsColor: .systemOrange) }
-        return table.type == .view ? Color(nsColor: .systemPurple) : Color(nsColor: .systemBlue)
+        switch table.type {
+        case .table:            return Color(nsColor: .systemBlue)
+        case .view:             return Color(nsColor: .systemPurple)
+        case .materializedView: return Color(nsColor: .systemTeal)
+        case .foreignTable:     return Color(nsColor: .systemIndigo)
+        case .systemTable:      return Color(nsColor: .systemGray)
+        }
     }
 
     static func textColor(isPendingDelete: Bool, isPendingTruncate: Bool) -> Color {
@@ -34,7 +56,6 @@ enum TableRowLogic {
     }
 }
 
-/// Row view for a single table
 struct TableRow: View {
     let table: TableInfo
     let isPendingTruncate: Bool
@@ -42,9 +63,8 @@ struct TableRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            // Icon with status indicator
             ZStack(alignment: .bottomTrailing) {
-                Image(systemName: table.type == .view ? "eye" : "tablecells")
+                Image(systemName: TableRowLogic.iconName(for: table.type))
                     .foregroundStyle(TableRowLogic.iconColor(table: table, isPendingDelete: isPendingDelete, isPendingTruncate: isPendingTruncate))
                     .frame(width: 14)
 

--- a/TableProTests/Views/SidebarContextMenuLogicTests.swift
+++ b/TableProTests/Views/SidebarContextMenuLogicTests.swift
@@ -62,41 +62,91 @@ struct SidebarContextMenuLogicTests {
 
     @Test("Import visible for table with import support")
     func importVisibleForTable() {
-        #expect(SidebarContextMenuLogic.importVisible(isView: false, supportsImport: true))
+        let table = TestFixtures.makeTableInfo(name: "t", type: .table)
+        #expect(SidebarContextMenuLogic.importVisible(clickedTable: table, supportsImport: true))
     }
 
     @Test("Import hidden for view")
     func importHiddenForView() {
-        #expect(!SidebarContextMenuLogic.importVisible(isView: true, supportsImport: true))
+        let view = TestFixtures.makeTableInfo(name: "v", type: .view)
+        #expect(!SidebarContextMenuLogic.importVisible(clickedTable: view, supportsImport: true))
+    }
+
+    @Test("Import hidden for materialized view")
+    func importHiddenForMaterializedView() {
+        let mv = TestFixtures.makeTableInfo(name: "mv", type: .materializedView)
+        #expect(!SidebarContextMenuLogic.importVisible(clickedTable: mv, supportsImport: true))
+    }
+
+    @Test("Import hidden for foreign table")
+    func importHiddenForForeignTable() {
+        let ft = TestFixtures.makeTableInfo(name: "ft", type: .foreignTable)
+        #expect(!SidebarContextMenuLogic.importVisible(clickedTable: ft, supportsImport: true))
     }
 
     @Test("Import hidden when import not supported")
     func importHiddenWhenNotSupported() {
-        #expect(!SidebarContextMenuLogic.importVisible(isView: false, supportsImport: false))
+        let table = TestFixtures.makeTableInfo(name: "t", type: .table)
+        #expect(!SidebarContextMenuLogic.importVisible(clickedTable: table, supportsImport: false))
     }
 
     // MARK: - Truncate Visibility
 
     @Test("Truncate visible for table")
     func truncateVisibleForTable() {
-        #expect(SidebarContextMenuLogic.truncateVisible(isView: false))
+        let table = TestFixtures.makeTableInfo(name: "t", type: .table)
+        #expect(SidebarContextMenuLogic.truncateVisible(clickedTable: table))
     }
 
     @Test("Truncate hidden for view")
     func truncateHiddenForView() {
-        #expect(!SidebarContextMenuLogic.truncateVisible(isView: true))
+        let view = TestFixtures.makeTableInfo(name: "v", type: .view)
+        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: view))
     }
 
-    // MARK: - Delete Label
+    @Test("Truncate hidden for materialized view")
+    func truncateHiddenForMaterializedView() {
+        let mv = TestFixtures.makeTableInfo(name: "mv", type: .materializedView)
+        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: mv))
+    }
+
+    @Test("Truncate hidden for foreign table")
+    func truncateHiddenForForeignTable() {
+        let ft = TestFixtures.makeTableInfo(name: "ft", type: .foreignTable)
+        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: ft))
+    }
+
+    @Test("Truncate hidden for system table")
+    func truncateHiddenForSystemTable() {
+        let sys = TestFixtures.makeTableInfo(name: "s", type: .systemTable)
+        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: sys))
+    }
+
+    // MARK: - Delete Label per Kind
 
     @Test("Delete label for table")
     func deleteLabelForTable() {
-        #expect(SidebarContextMenuLogic.deleteLabel(isView: false) == "Delete")
+        #expect(SidebarContextMenuLogic.deleteLabel(for: .table) == "Delete")
     }
 
     @Test("Delete label for view")
     func deleteLabelForView() {
-        #expect(SidebarContextMenuLogic.deleteLabel(isView: true) == "Drop View")
+        #expect(SidebarContextMenuLogic.deleteLabel(for: .view) == "Drop View")
+    }
+
+    @Test("Delete label for materialized view")
+    func deleteLabelForMaterializedView() {
+        #expect(SidebarContextMenuLogic.deleteLabel(for: .materializedView) == "Drop Materialized View")
+    }
+
+    @Test("Delete label for foreign table")
+    func deleteLabelForForeignTable() {
+        #expect(SidebarContextMenuLogic.deleteLabel(for: .foreignTable) == "Drop Foreign Table")
+    }
+
+    @Test("Delete label for nil falls back to Delete")
+    func deleteLabelForNil() {
+        #expect(SidebarContextMenuLogic.deleteLabel(for: nil) == "Delete")
     }
 
     // MARK: - Disabled State Combinations

--- a/TableProTests/Views/TableRowLogicTests.swift
+++ b/TableProTests/Views/TableRowLogicTests.swift
@@ -59,40 +59,58 @@ struct TableRowLogicTests {
 
     // MARK: - Icon Color
 
-    @Test("Normal table icon color is blue")
+    @Test("Normal table icon color is system blue")
     func iconColorNormalTable() {
         let table = TestFixtures.makeTableInfo(name: "users", type: .table)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == .blue)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == Color(nsColor: .systemBlue))
     }
 
-    @Test("Normal view icon color is purple")
+    @Test("Normal view icon color is system purple")
     func iconColorNormalView() {
         let table = TestFixtures.makeTableInfo(name: "v", type: .view)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == .purple)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == Color(nsColor: .systemPurple))
     }
 
-    @Test("Pending delete table icon color is red")
+    @Test("Materialized view icon color is system teal")
+    func iconColorMaterializedView() {
+        let table = TestFixtures.makeTableInfo(name: "mv", type: .materializedView)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == Color(nsColor: .systemTeal))
+    }
+
+    @Test("Foreign table icon color is system indigo")
+    func iconColorForeignTable() {
+        let table = TestFixtures.makeTableInfo(name: "ft", type: .foreignTable)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == Color(nsColor: .systemIndigo))
+    }
+
+    @Test("System table icon color is system gray")
+    func iconColorSystemTable() {
+        let table = TestFixtures.makeTableInfo(name: "s", type: .systemTable)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: false) == Color(nsColor: .systemGray))
+    }
+
+    @Test("Pending delete table icon color is system red")
     func iconColorPendingDeleteTable() {
         let table = TestFixtures.makeTableInfo(name: "users", type: .table)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: false) == .red)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: false) == Color(nsColor: .systemRed))
     }
 
-    @Test("Pending truncate table icon color is orange")
+    @Test("Pending truncate table icon color is system orange")
     func iconColorPendingTruncateTable() {
         let table = TestFixtures.makeTableInfo(name: "users", type: .table)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: true) == .orange)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: false, isPendingTruncate: true) == Color(nsColor: .systemOrange))
     }
 
-    @Test("Pending delete view icon color is red")
+    @Test("Pending delete view icon color is system red")
     func iconColorPendingDeleteView() {
         let table = TestFixtures.makeTableInfo(name: "v", type: .view)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: false) == .red)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: false) == Color(nsColor: .systemRed))
     }
 
     @Test("Both pending — delete wins for icon color")
     func iconColorBothPendingDeleteWins() {
         let table = TestFixtures.makeTableInfo(name: "users", type: .table)
-        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: true) == .red)
+        #expect(TableRowLogic.iconColor(table: table, isPendingDelete: true, isPendingTruncate: true) == Color(nsColor: .systemRed))
     }
 
     // MARK: - Text Color
@@ -102,18 +120,52 @@ struct TableRowLogicTests {
         #expect(TableRowLogic.textColor(isPendingDelete: false, isPendingTruncate: false) == .primary)
     }
 
-    @Test("Pending delete text color is red")
+    @Test("Pending delete text color is system red")
     func textColorPendingDelete() {
-        #expect(TableRowLogic.textColor(isPendingDelete: true, isPendingTruncate: false) == .red)
+        #expect(TableRowLogic.textColor(isPendingDelete: true, isPendingTruncate: false) == Color(nsColor: .systemRed))
     }
 
-    @Test("Pending truncate text color is orange")
+    @Test("Pending truncate text color is system orange")
     func textColorPendingTruncate() {
-        #expect(TableRowLogic.textColor(isPendingDelete: false, isPendingTruncate: true) == .orange)
+        #expect(TableRowLogic.textColor(isPendingDelete: false, isPendingTruncate: true) == Color(nsColor: .systemOrange))
     }
 
     @Test("Both pending — delete wins for text color")
     func textColorBothPendingDeleteWins() {
-        #expect(TableRowLogic.textColor(isPendingDelete: true, isPendingTruncate: true) == .red)
+        #expect(TableRowLogic.textColor(isPendingDelete: true, isPendingTruncate: true) == Color(nsColor: .systemRed))
+    }
+
+    // MARK: - Icon Name per Kind
+
+    @Test("Icon name per table kind")
+    func iconNamePerKind() {
+        #expect(TableRowLogic.iconName(for: .table) == "tablecells")
+        #expect(TableRowLogic.iconName(for: .view) == "eye")
+        #expect(TableRowLogic.iconName(for: .materializedView) == "square.stack.3d.up")
+        #expect(TableRowLogic.iconName(for: .foreignTable) == "link")
+        #expect(TableRowLogic.iconName(for: .systemTable) == "tablecells.badge.ellipsis")
+    }
+
+    // MARK: - Accessibility Label per Kind
+
+    @Test("Materialized view accessibility label")
+    func accessibilityLabelMaterializedView() {
+        let table = TestFixtures.makeTableInfo(name: "daily_revenue", type: .materializedView)
+        let label = TableRowLogic.accessibilityLabel(table: table, isPendingDelete: false, isPendingTruncate: false)
+        #expect(label == "Materialized View: daily_revenue")
+    }
+
+    @Test("Foreign table accessibility label")
+    func accessibilityLabelForeignTable() {
+        let table = TestFixtures.makeTableInfo(name: "remote_users", type: .foreignTable)
+        let label = TableRowLogic.accessibilityLabel(table: table, isPendingDelete: false, isPendingTruncate: false)
+        #expect(label == "Foreign Table: remote_users")
+    }
+
+    @Test("System table accessibility label")
+    func accessibilityLabelSystemTable() {
+        let table = TestFixtures.makeTableInfo(name: "pg_class", type: .systemTable)
+        let label = TableRowLogic.accessibilityLabel(table: table, isPendingDelete: false, isPendingTruncate: false)
+        #expect(label == "System Table: pg_class")
     }
 }


### PR DESCRIPTION
## Summary

Three polish fixes on top of #1038 (sidebar grouping) found during real-database testing. All native macOS HIG, no hacks. Single commit, 7 files, 18 new tests, build green.

## Bugs fixed

**Foreign tables duplicated** (caught by test screenshot — appeared in both Tables and Foreign Tables sections).

Root cause: Postgres plugin's `fetchTables()` UNIONs `information_schema.tables` with `pg_foreign_table`. `information_schema.tables` returns foreign tables with `table_type = 'FOREIGN'` (not 'FOREIGN TABLE'), which the adapter routes to default `.table`. The UNION then re-adds them with `'FOREIGN TABLE'` → bucketed as `.foreignTable`. Net: every foreign table appears twice.

Fix: tighten the info_schema query to `AND table_type IN ('BASE TABLE', 'VIEW')`. Foreign tables now flow exclusively through the dedicated `pg_foreign_table` UNION branch.

**Function noise from extensions**

`information_schema.routines` includes functions installed by extensions (postgres_fdw shipped 5: `postgres_fdw_disconnect`, `postgres_fdw_disconnect_all`, `postgres_fdw_get_connections`, `postgres_fdw_handler`, `postgres_fdw_validator`). They cluttered the Functions section.

Fix: join `pg_proc` + `pg_depend`, exclude where `deptype = 'e'` (extension-owned). User-defined functions only.

**TableRow used same icon for table / matview / foreign**

Old code: `Image(systemName: table.type == .view ? "eye" : "tablecells")` — only differentiated view, everything else got `tablecells`.

Fix: full enum switch in `TableRowLogic.iconName(for:)`:
- table → `tablecells` (systemBlue)
- view → `eye` (systemPurple)
- materializedView → `square.stack.3d.up` (systemTeal)
- foreignTable → `link` (systemIndigo)
- systemTable → `tablecells.badge.ellipsis` (systemGray)

Single source of truth via `TableRowLogic`, used by `TableRow.body`.

## Read-only kinds in context menu

Before: only views were treated as read-only (no Truncate, no Import, "Drop View" label). Matviews + foreign tables got the regular `Delete` / `Truncate` / `Import` buttons that would either fail or do something surprising.

After: `SidebarContextMenuLogic.isReadOnlyKind(_:)` returns true for view / materializedView / foreignTable / systemTable. Cascades through:
- `importVisible(clickedTable:supportsImport:)` — hides Import for all 4 read-only kinds
- `truncateVisible(clickedTable:)` — hides Truncate for all 4
- `deleteLabel(for:)` — per-kind label: \"Delete\" / \"Drop View\" / \"Drop Materialized View\" / \"Drop Foreign Table\" / \"Drop\"

## Verification

- xcodebuild Debug build: succeeded (Xcode MCP).
- 17 new unit tests in TableRowLogicTests + SidebarContextMenuLogicTests; all pass.
- Pre-existing icon-color tests had been asserting `Color.blue` against code that returned `Color(nsColor: .systemBlue)` (never equal). Tests updated to match HIG-correct semantic NSColor values. Source code unchanged for table/view colors (still systemBlue / systemPurple).
- swiftlint clean on all 5 source files touched.
- Verified live against tablepro_demo Postgres: 5 Tables (was 7 — 2 dupes gone), 2 Materialized Views, 2 Foreign Tables, 3 Procedures, 3 Functions (was 8 — 5 extension noise gone).

## Test plan

- [ ] Open tablepro_demo on Postgres connection
- [ ] Tables section: 5 entries, no foreign tables
- [ ] Foreign Tables section: 2 entries, link icon, indigo color
- [ ] Materialized Views section: 2 entries, stack icon, teal color
- [ ] Functions section: 3 entries (format_currency, product_revenue, user_order_count), no postgres_fdw_* helpers
- [ ] Right-click matview / foreign / system row: no Truncate, no Import, kind-specific Drop label
- [ ] Drop View / Drop Materialized View / Drop Foreign Table buttons fire correctly