### PR TITLE
fix: correct CockroachDB supportsSchemaEditing test, drop unused loggers

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
@@ -9,13 +9,10 @@
 //
 
 import Foundation
-import os
 import TableProPluginKit
 
 final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     let core: LibPQDriverCore
-
-    private static let logger = Logger(subsystem: "com.TablePro.PostgreSQLDriver", category: "CockroachPluginDriver")
 
     private var cachedServerVersion: String?
 

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -7,12 +7,9 @@
 //
 
 import Foundation
-import os
 import TableProPluginKit
 
 final class LibPQDriverCore: @unchecked Sendable {
-    private static let logger = Logger(subsystem: "com.TablePro.PostgreSQLDriver", category: "LibPQDriverCore")
-
     private let config: DriverConnectionConfig
     private var libpqConnection: LibPQPluginConnection?
 

--- a/TableProTests/Models/DatabaseTypeCockroachDBTests.swift
+++ b/TableProTests/Models/DatabaseTypeCockroachDBTests.swift
@@ -32,9 +32,9 @@ struct DatabaseTypeCockroachDBTests {
         #expect(DatabaseType.cockroachdb.supportsForeignKeys == true)
     }
 
-    @Test("supportsSchemaEditing is true")
+    @Test("supportsSchemaEditing is false (no driver-side DDL generators)")
     func supportsSchemaEditing() {
-        #expect(DatabaseType.cockroachdb.supportsSchemaEditing == true)
+        #expect(DatabaseType.cockroachdb.supportsSchemaEditing == false)
     }
 
     @Test("iconName is cockroachdb-icon")


### PR DESCRIPTION
## Summary

Follow-up to #1262 (CockroachDB support). PR #1262 merged before this review-feedback commit could land, so `main` currently carries two issues this PR fixes:

- **Failing test.** `DatabaseTypeCockroachDBTests.supportsSchemaEditing()` asserts `== true`, but `DatabaseType.cockroachdb.supportsSchemaEditing` is `false` (CockroachDB ships with no driver-side DDL generators, matching Redshift). The assertion is corrected to `== false`.
- **Dead code.** Unused `Logger` instances in `LibPQDriverCore` and `CockroachPluginDriver`, plus their now-unused `import os`.

## Tests

`swiftlint --strict` clean. CockroachDB test suites pass, including `supportsSchemaEditing()`.