### PR TITLE
fix(connection-form): show Username field for MongoDB and other optional-auth databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MongoDB: the connection form now shows a Username field. It was hidden for databases where authentication is optional, so connections to auth-enabled servers saved with no credentials and every query failed with "requires authentication" even though the connection looked healthy.
 - SQL import dropped statements when the database executed them slower than the file was parsed, so a re-imported export could fail with errors like "relation does not exist". The parser now waits for each statement to be consumed before reading more. (#1264)
 - SQL import ignored the database dialect, so PostgreSQL dumps with dollar-quoted function bodies were split at semicolons inside the body. (#1264)
 - SQL export emitted `DROP TABLE` for views, materialized views, and foreign tables, so re-importing failed with "is not a table". It now emits `DROP VIEW`, `DROP MATERIALIZED VIEW`, or `DROP FOREIGN TABLE` to match the object. (#1264)

--- a/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
@@ -152,8 +152,7 @@ struct GeneralPaneView: View {
     private var authenticationSection: some View {
         if connectionMode != .fileBased {
             Section(String(localized: "Authentication")) {
-                if PluginManager.shared.requiresAuthentication(for: type)
-                    && connectionMode != .apiOnly {
+                if connectionMode == .network {
                     TextField(
                         String(localized: "Username"),
                         text: $coordinator.auth.username,


### PR DESCRIPTION
## Problem

A MongoDB connection to an auth-enabled server connects "successfully" but the sidebar table list shows `[13] Command listCollections requires authentication`. Compass connects to the same server fine.

The connection form never showed a **Username** field for MongoDB, so the connection saved with an empty username.

## Root cause

`MongoDBPlugin` declares `requiresAuthentication = false` (correct: local-dev MongoDB has no auth). But `GeneralPaneView` used that same flag to decide whether the Username field is *visible*. Those are different questions:

- *Is auth mandatory?* — no, for MongoDB
- *Should the Username field exist?* — yes, most real MongoDB servers need it

With the field hidden, the connection saved `username = ""`. The driver's `buildUri()` guards credentials behind `if !user.isEmpty`, so the URI had no userinfo at all. `connect()` only runs `{"ping": 1}`, which MongoDB allows unauthenticated, so the connection looked healthy. The first real operation, `listCollections` for the table list, failed with MongoDB error code 13 (`Unauthorized`).

## Fix

Gate the Username field on `connectionMode == .network` instead of `requiresAuthentication`. `authenticationSection` is only built for non-file-based connections, so the reachable modes are `.network` and `.apiOnly`. Every network database supports a username regardless of whether auth is enforced; `.apiOnly` connections authenticate through their own `authFields` and correctly keep it hidden.

Main-app only. No plugin change, no PluginKit ABI bump, no registry re-tag.

## Notes

Two related issues found but left out of this PR:
- The **Database** field is hidden for MongoDB by the same `requiresAuthentication` misuse. It doesn't cause this bug (MongoDB auto-discovers databases once authenticated).
- `MongoDBConnection.buildUri()` silently drops a password when the username is empty. That's a plugin-side change; once this fix lands, it's only reachable by deliberately leaving Username blank.

## Test plan

- [ ] Create a MongoDB connection: the Username field is now visible
- [ ] Enter credentials for an auth-enabled server, connect, confirm the table list loads
- [ ] Confirm `.apiOnly` connections (DynamoDB, BigQuery) still hide the Username field
- [ ] Confirm file-based connections (SQLite, CSV) are unaffected