### PR TITLE
fix(ios): stop empty-state flash during data browser reload

### DIFF
--- a/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
@@ -94,10 +94,15 @@ final class DataBrowserViewModel {
                 underlying: nil
             )
             isLoading = false
+            isPageLoading = false
             return
         }
 
-        if isInitial || legacyRows.isEmpty { isLoading = true }
+        if isInitial || legacyRows.isEmpty {
+            isLoading = true
+        } else {
+            isPageLoading = true
+        }
         loadError = nil
 
         do {
@@ -119,6 +124,7 @@ final class DataBrowserViewModel {
             if case .error(let err) = phase {
                 loadError = err
                 isLoading = false
+                isPageLoading = false
                 return
             }
 
@@ -139,12 +145,14 @@ final class DataBrowserViewModel {
             }
 
             isLoading = false
+            isPageLoading = false
         } catch {
             loadError = ErrorClassifier.classify(
                 error,
                 context: ErrorContext(operation: "loadData", databaseType: databaseType, host: host)
             )
             isLoading = false
+            isPageLoading = false
         }
     }
 
@@ -246,9 +254,7 @@ final class DataBrowserViewModel {
     }
 
     private func navigatePage() async {
-        isPageLoading = true
         await load()
-        isPageLoading = false
     }
 
     // MARK: - Sort / Filter / Search

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -69,7 +69,7 @@ struct DataBrowserView: View {
                 ]
             }
             .toolbar { topToolbar }
-            .toolbar(rows.isEmpty && !viewModel.hasActiveSearch && !viewModel.hasActiveFilters ? .hidden : .visible, for: .bottomBar)
+            .toolbar(rows.isEmpty && !viewModel.hasActiveSearch && !viewModel.hasActiveFilters && !viewModel.isPageLoading ? .hidden : .visible, for: .bottomBar)
             .toolbar { paginationToolbar }
             .task {
                 viewModel.attach(session: session, table: table, databaseType: connection.type, host: connection.host)
@@ -199,6 +199,9 @@ struct DataBrowserView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let appError = viewModel.loadError {
             ErrorView(error: appError) { await viewModel.load() }
+        } else if rows.isEmpty, viewModel.isPageLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if rows.isEmpty, viewModel.hasActiveSearch {
             ContentUnavailableView.search(text: viewModel.activeSearchText)
         } else if rows.isEmpty {

--- a/TableProMobile/TableProMobileTests/DataBrowserViewModelTests.swift
+++ b/TableProMobile/TableProMobileTests/DataBrowserViewModelTests.swift
@@ -92,6 +92,32 @@ struct DataBrowserViewModelTests {
         #expect(vm.activeSearchText == "")
     }
 
+    @Test("clearSearch with existing rows replaces them without leaving loading flags stuck")
+    func clearSearchReplacesRowsCleanly() async {
+        let driver = MockDatabaseDriver()
+        driver.scriptedColumns = makeColumns()
+        driver.scriptedExecuteResults = [
+            .success(QueryResult(columns: makeColumns(), rows: [["1", "Alice"]], rowsAffected: 0, executionTime: 0)),
+            .success(QueryResult(columns: [], rows: [["1"]], rowsAffected: 0, executionTime: 0))
+        ]
+        let vm = DataBrowserViewModel()
+        vm.attach(session: makeSession(driver: driver), table: TableInfo(name: "users"), databaseType: .mysql, host: "localhost")
+        await vm.load(isInitial: true)
+        #expect(vm.legacyRows.count == 1)
+        #expect(vm.isLoading == false)
+        #expect(vm.isPageLoading == false)
+
+        driver.scriptedExecuteResults = [
+            .success(QueryResult(columns: makeColumns(), rows: [["1", "Alice"], ["2", "Bob"]], rowsAffected: 0, executionTime: 0)),
+            .success(QueryResult(columns: [], rows: [["2"]], rowsAffected: 0, executionTime: 0))
+        ]
+        await vm.clearSearch()
+
+        #expect(vm.isLoading == false)
+        #expect(vm.isPageLoading == false)
+        #expect(vm.legacyRows.count == 2)
+    }
+
     @Test("pagination prev/next clamps at boundaries")
     func paginationClamps() async {
         let driver = MockDatabaseDriver()


### PR DESCRIPTION
## Summary

Two related iOS data browser bugs reported via TestFlight (iPhone 17 Pro / iOS 26.4.2) and reproduced locally:

1. Clear the search field on a PostgreSQL table → "No Data" empty state shows briefly instead of returning to the row list.
2. Any reload that follows a sort, filter, or page-size change flashes "No Data" between clearing the previous rows and the new rows streaming in.

## Root cause

`DataBrowserViewModel.load()` only set `isLoading = true` when `legacyRows.isEmpty || isInitial`. The downstream `loadPage()` then unconditionally calls `legacyRows.removeAll()` before streaming begins. For any reload that started with rows on screen (i.e., sort, filter, search, clear-search), `legacyRows` became empty mid-flight while both loading flags read false. The view's `if rows.isEmpty` branch fired in that window and rendered the "No Data" empty state, which then got replaced when rows arrived.

`navigatePage()` set `isPageLoading` manually around its `load()` call, but the other entry points (`applySort`, `applyFilters`, `clearFilters`, `applySearch`, `clearSearch`) did not.

## Fix

- `load()` now owns both loading flags. If `isInitial || legacyRows.isEmpty` it sets `isLoading = true` (full-screen spinner); otherwise it sets `isPageLoading = true` (in-list overlay that keeps the existing rows visible until they get replaced). Both flags reset on every exit path.
- `navigatePage()` no longer touches `isPageLoading` since `load()` handles it.
- `DataBrowserView.content` gets one new branch: `rows.isEmpty && isPageLoading` shows a `ProgressView` instead of falling through to the empty state.
- Bottom toolbar visibility includes `!viewModel.isPageLoading` so it stops flickering when an interaction clears rows.

## Test plan

- [ ] Search on a PostgreSQL table, clear the search field → row list returns directly with no "No Data" flash
- [ ] Apply a filter, then clear it → list reloads without empty-state flash
- [ ] Change sort column, change page size → in-list overlay shows, no empty state
- [ ] Open a genuinely empty table → "No Data" with Insert Row action still shows
- [ ] Search with zero matches → `ContentUnavailableView.search` still shows
- [ ] `DataBrowserViewModelTests/clearSearchReplacesRowsCleanly` passes