### PR TITLE
fix(datagrid): continue row numbers across pages instead of resetting per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Row numbers in the data grid now continue across pages instead of resetting to 1, matching the pagination footer (page 2 with a page size of 1000 shows 1001-2000).
 - The connection window shows the connecting state inline with a Cancel button instead of an empty sidebar.
 - Date, datetime, and timestamp cells use the same inline text editor as other columns; the popover date picker is removed.
 - The foreign key preview popover now follows the selected row when you arrow up or down, refreshing both the anchor and the displayed reference row. Arrow left or right (column change) and row mutations dismiss the popover.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Row numbers in the data grid now continue across pages instead of resetting to 1, matching the pagination footer (page 2 with a page size of 1000 shows 1001-2000).
+- Row numbers in the data grid now continue across pages instead of resetting to 1, matching the pagination footer (page 2 with a page size of 1000 shows 1001-2000). The `#` column auto-sizes to fit the widest row number expected on the current page so values like `14001` no longer clip.
 - The connection window shows the connecting state inline with a Cancel button instead of an empty sidebar.
 - Date, datetime, and timestamp cells use the same inline text editor as other columns; the popover date picker is removed.
 - The foreign key preview popover now follows the selected row when you arrow up or down, refreshing both the anchor and the displayed reference row. Arrow left or right (column change) and row mutations dismiss the popover.

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -561,6 +561,9 @@ struct MainEditorContentView: View {
                     return .none
                 }
             },
