### PR TITLE
ci(plugins): assert built bundle version matches tag

### DIFF
--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -74,6 +74,16 @@ build_plugin() {
 
     echo "Built: $plugin_bundle" >&2
 
+    if [ -n "$PLUGIN_VERSION" ]; then
+        actual_version=$(plutil -extract CFBundleShortVersionString raw -o - "$plugin_bundle/Contents/Info.plist" 2>/dev/null || echo "")
+        if [ "$actual_version" != "$PLUGIN_VERSION" ]; then
+            echo "FATAL: Built bundle CFBundleShortVersionString='$actual_version' but expected '$PLUGIN_VERSION'" >&2
+            echo "       MARKETING_VERSION injection failed. Users would see 'Update to v$PLUGIN_VERSION' loops." >&2
+            exit 1
+        fi
+        echo "Bundle version verified: CFBundleShortVersionString=$actual_version" >&2
+    fi
+
     # Strip the plugin binary to reduce size
     local plugin_name
     plugin_name=$(basename "$plugin_bundle" .tableplugin)


### PR DESCRIPTION
## Summary

Adds a post-build assertion in `scripts/build-plugin.sh` that fails the build if the plugin bundle's `CFBundleShortVersionString` doesn't match the requested version.

## Why

This is the bug we just hit: `plugin-duckdb-v1.0.20` (and the other 9 registry plugins) were tagged before `b2ecece9` landed the `MARKETING_VERSION` injection. Their ZIPs shipped with `CFBundleShortVersionString = 1.0`. Users who installed from the registry saw the plugin loop forever as "Update to v1.0.20" because the installed plist read "1.0", but registry said "1.0.20".

Without this guard, the same mistake can happen again any time `MARKETING_VERSION` injection regresses (typo in build script, env var dropped from CI, plist key added that shadows it).

## Test plan

- [ ] CI green on this PR
- [ ] Next plugin re-release (one of the 10 needing republish) shows `Bundle version verified: ...` in CI log
- [ ] Manually corrupt PLUGIN_VERSION arg locally and confirm the script aborts with the FATAL message