### PR TITLE
fix(connections): show inline connecting state and clean up on cancel (#1185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The connection window shows the connecting state inline with a Cancel button instead of an empty sidebar.
+
+### Fixed
+
+- Closing the connection window during a slow connect no longer leaves a stuck "Connecting…" window or a stray failure alert (#1185).
+
 ## [0.40.1] - 2026-05-12
 
 ### Changed

--- a/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
+++ b/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
@@ -12,4 +12,14 @@ extension DatabaseManager {
             try await self.connectToSession(connection)
         }
     }
+
+    func cancelEnsureConnected(_ connectionId: UUID) async {
+        await ensureConnectedDedup.cancel(key: connectionId)
+        if let session = activeSessions[connectionId], session.driver == nil {
+            removeSessionEntry(for: connectionId)
+            if currentSessionId == connectionId {
+                currentSessionId = nil
+            }
+        }
+    }
 }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -20,6 +20,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     // MARK: - Payload & Session
 
     let payload: EditorTabPayload?
+    private let payloadConnection: DatabaseConnection?
     private var currentSession: ConnectionSession?
     private var sessionState: SessionStateFactory.SessionState?
     private var rightPanelState: RightPanelState?
@@ -52,6 +53,12 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     init(payload: EditorTabPayload?, sessionState: SessionStateFactory.SessionState?) {
         self.payload = payload
+        if let connectionId = payload?.connectionId {
+            self.payloadConnection = DatabaseManager.shared.activeSessions[connectionId]?.connection
+                ?? ConnectionStorage.shared.loadConnections().first { $0.id == connectionId }
+        } else {
+            self.payloadConnection = nil
+        }
 
         let defaultTitle: String
         if payload?.tabType == .serverDashboard {
@@ -147,7 +154,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         inspectorSplitItem.maximumThickness = 400
         addSplitViewItem(inspectorSplitItem)
 
-        if currentSession == nil {
+        if currentSession?.driver == nil {
             sidebarSplitItem.isCollapsed = true
         } else if let session = currentSession, let coordinator = sessionState?.coordinator {
             sidebarContainer.updateSidebarState(
@@ -283,10 +290,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             installToolbar(coordinator: state.coordinator)
         }
 
+        let collapseSidebar = newSession.driver == nil
         if view.window?.isVisible == true {
-            sidebarSplitItem.animator().isCollapsed = false
+            sidebarSplitItem.animator().isCollapsed = collapseSidebar
         } else {
-            sidebarSplitItem.isCollapsed = false
+            sidebarSplitItem.isCollapsed = collapseSidebar
         }
         rebuildPanes()
     }
@@ -350,7 +358,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     @ViewBuilder
     private func buildDetailView() -> some View {
-        if let currentSession, let rightPanelState, let sessionState {
+        if let pendingConnection = connectingConnection {
+            ConnectingStateView(connection: pendingConnection) { [weak self] in
+                self?.cancelConnectionAttempt()
+            }
+        } else if let currentSession, let rightPanelState, let sessionState {
             MainContentView(
                 connection: currentSession.connection,
                 payload: payload,
@@ -367,15 +379,21 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             )
             .transaction { $0.animation = nil }
         } else {
-            VStack(spacing: 16) {
-                ProgressView()
-                    .scaleEffect(1.5)
-                Text("Connecting...")
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Color.clear
         }
+    }
+
+    private var connectingConnection: DatabaseConnection? {
+        guard closingSessionId == nil else { return nil }
+        guard let connectionId = payload?.connectionId else { return nil }
+        if let session = DatabaseManager.shared.activeSessions[connectionId] {
+            return session.driver == nil ? session.connection : nil
+        }
+        return payloadConnection
+    }
+
+    private func cancelConnectionAttempt() {
+        view.window?.performClose(nil)
     }
 
     @ViewBuilder

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -85,6 +85,12 @@ internal final class TabRouter {
         WindowManager.shared.openTab(payload: payload)
         NSApp.activate(ignoringOtherApps: true)
         try await DatabaseManager.shared.ensureConnected(connection)
+        guard WindowManager.shared.hasOpenWindow(for: connection.id) else {
+            Self.logger.info(
+                "[open] connection succeeded after window was closed; tearing down session connId=\(connection.id, privacy: .public)")
+            await DatabaseManager.shared.disconnectSession(connection.id)
+            return
+        }
         closeWelcomeWindows()
     }
 

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -155,6 +155,8 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
+        cancelPendingConnectionIfNeeded()
+
         window.saveFrame(usingName: Self.frameAutosaveName)
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
@@ -171,6 +173,15 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         activity?.invalidate()
         activity = nil
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) total ms=\(Int(Date().timeIntervalSince(t0) * 1_000))")
+    }
+
+    private func cancelPendingConnectionIfNeeded() {
+        let connectionId = payload.connectionId
+        let session = DatabaseManager.shared.activeSessions[connectionId]
+        guard session?.driver == nil else { return }
+        Task {
+            await DatabaseManager.shared.cancelEnsureConnected(connectionId)
+        }
     }
 
     // MARK: - NSUserActivity

--- a/TablePro/Core/Services/Infrastructure/WelcomeRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/WelcomeRouter.swift
@@ -8,6 +8,12 @@ import Combine
 import Foundation
 import Observation
 
+internal struct PendingConnectionError: Equatable {
+    let connectionId: UUID
+    let connectionName: String
+    let message: String
+}
+
 @MainActor
 @Observable
 internal final class WelcomeRouter {
@@ -16,6 +22,8 @@ internal final class WelcomeRouter {
     private(set) var pendingImport: ExportableConnection?
     private(set) var pendingConnectionShare: URL?
     private(set) var pendingSQLFiles: [URL] = []
+    private(set) var pendingError: PendingConnectionError?
+    private(set) var pendingPluginInstall: DatabaseConnection?
 
     @ObservationIgnored private var databaseDidConnectCancellable: AnyCancellable?
 
@@ -43,6 +51,20 @@ internal final class WelcomeRouter {
         showWelcomeWindow()
     }
 
+    internal func routeError(_ error: Error, for connection: DatabaseConnection) {
+        pendingError = PendingConnectionError(
+            connectionId: connection.id,
+            connectionName: connection.name,
+            message: error.localizedDescription
+        )
+        showWelcomeWindow()
+    }
+
+    internal func routePluginInstall(_ connection: DatabaseConnection) {
+        pendingPluginInstall = connection
+        showWelcomeWindow()
+    }
+
     internal func enqueueSQLFile(_ url: URL) {
         pendingSQLFiles.append(url)
     }
@@ -56,6 +78,18 @@ internal final class WelcomeRouter {
     internal func consumePendingShare() -> URL? {
         let value = pendingConnectionShare
         pendingConnectionShare = nil
+        return value
+    }
+
+    internal func consumePendingError() -> PendingConnectionError? {
+        let value = pendingError
+        pendingError = nil
+        return value
+    }
+
+    internal func consumePendingPluginInstall() -> DatabaseConnection? {
+        let value = pendingPluginInstall
+        pendingPluginInstall = nil
         return value
     }
 

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -108,6 +108,18 @@ internal final class WindowManager {
 
     // MARK: - Helpers
 
+    internal func hasOpenWindow(for connectionId: UUID) -> Bool {
+        controllers.values.contains { $0.payload.connectionId == connectionId }
+    }
+
+    internal func closeWindow(for connectionId: UUID) {
+        let matching = controllers.values.filter { $0.payload.connectionId == connectionId }
+        for controller in matching {
+            guard let window = controller.window, window.isVisible else { continue }
+            window.close()
+        }
+    }
+
     private static func isMainWindow(_ window: NSWindow) -> Bool {
         guard let raw = window.identifier?.rawValue else { return false }
         return raw == "main" || raw.hasPrefix("main-")

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -11105,6 +11105,9 @@
         }
       }
     },
+    "Connecting to %@" : {
+
+    },
     "Connecting..." : {
       "localizations" : {
         "tr" : {

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -207,6 +207,15 @@ final class WelcomeViewModel {
         }
         if let pendingImport = WelcomeRouter.shared.consumePendingImport() {
             activeSheet = .deeplinkImport(pendingImport)
+            return
+        }
+        if let pendingInstall = WelcomeRouter.shared.consumePendingPluginInstall() {
+            pluginInstallConnection = pendingInstall
+            return
+        }
+        if let pendingError = WelcomeRouter.shared.consumePendingError() {
+            connectionError = pendingError.message
+            showConnectionError = true
         }
     }
 
@@ -229,6 +238,8 @@ final class WelcomeViewModel {
                 withObservationTracking({
                     _ = WelcomeRouter.shared.pendingImport
                     _ = WelcomeRouter.shared.pendingConnectionShare
+                    _ = WelcomeRouter.shared.pendingError
+                    _ = WelcomeRouter.shared.pendingPluginInstall
                 }, onChange: {
                     box.resume(with: true)
                 })
@@ -281,36 +292,14 @@ final class WelcomeViewModel {
         Task {
             do {
                 try await TabRouter.shared.route(.openConnection(connection.id))
-            } catch is CancellationError {
-                closeConnectionWindows(for: connection.id)
-                WindowOpener.shared.openWelcome()
             } catch {
-                if case PluginError.pluginNotInstalled = error {
-                    Self.logger.info("Plugin not installed for \(connection.type.rawValue), prompting install")
-                    handleMissingPlugin(connection: connection)
-                } else {
-                    Self.logger.error(
-                        "Failed to connect: \(error.localizedDescription, privacy: .public)")
-                    handleConnectionFailure(error: error, connectionId: connection.id)
-                }
+                handleConnectError(error, connection: connection)
             }
         }
     }
 
     func connectAfterInstall(_ connection: DatabaseConnection) {
-        WindowOpener.shared.orderOutWelcome()
-        Task {
-            do {
-                try await TabRouter.shared.route(.openConnection(connection.id))
-            } catch is CancellationError {
-                closeConnectionWindows(for: connection.id)
-                WindowOpener.shared.openWelcome()
-            } catch {
-                Self.logger.error(
-                    "Failed to connect after plugin install: \(error.localizedDescription, privacy: .public)")
-                handleConnectionFailure(error: error, connectionId: connection.id)
-            }
-        }
+        connectToDatabase(connection)
     }
 
     func connectToLinkedConnection(_ linked: LinkedConnection) {
@@ -594,23 +583,28 @@ final class WelcomeViewModel {
 
     // MARK: - Private Helpers
 
-    private func handleConnectionFailure(error: Error, connectionId: UUID) {
-        closeConnectionWindows(for: connectionId)
+    private func handleConnectError(_ error: Error, connection: DatabaseConnection) {
+        if error is CancellationError {
+            Self.logger.info("Connection attempt cancelled for \(connection.name, privacy: .public)")
+            return
+        }
+
+        if !WindowManager.shared.hasOpenWindow(for: connection.id) {
+            Self.logger.info(
+                "Connection failed after window was closed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        if case PluginError.pluginNotInstalled = error {
+            Self.logger.info("Plugin not installed for \(connection.type.rawValue, privacy: .public)")
+            WindowManager.shared.closeWindow(for: connection.id)
+            pluginInstallConnection = connection
+            return
+        }
+
+        Self.logger.error("Failed to connect: \(error.localizedDescription, privacy: .public)")
+        WindowManager.shared.closeWindow(for: connection.id)
         connectionError = error.localizedDescription
         showConnectionError = true
-        WindowOpener.shared.openWelcome()
-    }
-
-    private func handleMissingPlugin(connection: DatabaseConnection) {
-        closeConnectionWindows(for: connection.id)
-        WindowOpener.shared.openWelcome()
-        pluginInstallConnection = connection
-    }
-
-    /// Close windows for a specific connection only, preserving other connections' windows.
-    private func closeConnectionWindows(for connectionId: UUID) {
-        for window in WindowLifecycleMonitor.shared.windows(for: connectionId) {
-            window.close()
-        }
     }
 }

--- a/TablePro/Views/Connection/ConnectingStateView.swift
+++ b/TablePro/Views/Connection/ConnectingStateView.swift
@@ -1,0 +1,74 @@
+//
+//  ConnectingStateView.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+struct ConnectingStateView: View {
+    let connection: DatabaseConnection
+    let onCancel: () -> Void
+    private let iconIsSymbol: Bool
+
+    init(connection: DatabaseConnection, onCancel: @escaping () -> Void) {
+        self.connection = connection
+        self.onCancel = onCancel
+        self.iconIsSymbol = NSImage(
+            systemSymbolName: connection.type.iconName,
+            accessibilityDescription: nil
+        ) != nil
+    }
+
+    var body: some View {
+        ContentUnavailableView {
+            Label {
+                Text(String(format: String(localized: "Connecting to %@"), connection.name))
+            } icon: {
+                iconView
+            }
+        } description: {
+            VStack(spacing: 14) {
+                if !endpointSubtitle.isEmpty {
+                    Text(endpointSubtitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                ProgressView()
+                    .controlSize(.small)
+            }
+        } actions: {
+            Button(role: .cancel, action: onCancel) {
+                Text(String(localized: "Cancel"))
+                    .frame(minWidth: 80)
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.cancelAction)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if iconIsSymbol {
+            Image(systemName: connection.type.iconName)
+                .symbolRenderingMode(.hierarchical)
+                .symbolEffect(.pulse, options: .repeating)
+        } else {
+            Image(connection.type.iconName)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+
+    private var endpointSubtitle: String {
+        if connection.host.isEmpty { return connection.database }
+        if connection.port > 0 {
+            return "\(connection.host):\(connection.port)"
+        }
+        return connection.host
+    }
+}

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -351,25 +351,27 @@ final class ConnectionFormCoordinator {
     }
 
     func handleConnectError(_ error: Error, connection: DatabaseConnection) {
-        if case PluginError.pluginNotInstalled = error {
-            handleMissingPlugin(connection: connection)
+        if error is CancellationError {
+            Self.logger.info("Connection attempt cancelled for \(connection.name, privacy: .public)")
             return
         }
-        closeConnectionWindows(for: connection.id)
-        WindowOpener.shared.openWelcome()
-        guard !(error is CancellationError) else { return }
-        Self.logger.error("Failed to connect: \(error.localizedDescription, privacy: .public)")
-        AlertHelper.showErrorSheet(
-            title: String(localized: "Connection Failed"),
-            message: error.localizedDescription,
-            window: nil
-        )
-    }
 
-    func handleMissingPlugin(connection: DatabaseConnection) {
-        closeConnectionWindows(for: connection.id)
-        WindowOpener.shared.openWelcome()
-        pluginInstallConnection = connection
+        if !WindowManager.shared.hasOpenWindow(for: connection.id) {
+            Self.logger.info(
+                "Connection failed after window was closed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        WindowManager.shared.closeWindow(for: connection.id)
+
+        if case PluginError.pluginNotInstalled = error {
+            Self.logger.info("Plugin not installed for \(connection.type.rawValue, privacy: .public)")
+            WelcomeRouter.shared.routePluginInstall(connection)
+            return
+        }
+
+        Self.logger.error("Failed to connect: \(error.localizedDescription, privacy: .public)")
+        WelcomeRouter.shared.routeError(error, for: connection)
     }
 
     func connectAfterInstall(_ connection: DatabaseConnection) {
@@ -380,12 +382,6 @@ final class ConnectionFormCoordinator {
             } catch {
                 handleConnectError(error, connection: connection)
             }
-        }
-    }
-
-    private func closeConnectionWindows(for connectionId: UUID) {
-        for window in WindowLifecycleMonitor.shared.windows(for: connectionId) {
-            window.close()
         }
     }
 


### PR DESCRIPTION
## Summary

- Replaces the empty/half-rendered editor window during connect with a native `ContentUnavailableView` showing the database type icon (with `.symbolEffect(.pulse)`), connection name, host:port, an in-line spinner, and a Cancel button.
- Cancels the in-flight `ensureConnected` task and drops the `.connecting` session entry when the user closes the editor window mid-connect, so the libpq result is discarded silently.
- Suppresses the post-cancel "Connection Failed" alert and the ghost "Connecting…" window: `WelcomeViewModel`/`ConnectionFormCoordinator` check `WindowManager.hasOpenWindow(for:)` and only present the alert when the editor window is still open.
- Tears down a successful late connection if the user already closed the window, so we don't leak a connected driver.

Closes #1185.

## Test plan

- [ ] Connect to a reachable host: connecting state shows briefly, then the editor takes over.
- [ ] Connect to an unreachable host (e.g. `192.168.79.78:5432`): connecting state shows; clicking Cancel or the X closes the window cleanly with no ghost and no alert.
- [ ] Wait for the libpq timeout instead: window closes itself and a single "Connection Failed" alert appears on Welcome.
- [ ] Save & Connect from the connection form to a bad host: same suppression applies.