### PR TITLE
feat(welcome): add Import from Other App button to the left pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Right-click Set Value submenu on date, datetime, and timestamp cells now offers current-value SQL function presets (`CURRENT_DATE` for date columns, `CURRENT_TIME` for time columns, `NOW()` and `CURRENT_TIMESTAMP` for datetime and timestamp columns).
+- Welcome screen left pane gains an Import from Other App button next to Create Connection and Try Sample Database, opening the existing TablePlus / Sequel Ace / DBeaver import flow.
 
 ### Changed
 

--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct WelcomeActionsPanel: View {
     let onActivateLicense: () -> Void
     let onCreateConnection: () -> Void
+    let onImportFromApp: () -> Void
     let onTrySample: () -> Void
 
     private let updaterBridge = UpdaterBridge.shared
@@ -41,6 +42,13 @@ struct WelcomeActionsPanel: View {
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button(action: onImportFromApp) {
+                    Label(String(localized: "Import from Other App..."), systemImage: "square.and.arrow.down.on.square")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.bordered)
                 .controlSize(.large)
 
                 Button(action: onTrySample) {

--- a/TablePro/Views/Connection/WelcomeWindowView.swift
+++ b/TablePro/Views/Connection/WelcomeWindowView.swift
@@ -198,6 +198,7 @@ struct WelcomeWindowView: View {
             WelcomeActionsPanel(
                 onActivateLicense: { vm.activeSheet = .activation },
                 onCreateConnection: { WindowOpener.shared.openConnectionForm() },
+                onImportFromApp: { vm.importConnectionsFromApp() },
                 onTrySample: { vm.openSampleDatabase() }
             )
             .frame(width: 240)


### PR DESCRIPTION
## Summary

- Adds a third button to the welcome screen's left actions panel: **Import from Other App...**, placed between **Create Connection...** and **Try Sample Database**.
- Wires it to the existing `WelcomeViewModel.importConnectionsFromApp()` flow, which opens the TablePlus / Sequel Ace / DBeaver import sheet (`ImportFromAppSheet`).

## Why

The same action lives in the `+` context menu since v0.40.1, but new users coming from another DB client don't discover it. Three vertical buttons keeps the ordering: primary onboarding (Create), alternative onboarding for switchers (Import), exploration fallback (Sample).

Reuses the existing icon and string (`square.and.arrow.down.on.square`, "Import from Other App...") that the context menu already uses, so localization and visual language stay consistent.

## Test plan

- [ ] Launch TablePro with the welcome window open. Three buttons appear in the left pane: Create Connection, Import from Other App, Try Sample Database.
- [ ] Click Import from Other App → the existing `ImportFromAppSheet` opens.
- [ ] Pick an app (TablePlus / Sequel Ace / DBeaver), confirm import → connections appear in the right pane.
- [ ] Context menu in the `+` button still offers the same action — both paths reach the same sheet.