### PR TITLE
fix(welcome): wire WindowOpener bridge from all scenes to fix missing-window race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Welcome window sometimes failed to open on launch (and Dock-icon clicks did nothing) when the previous session restored only main connection windows. `WindowOpenerBridge` was mounted only in the Welcome scene and used `.onAppear`, so if Welcome got `orderOut`'d before its first appearance the bridge never wired and every `openWelcome()` call queued forever. The bridge now mounts in all four SwiftUI scenes (Welcome, ConnectionForm, IntegrationsActivity, Settings) and uses `.task` so wiring fires reliably whenever any scene materializes
 - Plugin upgrades for built-in drivers (MySQL, PostgreSQL, SQLite, ClickHouse, Redis, etc.) no longer revert to the bundled version after restart. Discovery now scans both built-in and user plugin directories, picks the newest version by `CFBundleShortVersionString`, and only prunes user copies that are older than or equal to the built-in (#1192)
 - Concurrent plugin installs from the registry can no longer race past the `isInstalling` guard; the lock now wraps `installFromRegistry` and `updateFromRegistry` end-to-end
 - Plugin manager's `waitForInitialLoad` no longer leaks a continuation when its 10-second timeout fires before initial load completes

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -653,6 +653,7 @@ struct TableProApp: App {
 
         WindowGroup("New Connection", id: SceneId.connectionForm, for: UUID?.self) { $editingId in
             ConnectionFormView(connectionId: editingId ?? nil)
+                .background(WindowOpenerBridge())
                 .background(WindowChromeConfigurator(restorable: false))
                 .environment(\.appServices, .live)
         }
@@ -662,6 +663,7 @@ struct TableProApp: App {
 
         Window("Integrations Activity", id: SceneId.integrationsActivity) {
             IntegrationsActivityView()
+                .background(WindowOpenerBridge())
                 .environment(\.appServices, .live)
         }
         .windowResizability(.contentMinSize)
@@ -676,6 +678,7 @@ struct TableProApp: App {
 
         Settings {
             SettingsView()
+                .background(WindowOpenerBridge())
                 .environment(updaterBridge)
                 .environment(\.appServices, .live)
         }

--- a/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
+++ b/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
@@ -13,7 +13,7 @@ internal struct WindowOpenerBridge: View {
     var body: some View {
         Color.clear
             .frame(width: 0, height: 0)
-            .onAppear { wireUp() }
+            .task { wireUp() }
     }
 
     private func wireUp() {


### PR DESCRIPTION
## Summary

Welcome window sometimes failed to appear on launch and Dock-icon clicks did nothing. Console showed:
\`\`\`
WindowOpener call queued; bridge not yet wired
WindowOpener call queued; bridge not yet wired
WindowOpener call queued; bridge not yet wired
\`\`\`
…and the queue never drained.

## Root cause

\`WindowOpenerBridge\` is the SwiftUI view that hands \`openWindow\` / \`openSettings\` closures to the AppKit-world \`WindowOpener\` singleton. It was mounted only in the **Welcome scene** and wired itself in \`.onAppear { wireUp() }\`.

If state restoration or a launch intent caused Welcome to be \`orderOut\`'d before its view body's first appearance, \`.onAppear\` never fired, the bridge never wired, and every subsequent \`WindowOpener.shared.openWelcome()\` call from \`AppLaunchCoordinator\` / \`applicationShouldHandleReopen\` / etc. was queued indefinitely. The app would launch with no visible window and Dock-icon clicks would silently queue more calls onto the dead queue.

## Fix

1. Mount \`WindowOpenerBridge\` in all four SwiftUI scenes: Welcome, ConnectionForm, IntegrationsActivity, Settings. Whichever scene materializes first triggers the wire-up; subsequent scenes call \`wire(...)\` again, which is idempotent (overwrites the same closures, drains the now-empty queue).
2. Switch \`.onAppear\` → \`.task\`. \`.task\` fires reliably when the view enters the hierarchy, even if it never reaches the visible state.

## Test plan

- [ ] Launch the app cleanly (no restored state). Welcome window appears.
- [ ] Launch with a restored connection window. Welcome window does NOT appear (correct), but clicking the Dock icon shows Welcome.
- [ ] Cmd+, to open Settings works.
- [ ] Click "+" to open New Connection works.
- [ ] Console has no "WindowOpener call queued; bridge not yet wired" warnings during normal launch.