### PR TITLE
refactor(welcome): drop redundant import button from actions panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quick Switcher rewritten as a native SwiftUI sheet matching the Database Switcher style. Adds a Recent section per connection.
 - Double-click handling in sidebar, database switcher, and connection type chooser now uses `contextMenu(forSelectionType:primaryAction:)` instead of a custom NSEvent monitor.
+- Welcome screen drops the "Import Connections..." button; both import flows remain in the `+` menu.
 
 ### Fixed
 

--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -9,7 +9,6 @@ struct WelcomeActionsPanel: View {
     let onActivateLicense: () -> Void
     let onCreateConnection: () -> Void
     let onTrySample: () -> Void
-    let onImportFromFile: () -> Void
 
     private let updaterBridge = UpdaterBridge.shared
 
@@ -46,13 +45,6 @@ struct WelcomeActionsPanel: View {
 
                 Button(action: onTrySample) {
                     Label(String(localized: "Try Sample Database"), systemImage: "cylinder.split.1x2")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-
-                Button(action: onImportFromFile) {
-                    Label(String(localized: "Import Connections..."), systemImage: "square.and.arrow.down")
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
                 .buttonStyle(.bordered)

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -198,8 +198,7 @@ struct WelcomeWindowView: View {
             WelcomeActionsPanel(
                 onActivateLicense: { vm.activeSheet = .activation },
                 onCreateConnection: { WindowOpener.shared.openConnectionForm() },
-                onTrySample: { vm.openSampleDatabase() },
-                onImportFromFile: { vm.importConnectionsFromFile() }
+                onTrySample: { vm.openSampleDatabase() }
             )
             .frame(width: 240)
             .themeMaterial(.sidebar, .regularMaterial)


### PR DESCRIPTION
## Summary
- The big "Import Connections..." button on the welcome actions panel only handled TablePro's own export-file format, so it was rarely useful for new users.
- Both import flows ("Import Connections..." and "Import from Other App...") already live in the `+` context menu next to "New Connection...", so the panel button was redundant.
- Panel now shows just "Create Connection" (primary) and "Try Sample Database", which fits the first-launch CTA better.

## Test plan
- [ ] Launch with no existing connections; verify the welcome panel shows only Create / Try Sample buttons.
- [ ] Click the `+` button in the connections panel header; verify "Import Connections..." and "Import from Other App..." are still present.
- [ ] Both import flows still work end-to-end.