### PR TITLE
fix(plugins): respect Settings > Query timeout in HTTP transports (#1267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ClickHouse, BigQuery, CloudflareD1, LibSQL, Etcd, and DynamoDB: long-running queries no longer fail at 30 seconds when Settings > Query timeout is set higher. The HTTP transport now uses the configured query timeout plus a 30-second grace, so the server's `max_execution_time` (or equivalent) fires before the client gives up. Setting "No limit" raises the transport ceiling to 1 hour. (#1267)
 - AI Chat: DeepSeek V4 thinking content (`reasoning_content`) is now captured during streaming and passed back in subsequent turns, fixing 400 errors when using deepseek-v4-pro or deepseek-v4-flash.
 - MongoDB: the connection form now shows a Username field. It was hidden for databases where authentication is optional, so connections to auth-enabled servers saved with no credentials and every query failed with "requires authentication" even though the connection looked healthy.
 - SQL import dropped statements when the database executed them slower than the file was parsed, so a re-imported export could fail with errors like "relation does not exist". The parser now waits for each statement to be consumed before reading more. (#1264)

--- a/Plugins/BigQueryDriverPlugin/BigQueryConnection.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryConnection.swift
@@ -284,6 +284,7 @@ internal final class BigQueryConnection: @unchecked Sendable {
     private var _currentJobId: String?
     private var _currentJobLocation: String?
     private var _queryTimeoutSeconds: Int = 300
+    private var _queryTimeout = HttpQueryTimeout()
     private let location: String?
     private static let logger = Logger(subsystem: "com.TablePro", category: "BigQueryConnection")
     private static let baseUrl = "https://bigquery.googleapis.com/bigquery/v2"
@@ -293,7 +294,10 @@ internal final class BigQueryConnection: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.withLock { _queryTimeoutSeconds = max(seconds, 30) }
+        lock.withLock {
+            _queryTimeoutSeconds = max(seconds, 30)
+            _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        }
     }
 
     init(config: DriverConnectionConfig) {
@@ -306,8 +310,8 @@ internal final class BigQueryConnection: @unchecked Sendable {
         let authProvider = try createAuthProvider()
 
         let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.timeoutIntervalForRequest = 60
-        sessionConfig.timeoutIntervalForResource = 300
+        sessionConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        sessionConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
         let urlSession = URLSession(configuration: sessionConfig)
 
         lock.withLock {
@@ -836,8 +840,10 @@ internal final class BigQueryConnection: @unchecked Sendable {
         _ request: URLRequest,
         session: URLSession
     ) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = session.dataTask(with: request) { [weak self] data, response, error in
+        var timedRequest = request
+        timedRequest.timeoutInterval = lock.withLock { _queryTimeout.requestTimeoutInterval }
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = session.dataTask(with: timedRequest) { [weak self] data, response, error in
                 self?.lock.withLock { self?._currentTask = nil }
                 if let error {
                     if (error as? URLError)?.code == .cancelled {

--- a/Plugins/BigQueryDriverPlugin/BigQueryConnection.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryConnection.swift
@@ -284,7 +284,7 @@ internal final class BigQueryConnection: @unchecked Sendable {
     private var _currentJobId: String?
     private var _currentJobLocation: String?
     private var _queryTimeoutSeconds: Int = 300
-    private var _queryTimeout = HttpQueryTimeout()
+    private let _queryTimeout = HttpQueryTimeoutBox()
     private let location: String?
     private static let logger = Logger(subsystem: "com.TablePro", category: "BigQueryConnection")
     private static let baseUrl = "https://bigquery.googleapis.com/bigquery/v2"
@@ -294,10 +294,8 @@ internal final class BigQueryConnection: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.withLock {
-            _queryTimeoutSeconds = max(seconds, 30)
-            _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        }
+        lock.withLock { _queryTimeoutSeconds = max(seconds, 30) }
+        _queryTimeout.set(serverTimeoutSeconds: seconds)
     }
 
     init(config: DriverConnectionConfig) {
@@ -841,7 +839,7 @@ internal final class BigQueryConnection: @unchecked Sendable {
         session: URLSession
     ) async throws -> (Data, URLResponse) {
         var timedRequest = request
-        timedRequest.timeoutInterval = lock.withLock { _queryTimeout.requestTimeoutInterval }
+        timedRequest.timeoutInterval = _queryTimeout.requestTimeoutInterval
         return try await withCheckedThrowingContinuation { continuation in
             let task = session.dataTask(with: timedRequest) { [weak self] data, response, error in
                 self?.lock.withLock { self?._currentTask = nil }

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>TableProPluginKitVersion</key>
 	<integer>12</integer>
+	<key>TableProMinAppVersion</key>
+	<string>0.42.0</string>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -145,7 +145,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var currentTask: URLSessionDataTask?
     private var _currentDatabase: String
     private var _lastQueryId: String?
-    private var _queryTimeout = HttpQueryTimeout()
+    private let _queryTimeout = HttpQueryTimeoutBox()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ClickHousePluginDriver")
 
@@ -733,9 +733,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
-        lock.lock()
-        _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
+        _queryTimeout.set(serverTimeoutSeconds: seconds)
         guard seconds > 0 else { return }
         _ = try await execute(query: "SET max_execution_time = \(seconds)")
     }
@@ -804,11 +802,10 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if let queryId {
             _lastQueryId = queryId
         }
-        let timeoutInterval = _queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = try buildRequest(query: query, database: database, queryId: queryId)
-        request.timeoutInterval = timeoutInterval
+        request.timeoutInterval = _queryTimeout.requestTimeoutInterval
         let isSelect = Self.isSelectLikeQuery(query)
 
         let (data, response) = try await withTaskCancellationHandler {
@@ -865,11 +862,10 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if let queryId {
             _lastQueryId = queryId
         }
-        let timeoutInterval = _queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = try buildRequest(query: query, database: database, queryId: queryId, params: params)
-        request.timeoutInterval = timeoutInterval
+        request.timeoutInterval = _queryTimeout.requestTimeoutInterval
         let isSelect = Self.isSelectLikeQuery(query)
 
         let (data, response) = try await withTaskCancellationHandler {

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -145,6 +145,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var currentTask: URLSessionDataTask?
     private var _currentDatabase: String
     private var _lastQueryId: String?
+    private var _queryTimeout = HttpQueryTimeout()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ClickHousePluginDriver")
 
@@ -196,8 +197,8 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func connect() async throws {
         let urlConfig = URLSessionConfiguration.default
-        urlConfig.timeoutIntervalForRequest = 30
-        urlConfig.timeoutIntervalForResource = 300
+        urlConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        urlConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
 
         lock.lock()
         if let delegate = ClickHouseTLSDelegate.make(for: config.ssl) {
@@ -732,6 +733,9 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
+        lock.lock()
+        _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
         guard seconds > 0 else { return }
         _ = try await execute(query: "SET max_execution_time = \(seconds)")
     }
@@ -800,9 +804,11 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if let queryId {
             _lastQueryId = queryId
         }
+        let timeoutInterval = _queryTimeout.requestTimeoutInterval
         lock.unlock()
 
-        let request = try buildRequest(query: query, database: database, queryId: queryId)
+        var request = try buildRequest(query: query, database: database, queryId: queryId)
+        request.timeoutInterval = timeoutInterval
         let isSelect = Self.isSelectLikeQuery(query)
 
         let (data, response) = try await withTaskCancellationHandler {
@@ -859,9 +865,11 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if let queryId {
             _lastQueryId = queryId
         }
+        let timeoutInterval = _queryTimeout.requestTimeoutInterval
         lock.unlock()
 
-        let request = try buildRequest(query: query, database: database, queryId: queryId, params: params)
+        var request = try buildRequest(query: query, database: database, queryId: queryId, params: params)
+        request.timeoutInterval = timeoutInterval
         let isSelect = Self.isSelectLikeQuery(query)
 
         let (data, response) = try await withTaskCancellationHandler {

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
@@ -182,6 +182,13 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
         lock.unlock()
     }
 
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        lock.lock()
+        let client = httpClient
+        lock.unlock()
+        client?.setQueryTimeout(seconds)
+    }
+
     // MARK: - Streaming
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {

--- a/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
+++ b/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
@@ -137,7 +137,7 @@ final class D1HttpClient: @unchecked Sendable {
     private var _databaseId: String
     private var session: URLSession?
     private var currentTask: URLSessionDataTask?
-    private var queryTimeout = HttpQueryTimeout()
+    private let queryTimeout = HttpQueryTimeoutBox()
 
     var databaseId: String {
         get {
@@ -159,9 +159,7 @@ final class D1HttpClient: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.lock()
-        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
+        queryTimeout.set(serverTimeoutSeconds: seconds)
     }
 
     func createSession() {
@@ -311,12 +309,11 @@ final class D1HttpClient: @unchecked Sendable {
             lock.unlock()
             throw D1HttpError(message: String(localized: "Not connected to database"))
         }
-        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = method
-        request.timeoutInterval = timeoutInterval
+        request.timeoutInterval = queryTimeout.requestTimeoutInterval
         request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = body

--- a/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
+++ b/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
@@ -139,12 +139,6 @@ final class D1HttpClient: @unchecked Sendable {
     private var currentTask: URLSessionDataTask?
     private var queryTimeout = HttpQueryTimeout()
 
-    func setQueryTimeout(_ seconds: Int) {
-        lock.lock()
-        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
-    }
-
     var databaseId: String {
         get {
             lock.lock()
@@ -162,6 +156,12 @@ final class D1HttpClient: @unchecked Sendable {
         self.accountId = accountId
         self.apiToken = apiToken
         self._databaseId = databaseId
+    }
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.lock()
+        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
     }
 
     func createSession() {

--- a/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
+++ b/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import os
+import TableProPluginKit
 
 // MARK: - API Response Types
 
@@ -136,6 +137,13 @@ final class D1HttpClient: @unchecked Sendable {
     private var _databaseId: String
     private var session: URLSession?
     private var currentTask: URLSessionDataTask?
+    private var queryTimeout = HttpQueryTimeout()
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.lock()
+        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
+    }
 
     var databaseId: String {
         get {
@@ -158,8 +166,8 @@ final class D1HttpClient: @unchecked Sendable {
 
     func createSession() {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 300
+        config.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        config.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
 
         lock.lock()
         session = URLSession(configuration: config)
@@ -303,10 +311,12 @@ final class D1HttpClient: @unchecked Sendable {
             lock.unlock()
             throw D1HttpError(message: String(localized: "Not connected to database"))
         }
+        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = method
+        request.timeoutInterval = timeoutInterval
         request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = body

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>TableProPluginKitVersion</key>
 	<integer>12</integer>
+	<key>TableProMinAppVersion</key>
+	<string>0.42.0</string>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
@@ -9,7 +9,6 @@ import CommonCrypto
 import Foundation
 import os
 import TableProPluginKit
-import TableProPluginKit
 
 // MARK: - DynamoDB Attribute Value
 

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
@@ -9,6 +9,7 @@ import CommonCrypto
 import Foundation
 import os
 import TableProPluginKit
+import TableProPluginKit
 
 // MARK: - DynamoDB Attribute Value
 
@@ -261,6 +262,7 @@ internal final class DynamoDBConnection: @unchecked Sendable {
     private var _session: URLSession?
     private var _credentials: AWSCredentials?
     private var _currentTask: URLSessionDataTask?
+    private var _queryTimeout = HttpQueryTimeout()
     private let region: String
     private let endpointUrl: String
     private static let logger = Logger(subsystem: "com.TablePro", category: "DynamoDBConnection")
@@ -268,6 +270,10 @@ internal final class DynamoDBConnection: @unchecked Sendable {
 
     var session: URLSession? {
         lock.withLock { _session }
+    }
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.withLock { _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds) }
     }
 
     init(config: DriverConnectionConfig) {
@@ -298,8 +304,8 @@ internal final class DynamoDBConnection: @unchecked Sendable {
     func connect() async throws {
         let credentials = try resolveCredentials()
         let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.timeoutIntervalForRequest = 30
-        sessionConfig.timeoutIntervalForResource = 60
+        sessionConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        sessionConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
         let urlSession = URLSession(configuration: sessionConfig)
 
         lock.withLock {
@@ -442,6 +448,7 @@ internal final class DynamoDBConnection: @unchecked Sendable {
         urlRequest.setValue(hostHeader, forHTTPHeaderField: "Host")
 
         signRequest(&urlRequest, body: bodyData, credentials: credentials)
+        urlRequest.timeoutInterval = lock.withLock { _queryTimeout.requestTimeoutInterval }
 
         let (data, response) = try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<(Data, URLResponse), Error>) in

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBConnection.swift
@@ -261,7 +261,7 @@ internal final class DynamoDBConnection: @unchecked Sendable {
     private var _session: URLSession?
     private var _credentials: AWSCredentials?
     private var _currentTask: URLSessionDataTask?
-    private var _queryTimeout = HttpQueryTimeout()
+    private let _queryTimeout = HttpQueryTimeoutBox()
     private let region: String
     private let endpointUrl: String
     private static let logger = Logger(subsystem: "com.TablePro", category: "DynamoDBConnection")
@@ -272,7 +272,7 @@ internal final class DynamoDBConnection: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.withLock { _queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds) }
+        _queryTimeout.set(serverTimeoutSeconds: seconds)
     }
 
     init(config: DriverConnectionConfig) {
@@ -447,7 +447,7 @@ internal final class DynamoDBConnection: @unchecked Sendable {
         urlRequest.setValue(hostHeader, forHTTPHeaderField: "Host")
 
         signRequest(&urlRequest, body: bodyData, credentials: credentials)
-        urlRequest.timeoutInterval = lock.withLock { _queryTimeout.requestTimeoutInterval }
+        urlRequest.timeoutInterval = _queryTimeout.requestTimeoutInterval
 
         let (data, response) = try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<(Data, URLResponse), Error>) in

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
@@ -197,7 +197,9 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         connection?.cancelCurrentRequest()
     }
 
-    func applyQueryTimeout(_ seconds: Int) async throws {}
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        connection?.setQueryTimeout(seconds)
+    }
 
     // MARK: - Schema Operations
 

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>TableProPluginKitVersion</key>
 	<integer>12</integer>
+	<key>TableProMinAppVersion</key>
+	<string>0.42.0</string>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
@@ -315,6 +315,13 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     private var authToken: String?
     private var _isAuthenticating = false
     private var apiPrefix = "v3"
+    private var queryTimeout = HttpQueryTimeout()
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.lock()
+        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
+    }
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "EtcdHttpClient")
 
@@ -347,8 +354,8 @@ internal final class EtcdHttpClient: @unchecked Sendable {
         let tlsMode = config.additionalFields["etcdTlsMode"] ?? "Disabled"
 
         let urlConfig = URLSessionConfiguration.default
-        urlConfig.timeoutIntervalForRequest = 30
-        urlConfig.timeoutIntervalForResource = 300
+        urlConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        urlConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
 
         let delegate: URLSessionDelegate?
         switch tlsMode {
@@ -710,6 +717,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
         }
         let token = authToken
         let generation = sessionGeneration
+        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         guard let url = URL(string: "\(baseUrl)/\(path)") else {
@@ -718,6 +726,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.timeoutInterval = timeoutInterval
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token {
             request.setValue(token, forHTTPHeaderField: "Authorization")

--- a/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
@@ -317,16 +317,16 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     private var apiPrefix = "v3"
     private var queryTimeout = HttpQueryTimeout()
 
-    func setQueryTimeout(_ seconds: Int) {
-        lock.lock()
-        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
-    }
-
     private static let logger = Logger(subsystem: "com.TablePro", category: "EtcdHttpClient")
 
     init(config: DriverConnectionConfig) {
         self.config = config
+    }
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.lock()
+        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
     }
 
     // MARK: - Base URL

--- a/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
@@ -315,7 +315,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     private var authToken: String?
     private var _isAuthenticating = false
     private var apiPrefix = "v3"
-    private var queryTimeout = HttpQueryTimeout()
+    private let queryTimeout = HttpQueryTimeoutBox()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "EtcdHttpClient")
 
@@ -324,9 +324,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.lock()
-        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
+        queryTimeout.set(serverTimeoutSeconds: seconds)
     }
 
     // MARK: - Base URL
@@ -717,7 +715,6 @@ internal final class EtcdHttpClient: @unchecked Sendable {
         }
         let token = authToken
         let generation = sessionGeneration
-        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         guard let url = URL(string: "\(baseUrl)/\(path)") else {
@@ -726,7 +723,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = timeoutInterval
+        request.timeoutInterval = queryTimeout.requestTimeoutInterval
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token {
             request.setValue(token, forHTTPHeaderField: "Authorization")

--- a/Plugins/EtcdDriverPlugin/EtcdPluginDriver.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdPluginDriver.swift
@@ -264,7 +264,9 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         httpClient?.cancelCurrentRequest()
     }
 
-    func applyQueryTimeout(_ seconds: Int) async throws {}
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        httpClient?.setQueryTimeout(seconds)
+    }
 
     // MARK: - Schema Operations
 

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>TableProPluginKitVersion</key>
 	<integer>12</integer>
+	<key>TableProMinAppVersion</key>
+	<string>0.42.0</string>
 </dict>
 </plist>

--- a/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
+++ b/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
@@ -115,7 +115,7 @@ final class HranaHttpClient: @unchecked Sendable {
     private let lock = NSLock()
     private var session: URLSession?
     private var currentTask: URLSessionDataTask?
-    private var queryTimeout = HttpQueryTimeout()
+    private let queryTimeout = HttpQueryTimeoutBox()
 
     init(baseUrl: URL, authToken: String?) {
         self.baseUrl = baseUrl
@@ -123,9 +123,7 @@ final class HranaHttpClient: @unchecked Sendable {
     }
 
     func setQueryTimeout(_ seconds: Int) {
-        lock.lock()
-        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
-        lock.unlock()
+        queryTimeout.set(serverTimeoutSeconds: seconds)
     }
 
     func createSession() {
@@ -215,12 +213,11 @@ final class HranaHttpClient: @unchecked Sendable {
             lock.unlock()
             throw HranaHttpError(message: String(localized: "Not connected to database"))
         }
-        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = timeoutInterval
+        request.timeoutInterval = queryTimeout.requestTimeoutInterval
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token = authToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
+++ b/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import os
+import TableProPluginKit
 
 // MARK: - Hrana Protocol Types
 
@@ -114,6 +115,13 @@ final class HranaHttpClient: @unchecked Sendable {
     private let lock = NSLock()
     private var session: URLSession?
     private var currentTask: URLSessionDataTask?
+    private var queryTimeout = HttpQueryTimeout()
+
+    func setQueryTimeout(_ seconds: Int) {
+        lock.lock()
+        queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
+        lock.unlock()
+    }
 
     init(baseUrl: URL, authToken: String?) {
         self.baseUrl = baseUrl
@@ -122,8 +130,8 @@ final class HranaHttpClient: @unchecked Sendable {
 
     func createSession() {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 300
+        config.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
+        config.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
 
         lock.lock()
         session = URLSession(configuration: config)
@@ -207,10 +215,12 @@ final class HranaHttpClient: @unchecked Sendable {
             lock.unlock()
             throw HranaHttpError(message: String(localized: "Not connected to database"))
         }
+        let timeoutInterval = queryTimeout.requestTimeoutInterval
         lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.timeoutInterval = timeoutInterval
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token = authToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
+++ b/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
@@ -117,15 +117,15 @@ final class HranaHttpClient: @unchecked Sendable {
     private var currentTask: URLSessionDataTask?
     private var queryTimeout = HttpQueryTimeout()
 
+    init(baseUrl: URL, authToken: String?) {
+        self.baseUrl = baseUrl
+        self.authToken = authToken
+    }
+
     func setQueryTimeout(_ seconds: Int) {
         lock.lock()
         queryTimeout = HttpQueryTimeout(serverTimeoutSeconds: seconds)
         lock.unlock()
-    }
-
-    init(baseUrl: URL, authToken: String?) {
-        self.baseUrl = baseUrl
-        self.authToken = authToken
     }
 
     func createSession() {

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>TableProPluginKitVersion</key>
 	<integer>12</integer>
+	<key>TableProMinAppVersion</key>
+	<string>0.42.0</string>
 </dict>
 </plist>

--- a/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
+++ b/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
@@ -161,6 +161,13 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         lock.unlock()
     }
 
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        lock.lock()
+        let client = httpClient
+        lock.unlock()
+        client?.setQueryTimeout(seconds)
+    }
+
     // MARK: - Streaming
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {

--- a/Plugins/TableProPluginKit/HttpQueryTimeout.swift
+++ b/Plugins/TableProPluginKit/HttpQueryTimeout.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct HttpQueryTimeout: Sendable, Equatable {
+    public static let bootstrapSeconds: Int = 60
+    public static let defaultGraceSeconds: Int = 30
+    public static let resourceCeilingSeconds: Int = 3_600
+
+    public let serverTimeoutSeconds: Int
+    public let graceSeconds: Int
+
+    public init(
+        serverTimeoutSeconds: Int = HttpQueryTimeout.bootstrapSeconds,
+        graceSeconds: Int = HttpQueryTimeout.defaultGraceSeconds
+    ) {
+        self.serverTimeoutSeconds = serverTimeoutSeconds
+        self.graceSeconds = max(graceSeconds, 0)
+    }
+
+    public var requestTimeoutInterval: TimeInterval {
+        guard serverTimeoutSeconds > 0 else {
+            return TimeInterval(HttpQueryTimeout.resourceCeilingSeconds)
+        }
+        return TimeInterval(serverTimeoutSeconds + graceSeconds)
+    }
+
+    public static var sessionResourceTimeout: TimeInterval {
+        TimeInterval(resourceCeilingSeconds)
+    }
+
+    public static var sessionBootstrapRequestTimeout: TimeInterval {
+        TimeInterval(bootstrapSeconds)
+    }
+}

--- a/Plugins/TableProPluginKit/HttpQueryTimeout.swift
+++ b/Plugins/TableProPluginKit/HttpQueryTimeout.swift
@@ -9,8 +9,8 @@ public struct HttpQueryTimeout: Sendable, Equatable {
     public let graceSeconds: Int
 
     public init(
-        serverTimeoutSeconds: Int = HttpQueryTimeout.bootstrapSeconds,
-        graceSeconds: Int = HttpQueryTimeout.defaultGraceSeconds
+        serverTimeoutSeconds: Int = Self.bootstrapSeconds,
+        graceSeconds: Int = Self.defaultGraceSeconds
     ) {
         self.serverTimeoutSeconds = serverTimeoutSeconds
         self.graceSeconds = max(graceSeconds, 0)
@@ -18,7 +18,7 @@ public struct HttpQueryTimeout: Sendable, Equatable {
 
     public var requestTimeoutInterval: TimeInterval {
         guard serverTimeoutSeconds > 0 else {
-            return TimeInterval(HttpQueryTimeout.resourceCeilingSeconds)
+            return TimeInterval(Self.resourceCeilingSeconds)
         }
         return TimeInterval(serverTimeoutSeconds + graceSeconds)
     }

--- a/Plugins/TableProPluginKit/HttpQueryTimeoutBox.swift
+++ b/Plugins/TableProPluginKit/HttpQueryTimeoutBox.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public final class HttpQueryTimeoutBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: HttpQueryTimeout
+
+    public init(_ initial: HttpQueryTimeout = HttpQueryTimeout()) {
+        self.stored = initial
+    }
+
+    public func set(serverTimeoutSeconds seconds: Int, graceSeconds grace: Int = HttpQueryTimeout.defaultGraceSeconds) {
+        lock.lock()
+        stored = HttpQueryTimeout(serverTimeoutSeconds: seconds, graceSeconds: grace)
+        lock.unlock()
+    }
+
+    public var current: HttpQueryTimeout {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    public var requestTimeoutInterval: TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored.requestTimeoutInterval
+    }
+}

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -139,16 +139,13 @@ extension DatabaseManager {
             throw error
         }
 
-        // Apply timeout (best-effort)
         let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
-        if timeoutSeconds > 0 {
-            do {
-                try await driver.applyQueryTimeout(timeoutSeconds)
-            } catch {
-                Self.logger.warning(
-                    "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
-                )
-            }
+        do {
+            try await driver.applyQueryTimeout(timeoutSeconds)
+        } catch {
+            Self.logger.warning(
+                "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
+            )
         }
 
         await executeStartupCommands(
@@ -237,16 +234,13 @@ extension DatabaseManager {
             )
             try await driver.connect()
 
-            // Apply timeout (best-effort)
             let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
-            if timeoutSeconds > 0 {
-                do {
-                    try await driver.applyQueryTimeout(timeoutSeconds)
-                } catch {
-                    Self.logger.warning(
-                        "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
-                    )
-                }
+            do {
+                try await driver.applyQueryTimeout(timeoutSeconds)
+            } catch {
+                Self.logger.warning(
+                    "Query timeout not supported for \(session.connection.name): \(error.localizedDescription)"
+                )
             }
 
             await executeStartupCommands(

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -102,16 +102,12 @@ extension DatabaseManager {
             try await driver.connect()
 
             let timeoutSeconds = AppSettingsManager.shared.general.queryTimeoutSeconds
-            if timeoutSeconds > 0 {
-                do {
-                    try await driver.applyQueryTimeout(timeoutSeconds)
-                } catch {
-                    // Best-effort: some PostgreSQL-compatible databases like Aurora DSQL
-                    // don't support SET statement_timeout.
-                    Self.logger.warning(
-                        "Query timeout not supported for \(connection.name): \(error.localizedDescription)"
-                    )
-                }
+            do {
+                try await driver.applyQueryTimeout(timeoutSeconds)
+            } catch {
+                Self.logger.warning(
+                    "Query timeout not supported for \(connection.name): \(error.localizedDescription)"
+                )
             }
 
             await executeStartupCommands(

--- a/TableProTests/Plugins/HttpQueryTimeoutBoxTests.swift
+++ b/TableProTests/Plugins/HttpQueryTimeoutBoxTests.swift
@@ -1,0 +1,60 @@
+//
+//  HttpQueryTimeoutBoxTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("HttpQueryTimeoutBox")
+struct HttpQueryTimeoutBoxTests {
+    @Test("Default-initialized box exposes bootstrap policy")
+    func defaultBoxIsBootstrap() {
+        let box = HttpQueryTimeoutBox()
+        #expect(box.current.serverTimeoutSeconds == HttpQueryTimeout.bootstrapSeconds)
+        #expect(box.requestTimeoutInterval == TimeInterval(60 + 30))
+    }
+
+    @Test("set updates both current and requestTimeoutInterval")
+    func setUpdatesBoth() {
+        let box = HttpQueryTimeoutBox()
+        box.set(serverTimeoutSeconds: 600)
+        #expect(box.current.serverTimeoutSeconds == 600)
+        #expect(box.requestTimeoutInterval == TimeInterval(630))
+    }
+
+    @Test("set with serverTimeoutSeconds = 0 falls back to resource ceiling")
+    func setZeroUsesCeiling() {
+        let box = HttpQueryTimeoutBox()
+        box.set(serverTimeoutSeconds: 0)
+        #expect(box.requestTimeoutInterval == TimeInterval(HttpQueryTimeout.resourceCeilingSeconds))
+    }
+
+    @Test("set with custom grace is honored")
+    func setCustomGrace() {
+        let box = HttpQueryTimeoutBox()
+        box.set(serverTimeoutSeconds: 120, graceSeconds: 5)
+        #expect(box.requestTimeoutInterval == TimeInterval(125))
+    }
+
+    @Test("Concurrent set and read does not crash")
+    func concurrentAccess() async {
+        let box = HttpQueryTimeoutBox()
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<32 {
+                group.addTask { box.set(serverTimeoutSeconds: 30 + index * 10) }
+                group.addTask { _ = box.requestTimeoutInterval }
+            }
+        }
+        #expect(box.requestTimeoutInterval >= TimeInterval(30))
+    }
+
+    @Test("Custom initial timeout is preserved until set is called")
+    func customInitial() {
+        let box = HttpQueryTimeoutBox(HttpQueryTimeout(serverTimeoutSeconds: 300, graceSeconds: 15))
+        #expect(box.requestTimeoutInterval == TimeInterval(315))
+        box.set(serverTimeoutSeconds: 600)
+        #expect(box.requestTimeoutInterval == TimeInterval(630))
+    }
+}

--- a/TableProTests/Plugins/HttpQueryTimeoutTests.swift
+++ b/TableProTests/Plugins/HttpQueryTimeoutTests.swift
@@ -1,0 +1,64 @@
+//
+//  HttpQueryTimeoutTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("HttpQueryTimeout")
+struct HttpQueryTimeoutTests {
+    @Test("Default values match the documented bootstrap policy")
+    func defaultsMatchBootstrap() {
+        let timeout = HttpQueryTimeout()
+        #expect(timeout.serverTimeoutSeconds == HttpQueryTimeout.bootstrapSeconds)
+        #expect(timeout.graceSeconds == HttpQueryTimeout.defaultGraceSeconds)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(60 + 30))
+    }
+
+    @Test("Positive server timeout adds grace to request interval")
+    func positiveServerTimeoutAddsGrace() {
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: 600, graceSeconds: 30)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(630))
+    }
+
+    @Test("Custom grace is honored")
+    func customGrace() {
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: 120, graceSeconds: 5)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(125))
+    }
+
+    @Test("Zero server timeout falls back to the resource ceiling")
+    func zeroServerTimeoutUsesCeiling() {
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: 0)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(HttpQueryTimeout.resourceCeilingSeconds))
+    }
+
+    @Test("Negative server timeout is treated as unlimited")
+    func negativeServerTimeoutUsesCeiling() {
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: -1)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(HttpQueryTimeout.resourceCeilingSeconds))
+    }
+
+    @Test("Negative grace is clamped to zero")
+    func negativeGraceClamped() {
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: 60, graceSeconds: -10)
+        #expect(timeout.graceSeconds == 0)
+        #expect(timeout.requestTimeoutInterval == TimeInterval(60))
+    }
+
+    @Test("Static session timeouts expose the documented ceilings")
+    func staticSessionTimeouts() {
+        #expect(HttpQueryTimeout.sessionBootstrapRequestTimeout == TimeInterval(60))
+        #expect(HttpQueryTimeout.sessionResourceTimeout == TimeInterval(3_600))
+    }
+
+    @Test("URLRequest.timeoutInterval can be assigned from the helper")
+    func appliesToUrlRequest() {
+        var request = URLRequest(url: URL(string: "https://example.com")!)
+        let timeout = HttpQueryTimeout(serverTimeoutSeconds: 300)
+        request.timeoutInterval = timeout.requestTimeoutInterval
+        #expect(request.timeoutInterval == TimeInterval(330))
+    }
+}

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -36,7 +36,7 @@ System (default), English, Tiếng Việt, Türkçe. Changing the language requi
 
 Maximum seconds a query runs before cancellation. Default 60, range 0-600 (0 means no limit).
 
-Enforced at the database level: `statement_timeout` (PostgreSQL), `max_execution_time` (MySQL), `max_statement_time` (MariaDB), `sqlite3_busy_timeout` (SQLite). Applies on new connections; change requires reconnect.
+Enforced at the database level where supported: `statement_timeout` (PostgreSQL), `max_execution_time` (MySQL, ClickHouse), `max_statement_time` (MariaDB), `sqlite3_busy_timeout` (SQLite). HTTP-based drivers (ClickHouse, BigQuery, CloudflareD1, LibSQL, Etcd, DynamoDB) also bound the HTTP request timeout to the configured value plus a 30-second grace, so the server-side error fires first. Setting "No limit" raises the HTTP transport ceiling to 1 hour. Applies on new connections; change requires reconnect.
 
 ### Software Update
 


### PR DESCRIPTION
Fixes #1267.

## Root cause

Six HTTP-transport plugins hardcoded `URLSessionConfiguration.timeoutIntervalForRequest = 30` (60 for BigQuery) at session creation. The user's `Settings > Query timeout` IS applied (`DatabaseManager+Sessions.swift:104` calls `driver.applyQueryTimeout(seconds)` after connect, which sends `SET max_execution_time = N` for ClickHouse), but the URLSession cancels the underlying HTTP request before the server can respond. The user sees `NSURLErrorTimedOut` instead of the server's `Code: 159. Max execution time exceeded`.

TCP-transport plugins (MySQL, PostgreSQL, MSSQL, SQLite, DuckDB, Oracle, Cassandra, Redis, MongoDB) are unaffected because socket reads block indefinitely.

## Fix

Added `HttpQueryTimeout` to `TableProPluginKit` (Sendable struct, no protocol changes, no ABI bump). Each HTTP plugin stores one under its existing lock, updates it in `applyQueryTimeout`, and sets `URLRequest.timeoutInterval = configured + 30s grace` per request. The 30-second grace ensures the server-side limit fires first with a meaningful error.

Also removed the `if timeoutSeconds > 0` short-circuit at three host sites so `Settings > Query timeout = 0` ("No limit") now reaches drivers and bounds the transport at the 1-hour resource ceiling instead of silently keeping the 30-second cap.

## Plugins changed

| Plugin | Status | Notes |
|---|---|---|
| ClickHouse | bundled | Per-request applied in `executeRaw` / `executeRawWithParams` at call site, not inside `buildRequest` (kill RPC shares it and keeps its 5s ceiling) |
| BigQuery | registry | Parallel `queryTimeout` field alongside existing `_queryTimeoutSeconds` (polling math untouched) |
| DynamoDB | registry | Implemented previously-no-op `applyQueryTimeout`; resource ceiling normalized 60s → 3600s (the old 60s silently truncated long Scan operations) |
| Etcd | registry | Implemented previously-no-op `applyQueryTimeout` |
| CloudflareD1 | registry | New `applyQueryTimeout` override in driver wrapper |
| LibSQL | registry | New `applyQueryTimeout` override in driver wrapper |

## ABI strategy

No `currentPluginKitVersion` bump. Adding a new public struct to `TableProPluginKit` doesn't change `PluginDatabaseDriver` / `DriverPlugin` witness tables, so the five untouched registry plugins (MongoDB, Oracle, DuckDB, MSSQL, Cassandra) keep loading at version 12.

The five touched registry plugins get `TableProMinAppVersion = "0.42.0"` in their `Info.plist`, so an old TablePro build cleanly rejects a newly re-tagged plugin via `PluginManager.swift:380` instead of risking a dyld symbol-not-found at runtime.

## Verification

- `xcodebuild ... build`: BUILD SUCCEEDED
- `swiftlint lint --strict`: 0 violations across 868 files
- `HttpQueryTimeoutTests`: 8/8 passed (default + grace + zero + negative + clamp + statics + URLRequest assignment)

## Post-merge release flow

- Bundled ClickHouse ships with TablePro 0.42.0.
- Re-tag the 5 registry plugins individually after merge: `plugin-bigquery-v*`, `plugin-dynamodb-v*`, `plugin-etcd-v*`, `plugin-cloudflare-d1-v*`, `plugin-libsql-v*` (CI fires once per multi-tag push, push one at a time).
- Update `plugins.json` in `TableProApp/plugins` with new `version` + `downloadURL` + both arch `sha256` for each.

## Out of scope

- Live re-apply when user changes `Settings > Query timeout` on an open session. Today the help text says "Applied to new connections." and that stays accurate.
- Per-connection timeout override in the connection form.
- BigQuery polling math (`_queryTimeoutSeconds * 2` retry budget): own bug, separate fix.
- Resource ceiling above 1h for compaction-style very-long jobs: defaults key, future work.

---

Plan: [velvety-bouncing-wand.md](https://github.com/anthropics/claude-code/issues) (local artifact; ask if you want the full text inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
