### PR TITLE
fix(plugins): native version-based discovery, restart UX, registry hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Plugin upgrades for built-in drivers (MySQL, PostgreSQL, SQLite, ClickHouse, Redis, etc.) no longer revert to the bundled version after restart. Discovery now scans both built-in and user plugin directories, picks the newest version by `CFBundleShortVersionString`, and only prunes user copies that are older than or equal to the built-in (#1192)
-- Concurrent plugin installs from the registry can no longer race past the `isInstalling` guard; the lock now wraps `installFromRegistry` and `updateFromRegistry` end-to-end
-- Plugin manager's `waitForInitialLoad` no longer leaks a continuation when its 10-second timeout fires before initial load completes
-- Multi-bundle ZIP archives are now rejected with a clear error instead of silently installing only the last bundle
-
-### Changed
-
-- Plugin registry manifest cache moved from `UserDefaults` to `~/Library/Caches/<bundle-id>/registry-manifest.json`; legacy keys are removed on first launch
-- Plugin signing requirement reads the team identifier from the running app's signature at runtime instead of a hardcoded value, with a documented fallback
-- Plugin install loading happens off the main actor; large dylibs no longer hitch the UI during install
-- "Restart TablePro" banner gets a Quit & Reopen button that relaunches via `NSWorkspace.openApplication`
-- Completed plugin install badges auto-clear after 3 seconds (failed installs still persist until dismissed)
-- Default `escapeStringLiteral` in `TableProPluginKit` no longer escapes backslashes; drivers that need MySQL-style escaping opt in via `requiresBackslashEscapingInLiterals`
-- `needsRestart` flag is in-memory only; stale "restart needed" banners no longer persist across launches
-
 ### Added
 
 - Sidebar groups database objects into Tables, Views, Materialized Views, Foreign Tables, Procedures, and Functions sections; routines load automatically on connect for Postgres and MySQL, each section header has its own Refresh action, and "Show DDL" on a procedure or function opens its definition in a new query tab (#1038)
@@ -104,9 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Result-grid cells render via direct `draw(_:)` on a layer-backed `NSView` instead of an `NSTableCellView` wrapping an `NSTextField` plus an `NSButton` accessory. Per cell during scroll there is no Auto Layout solving, no `NSTextField` re-layout, and no `NSButton` tracking-area work. Editing for plain-text columns now opens the overlay editor (the same surface previously used for multi-line cells) rather than an inline text field.
 - Plugin contract: `PluginQueryResult.rows` carries typed `PluginCellValue` cells (`.null` / `.text(String)` / `.bytes(Data)`) instead of `String?`. Driver plugins emit `.bytes(Data)` for binary columns (PostgreSQL BYTEA, Oracle RAW/LONG_RAW/BLOB, MySQL BLOB family, SQLite BLOB, MSSQL VARBINARY/IMAGE, DuckDB BLOB, Cassandra blob, MongoDB BSON binary, DynamoDB B, BigQuery BYTES). The typed value flows end-to-end: read display, sidebar, hex editor, change tracking, SQL emission. Hex-editor saves bind raw `Data` through libpq's binary parameter format instead of UTF-8 re-encoded text. Fixes wrong BYTEA hex preview, wrong byte count, and corrupted bytes on save for high-byte binary cells (#1188).
 - Double-click and Return on a binary cell now open the hex editor directly. Type-based routing runs before the line-break/JSON content heuristics so binary bytes that incidentally contain 0x0C or `{` no longer route through the multi-line text editor and corrupt the value.
+- Plugin registry manifest cache moved from `UserDefaults` to `~/Library/Caches/<bundle-id>/registry-manifest.json`; legacy keys are removed on first launch
+- Plugin signing requirement reads the team identifier from the running app's signature at runtime instead of a hardcoded value, with a documented fallback
+- Plugin install loading happens off the main actor; large dylibs no longer hitch the UI during install
+- "Restart TablePro" banner gets a Quit & Reopen button that relaunches via `NSWorkspace.openApplication`; if the relaunch fails the user sees an alert and the running instance stays alive
+- Completed plugin install badges auto-clear after 3 seconds (failed installs still persist until dismissed)
+- Default `escapeStringLiteral` in `TableProPluginKit` no longer escapes backslashes; drivers that need MySQL-style escaping opt in via `requiresBackslashEscapingInLiterals`
+- `needsRestart` flag is in-memory only; stale "restart needed" banners no longer persist across launches
 
 ### Fixed
 
+- Plugin upgrades for built-in drivers (MySQL, PostgreSQL, SQLite, ClickHouse, Redis, etc.) no longer revert to the bundled version after restart. Discovery now scans both built-in and user plugin directories, picks the newest version by `CFBundleShortVersionString`, and only prunes user copies that are older than or equal to the built-in (#1192)
+- Concurrent plugin installs from the registry can no longer race past the `isInstalling` guard; the lock now wraps `installFromRegistry` and `updateFromRegistry` end-to-end
+- Plugin manager's `waitForInitialLoad` no longer leaks a continuation when its 10-second timeout fires before initial load completes
+- Multi-bundle ZIP archives are now rejected with a clear error instead of silently installing only the last bundle
 - MySQL/MariaDB: numeric, decimal, date and time columns display their values again instead of rendering as hex bytes (e.g. `1` instead of `0x31`, `12.50` instead of `0x31322E3530`). The typed `PluginCellValue` refactor in #1190 routed any column with charset 63 to the binary path, but MariaDB reports charset 63 for every non-character type. The binary check now also requires a BLOB or BINARY/VARBINARY field type
 - Structure tab: double-click and Return on dropdown / type-picker columns (Nullable, Primary Key, Auto Increment, Unique, On Delete, On Update, Type) now enter inline text edit so the user can type a value the picker doesn't list (e.g. a custom column type, a numeric default). Previously these gestures appeared to do nothing because `editEligibility` blocked dropdown/type-picker columns from inline edit. The chevron button continues to open the picker; the cell body opens the text editor.
 - Structure tab: pressing Cmd+Shift+N (or any path that adds a column / index / foreign key while changes already exist) now displays the new row in the grid. Previously the row was added to the change manager and the SQL Preview reflected it, but the grid kept the old row count because `TableStructureView` only observed `hasChanges` (which had already been true). The view now also observes `reloadVersion` and re-evaluates the grid snapshot on every mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Plugin upgrades for built-in drivers (MySQL, PostgreSQL, SQLite, ClickHouse, Redis, etc.) no longer revert to the bundled version after restart. Discovery now scans both built-in and user plugin directories, picks the newest version by `CFBundleShortVersionString`, and only prunes user copies that are older than or equal to the built-in (#1192)
+- Concurrent plugin installs from the registry can no longer race past the `isInstalling` guard; the lock now wraps `installFromRegistry` and `updateFromRegistry` end-to-end
+- Plugin manager's `waitForInitialLoad` no longer leaks a continuation when its 10-second timeout fires before initial load completes
+- Multi-bundle ZIP archives are now rejected with a clear error instead of silently installing only the last bundle
+
+### Changed
+
+- Plugin registry manifest cache moved from `UserDefaults` to `~/Library/Caches/<bundle-id>/registry-manifest.json`; legacy keys are removed on first launch
+- Plugin signing requirement reads the team identifier from the running app's signature at runtime instead of a hardcoded value, with a documented fallback
+- Plugin install loading happens off the main actor; large dylibs no longer hitch the UI during install
+- "Restart TablePro" banner gets a Quit & Reopen button that relaunches via `NSWorkspace.openApplication`
+- Completed plugin install badges auto-clear after 3 seconds (failed installs still persist until dismissed)
+- Default `escapeStringLiteral` in `TableProPluginKit` no longer escapes backslashes; drivers that need MySQL-style escaping opt in via `requiresBackslashEscapingInLiterals`
+- `needsRestart` flag is in-memory only; stale "restart needed" banners no longer persist across launches
+
 ### Added
 
 - Sidebar groups database objects into Tables, Views, Materialized Views, Foreign Tables, Procedures, and Functions sections; routines load automatically on connect for Postgres and MySQL, each section header has its own Refresh action, and "Show DDL" on a procedure or function opens its definition in a new query tab (#1038)
@@ -90,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MySQL/MariaDB: numeric, decimal, date and time columns display their values again instead of rendering as hex bytes (e.g. `1` instead of `0x31`, `12.50` instead of `0x31322E3530`). The typed `PluginCellValue` refactor in #1190 routed any column with charset 63 to the binary path, but MariaDB reports charset 63 for every non-character type. The binary check now also requires a BLOB or BINARY/VARBINARY field type
 - Structure tab: double-click and Return on dropdown / type-picker columns (Nullable, Primary Key, Auto Increment, Unique, On Delete, On Update, Type) now enter inline text edit so the user can type a value the picker doesn't list (e.g. a custom column type, a numeric default). Previously these gestures appeared to do nothing because `editEligibility` blocked dropdown/type-picker columns from inline edit. The chevron button continues to open the picker; the cell body opens the text editor.
 - Structure tab: pressing Cmd+Shift+N (or any path that adds a column / index / foreign key while changes already exist) now displays the new row in the grid. Previously the row was added to the change manager and the SQL Preview reflected it, but the grid kept the old row count because `TableStructureView` only observed `hasChanges` (which had already been true). The view now also observes `reloadVersion` and re-evaluates the grid snapshot on every mutation.
 - Structure tab: pressing Delete on a row now turns the entire row red, not just the focused cell. `StructureRowViewWithMenu` inherits from `DataGridRowView` so it gets the deleted-row tint, layer-backing optimization, and the cell-emphasis invalidation that all data-tab rows already had. The grid's `tableView(_:rowViewForRow:)` also now applies the visual state to delegate-provided row views, so recycled rows pick up state changes. `StructureGridDelegate.dataGridDeleteRows` calls `tableView.reloadData(forRowIndexes:columnIndexes:)` for visible rows so the soft-deleted row repaints (existing-column deletes leave the row in place with a red tint, so row count alone doesn't trigger a reload).

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -24,6 +24,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     var serverVersion: String? { _serverVersion }
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { true }
+    var requiresBackslashEscapingInLiterals: Bool { true }
 
     var capabilities: PluginCapabilities {
         [

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -71,8 +71,6 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     var serverVersion: String? { get }
     var parameterStyle: ParameterStyle { get }
 
-    /// Whether string literals require backslash escaping for `\`, `\n`, `\r`, `\t`, and `\Z`.
-    /// MySQL/MariaDB: true. PostgreSQL (with `standard_conforming_strings = on`), SQLite, MSSQL: false.
     var requiresBackslashEscapingInLiterals: Bool { get }
 
     // Batch operations

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -71,6 +71,10 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     var serverVersion: String? { get }
     var parameterStyle: ParameterStyle { get }
 
+    /// Whether string literals require backslash escaping for `\`, `\n`, `\r`, `\t`, and `\Z`.
+    /// MySQL/MariaDB: true. PostgreSQL (with `standard_conforming_strings = on`), SQLite, MSSQL: false.
+    var requiresBackslashEscapingInLiterals: Bool { get }
+
     // Batch operations
     func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int?
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]]
@@ -178,6 +182,8 @@ public extension PluginDatabaseDriver {
     var serverVersion: String? { nil }
 
     var parameterStyle: ParameterStyle { .questionMark }
+
+    var requiresBackslashEscapingInLiterals: Bool { false }
 
     func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? { nil }
 
@@ -319,15 +325,15 @@ public extension PluginDatabaseDriver {
         let sql: String
         switch parameterStyle {
         case .questionMark:
-            sql = Self.substituteQuestionMarks(query: query, parameters: parameters)
+            sql = substituteQuestionMarks(query: query, parameters: parameters)
         case .dollar:
-            sql = Self.substituteDollarParams(query: query, parameters: parameters)
+            sql = substituteDollarParams(query: query, parameters: parameters)
         }
 
         return try await execute(query: sql)
     }
 
-    private static func substituteQuestionMarks(query: String, parameters: [PluginCellValue]) -> String {
+    private func substituteQuestionMarks(query: String, parameters: [PluginCellValue]) -> String {
         let nsQuery = query as NSString
         let length = nsQuery.length
         var sql = ""
@@ -390,7 +396,7 @@ public extension PluginDatabaseDriver {
         return sql
     }
 
-    private static func substituteDollarParams(query: String, parameters: [PluginCellValue]) -> String {
+    private func substituteDollarParams(query: String, parameters: [PluginCellValue]) -> String {
         let nsQuery = query as NSString
         let length = nsQuery.length
         var sql = ""
@@ -466,7 +472,7 @@ public extension PluginDatabaseDriver {
         return sql
     }
 
-    static func sqlLiteral(for value: PluginCellValue) -> String {
+    func sqlLiteral(for value: PluginCellValue) -> String {
         switch value {
         case .null:
             return "NULL"
@@ -483,28 +489,29 @@ public extension PluginDatabaseDriver {
         }
     }
 
-    static func escapedParameterValue(_ value: String) -> String {
-        if isNumericLiteral(value) {
+    func escapedParameterValue(_ value: String) -> String {
+        if Self.isNumericLiteral(value) {
             return value
         }
         var escaped = ""
         escaped.reserveCapacity(value.count + 2)
         escaped.append("'")
+        let escapeBackslashes = requiresBackslashEscapingInLiterals
         for char in value {
             switch char {
             case "'":
                 escaped.append("''")
             case "\0":
                 continue
-            case "\\":
+            case "\\" where escapeBackslashes:
                 escaped.append("\\\\")
-            case "\n":
+            case "\n" where escapeBackslashes:
                 escaped.append("\\n")
-            case "\r":
+            case "\r" where escapeBackslashes:
                 escaped.append("\\r")
-            case "\t":
+            case "\t" where escapeBackslashes:
                 escaped.append("\\t")
-            case "\u{1A}":
+            case "\u{1A}" where escapeBackslashes:
                 escaped.append("\\Z")
             default:
                 escaped.append(char)

--- a/TablePro/Core/Plugins/PluginManager+Lifecycle.swift
+++ b/TablePro/Core/Plugins/PluginManager+Lifecycle.swift
@@ -46,15 +46,18 @@ extension PluginManager {
         }
         isInstalling = true
         defer { isInstalling = false }
+        return try await performInstall(from: url)
+    }
 
+    func performInstall(from url: URL) async throws -> PluginEntry {
         if url.pathExtension == "tableplugin" {
-            return try installBundle(from: url)
+            return try await installBundle(from: url)
         } else {
             return try await installFromZip(from: url)
         }
     }
 
-    private func installBundle(from url: URL) throws -> PluginEntry {
+    private func installBundle(from url: URL) async throws -> PluginEntry {
         guard let sourceBundle = Bundle(url: url) else {
             throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
         }
@@ -62,10 +65,6 @@ extension PluginManager {
         try verifyCodeSignature(bundle: sourceBundle)
 
         let newBundleId = sourceBundle.bundleIdentifier ?? url.lastPathComponent
-        if let existing = plugins.first(where: { $0.id == newBundleId }), existing.source == .builtIn {
-            throw PluginError.pluginConflict(existingName: existing.name)
-        }
-
         replaceExistingPlugin(bundleId: newBundleId)
 
         let fm = FileManager.default
@@ -79,7 +78,7 @@ extension PluginManager {
             try fm.copyItem(at: url, to: destURL)
         }
 
-        let entry = try loadPlugin(at: destURL, source: .userInstalled)
+        let entry = try await loadPluginAsync(at: destURL, source: .userInstalled)
 
         Self.logger.info("Installed plugin '\(entry.name)' v\(entry.version)")
         return entry
@@ -126,37 +125,32 @@ extension PluginManager {
             throw PluginError.installFailed("No .tableplugin bundle found in archive")
         }
 
-        var lastEntry: PluginEntry?
-        for extracted in extractedBundles {
-            guard let extractedBundle = Bundle(url: extracted) else {
-                throw PluginError.invalidBundle("Cannot create bundle from extracted plugin '\(extracted.lastPathComponent)'")
-            }
-
-            try verifyCodeSignature(bundle: extractedBundle)
-
-            let newBundleId = extractedBundle.bundleIdentifier ?? extracted.lastPathComponent
-            if let existing = plugins.first(where: { $0.id == newBundleId }), existing.source == .builtIn {
-                throw PluginError.pluginConflict(existingName: existing.name)
-            }
-
-            replaceExistingPlugin(bundleId: newBundleId)
-
-            try fm.createDirectory(at: userPluginsDir, withIntermediateDirectories: true)
-            let destURL = userPluginsDir.appendingPathComponent(extracted.lastPathComponent)
-
-            if fm.fileExists(atPath: destURL.path) {
-                try fm.removeItem(at: destURL)
-            }
-            try fm.copyItem(at: extracted, to: destURL)
-
-            let entry = try loadPlugin(at: destURL, source: .userInstalled)
-            Self.logger.info("Installed plugin '\(entry.name)' v\(entry.version)")
-            lastEntry = entry
+        guard extractedBundles.count == 1 else {
+            throw PluginError.installFailed(
+                "Archive contains \(extractedBundles.count) plugins; only single-plugin archives are supported"
+            )
         }
 
-        guard let entry = lastEntry else {
-            throw PluginError.installFailed("No .tableplugin bundle found in archive")
+        let extracted = extractedBundles[0]
+        guard let extractedBundle = Bundle(url: extracted) else {
+            throw PluginError.invalidBundle("Cannot create bundle from extracted plugin '\(extracted.lastPathComponent)'")
         }
+
+        try verifyCodeSignature(bundle: extractedBundle)
+
+        let newBundleId = extractedBundle.bundleIdentifier ?? extracted.lastPathComponent
+        replaceExistingPlugin(bundleId: newBundleId)
+
+        try fm.createDirectory(at: userPluginsDir, withIntermediateDirectories: true)
+        let destURL = userPluginsDir.appendingPathComponent(extracted.lastPathComponent)
+
+        if fm.fileExists(atPath: destURL.path) {
+            try fm.removeItem(at: destURL)
+        }
+        try fm.copyItem(at: extracted, to: destURL)
+
+        let entry = try await loadPluginAsync(at: destURL, source: .userInstalled)
+        Self.logger.info("Installed plugin '\(entry.name)' v\(entry.version)")
         return entry
     }
 
@@ -191,6 +185,6 @@ extension PluginManager {
         queryBuildingDriverCache.removeAll()
 
         Self.logger.info("Uninstalled plugin '\(id)'")
-        needsRestartStorage = true
+        needsRestart = true
     }
 }

--- a/TablePro/Core/Plugins/PluginManager+Lifecycle.swift
+++ b/TablePro/Core/Plugins/PluginManager+Lifecycle.swift
@@ -46,10 +46,10 @@ extension PluginManager {
         }
         isInstalling = true
         defer { isInstalling = false }
-        return try await performInstall(from: url)
+        return try await performInstallAssumingLock(from: url)
     }
 
-    func performInstall(from url: URL) async throws -> PluginEntry {
+    func performInstallAssumingLock(from url: URL) async throws -> PluginEntry {
         if url.pathExtension == "tableplugin" {
             return try await installBundle(from: url)
         } else {

--- a/TablePro/Core/Plugins/PluginManager+Validation.swift
+++ b/TablePro/Core/Plugins/PluginManager+Validation.swift
@@ -30,11 +30,43 @@ extension PluginManager {
 
     // MARK: - Code Signature Verification
 
-    private static var signingTeamId: String { "D7HJ5TFYCU" }
+    private static let fallbackSigningTeamId = "D7HJ5TFYCU"
+
+    private static let resolvedSigningTeamId: String = {
+        guard let teamId = teamIdFromBundleSignature() else {
+            logger.warning("Could not derive team ID from app signature; using fallback '\(fallbackSigningTeamId)'")
+            return fallbackSigningTeamId
+        }
+        return teamId
+    }()
+
+    private static func teamIdFromBundleSignature() -> String? {
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(
+            Bundle.main.bundleURL as CFURL,
+            SecCSFlags(),
+            &staticCode
+        )
+        guard createStatus == errSecSuccess, let code = staticCode else { return nil }
+
+        var info: CFDictionary?
+        let infoStatus = SecCodeCopySigningInformation(
+            code,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &info
+        )
+        guard infoStatus == errSecSuccess,
+              let infoDict = info as? [String: Any],
+              let teamId = infoDict[kSecCodeInfoTeamIdentifier as String] as? String,
+              !teamId.isEmpty
+        else { return nil }
+        return teamId
+    }
 
     private func createSigningRequirement() -> SecRequirement? {
         var requirement: SecRequirement?
-        let requirementString = "anchor apple generic and certificate leaf[subject.OU] = \"\(Self.signingTeamId)\"" as CFString
+        let teamId = Self.resolvedSigningTeamId
+        let requirementString = "anchor apple generic and certificate leaf[subject.OU] = \"\(teamId)\"" as CFString
         SecRequirementCreateWithString(requirementString, SecCSFlags(), &requirement)
         return requirement
     }

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -28,45 +28,48 @@ final class PluginManager {
     internal(set) var hasFinishedInitialLoad = false {
         didSet {
             if hasFinishedInitialLoad {
-                for continuation in initialLoadWaiters {
-                    continuation.resume()
-                }
+                let pending = initialLoadWaiters
                 initialLoadWaiters.removeAll()
+                for waiter in pending {
+                    waiter.continuation.resume()
+                }
             }
         }
     }
 
-    private var initialLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    @ObservationIgnored private var initialLoadWaiters: [LoadWaiter] = []
+
+    private struct LoadWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Never>
+    }
 
     func waitForInitialLoad() async {
         if hasFinishedInitialLoad { return }
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { @MainActor in
-                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                    if self.hasFinishedInitialLoad {
-                        continuation.resume()
-                    } else {
-                        self.initialLoadWaiters.append(continuation)
-                    }
-                }
-            }
-            group.addTask {
-                try? await Task.sleep(for: .seconds(10))
-            }
-            await group.next()
-            group.cancelAll()
+        let waiterId = UUID()
+        let timeoutTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(10))
+            self?.resumeWaiter(id: waiterId)
         }
+        defer { timeoutTask.cancel() }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if hasFinishedInitialLoad {
+                continuation.resume()
+                return
+            }
+            initialLoadWaiters.append(LoadWaiter(id: waiterId, continuation: continuation))
+        }
+    }
+
+    private func resumeWaiter(id: UUID) {
+        guard let index = initialLoadWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = initialLoadWaiters.remove(at: index)
+        waiter.continuation.resume()
     }
 
     internal(set) var rejectedPlugins: [RejectedPlugin] = []
 
-    private static let needsRestartKey = "com.TablePro.needsRestart"
-
-    var needsRestartStorage: Bool {
-        didSet { defaults.set(needsRestartStorage, forKey: Self.needsRestartKey) }
-    }
-
-    var needsRestart: Bool { needsRestartStorage }
+    var needsRestart: Bool = false
 
     internal(set) var driverPlugins: [String: any DriverPlugin] = [:]
 
@@ -100,7 +103,14 @@ final class PluginManager {
         self.defaults = userDefaults
         self.builtInPluginsURL = builtInPluginsURL
         self.userPluginsDir = userPluginsDir
-        self.needsRestartStorage = userDefaults.bool(forKey: Self.needsRestartKey)
+        Self.clearLegacyNeedsRestartKey(in: userDefaults)
+    }
+
+    nonisolated private static func clearLegacyNeedsRestartKey(in defaults: UserDefaults) {
+        let legacyKey = "com.TablePro.needsRestart"
+        if defaults.object(forKey: legacyKey) != nil {
+            defaults.removeObject(forKey: legacyKey)
+        }
     }
 
     nonisolated static func defaultUserPluginsDir() -> URL {
@@ -111,8 +121,19 @@ final class PluginManager {
     // MARK: - Registry Metadata
 
     private struct RegistryMetadata: Codable {
-        let version: String
         let pluginId: String
+        let version: String?
+
+        enum CodingKeys: String, CodingKey {
+            case pluginId
+            case version
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(pluginId, forKey: .pluginId)
+            try container.encodeIfPresent(version, forKey: .version)
+        }
     }
 
     nonisolated private static func metadataURL(for pluginURL: URL) -> URL {
@@ -126,8 +147,15 @@ final class PluginManager {
         return try? JSONDecoder().decode(RegistryMetadata.self, from: data)
     }
 
-    func saveRegistryMetadata(version: String, pluginId: String, pluginURL: URL) {
-        let metadata = RegistryMetadata(version: version, pluginId: pluginId)
+    nonisolated static func bundleVersion(at pluginURL: URL) -> String? {
+        guard let bundle = Bundle(url: pluginURL),
+              let info = bundle.infoDictionary
+        else { return nil }
+        return info["CFBundleShortVersionString"] as? String
+    }
+
+    func saveRegistryMetadata(pluginId: String, pluginURL: URL) {
+        let metadata = RegistryMetadata(pluginId: pluginId, version: nil)
         let url = Self.metadataURL(for: pluginURL)
         do {
             let data = try JSONEncoder().encode(metadata)
@@ -137,15 +165,15 @@ final class PluginManager {
         }
     }
 
-    func updatePluginVersion(id: String, version: String) {
-        if let index = plugins.firstIndex(where: { $0.id == id }) {
-            plugins[index].version = version
-        }
-    }
-
     func removeRegistryMetadata(for pluginURL: URL) {
         let url = Self.metadataURL(for: pluginURL)
-        try? FileManager.default.removeItem(at: url)
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch CocoaError.fileNoSuchFile {
+            // Already gone, nothing to log.
+        } catch {
+            Self.logger.error("Failed to remove registry metadata at \(url.lastPathComponent): \(error.localizedDescription)")
+        }
     }
 
     private func migrateDisabledPluginsKey() {
@@ -171,6 +199,9 @@ final class PluginManager {
                 lazyPending.append((url: entry.url, source: entry.source, manifest: manifest))
             } else {
                 eagerPending.append(entry)
+                if entry.source == .userInstalled, let bundleId = Bundle(url: entry.url)?.bundleIdentifier {
+                    Self.logger.warning("Plugin '\(bundleId)' declared no TableProProvides* capability keys in Info.plist; eager loading will block startup. Add TableProProvidesDatabaseTypeIds / ExportFormatIds / ImportFormatIds for lazy load.")
+                }
             }
         }
         pendingPluginURLs.removeAll()
@@ -184,7 +215,7 @@ final class PluginManager {
                 await self.autoUpdateRejectedPlugins()
             }
             let validated = await Self.validateAndLoadBundles(eagerPending)
-            self.needsRestartStorage = false
+            self.needsRestart = false
             self.registerValidatedBundles(validated)
             self.validateDependencies()
             self.hasFinishedInitialLoad = true
@@ -235,14 +266,6 @@ final class PluginManager {
         }
 
         let bundleId = manifest.bundleId
-        if source == .userInstalled,
-           let existing = plugins.first(where: { $0.id == bundleId }),
-           existing.source == .builtIn
-        {
-            Self.logger.info("Skipping user-installed lazy '\(bundleId)': built-in version already registered")
-            return
-        }
-
         let primaryTypeId = manifest.providedDatabaseTypeIds.first
         let additionalTypeIds = Array(manifest.providedDatabaseTypeIds.dropFirst())
         let registrySnapshot = primaryTypeId.flatMap {
@@ -255,9 +278,7 @@ final class PluginManager {
         if !manifest.providedImportFormatIds.isEmpty { capabilities.append(.importFormat) }
 
         let info = bundle.infoDictionary ?? [:]
-        let version = Self.readRegistryMetadata(for: url)?.version
-            ?? (info["CFBundleShortVersionString"] as? String)
-            ?? "1.0.0"
+        let version = (info["CFBundleShortVersionString"] as? String) ?? "0.0.0"
         let displayName = registrySnapshot?.displayName
             ?? bundleId.split(separator: ".").last.map(String.init)
             ?? bundleId
@@ -423,14 +444,6 @@ final class PluginManager {
 
         let bundleId = bundle.bundleIdentifier ?? url.lastPathComponent
 
-        if source == .userInstalled,
-           let existing = plugins.first(where: { $0.id == bundleId }),
-           existing.source == .builtIn
-        {
-            Self.logger.info("Skipping user-installed '\(bundleId)' — built-in version already loaded")
-            return existing
-        }
-
         let rawDriverType = principalClass as? any DriverPlugin.Type
         let pluginKitVersion = bundle.infoDictionary?["TableProPluginKitVersion"] as? Int ?? 0
         if rawDriverType != nil, source == .userInstalled, pluginKitVersion != Self.currentPluginKitVersion {
@@ -451,7 +464,7 @@ final class PluginManager {
 
         let disabled = disabledPluginIds
         let driverType = rawDriverType
-        let version = Self.readRegistryMetadata(for: url)?.version ?? principalClass.pluginVersion
+        let version = (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0"
         let entry = PluginEntry(
             id: bundleId,
             bundle: bundle,
@@ -497,19 +510,122 @@ final class PluginManager {
             }
         }
 
+        var candidates: [PluginCandidate] = []
         if let builtInDir = builtInPluginsURL {
-            discoverPlugins(from: builtInDir, source: .builtIn)
-            removeUserInstalledDuplicates(builtInDir: builtInDir)
+            candidates += Self.collectCandidates(in: builtInDir, source: .builtIn)
         }
+        candidates += Self.collectCandidates(in: userPluginsDir, source: .userInstalled)
 
-        discoverPlugins(from: userPluginsDir, source: .userInstalled)
+        let winners = Self.selectWinners(candidates: candidates)
+        pruneOutdatedUserCopies(candidates: candidates, winners: winners)
+
+        for winner in winners.values {
+            do {
+                try discoverPlugin(at: winner.url, source: winner.source)
+            } catch {
+                Self.logger.error("Failed to discover plugin at \(winner.url.lastPathComponent): \(error.localizedDescription)")
+                if winner.source == .userInstalled {
+                    let bundle = Bundle(url: winner.url)
+                    rejectedPlugins.append(RejectedPlugin(
+                        url: winner.url,
+                        bundleId: bundle?.bundleIdentifier,
+                        registryId: Self.readRegistryMetadata(for: winner.url)?.pluginId,
+                        name: winner.url.deletingPathExtension().lastPathComponent,
+                        reason: error.localizedDescription,
+                        isOutdated: (error as? PluginError)?.isOutdated ?? false
+                    ))
+                }
+            }
+        }
 
         Self.logger.info("Discovered \(self.pendingPluginURLs.count) plugin(s), will load on first use")
     }
 
+    private struct PluginCandidate {
+        let url: URL
+        let source: PluginSource
+        let bundleId: String
+        let version: String
+    }
+
+    nonisolated private static func collectCandidates(
+        in directory: URL,
+        source: PluginSource
+    ) -> [PluginCandidate] {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        var results: [PluginCandidate] = []
+        for itemURL in contents where itemURL.pathExtension == "tableplugin" {
+            guard let bundle = Bundle(url: itemURL),
+                  let bundleId = bundle.bundleIdentifier
+            else { continue }
+            let version = (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0"
+            results.append(PluginCandidate(url: itemURL, source: source, bundleId: bundleId, version: version))
+        }
+        return results
+    }
+
+    nonisolated private static func selectWinners(
+        candidates: [PluginCandidate]
+    ) -> [String: PluginCandidate] {
+        var winners: [String: PluginCandidate] = [:]
+        for candidate in candidates {
+            guard let existing = winners[candidate.bundleId] else {
+                winners[candidate.bundleId] = candidate
+                continue
+            }
+            let order = candidate.version.compare(existing.version, options: .numeric)
+            let candidateWins = order == .orderedDescending
+                || (order == .orderedSame && candidate.source == .builtIn)
+            if candidateWins {
+                winners[candidate.bundleId] = candidate
+            }
+        }
+        return winners
+    }
+
+    private func pruneOutdatedUserCopies(
+        candidates: [PluginCandidate],
+        winners: [String: PluginCandidate]
+    ) {
+        let fm = FileManager.default
+        for candidate in candidates where candidate.source == .userInstalled {
+            guard let winner = winners[candidate.bundleId], winner.url != candidate.url else { continue }
+            do {
+                try fm.removeItem(at: candidate.url)
+                Self.removeRegistryMetadataFile(for: candidate.url)
+                Self.logger.info(
+                    "Pruned outdated user-installed '\(candidate.bundleId)' v\(candidate.version) (built-in v\(winner.version) takes precedence)"
+                )
+            } catch {
+                Self.logger.warning(
+                    "Failed to prune outdated user copy '\(candidate.bundleId)' at \(candidate.url.lastPathComponent): \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    nonisolated private static func removeRegistryMetadataFile(for pluginURL: URL) {
+        let url = metadataURL(for: pluginURL)
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch CocoaError.fileNoSuchFile {
+            return
+        } catch {
+            logger.warning("Failed to remove metadata sidecar at \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
     func loadPendingPluginsAsync(clearRestartFlag: Bool = false) async {
         if clearRestartFlag {
-            needsRestartStorage = false
+            needsRestart = false
         }
         guard !pendingPluginURLs.isEmpty else { return }
         let pending = pendingPluginURLs
@@ -524,7 +640,7 @@ final class PluginManager {
 
     func loadPendingPlugins(clearRestartFlag: Bool = false) {
         if clearRestartFlag {
-            needsRestartStorage = false
+            needsRestart = false
         }
         guard !pendingPluginURLs.isEmpty else { return }
         let pending = pendingPluginURLs
@@ -542,70 +658,6 @@ final class PluginManager {
         hasFinishedInitialLoad = true
         validateDependencies()
         Self.logger.info("Loaded \(self.plugins.count) plugin(s): \(self.driverPlugins.count) driver(s), \(self.exportPlugins.count) export format(s), \(self.importPlugins.count) import format(s)")
-    }
-
-    private func discoverPlugins(from directory: URL, source: PluginSource) {
-        let fm = FileManager.default
-        guard let contents = try? fm.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else {
-            return
-        }
-
-        for itemURL in contents where itemURL.pathExtension == "tableplugin" {
-            do {
-                try discoverPlugin(at: itemURL, source: source)
-            } catch {
-                Self.logger.error("Failed to discover plugin at \(itemURL.lastPathComponent): \(error.localizedDescription)")
-                if source == .userInstalled {
-                    let bundle = Bundle(url: itemURL)
-                    rejectedPlugins.append(RejectedPlugin(
-                        url: itemURL,
-                        bundleId: bundle?.bundleIdentifier,
-                        registryId: Self.readRegistryMetadata(for: itemURL)?.pluginId,
-                        name: itemURL.deletingPathExtension().lastPathComponent,
-                        reason: error.localizedDescription,
-                        isOutdated: (error as? PluginError)?.isOutdated ?? false
-                    ))
-                }
-            }
-        }
-    }
-
-    private func removeUserInstalledDuplicates(builtInDir: URL) {
-        let fm = FileManager.default
-        guard let builtInBundles = try? fm.contentsOfDirectory(
-            at: builtInDir,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        var builtInBundleIds = Set<String>()
-        for url in builtInBundles where url.pathExtension == "tableplugin" {
-            if let bundle = Bundle(url: url), let id = bundle.bundleIdentifier {
-                builtInBundleIds.insert(id)
-            }
-        }
-
-        guard let userPlugins = try? fm.contentsOfDirectory(
-            at: userPluginsDir,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        for url in userPlugins where url.pathExtension == "tableplugin" {
-            guard let bundle = Bundle(url: url), let id = bundle.bundleIdentifier else { continue }
-            if builtInBundleIds.contains(id) {
-                do {
-                    try fm.removeItem(at: url)
-                    Self.logger.info("Removed user-installed '\(id)' — now ships as built-in")
-                } catch {
-                    Self.logger.warning("Failed to remove duplicate plugin '\(id)': \(error.localizedDescription)")
-                }
-            }
-        }
     }
 
     private func discoverPlugin(at url: URL, source: PluginSource) throws {
@@ -643,6 +695,40 @@ final class PluginManager {
         }
 
         return entry
+    }
+
+    @discardableResult
+    func loadPluginAsync(at url: URL, source: PluginSource) async throws -> PluginEntry {
+        if source == .userInstalled {
+            guard let bundle = Bundle(url: url) else {
+                throw PluginError.invalidBundle("Cannot create bundle from \(url.lastPathComponent)")
+            }
+            try verifyCodeSignature(bundle: bundle)
+        }
+
+        let loaded = try await Self.validateAndLoadBundleAsync(at: url, source: source)
+
+        guard let entry = registerBundle(loaded, url: url, source: source) else {
+            throw PluginError.invalidBundle("Principal class does not conform to TableProPlugin")
+        }
+
+        return entry
+    }
+
+    nonisolated private static func validateAndLoadBundleAsync(
+        at url: URL,
+        source: PluginSource
+    ) async throws -> Bundle {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let bundle = try validateAndLoadBundle(at: url, source: source)
+                    continuation.resume(returning: bundle)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
     func diagnose(error: Error, for type: DatabaseType) -> PluginDiagnostic? {

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -122,18 +122,6 @@ final class PluginManager {
 
     private struct RegistryMetadata: Codable {
         let pluginId: String
-        let version: String?
-
-        enum CodingKeys: String, CodingKey {
-            case pluginId
-            case version
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(pluginId, forKey: .pluginId)
-            try container.encodeIfPresent(version, forKey: .version)
-        }
     }
 
     nonisolated private static func metadataURL(for pluginURL: URL) -> URL {
@@ -155,7 +143,7 @@ final class PluginManager {
     }
 
     func saveRegistryMetadata(pluginId: String, pluginURL: URL) {
-        let metadata = RegistryMetadata(pluginId: pluginId, version: nil)
+        let metadata = RegistryMetadata(pluginId: pluginId)
         let url = Self.metadataURL(for: pluginURL)
         do {
             let data = try JSONEncoder().encode(metadata)
@@ -601,12 +589,14 @@ final class PluginManager {
             do {
                 try fm.removeItem(at: candidate.url)
                 Self.removeRegistryMetadataFile(for: candidate.url)
+                let order = candidate.version.compare(winner.version, options: .numeric)
+                let reason = order == .orderedSame ? "equal version" : "older version"
                 Self.logger.info(
-                    "Pruned outdated user-installed '\(candidate.bundleId)' v\(candidate.version) (built-in v\(winner.version) takes precedence)"
+                    "Pruned user-installed '\(candidate.bundleId)' v\(candidate.version) (\(reason); \(winner.source == .builtIn ? "built-in" : "winning") v\(winner.version) takes precedence)"
                 )
             } catch {
                 Self.logger.warning(
-                    "Failed to prune outdated user copy '\(candidate.bundleId)' at \(candidate.url.lastPathComponent): \(error.localizedDescription)"
+                    "Failed to prune user copy '\(candidate.bundleId)' at \(candidate.url.lastPathComponent): \(error.localizedDescription)"
                 )
             }
         }

--- a/TablePro/Core/Plugins/Registry/PluginInstallTracker.swift
+++ b/TablePro/Core/Plugins/Registry/PluginInstallTracker.swift
@@ -27,6 +27,12 @@ final class PluginInstallTracker {
 
     func completeInstall(pluginId: String) {
         activeInstalls[pluginId]?.phase = .completed
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            if case .completed = self.activeInstalls[pluginId]?.phase {
+                self.activeInstalls.removeValue(forKey: pluginId)
+            }
+        }
     }
 
     func failInstall(pluginId: String, error: String) {

--- a/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
+++ b/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
@@ -105,7 +105,7 @@ extension PluginManager {
 
         try FileManager.default.moveItem(at: tempDownloadURL, to: tempZipURL)
 
-        let entry = try await performInstall(from: tempZipURL)
+        let entry = try await performInstallAssumingLock(from: tempZipURL)
 
         saveRegistryMetadata(
             pluginId: registryPlugin.id,

--- a/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
+++ b/TablePro/Core/Plugins/Registry/PluginManager+Registry.swift
@@ -11,6 +11,46 @@ extension PluginManager {
         _ registryPlugin: RegistryPlugin,
         progress: @escaping @MainActor @Sendable (Double) -> Void
     ) async throws -> PluginEntry {
+        guard !isInstalling else {
+            throw PluginError.installFailed("Another plugin installation is already in progress")
+        }
+        isInstalling = true
+        defer { isInstalling = false }
+
+        try validateRegistryCompatibility(registryPlugin)
+
+        if plugins.contains(where: { $0.id == registryPlugin.id }) {
+            throw PluginError.pluginConflict(existingName: registryPlugin.name)
+        }
+
+        return try await downloadAndInstall(registryPlugin, progress: progress)
+    }
+
+    func updateFromRegistry(
+        _ registryPlugin: RegistryPlugin,
+        existingPluginLoaded: Bool = true,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> PluginEntry {
+        guard !isInstalling else {
+            throw PluginError.installFailed("Another plugin installation is already in progress")
+        }
+        isInstalling = true
+        defer { isInstalling = false }
+
+        try validateRegistryCompatibility(registryPlugin)
+
+        replaceExistingPlugin(bundleId: registryPlugin.id)
+
+        let entry = try await downloadAndInstall(registryPlugin, progress: progress)
+
+        if existingPluginLoaded {
+            needsRestart = true
+        }
+
+        return entry
+    }
+
+    private func validateRegistryCompatibility(_ registryPlugin: RegistryPlugin) throws {
         if let minAppVersion = registryPlugin.minAppVersion {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
             if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
@@ -21,11 +61,12 @@ extension PluginManager {
         if let minKit = registryPlugin.minPluginKitVersion, minKit > Self.currentPluginKitVersion {
             throw PluginError.incompatibleVersion(required: minKit, current: Self.currentPluginKitVersion)
         }
+    }
 
-        if plugins.contains(where: { $0.id == registryPlugin.id }) {
-            throw PluginError.pluginConflict(existingName: registryPlugin.name)
-        }
-
+    private func downloadAndInstall(
+        _ registryPlugin: RegistryPlugin,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> PluginEntry {
         let resolved = try registryPlugin.resolvedBinary()
 
         guard let downloadURL = URL(string: resolved.url) else {
@@ -41,9 +82,7 @@ extension PluginManager {
             try? FileManager.default.removeItem(at: tempDir)
         }
 
-        // Use the registry client's configured session for consistent timeouts
         let session = RegistryClient.shared.session
-
         let (tempDownloadURL, response) = try await session.download(from: downloadURL)
 
         guard let httpResponse = response as? HTTPURLResponse,
@@ -54,7 +93,6 @@ extension PluginManager {
 
         progress(0.5)
 
-        // Verify SHA-256 checksum
         let downloadedData = try Data(contentsOf: tempDownloadURL)
         let digest = SHA256.hash(data: downloadedData)
         let hexChecksum = digest.map { String(format: "%02x", $0) }.joined()
@@ -65,45 +103,14 @@ extension PluginManager {
 
         progress(1.0)
 
-        // Move to our temp directory for installPlugin
         try FileManager.default.moveItem(at: tempDownloadURL, to: tempZipURL)
 
-        var entry = try await installPlugin(from: tempZipURL)
+        let entry = try await performInstall(from: tempZipURL)
 
         saveRegistryMetadata(
-            version: registryPlugin.version,
             pluginId: registryPlugin.id,
             pluginURL: entry.url
         )
-        entry.version = registryPlugin.version
-        updatePluginVersion(id: entry.id, version: registryPlugin.version)
-
-        return entry
-    }
-
-    func updateFromRegistry(
-        _ registryPlugin: RegistryPlugin,
-        existingPluginLoaded: Bool = true,
-        progress: @escaping @MainActor @Sendable (Double) -> Void
-    ) async throws -> PluginEntry {
-        if let minAppVersion = registryPlugin.minAppVersion {
-            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-            if appVersion.compare(minAppVersion, options: .numeric) == .orderedAscending {
-                throw PluginError.incompatibleWithCurrentApp(minimumRequired: minAppVersion)
-            }
-        }
-
-        if let minKit = registryPlugin.minPluginKitVersion, minKit > Self.currentPluginKitVersion {
-            throw PluginError.incompatibleVersion(required: minKit, current: Self.currentPluginKitVersion)
-        }
-
-        replaceExistingPlugin(bundleId: registryPlugin.id)
-
-        let entry = try await installFromRegistry(registryPlugin, progress: progress)
-
-        if existingPluginLoaded {
-            needsRestartStorage = true
-        }
 
         return entry
     }

--- a/TablePro/Core/Plugins/Registry/RegistryClient.swift
+++ b/TablePro/Core/Plugins/Registry/RegistryClient.swift
@@ -15,8 +15,8 @@ final class RegistryClient {
     private(set) var lastFetchDate: Date?
 
     private var cachedETag: String? {
-        get { UserDefaults.standard.string(forKey: "registryETag") }
-        set { UserDefaults.standard.set(newValue, forKey: "registryETag") }
+        get { UserDefaults.standard.string(forKey: Self.etagKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.etagKey) }
     }
 
     let session: URLSession
@@ -27,6 +27,11 @@ final class RegistryClient {
 
     static let customRegistryURLKey = "com.TablePro.customRegistryURL"
     private static let lastRegistryURLKey = "com.TablePro.lastRegistryURL"
+    private static let etagKey = "com.TablePro.registryETag"
+    private static let lastFetchKey = "com.TablePro.registryLastFetch"
+    private static let legacyManifestCacheKey = "registryManifestCache"
+    private static let legacyETagKey = "registryETag"
+    private static let legacyLastFetchKey = "registryLastFetch"
 
     var isUsingCustomRegistry: Bool {
         registryURL != Self.defaultRegistryURL
@@ -41,8 +46,15 @@ final class RegistryClient {
         return Self.defaultRegistryURL
     }
 
-    private static let manifestCacheKey = "registryManifestCache"
-    private static let lastFetchKey = "registryLastFetch"
+    private static let manifestCacheFileName = "registry-manifest.json"
+
+    private static var manifestCacheURL: URL? {
+        let fm = FileManager.default
+        guard let dir = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
+        let bundleId = Bundle.main.bundleIdentifier ?? "com.TablePro"
+        return dir.appendingPathComponent(bundleId, isDirectory: true)
+            .appendingPathComponent(manifestCacheFileName)
+    }
 
     private init() {
         let config = URLSessionConfiguration.default
@@ -51,10 +63,48 @@ final class RegistryClient {
         config.waitsForConnectivity = true
         self.session = URLSession(configuration: config)
 
-        if let cachedData = UserDefaults.standard.data(forKey: Self.manifestCacheKey),
-           let cached = try? JSONDecoder().decode(RegistryManifest.self, from: cachedData) {
-            manifest = cached
-            lastFetchDate = UserDefaults.standard.object(forKey: Self.lastFetchKey) as? Date
+        Self.migrateLegacyKeys()
+        loadCachedManifest()
+    }
+
+    private static func migrateLegacyKeys() {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: legacyETagKey) != nil {
+            if defaults.string(forKey: etagKey) == nil,
+               let legacyETag = defaults.string(forKey: legacyETagKey) {
+                defaults.set(legacyETag, forKey: etagKey)
+            }
+            defaults.removeObject(forKey: legacyETagKey)
+        }
+        if defaults.object(forKey: legacyLastFetchKey) != nil {
+            if defaults.object(forKey: lastFetchKey) == nil,
+               let legacyDate = defaults.object(forKey: legacyLastFetchKey) as? Date {
+                defaults.set(legacyDate, forKey: lastFetchKey)
+            }
+            defaults.removeObject(forKey: legacyLastFetchKey)
+        }
+        if defaults.object(forKey: legacyManifestCacheKey) != nil {
+            defaults.removeObject(forKey: legacyManifestCacheKey)
+        }
+    }
+
+    private func loadCachedManifest() {
+        guard let url = Self.manifestCacheURL,
+              let data = try? Data(contentsOf: url),
+              let cached = try? JSONDecoder().decode(RegistryManifest.self, from: data)
+        else { return }
+        manifest = cached
+        lastFetchDate = UserDefaults.standard.object(forKey: Self.lastFetchKey) as? Date
+    }
+
+    private static func writeCachedManifest(_ data: Data) {
+        guard let url = manifestCacheURL else { return }
+        let dir = url.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            logger.warning("Failed to write registry cache: \(error.localizedDescription)")
         }
     }
 
@@ -92,7 +142,7 @@ final class RegistryClient {
                 let decoded = try JSONDecoder().decode(RegistryManifest.self, from: data)
                 manifest = decoded
 
-                UserDefaults.standard.set(data, forKey: Self.manifestCacheKey)
+                Self.writeCachedManifest(data)
                 cachedETag = httpResponse.value(forHTTPHeaderField: "ETag")
                 lastFetchDate = Date()
                 UserDefaults.standard.set(lastFetchDate, forKey: Self.lastFetchKey)

--- a/TablePro/Core/Plugins/Registry/RegistryClient.swift
+++ b/TablePro/Core/Plugins/Registry/RegistryClient.swift
@@ -70,17 +70,9 @@ final class RegistryClient {
     private static func migrateLegacyKeys() {
         let defaults = UserDefaults.standard
         if defaults.object(forKey: legacyETagKey) != nil {
-            if defaults.string(forKey: etagKey) == nil,
-               let legacyETag = defaults.string(forKey: legacyETagKey) {
-                defaults.set(legacyETag, forKey: etagKey)
-            }
             defaults.removeObject(forKey: legacyETagKey)
         }
         if defaults.object(forKey: legacyLastFetchKey) != nil {
-            if defaults.object(forKey: lastFetchKey) == nil,
-               let legacyDate = defaults.object(forKey: legacyLastFetchKey) as? Date {
-                defaults.set(legacyDate, forKey: lastFetchKey)
-            }
             defaults.removeObject(forKey: legacyLastFetchKey)
         }
         if defaults.object(forKey: legacyManifestCacheKey) != nil {
@@ -136,6 +128,12 @@ final class RegistryClient {
             switch httpResponse.statusCode {
             case 304:
                 Self.logger.debug("Registry manifest not modified (304)")
+                if manifest == nil {
+                    Self.logger.warning("Got 304 but no cached manifest in memory; retrying without If-None-Match")
+                    cachedETag = nil
+                    await fetchManifest(forceRefresh: true)
+                    return
+                }
                 fetchState = .loaded
 
             case 200...299:

--- a/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
@@ -75,12 +75,26 @@ struct InstalledPluginsView: View {
             Text("Restart TablePro to fully unload removed plugins.")
                 .font(.callout)
             Spacer()
+            Button("Quit & Reopen") { relaunchApp() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             Button("Dismiss") { dismissedRestartBanner = true }
                 .buttonStyle(.borderless)
                 .font(.callout)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    private func relaunchApp() {
+        let bundleURL = Bundle.main.bundleURL
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { _, _ in
+            DispatchQueue.main.async {
+                NSApp.terminate(nil)
+            }
+        }
     }
 
     // MARK: - Plugin List

--- a/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
@@ -90,8 +90,15 @@ struct InstalledPluginsView: View {
         let bundleURL = Bundle.main.bundleURL
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.createsNewApplicationInstance = true
-        NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { _, _ in
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { newApp, error in
             DispatchQueue.main.async {
+                guard newApp != nil else {
+                    errorAlertTitle = String(localized: "Relaunch Failed")
+                    errorAlertMessage = error?.localizedDescription
+                        ?? String(localized: "Could not start a new TablePro instance. Quit and reopen manually.")
+                    showErrorAlert = true
+                    return
+                }
                 NSApp.terminate(nil)
             }
         }

--- a/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
+++ b/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
@@ -12,6 +12,34 @@ private final class StubDriver: PluginDatabaseDriver {
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }
     var serverVersion: String? { nil }
+    var requiresBackslashEscapingInLiterals: Bool { true }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func ping() async throws {}
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+    }
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+private final class SqlStandardStubDriver: PluginDatabaseDriver {
+    var supportsSchemas: Bool { false }
+    var supportsTransactions: Bool { false }
+    var currentSchema: String? { nil }
+    var serverVersion: String? { nil }
 
     func connect() async throws {}
     func disconnect() {}
@@ -82,57 +110,85 @@ struct IsNumericLiteralTests {
 
 // MARK: - escapedParameterValue
 
-@Suite("escapedParameterValue")
+@Suite("escapedParameterValue (MySQL-style)")
 struct EscapedParameterValueTests {
+    private let driver = StubDriver()
 
     @Test("Numeric values returned unquoted")
     func numericUnquoted() {
-        #expect(StubDriver.escapedParameterValue("123") == "123")
-        #expect(StubDriver.escapedParameterValue("-42") == "-42")
-        #expect(StubDriver.escapedParameterValue("3.14") == "3.14")
-        #expect(StubDriver.escapedParameterValue("1e5") == "1e5")
+        #expect(driver.escapedParameterValue("123") == "123")
+        #expect(driver.escapedParameterValue("-42") == "-42")
+        #expect(driver.escapedParameterValue("3.14") == "3.14")
+        #expect(driver.escapedParameterValue("1e5") == "1e5")
     }
 
     @Test("Plain strings quoted")
     func plainStringsQuoted() {
-        #expect(StubDriver.escapedParameterValue("hello") == "'hello'")
-        #expect(StubDriver.escapedParameterValue("") == "''")
+        #expect(driver.escapedParameterValue("hello") == "'hello'")
+        #expect(driver.escapedParameterValue("") == "''")
     }
 
     @Test("Single quotes escaped")
     func singleQuotesEscaped() {
-        #expect(StubDriver.escapedParameterValue("O'Brien") == "'O''Brien'")
-        #expect(StubDriver.escapedParameterValue("it''s") == "'it''''s'")
+        #expect(driver.escapedParameterValue("O'Brien") == "'O''Brien'")
+        #expect(driver.escapedParameterValue("it''s") == "'it''''s'")
     }
 
     @Test("Control characters escaped")
     func controlCharactersEscaped() {
-        #expect(StubDriver.escapedParameterValue("a\nb") == "'a\\nb'")
-        #expect(StubDriver.escapedParameterValue("a\rb") == "'a\\rb'")
-        #expect(StubDriver.escapedParameterValue("a\tb") == "'a\\tb'")
-        #expect(StubDriver.escapedParameterValue("a\\b") == "'a\\\\b'")
+        #expect(driver.escapedParameterValue("a\nb") == "'a\\nb'")
+        #expect(driver.escapedParameterValue("a\rb") == "'a\\rb'")
+        #expect(driver.escapedParameterValue("a\tb") == "'a\\tb'")
+        #expect(driver.escapedParameterValue("a\\b") == "'a\\\\b'")
     }
 
     @Test("NUL bytes stripped")
     func nulBytesStripped() {
-        #expect(StubDriver.escapedParameterValue("a\0b") == "'ab'")
+        #expect(driver.escapedParameterValue("a\0b") == "'ab'")
     }
 
     @Test("SUB character escaped")
     func subCharacterEscaped() {
-        #expect(StubDriver.escapedParameterValue("a\u{1A}b") == "'a\\Zb'")
+        #expect(driver.escapedParameterValue("a\u{1A}b") == "'a\\Zb'")
     }
 
     @Test("SQL injection attempt quoted")
     func sqlInjectionQuoted() {
-        #expect(StubDriver.escapedParameterValue("1 OR 1=1") == "'1 OR 1=1'")
-        #expect(StubDriver.escapedParameterValue("'; DROP TABLE users; --") == "'''; DROP TABLE users; --'")
+        #expect(driver.escapedParameterValue("1 OR 1=1") == "'1 OR 1=1'")
+        #expect(driver.escapedParameterValue("'; DROP TABLE users; --") == "'''; DROP TABLE users; --'")
     }
 
     @Test("NaN and inf are quoted as strings")
     func nanInfQuoted() {
-        #expect(StubDriver.escapedParameterValue("NaN") == "'NaN'")
-        #expect(StubDriver.escapedParameterValue("inf") == "'inf'")
-        #expect(StubDriver.escapedParameterValue("-Infinity") == "'-Infinity'")
+        #expect(driver.escapedParameterValue("NaN") == "'NaN'")
+        #expect(driver.escapedParameterValue("inf") == "'inf'")
+        #expect(driver.escapedParameterValue("-Infinity") == "'-Infinity'")
+    }
+}
+
+@Suite("escapedParameterValue (SQL-standard, no backslash escape)")
+struct SqlStandardEscapeTests {
+    private let driver = SqlStandardStubDriver()
+
+    @Test("Backslash preserved verbatim")
+    func backslashPreserved() {
+        #expect(driver.escapedParameterValue("a\\b") == "'a\\b'")
+        #expect(driver.escapedParameterValue("C:\\path\\to\\file") == "'C:\\path\\to\\file'")
+    }
+
+    @Test("Newline/tab preserved as literal control bytes")
+    func controlCharactersPreserved() {
+        #expect(driver.escapedParameterValue("a\nb") == "'a\nb'")
+        #expect(driver.escapedParameterValue("a\tb") == "'a\tb'")
+    }
+
+    @Test("Single quote still doubled")
+    func singleQuoteStillDoubled() {
+        #expect(driver.escapedParameterValue("O'Brien") == "'O''Brien'")
+    }
+
+    @Test("NUL bytes still stripped")
+    func nulBytesStripped() {
+        #expect(driver.escapedParameterValue("a\0b") == "'ab'")
     }
 }


### PR DESCRIPTION
## Summary

End-to-end audit and rewrite of the plugin system. Closes #1192 and addresses 14 other issues found in the audit (P0–P3).

### Plugin discovery (#1192)

Rewrote discovery to follow the native NSBundle pattern: scan both `Contents/PlugIns` (built-in) and `~/Library/Application Support/TablePro/Plugins` (user-installed), group by bundle ID, pick the newest version by `CFBundleShortVersionString`. The "skip user-installed if built-in exists" branches in `registerBundle` and `registerLazyManifest` are gone — discovery dedupes by construction. `pruneOutdatedUserCopies` only deletes user copies that are older than or equal to the built-in version, so upgraded built-in plugins survive restart.

Plugin version is now read from Info.plist (`CFBundleShortVersionString`) instead of the hardcoded `principalClass.pluginVersion` static. The `.metadata.json` sidecar no longer stores version — only the registry plugin ID for update lookups.

### Concurrency hardening

- `installFromRegistry` and `updateFromRegistry` set `isInstalling` at their own entry points. The internal `performInstall` helper bypasses the guard so registry methods do not double-set.
- `waitForInitialLoad` wraps the 10-second timeout in `withTaskCancellationHandler` and a UUID-keyed waiter, so the continuation is always resumed and removed from `initialLoadWaiters` on cancel.
- `installFromZip` rejects multi-bundle archives. `installBundle` and `installFromZip` now run `bundle.load()` on `DispatchQueue.global(qos: .userInitiated)` via `validateAndLoadBundleAsync`, off the main actor.

### Storage & security

- Registry manifest cache moved from UserDefaults binary blob to `~/Library/Caches/<bundle-id>/registry-manifest.json`. Legacy `registryManifestCache`, `registryETag`, `registryLastFetch` keys are removed on first launch.
- `registryETag` namespaced to `com.TablePro.registryETag`.
- Signing requirement reads team identifier from `Bundle.main` at runtime via `SecCodeCopySigningInformation`. Falls back to the previous hardcoded value if no signature is available (DEBUG / ad-hoc).
- `removeRegistryMetadata` logs errors instead of swallowing them silently.

### HIG & UX

- Restart banner gets a native **Quit & Reopen** button (`NSWorkspace.openApplication` + `NSApp.terminate`).
- `needsRestart` is in-memory only; the banner no longer persists across launches.
- Completed install badges auto-clear after 3 seconds. Failed installs still persist until the user retries.

### Plugin SDK

- Default `escapeStringLiteral` follows SQL standard — no longer escapes backslashes by default. Drivers opt in via `requiresBackslashEscapingInLiterals`. `MySQLPluginDriver` sets the flag.
- Eager-loading fallback warns when user-installed plugins lack `TableProProvides*` Info.plist keys.

## Test plan

- [x] `EscapedParameterValueTests` (8 tests, MySQL-style) pass
- [x] `SqlStandardEscapeTests` (4 new tests, SQL-standard mode) pass
- [x] `IsNumericLiteralTests` (4 tests) pass
- [x] `PluginLazyLoadingTests` (3 tests) pass
- [x] `RegistryClientURLTests` (4 tests) pass
- [x] Full project build passes
- [ ] Install an outdated MSSQL plugin (or any built-in), upgrade via Settings → Plugins, restart, verify the upgraded version persists and the upgrade prompt does not reappear
- [ ] Click "Quit & Reopen" in the restart banner and verify the app relaunches with the new plugin loaded
- [ ] Try to install a ZIP archive containing two `.tableplugin` bundles; verify it is rejected with a clear error