### PR TITLE
fix(plugin-postgresql): rename versioned capabilities to avoid name collision

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLCapabilities.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLCapabilities.swift
@@ -24,4 +24,5 @@ struct PostgreSQLCapabilities: Sendable, Equatable {
 
     var hasDatabaseICULocale: Bool { serverVersion >= 150_000 }
     var hasDatabaseLocale: Bool { serverVersion >= 170_000 }
+    var hasModernICUSyntax: Bool { serverVersion >= 160_000 }
 }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
@@ -10,7 +10,7 @@ extension PostgreSQLPluginDriver {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
         let safeSchema = escapeLiteralForColumns(currentSchema ?? "public")
         let safeTable = escapeLiteralForColumns(table)
-        let caps = capabilities
+        let caps = versionedCapabilities
         let identityProjection = caps.hasIdentityColumns ? "a.attidentity" : "NULL::text"
         let generatedProjection = caps.hasGeneratedColumns ? "a.attgenerated" : "NULL::text"
         let attributeJoin = (caps.hasIdentityColumns || caps.hasGeneratedColumns) ? """
@@ -60,7 +60,7 @@ extension PostgreSQLPluginDriver {
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
         let safeSchema = escapeLiteralForColumns(currentSchema ?? "public")
-        let caps = capabilities
+        let caps = versionedCapabilities
         let identityProjection = caps.hasIdentityColumns ? "a.attidentity" : "NULL::text"
         let generatedProjection = caps.hasGeneratedColumns ? "a.attgenerated" : "NULL::text"
         let attributeJoin = (caps.hasIdentityColumns || caps.hasGeneratedColumns) ? """

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -22,7 +22,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsTransactions: Bool { true }
     var serverVersion: String? { libpqConnection?.serverVersion() }
     var serverVersionNumber: Int32 { libpqConnection?.serverVersionNumber() ?? 0 }
-    var capabilities: PostgreSQLCapabilities {
+    var versionedCapabilities: PostgreSQLCapabilities {
         PostgreSQLCapabilities(serverVersion: serverVersionNumber)
     }
     var parameterStyle: ParameterStyle { .dollar }
@@ -234,7 +234,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let schemaLiteral = escapeLiteral(schema ?? _currentSchema)
-        let caps = capabilities
+        let caps = versionedCapabilities
 
         var unions: [String] = [
             """
@@ -284,7 +284,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
 
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
-        let columnOrdering = capabilities.hasArrayPosition
+        let columnOrdering = versionedCapabilities.hasArrayPosition
             ? "ORDER BY array_position(ix.indkey, a.attnum)"
             : "ORDER BY a.attnum"
         let query = """
@@ -433,7 +433,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
         let safeTable = escapeLiteral(table)
         let quotedTable = "\"\(table.replacingOccurrences(of: "\"", with: "\"\""))\""
-        let caps = capabilities
+        let caps = versionedCapabilities
 
         let identityClause: String = caps.hasIdentityColumns ? """
                 CASE
@@ -672,7 +672,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchDependentSequences(table: String, schema: String?) async throws -> [(name: String, ddl: String)] {
-        guard capabilities.hasSequencesCatalog else { return [] }
+        guard versionedCapabilities.hasSequencesCatalog else { return [] }
         let safeTable = escapeLiteral(table)
         let query = """
             SELECT s.sequencename,
@@ -720,7 +720,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     ]
 
     func createDatabaseFormSpec() async throws -> PluginCreateDatabaseFormSpec? {
-        let supportsProvider = capabilities.hasDatabaseICULocale
+        let supportsProvider = versionedCapabilities.hasDatabaseICULocale
 
         async let templateDefaultsTask = fetchTemplate1Defaults()
         async let collationsTask = fetchCollations()
@@ -813,7 +813,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         var sql = "CREATE DATABASE \"\(quotedName)\" ENCODING '\(encoding)'"
 
-        let supportsProvider = capabilities.hasDatabaseICULocale
+        let supportsProvider = versionedCapabilities.hasDatabaseICULocale
         let provider = supportsProvider ? (request.values["provider"] ?? "libc") : "libc"
 
         switch provider {
@@ -873,7 +873,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 )
             }
             let escapedIcu = escapeLiteral(icuLocale)
-            if let major = majorVersion, major >= 16 {
+            if versionedCapabilities.hasModernICUSyntax {
                 sql += " LOCALE_PROVIDER 'icu' LOCALE '\(escapedIcu)' TEMPLATE template0"
             } else {
                 sql += " LOCALE_PROVIDER 'icu' ICU_LOCALE '\(escapedIcu)' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0"
@@ -903,7 +903,7 @@ final class PostgreSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func fetchTemplate1Defaults() async -> Template1Defaults? {
-        let caps = capabilities
+        let caps = versionedCapabilities
         let selectColumns: String
         if caps.hasDatabaseLocale {
             selectColumns = "datcollate, datctype, datlocprovider, datlocale"


### PR DESCRIPTION
## Summary

Main is broken: `PostgreSQLPluginDriver` declares two properties named `capabilities` — `PostgreSQLCapabilities` (from PR #1241) and `PluginCapabilities` (from the protocol). The compiler can't disambiguate at the call sites in `PostgreSQLPluginDriver+Columns.swift`.

Also fixes a stray `majorVersion` reference left over from the helper that PR #1241 removed.

## Changes

- Rename `var capabilities: PostgreSQLCapabilities` → `var versionedCapabilities`. Updates all call sites in `PostgreSQLPluginDriver.swift` and `PostgreSQLPluginDriver+Columns.swift`.
- Add `PostgreSQLCapabilities.hasModernICUSyntax` (PG 16+) and replace the dangling `majorVersion` check in `CREATE DATABASE` ICU locale branch with `versionedCapabilities.hasModernICUSyntax`.

## Why two properties named `capabilities`?

`PluginCapabilities` is an `OptionSet` declared in the plugin protocol (`alterTableDDL`, `materializedViews`, etc.). Each plugin exposes the set it supports. `PostgreSQLCapabilities` from #1241 is per-server-version (gates against `pg_matviews`, `attidentity`, etc.). The two are unrelated; same name was a collision, not a design choice.

`versionedCapabilities` makes the distinction explicit.

## Test plan

- [ ] `xcodebuild build` — green (was failing on main).