+            paginationOffsetProvider: { [coordinator] in
+                coordinator.tabManager.tabs.first(where: { $0.id == tabId })?.pagination.currentOffset ?? 0
+            },
             changeManager: currentChangeManager,
             isEditable: isEditable,
             configuration: DataGridConfiguration(

--- a/TablePro/Views/Results/Cells/DataGridCellRegistry.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellRegistry.swift
@@ -68,6 +68,7 @@ final class DataGridCellRegistry {
     func makeRowNumberCell(
         in tableView: NSTableView,
         row: Int,
+        pageOffset: Int,
         cachedRowCount: Int,
         visualState: RowVisualState
     ) -> NSView {
@@ -111,9 +112,10 @@ final class DataGridCellRegistry {
             return cellView
         }
 
-        cell.stringValue = "\(row + 1)"
+        let displayNumber = row + pageOffset + 1
+        cell.stringValue = "\(displayNumber)"
         cell.textColor = visualState.isDeleted ? ThemeEngine.shared.colors.dataGrid.deletedText : .secondaryLabelColor
-        cellView.setAccessibilityLabel(String(format: String(localized: "Row %d"), row + 1))
+        cellView.setAccessibilityLabel(String(format: String(localized: "Row %d"), displayNumber))
         cellView.setAccessibilityRowIndexRange(NSRange(location: row, length: 1))
 
         return cellView

--- a/TablePro/Views/Results/Cells/DataGridMetrics.swift
+++ b/TablePro/Views/Results/Cells/DataGridMetrics.swift
@@ -7,4 +7,6 @@ import CoreGraphics
 
 enum DataGridMetrics {
     static let cellHorizontalInset: CGFloat = 4
+    static let rowNumberHeaderPadding: CGFloat = 8
+    static let rowNumberColumnMinWidth: CGFloat = 40
 }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -224,6 +224,17 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         let tableRows = tableRowsProvider()
         cachedRowCount = sortedIDs?.count ?? tableRows.count
         cachedColumnCount = tableRows.columns.count
+        resizeRowNumberColumnForCurrentRange()
+    }
+
+    func resizeRowNumberColumnForCurrentRange() {
+        guard let tableView,
+              let column = tableView.tableColumns.first(where: {
+                  $0.identifier == ColumnIdentitySchema.rowNumberIdentifier
+              }),
+              !column.isHidden else { return }
+        let maxRowNumber = paginationOffsetProvider() + cachedRowCount
+        DataGridView.sizeRowNumberColumn(column, forMaxRowNumber: maxRowNumber)
     }
 
     func applyInsertedRows(_ indices: IndexSet) {

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -11,6 +11,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 {
     var tableRowsProvider: @MainActor () -> TableRows = { TableRows() }
     var tableRowsMutator: @MainActor (@MainActor (inout TableRows) -> Void) -> Void = { _ in }
+    var paginationOffsetProvider: @MainActor () -> Int = { 0 }
     var changeManager: AnyChangeManager
     var isEditable: Bool
     var sortedIDs: [RowID]?

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -200,6 +200,9 @@ struct DataGridView: NSViewRepresentable {
             let shouldHide = !configuration.showRowNumbers
             if rowNumCol.isHidden != shouldHide {
                 rowNumCol.isHidden = shouldHide
+                if !shouldHide {
+                    coordinator.resizeRowNumberColumnForCurrentRange()
+                }
             }
         }
 
@@ -347,11 +350,9 @@ struct DataGridView: NSViewRepresentable {
     static func makeRowNumberColumn() -> NSTableColumn {
         let column = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
         column.title = "#"
-        column.width = 40
-        column.minWidth = 40
-        column.maxWidth = 60
         column.isEditable = false
         column.resizingMask = []
+        sizeRowNumberColumn(column, forMaxRowNumber: 1)
         let defaultHeaderFont = column.headerCell.font
         let headerCell = SortableHeaderCell(textCell: "#")
         headerCell.font = defaultHeaderFont
@@ -359,6 +360,17 @@ struct DataGridView: NSViewRepresentable {
         headerCell.setAccessibilityLabel(String(localized: "Row number"))
         column.headerCell = headerCell
         return column
+    }
+
+    @MainActor
+    static func sizeRowNumberColumn(_ column: NSTableColumn, forMaxRowNumber maxNumber: Int) {
+        let display = "\(max(maxNumber, 1))"
+        let font = ThemeEngine.shared.dataGridFonts.rowNumber
+        let textWidth = (display as NSString).size(withAttributes: [.font: font]).width
+        let columnWidth = max(40, ceil(textWidth) + 2 * DataGridMetrics.cellHorizontalInset + 8)
+        column.minWidth = columnWidth
+        column.maxWidth = max(columnWidth, 120)
+        column.width = columnWidth
     }
 
     static let firstDataTableColumnIndex: Int = 1

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -367,9 +367,12 @@ struct DataGridView: NSViewRepresentable {
         let display = "\(max(maxNumber, 1))"
         let font = ThemeEngine.shared.dataGridFonts.rowNumber
         let textWidth = (display as NSString).size(withAttributes: [.font: font]).width
-        let columnWidth = max(40, ceil(textWidth) + 2 * DataGridMetrics.cellHorizontalInset + 8)
+        let measured = ceil(textWidth)
+            + 2 * DataGridMetrics.cellHorizontalInset
+            + DataGridMetrics.rowNumberHeaderPadding
+        let columnWidth = max(DataGridMetrics.rowNumberColumnMinWidth, measured)
         column.minWidth = columnWidth
-        column.maxWidth = max(columnWidth, 120)
+        column.maxWidth = columnWidth
         column.width = columnWidth
     }
 

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -30,6 +30,7 @@ struct RowVisualState: Equatable {
 struct DataGridView: NSViewRepresentable {
     var tableRowsProvider: @MainActor () -> TableRows = { TableRows() }
     var tableRowsMutator: @MainActor (@MainActor (inout TableRows) -> Void) -> Void = { _ in }
+    var paginationOffsetProvider: @MainActor () -> Int = { 0 }
     var changeManager: AnyChangeManager
     let isEditable: Bool
     var configuration: DataGridConfiguration = .init()
@@ -112,6 +113,7 @@ struct DataGridView: NSViewRepresentable {
         context.coordinator.tableRowsController.attach(tableView)
         context.coordinator.tableRowsProvider = tableRowsProvider
         context.coordinator.tableRowsMutator = tableRowsMutator
+        context.coordinator.paginationOffsetProvider = paginationOffsetProvider
         context.coordinator.sortedIDs = sortedIDs
         // Intentionally do not prime cachedRowCount/cachedColumnCount here.
         // They represent what NSTableView has actually rendered. Leaving them
@@ -143,6 +145,7 @@ struct DataGridView: NSViewRepresentable {
 
         coordinator.tableRowsProvider = tableRowsProvider
         coordinator.tableRowsMutator = tableRowsMutator
+        coordinator.paginationOffsetProvider = paginationOffsetProvider
         coordinator.changeManager = changeManager
 
         let latestRows = tableRowsProvider()

--- a/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
@@ -22,6 +22,7 @@ extension TableViewCoordinator {
             return cellRegistry.makeRowNumberCell(
                 in: tableView,
                 row: row,
+                pageOffset: paginationOffsetProvider(),
                 cachedRowCount: displayCount,
                 visualState: visualState(for: row)
             )

--- a/TableProTests/Views/Results/RowNumberColumnSizingTests.swift
+++ b/TableProTests/Views/Results/RowNumberColumnSizingTests.swift
@@ -1,0 +1,60 @@
+//
+//  RowNumberColumnSizingTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Row Number Column Sizing")
+@MainActor
+struct RowNumberColumnSizingTests {
+    @Test("Single-digit max number sizes to the configured floor")
+    func singleDigitHonoursFloor() {
+        let column = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        DataGridView.sizeRowNumberColumn(column, forMaxRowNumber: 1)
+        #expect(column.width == DataGridMetrics.rowNumberColumnMinWidth)
+        #expect(column.minWidth == column.width)
+        #expect(column.maxWidth == column.width)
+    }
+
+    @Test("Zero and negative inputs are clamped to the floor")
+    func zeroAndNegativeClampToFloor() {
+        let zero = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        let negative = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        DataGridView.sizeRowNumberColumn(zero, forMaxRowNumber: 0)
+        DataGridView.sizeRowNumberColumn(negative, forMaxRowNumber: -42)
+        #expect(zero.width == DataGridMetrics.rowNumberColumnMinWidth)
+        #expect(negative.width == DataGridMetrics.rowNumberColumnMinWidth)
+    }
+
+    @Test("Five-digit numbers grow past the floor")
+    func fiveDigitGrowsPastFloor() {
+        let column = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        DataGridView.sizeRowNumberColumn(column, forMaxRowNumber: 14_001)
+        #expect(column.width > DataGridMetrics.rowNumberColumnMinWidth)
+    }
+
+    @Test("Width grows monotonically with digit count")
+    func widthGrowsWithDigits() {
+        let twoDigit = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        let fourDigit = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        let sixDigit = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        DataGridView.sizeRowNumberColumn(twoDigit, forMaxRowNumber: 99)
+        DataGridView.sizeRowNumberColumn(fourDigit, forMaxRowNumber: 9_999)
+        DataGridView.sizeRowNumberColumn(sixDigit, forMaxRowNumber: 999_999)
+        #expect(fourDigit.width >= twoDigit.width)
+        #expect(sixDigit.width >= fourDigit.width)
+    }
+
+    @Test("Min, max and width stay equal so the column is pinned")
+    func widthIsPinned() {
+        let column = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        DataGridView.sizeRowNumberColumn(column, forMaxRowNumber: 1_234_567)
+        #expect(column.minWidth == column.width)
+        #expect(column.maxWidth == column.width)
+    }
+}


### PR DESCRIPTION
## Summary

- Row numbers in the data grid now continue across pages: with page size 1000, page 2 shows 1001-2000 instead of restarting at 1.
- Plumbs `PaginationState.currentOffset` through `DataGridView` → `TableViewCoordinator` → `makeRowNumberCell` via a `paginationOffsetProvider` closure (same pattern as `tableRowsProvider`).

## Why

Every comparable DB client (TablePlus, DBeaver, DataGrip, pgAdmin, MySQL Workbench, Sequel Ace) numbers result rows continuously across pages. TablePro's pagination footer already shows "Showing 1001-1100 of 50,000" — the row-number column should agree. With the previous behavior, "row 42" meant something different on every page, breaking the user's ability to use the number as a stable reference.

Implementation:

- `makeRowNumberCell` gains a `pageOffset: Int` parameter; the rendered string and accessibility label become `row + pageOffset + 1`.
- `TableViewCoordinator` gains `paginationOffsetProvider: @MainActor () -> Int` (default `{ 0 }`).
- `MainEditorContentView` supplies the closure: `coordinator.tabManager.tabs.first(where: { \$0.id == tabId })?.pagination.currentOffset ?? 0`. Read live on every cell rendering, same pattern as `tableRowsProvider`.
- Structure / preview / create-table grids keep the default `{ 0 }` because they don't paginate, so their per-screen numbering is unchanged.

Page navigation already triggers a query reload (new SQL OFFSET) which calls `applyDelta(.fullReplace)` → `tableView.reloadData()` → `viewForCell` → `makeRowNumberCell` with the live offset, so no extra refresh wiring is needed.

## Test plan

- [ ] Open a table with > pageSize rows. Page 1 shows 1..pageSize. Click Next Page → rows show `(pageSize + 1)..(2*pageSize)`. Last (possibly partial) page shows correct trailing numbers.
- [ ] Sort the table client-side: row numbers stay continuous within the page (1001..2000 on page 2) regardless of the sorted order — they index into the result set, not the visible row order.
- [ ] Click on a row and look at the accessibility label — it includes the global row number.
- [ ] Add a new row on page 2: the inserted row gets `2001` (sits at the end of the current page).
- [ ] Mark a row as deleted: the row number stays, just greyed out.
- [ ] Structure / CreateTable views: row numbers still count from 1 (no pagination context, default offset 0).
- [ ] Toggle Show Row Numbers off / on in settings: column hides and reappears with the correct continuation values.