### PR TITLE
polish(sidebar): show DDL for routines, native selection contrast, drop count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Sidebar groups database objects into Tables, Views, Materialized Views, Foreign Tables, Procedures, and Functions sections; routines load automatically on connect for Postgres and MySQL, and each section header has its own Refresh action (#1038)
+- Sidebar groups database objects into Tables, Views, Materialized Views, Foreign Tables, Procedures, and Functions sections; routines load automatically on connect for Postgres and MySQL, each section header has its own Refresh action, and "Show DDL" on a procedure or function opens its definition in a new query tab (#1038)
 - iOS: Live Activity for running queries shows query preview, elapsed time, and row count on the lock screen and Dynamic Island
 - iOS: multi-window support on iPad - drag a tab off to open a second window, each window remembers its own selected connection across launches
 - iOS: VoiceOver "Delete row" / "Delete group" / "Delete tag" custom actions on rows whose only deletion path was a swipe gesture
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sidebar: selected row icon and label tint to white so kind colors (indigo, teal, purple) stay readable on the blue selection background
+- Sidebar: drop the per-section item count; empty optional-kind sections are already hidden, so the count was visual noise that also jittered next to the hover-revealed disclosure chevron
+- Internal: sidebar rows use `Label` instead of hand-rolled `HStack`, and the selection-aware tint lives in a single `sidebarTint(_:)` modifier shared by table and routine rows
 - Data grid: skip the structural update pipeline when the inputs to `updateNSView` are unchanged, and pull binding and selection synchronization out so they always run cheaply
 - Data grid: theme changes now reload visible rows so the direct-draw cell picks up the new palette; the legacy `updateVisibleCellFonts` path is removed
 - Data grid: background prewarm fills the display cache in frame-budgeted batches after each structural reload, so scrolling stays a cache hit instead of running the date formatter on the main thread

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -323,6 +323,23 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         }
     }
 
+    func fetchRoutineDDL(routine: RoutineInfo) async throws -> String {
+        guard let support = pluginDriver as? PluginProcedureFunctionSupport else {
+            throw NSError(
+                domain: "PluginDriverAdapter",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: String(localized: "This driver does not expose routine DDL.")]
+            )
+        }
+        let resolvedSchema = routine.schema ?? pluginDriver.currentSchema
+        switch routine.kind {
+        case .procedure:
+            return try await support.fetchProcedureDDL(name: routine.name, schema: resolvedSchema)
+        case .function:
+            return try await support.fetchFunctionDDL(name: routine.name, schema: resolvedSchema)
+        }
+    }
+
     func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata {
         let pluginMeta = try await pluginDriver.fetchDatabaseMetadata(database)
         return DatabaseMetadata(

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -8369,6 +8369,9 @@
         }
       }
     },
+    "Cannot Show DDL" : {
+
+    },
     "Cap user query results at the configured row count" : {
       "localizations" : {
         "tr" : {
@@ -20184,6 +20187,9 @@
         }
       }
     },
+    "Failed to Fetch DDL" : {
+
+    },
     "Failed to fetch models from %@" : {
 
     },
@@ -22384,6 +22390,9 @@
           }
         }
       }
