### PR TITLE
fix(ai-chat): reset Copilot conversation when starting a new chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AI Chat: starting a new conversation now resets the Copilot server-side conversation. Previously the next message reused the prior conversation's context.
 - Cassandra: connection now fails fast with a clear "Cassandra 2.x is not supported" message instead of cryptic "table not found" errors during sidebar load.
 - MongoDB: dropped the `nameOnly: true` flag on `listDatabases` for servers older than 3.4, which previously rejected the flag.
 - ClickHouse: index sidebar no longer fails on ClickHouse older than 19.17 by skipping the `system.data_skipping_indices` lookup when the table doesn't exist.

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -180,6 +180,7 @@ final class AIChatViewModel {
     }
 
     func startNewConversation() {
+        AIProviderFactory.resetCopilotConversation()
         cancelStream()
         persistCurrentConversation()
         messages.removeAll()


### PR DESCRIPTION
## Summary

`AIChatViewModel.startNewConversation()` cleared the local UI state (messages, active id, error) but never told `CopilotChatProvider` to drop its server-side `conversationId`. The next message sent after "new conversation" was attached to the **prior** server-side conversation, so the AI's response was contaminated by the previous chat's context.

`switchConversation(to:)` already calls `AIProviderFactory.resetCopilotConversation()`. `startNewConversation()` was missing the same call.

## Fix

One line:

```swift
func startNewConversation() {
    AIProviderFactory.resetCopilotConversation()   // added
    cancelStream()
    persistCurrentConversation()
    messages.removeAll()
    activeConversationID = nil
    clearError()
}
```

This covers all four entry points that reach `startNewConversation()`:
- `/clear` slash command
- `/new` slash command
- `handleFixError` (when an SQL error is forwarded to AI)
- The "+" button on the right-side chat header (`UnifiedRightPanelView`)

## Why only Copilot

Most providers (OpenAI, Anthropic direct, Gemini) are stateless from the API's perspective — TablePro sends the entire conversation history each turn, so clearing local `messages` is sufficient. Copilot is the exception: the claude.ai Code API stores the conversation server-side and we send only the new turn plus the cached `conversationId`. That ID lives on `CopilotChatProvider` and survives across our local conversation boundaries unless we reset it.

## Test plan

Pre-fix repro:
1. Open AI Chat with Copilot provider.
2. Ask: "remember the number 42".
3. Click "+" to start a new conversation.
4. Ask: "what number did I say?"
5. Bug: the model answers "42".

Post-fix:
5. Model answers something like "I don't have any prior context."