+    },
+    "Function: %@" : {
+
     },
     "Functions" : {
 
@@ -35736,6 +35745,9 @@
     "Procedure" : {
 
     },
+    "Procedure: %@" : {
+
+    },
     "Procedures" : {
 
     },
@@ -47121,6 +47133,9 @@
       }
     },
     "This discards your edits to the Chinook sample and restores the original copy." : {
+
+    },
+    "This driver does not expose routine DDL." : {
 
     },
     "This DROP query will permanently remove database objects. This action cannot be undone." : {

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -523,6 +523,43 @@ final class MainContentCoordinator {
         await services.schemaService.reloadFunctions(connectionId: connectionId, driver: driver)
     }
 
+    func showRoutineDDL(_ routine: RoutineInfo) {
+        guard let adapter = services.databaseManager.driver(for: connectionId) as? PluginDriverAdapter else {
+            AlertHelper.showErrorSheet(
+                title: String(localized: "Cannot Show DDL"),
+                message: String(localized: "This driver does not expose routine DDL."),
+                window: nil
+            )
+            return
+        }
+        Task { [connectionId = connection.id, routine] in
+            do {
+                let ddl = try await adapter.fetchRoutineDDL(routine: routine)
+                let titleFormat: String = routine.kind == .procedure
+                    ? String(localized: "Procedure: %@")
+                    : String(localized: "Function: %@")
+                let payload = EditorTabPayload(
+                    connectionId: connectionId,
+                    tabType: .query,
+                    initialQuery: ddl,
+                    skipAutoExecute: true,
+                    tabTitle: String(format: titleFormat, routine.name)
+                )
+                await MainActor.run {
+                    WindowManager.shared.openTab(payload: payload)
+                }
+            } catch {
+                await MainActor.run {
+                    AlertHelper.showErrorSheet(
+                        title: String(localized: "Failed to Fetch DDL"),
+                        message: error.localizedDescription,
+                        window: nil
+                    )
+                }
+            }
+        }
+    }
+
     /// Push the SchemaService table list into the autocomplete provider and prune sidebar
     /// state for tables that no longer exist.
     private func reconcilePostSchemaLoad() async {

--- a/TablePro/Views/Sidebar/RoutineRowView.swift
+++ b/TablePro/Views/Sidebar/RoutineRowView.swift
@@ -41,15 +41,16 @@ struct RoutineRowView: View {
     let routine: RoutineInfo
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: RoutineRowLogic.iconName(for: routine.kind))
-                .foregroundStyle(RoutineRowLogic.iconColor(for: routine.kind))
-                .frame(width: 14)
-
+        Label {
             Text(routine.name)
                 .font(.system(.callout, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .sidebarTint(.primary)
+        } icon: {
+            Image(systemName: RoutineRowLogic.iconName(for: routine.kind))
+                .sidebarTint(RoutineRowLogic.iconColor(for: routine.kind))
+                .frame(width: 14)
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)

--- a/TablePro/Views/Sidebar/SidebarTint.swift
+++ b/TablePro/Views/Sidebar/SidebarTint.swift
@@ -1,0 +1,21 @@
+//
+//  SidebarTint.swift
+//  TablePro
+//
+
+import SwiftUI
+
+private struct SidebarTint: ViewModifier {
+    let color: Color
+    @Environment(\.backgroundProminence) private var backgroundProminence
+
+    func body(content: Content) -> some View {
+        content.foregroundStyle(backgroundProminence == .increased ? Color.white : color)
+    }
+}
+
+extension View {
+    func sidebarTint(_ color: Color) -> some View {
+        modifier(SidebarTint(color: color))
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -239,7 +239,7 @@ struct SidebarView: View {
             Section(isExpanded: isExpanded) {
                 sectionRows(for: kind)
             } header: {
-                sectionHeader(for: kind, count: count)
+                sectionHeader(for: kind)
             }
         }
     }
@@ -258,7 +258,9 @@ struct SidebarView: View {
                 RoutineRowView(routine: routine)
                     .tag(routine)
                     .contextMenu {
-                        RoutineContextMenu(routine: routine) { _ in }
+                        RoutineContextMenu(routine: routine) { selected in
+                            coordinator?.showRoutineDDL(selected)
+                        }
                     }
             }
         } else {
@@ -288,26 +290,17 @@ struct SidebarView: View {
         }
     }
 
-    private func sectionHeader(for kind: SidebarObjectKind, count: Int) -> some View {
+    private func sectionHeader(for kind: SidebarObjectKind) -> some View {
         let title = sectionTitle(for: kind)
         let helpLabel = String(
             format: String(localized: "Right-click to show all %@"),
             title.lowercased()
         )
-        return HStack(spacing: 8) {
-            Text(title)
-            Spacer()
-            if count > 0 {
-                Text("\(count)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
+        return Text(title)
+            .help(helpLabel)
+            .contextMenu {
+                sectionHeaderMenu(for: kind, title: title)
             }
-        }
-        .help(helpLabel)
-        .contextMenu {
-            sectionHeaderMenu(for: kind, title: title)
-        }
     }
 
     @ViewBuilder

--- a/TablePro/Views/Sidebar/TableRowView.swift
+++ b/TablePro/Views/Sidebar/TableRowView.swift
@@ -61,31 +61,38 @@ struct TableRow: View {
     let isPendingTruncate: Bool
     let isPendingDelete: Bool
 
+    private var iconColor: Color {
+        TableRowLogic.iconColor(table: table, isPendingDelete: isPendingDelete, isPendingTruncate: isPendingTruncate)
+    }
+
+    private var textColor: Color {
+        TableRowLogic.textColor(isPendingDelete: isPendingDelete, isPendingTruncate: isPendingTruncate)
+    }
+
     var body: some View {
-        HStack(spacing: 8) {
+        Label {
+            Text(table.name)
+                .font(.system(.callout, design: .monospaced))
+                .lineLimit(1)
+                .sidebarTint(textColor)
+        } icon: {
             ZStack(alignment: .bottomTrailing) {
                 Image(systemName: TableRowLogic.iconName(for: table.type))
-                    .foregroundStyle(TableRowLogic.iconColor(table: table, isPendingDelete: isPendingDelete, isPendingTruncate: isPendingTruncate))
+                    .sidebarTint(iconColor)
                     .frame(width: 14)
 
-                // Pending operation indicator
                 if isPendingDelete {
                     Image(systemName: "minus.circle.fill")
                         .font(.caption)
-                        .foregroundStyle(Color(nsColor: .systemRed))
+                        .sidebarTint(Color(nsColor: .systemRed))
                         .offset(x: 4, y: 4)
                 } else if isPendingTruncate {
                     Image(systemName: "exclamationmark.circle.fill")
                         .font(.caption)
-                        .foregroundStyle(Color(nsColor: .systemOrange))
+                        .sidebarTint(Color(nsColor: .systemOrange))
                         .offset(x: 4, y: 4)
                 }
             }
-
-            Text(table.name)
-                .font(.system(.callout, design: .monospaced))
-                .lineLimit(1)
-                .foregroundStyle(TableRowLogic.textColor(isPendingDelete: isPendingDelete, isPendingTruncate: isPendingTruncate))
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
## Summary

- **Show DDL for procedures and functions** is now wired. Right-click a routine in the sidebar, pick Show DDL, and the CREATE statement opens in a new query tab (titled "Procedure: foo" / "Function: foo", `skipAutoExecute: true`). Previously the menu item existed but the handler was a no-op.
- **Selected-row contrast** uses `\.backgroundProminence`. Per-kind icon colors (indigo foreign tables, teal matviews, purple views, etc.) stay readable on the blue selection background because icon and label flip to white.
- **Per-section item counts dropped.** Empty optional-kind sections are already hidden by `sectionShouldRender`, so the count was visual noise that also jittered next to the hover-revealed disclosure chevron.
- **Row layout uses `Label`** instead of hand-rolled `HStack { Image; Text }`. Apple-idiomatic, no spacing magic.
- **Selection-aware tint extracted** to a single `sidebarTint(_:)` modifier shared by table and routine rows. No duplicated `@Environment(\.backgroundProminence)` boilerplate.

## Test plan

- [ ] Build the app, open a Postgres connection with the issue-1038 seed.
- [ ] Click rows in each of the 6 sections (Tables, Views, Materialized Views, Foreign Tables, Procedures, Functions). Icon and name turn white on the blue selection.
- [ ] Hover a section header. Title stays put, no count shifts because there is no count.
- [ ] Right-click `place_order` (procedure) → Show DDL. New query tab opens with the `CREATE OR REPLACE PROCEDURE ...` body.
- [ ] Right-click `format_currency` (function) → Show DDL. Same flow with `CREATE OR REPLACE FUNCTION ...`.
- [ ] Click a procedure or function row. (Known limitation: routines are not selectable via List selection and have no double-click handler. Right-click context menu is the only interaction.)
- [ ] VoiceOver on (Cmd+F5). Tab into the sidebar. Section headers read their title; rows read kind plus name.
- [ ] `swiftlint --strict` clean on the 6 touched Swift files.