### PR TITLE
fix(mysql): display BIT field values as decimal instead of hex bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MySQL/MariaDB: `BIT(N)` columns now display as decimal numbers (`0`, `1`, `255`) instead of raw bytes that showed up as control characters like `^A` in the data grid. (#1272)
 - ClickHouse, BigQuery, CloudflareD1, LibSQL, Etcd, and DynamoDB: long-running queries no longer fail at 30 seconds when Settings > Query timeout is set higher. The HTTP transport now uses the configured query timeout plus a 30-second grace, so the server's `max_execution_time` (or equivalent) fires before the client gives up. Setting "No limit" raises the transport ceiling to 1 hour. (#1267)
 - AI Chat: DeepSeek V4 thinking content (`reasoning_content`) is now captured during streaming and passed back in subsequent turns, fixing 400 errors when using deepseek-v4-pro or deepseek-v4-flash.
 - MongoDB: the connection form now shows a Username field. It was hidden for databases where authentication is optional, so connections to auth-enabled servers saved with no credentials and every query failed with "requires authentication" even though the connection looked healthy.

--- a/Plugins/MySQLDriverPlugin/MariaDBFieldClassifier.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBFieldClassifier.swift
@@ -11,12 +11,13 @@ internal enum MariaDBFieldClassifier {
     private static let blobOrStringTypes: Set<UInt32> = [249, 250, 251, 252, 253, 254]
 
     static func isBinary(typeRaw: UInt32, charset: UInt32) -> Bool {
-        if typeRaw == bitType {
-            return true
-        }
         guard charset == binaryCharset else {
             return false
         }
         return blobOrStringTypes.contains(typeRaw)
+    }
+
+    static func isBit(typeRaw: UInt32) -> Bool {
+        return typeRaw == bitType
     }
 }

--- a/Plugins/MySQLDriverPlugin/MariaDBFieldClassifier.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBFieldClassifier.swift
@@ -18,6 +18,19 @@ internal enum MariaDBFieldClassifier {
     }
 
     static func isBit(typeRaw: UInt32) -> Bool {
-        return typeRaw == bitType
+        typeRaw == bitType
+    }
+
+    static func bitFieldToString(_ buffer: UnsafeRawBufferPointer) -> String {
+        guard !buffer.isEmpty else { return "0" }
+        var value: UInt64 = 0
+        for byte in buffer {
+            value = (value << 8) | UInt64(byte)
+        }
+        return String(value)
+    }
+
+    static func bitFieldToString(_ data: Data) -> String {
+        data.withUnsafeBytes { bitFieldToString($0) }
     }
 }

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -44,6 +44,7 @@ struct MariaDBPluginQueryResult {
     let affectedRows: UInt64
     let insertId: UInt64
     let isTruncated: Bool
+    let columnIsBit: [Bool]
 }
 
 // MARK: - SSL Configuration
@@ -130,6 +131,19 @@ internal func mariaDBTypeName(
     case 255: return "GEOMETRY"
     default: return "UNKNOWN"
     }
+}
+
+/// Converts a MySQL/MariaDB BIT field's raw byte buffer to its decimal string representation.
+///
+/// MySQL stores BIT(N) as a binary value with N bits packed into ceil(N/8) bytes,
+/// most-significant-bit first. For bit(1), the buffer contains a single byte like 0x00 or 0x01.
+private func bitFieldToString(_ buffer: UnsafeRawBufferPointer) -> String {
+    guard !buffer.isEmpty else { return "0" }
+    var value: UInt64 = 0
+    for byte in buffer {
+        value = (value << 8) | UInt64(byte)
+    }
+    return String(value)
 }
 
 // MARK: - Connection Class
@@ -441,10 +455,12 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var columnTypes: [UInt32] = []
         var columnTypeNames: [String] = []
         var columnIsBinary: [Bool] = []
+        var columnIsBit: [Bool] = []
         columns.reserveCapacity(numFields)
         columnTypes.reserveCapacity(numFields)
         columnTypeNames.reserveCapacity(numFields)
         columnIsBinary.reserveCapacity(numFields)
+        columnIsBit.reserveCapacity(numFields)
 
         if let fields = mysql_fetch_fields(resultPtr) {
             for i in 0..<numFields {
@@ -466,6 +482,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                         charset: field.charsetnr
                     )
                 )
+                columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
             }
         }
 
@@ -511,6 +528,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                     if columnTypes[i] == 255 {
                         row.append(.text(GeometryWKBParser.parse(bufferPtr)))
+                    } else if columnIsBit[i] {
+                        row.append(.text(bitFieldToString(bufferPtr)))
                     } else if columnIsBinary[i] {
                         row.append(.bytes(Data(bufferPtr)))
                     } else if let str = String(bytes: bufferPtr, encoding: .utf8) {
@@ -542,7 +561,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
         return MariaDBPluginQueryResult(
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
-            rows: rows, affectedRows: UInt64(rows.count), insertId: 0, isTruncated: truncated
+            rows: rows, affectedRows: UInt64(rows.count), insertId: 0, isTruncated: truncated,
+            columnIsBit: columnIsBit
         )
     }
 
@@ -628,7 +648,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         columns: [String],
         columnTypes: [UInt32],
         columnTypeNames: [String],
-        columnIsBinary: [Bool]
+        columnIsBinary: [Bool],
+        columnIsBit: [Bool]
     ) throws -> (rows: [[PluginCellValue]], isTruncated: Bool) {
         let numFields = columns.count
         var resultBinds: [MYSQL_BIND] = Array(repeating: MYSQL_BIND(), count: numFields)
@@ -710,7 +731,9 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                     let length = Int(resultBinds[i].length?.pointee ?? 0)
                     let buffer = resultBuffers[i].assumingMemoryBound(to: UInt8.self)
                     let data = Data(bytes: buffer, count: length)
-                    if columnIsBinary[i] {
+                    if columnIsBit[i] {
+                        row.append(.text(bitFieldToString(data)))
+                    } else if columnIsBinary[i] {
                         row.append(.bytes(data))
                     } else if let str = String(data: data, encoding: .utf8) {
                         row.append(.text(str))
@@ -795,6 +818,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var columnTypes: [UInt32] = []
         var columnTypeNames: [String] = []
         var columnIsBinary: [Bool] = []
+        var columnIsBit: [Bool] = []
         let numFields = Int(mysql_num_fields(metadata))
 
         if let fields = mysql_fetch_fields(metadata) {
@@ -817,19 +841,20 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                         charset: field.charsetnr
                     )
                 )
+                columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
             }
         }
 
         let fetchResult = try fetchResultSet(
             from: stmt, metadata: metadata,
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
-            columnIsBinary: columnIsBinary
+            columnIsBinary: columnIsBinary, columnIsBit: columnIsBit
         )
 
         return MariaDBPluginQueryResult(
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
             rows: fetchResult.rows, affectedRows: UInt64(fetchResult.rows.count),
-            insertId: 0, isTruncated: fetchResult.isTruncated
+            insertId: 0, isTruncated: fetchResult.isTruncated, columnIsBit: columnIsBit
         )
     }
 
@@ -896,10 +921,12 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 var columnTypes: [UInt32] = []
                 var columnTypeNames: [String] = []
                 var columnIsBinary: [Bool] = []
+                var columnIsBit: [Bool] = []
                 columns.reserveCapacity(numFields)
                 columnTypes.reserveCapacity(numFields)
                 columnTypeNames.reserveCapacity(numFields)
                 columnIsBinary.reserveCapacity(numFields)
+                columnIsBit.reserveCapacity(numFields)
 
                 if let fields = mysql_fetch_fields(resultPtr) {
                     for i in 0..<numFields {
@@ -921,6 +948,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                                 charset: field.charsetnr
                             )
                         )
+                        columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
                     }
                 }
 
@@ -956,6 +984,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                             if columnTypes[i] == 255 {
                                 row.append(.text(GeometryWKBParser.parse(bufferPtr)))
+                            } else if columnIsBit[i] {
+                                row.append(.text(bitFieldToString(bufferPtr)))
                             } else if columnIsBinary[i] {
                                 row.append(.bytes(Data(bufferPtr)))
                             } else if let str = String(bytes: bufferPtr, encoding: .utf8) {

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -44,7 +44,6 @@ struct MariaDBPluginQueryResult {
     let affectedRows: UInt64
     let insertId: UInt64
     let isTruncated: Bool
-    let columnIsBit: [Bool]
 }
 
 // MARK: - SSL Configuration
@@ -131,19 +130,6 @@ internal func mariaDBTypeName(
     case 255: return "GEOMETRY"
     default: return "UNKNOWN"
     }
-}
-
-/// Converts a MySQL/MariaDB BIT field's raw byte buffer to its decimal string representation.
-///
-/// MySQL stores BIT(N) as a binary value with N bits packed into ceil(N/8) bytes,
-/// most-significant-bit first. For bit(1), the buffer contains a single byte like 0x00 or 0x01.
-private func bitFieldToString(_ buffer: UnsafeRawBufferPointer) -> String {
-    guard !buffer.isEmpty else { return "0" }
-    var value: UInt64 = 0
-    for byte in buffer {
-        value = (value << 8) | UInt64(byte)
-    }
-    return String(value)
 }
 
 // MARK: - Connection Class
@@ -455,12 +441,10 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var columnTypes: [UInt32] = []
         var columnTypeNames: [String] = []
         var columnIsBinary: [Bool] = []
-        var columnIsBit: [Bool] = []
         columns.reserveCapacity(numFields)
         columnTypes.reserveCapacity(numFields)
         columnTypeNames.reserveCapacity(numFields)
         columnIsBinary.reserveCapacity(numFields)
-        columnIsBit.reserveCapacity(numFields)
 
         if let fields = mysql_fetch_fields(resultPtr) {
             for i in 0..<numFields {
@@ -482,7 +466,6 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                         charset: field.charsetnr
                     )
                 )
-                columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
             }
         }
 
@@ -528,8 +511,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                     if columnTypes[i] == 255 {
                         row.append(.text(GeometryWKBParser.parse(bufferPtr)))
-                    } else if columnIsBit[i] {
-                        row.append(.text(bitFieldToString(bufferPtr)))
+                    } else if MariaDBFieldClassifier.isBit(typeRaw: columnTypes[i]) {
+                        row.append(.text(MariaDBFieldClassifier.bitFieldToString(bufferPtr)))
                     } else if columnIsBinary[i] {
                         row.append(.bytes(Data(bufferPtr)))
                     } else if let str = String(bytes: bufferPtr, encoding: .utf8) {
@@ -561,8 +544,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
         return MariaDBPluginQueryResult(
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
-            rows: rows, affectedRows: UInt64(rows.count), insertId: 0, isTruncated: truncated,
-            columnIsBit: columnIsBit
+            rows: rows, affectedRows: UInt64(rows.count), insertId: 0, isTruncated: truncated
         )
     }
 
@@ -648,8 +630,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         columns: [String],
         columnTypes: [UInt32],
         columnTypeNames: [String],
-        columnIsBinary: [Bool],
-        columnIsBit: [Bool]
+        columnIsBinary: [Bool]
     ) throws -> (rows: [[PluginCellValue]], isTruncated: Bool) {
         let numFields = columns.count
         var resultBinds: [MYSQL_BIND] = Array(repeating: MYSQL_BIND(), count: numFields)
@@ -731,8 +712,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                     let length = Int(resultBinds[i].length?.pointee ?? 0)
                     let buffer = resultBuffers[i].assumingMemoryBound(to: UInt8.self)
                     let data = Data(bytes: buffer, count: length)
-                    if columnIsBit[i] {
-                        row.append(.text(bitFieldToString(data)))
+                    if MariaDBFieldClassifier.isBit(typeRaw: columnTypes[i]) {
+                        row.append(.text(MariaDBFieldClassifier.bitFieldToString(data)))
                     } else if columnIsBinary[i] {
                         row.append(.bytes(data))
                     } else if let str = String(data: data, encoding: .utf8) {
@@ -818,7 +799,6 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var columnTypes: [UInt32] = []
         var columnTypeNames: [String] = []
         var columnIsBinary: [Bool] = []
-        var columnIsBit: [Bool] = []
         let numFields = Int(mysql_num_fields(metadata))
 
         if let fields = mysql_fetch_fields(metadata) {
@@ -841,20 +821,19 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                         charset: field.charsetnr
                     )
                 )
-                columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
             }
         }
 
         let fetchResult = try fetchResultSet(
             from: stmt, metadata: metadata,
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
-            columnIsBinary: columnIsBinary, columnIsBit: columnIsBit
+            columnIsBinary: columnIsBinary
         )
 
         return MariaDBPluginQueryResult(
             columns: columns, columnTypes: columnTypes, columnTypeNames: columnTypeNames,
             rows: fetchResult.rows, affectedRows: UInt64(fetchResult.rows.count),
-            insertId: 0, isTruncated: fetchResult.isTruncated, columnIsBit: columnIsBit
+            insertId: 0, isTruncated: fetchResult.isTruncated
         )
     }
 
@@ -921,12 +900,10 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 var columnTypes: [UInt32] = []
                 var columnTypeNames: [String] = []
                 var columnIsBinary: [Bool] = []
-                var columnIsBit: [Bool] = []
                 columns.reserveCapacity(numFields)
                 columnTypes.reserveCapacity(numFields)
                 columnTypeNames.reserveCapacity(numFields)
                 columnIsBinary.reserveCapacity(numFields)
-                columnIsBit.reserveCapacity(numFields)
 
                 if let fields = mysql_fetch_fields(resultPtr) {
                     for i in 0..<numFields {
@@ -948,7 +925,6 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                                 charset: field.charsetnr
                             )
                         )
-                        columnIsBit.append(MariaDBFieldClassifier.isBit(typeRaw: field.type.rawValue))
                     }
                 }
 
@@ -984,8 +960,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                             if columnTypes[i] == 255 {
                                 row.append(.text(GeometryWKBParser.parse(bufferPtr)))
-                            } else if columnIsBit[i] {
-                                row.append(.text(bitFieldToString(bufferPtr)))
+                            } else if MariaDBFieldClassifier.isBit(typeRaw: columnTypes[i]) {
+                                row.append(.text(MariaDBFieldClassifier.bitFieldToString(bufferPtr)))
                             } else if columnIsBinary[i] {
                                 row.append(.bytes(Data(bufferPtr)))
                             } else if let str = String(bytes: bufferPtr, encoding: .utf8) {

--- a/TableProTests/Plugins/MariaDBFieldClassifierTests.swift
+++ b/TableProTests/Plugins/MariaDBFieldClassifierTests.swift
@@ -4,17 +4,67 @@
 //
 
 #if canImport(MySQLDriverPlugin)
+import Foundation
 import Testing
 
 @testable import MySQLDriverPlugin
 
 @Suite("MariaDBFieldClassifier")
 struct MariaDBFieldClassifierTests {
-    @Test("BIT routes to binary regardless of charset")
-    func bitIsBinary() {
-        #expect(MariaDBFieldClassifier.isBinary(typeRaw: 16, charset: 63))
-        #expect(MariaDBFieldClassifier.isBinary(typeRaw: 16, charset: 33))
+    @Test("BIT no longer routes to binary (it was rendering as raw control characters in the data grid)")
+    func bitIsNotBinary() {
+        #expect(!MariaDBFieldClassifier.isBinary(typeRaw: 16, charset: 63))
+        #expect(!MariaDBFieldClassifier.isBinary(typeRaw: 16, charset: 33))
     }
+
+    @Test("isBit identifies type code 16 and only type code 16")
+    func isBitMatchesOnlyBitType() {
+        #expect(MariaDBFieldClassifier.isBit(typeRaw: 16))
+        for typeRaw: UInt32 in [0, 1, 2, 3, 7, 12, 15, 17, 245, 252, 255] {
+            #expect(!MariaDBFieldClassifier.isBit(typeRaw: typeRaw))
+        }
+    }
+
+    @Test("bitFieldToString decodes a single byte big-endian")
+    func bitFieldSingleByte() {
+        #expect(decodeBitField([0x00]) == "0")
+        #expect(decodeBitField([0x01]) == "1")
+        #expect(decodeBitField([0x7f]) == "127")
+        #expect(decodeBitField([0xff]) == "255")
+    }
+
+    @Test("bitFieldToString decodes multi-byte values MSB-first")
+    func bitFieldMultiByte() {
+        #expect(decodeBitField([0x01, 0x00]) == "256")
+        #expect(decodeBitField([0xff, 0xff]) == "65535")
+        #expect(decodeBitField([0x12, 0x34]) == "4660")
+    }
+
+    @Test("bitFieldToString handles BIT(64) up to UInt64.max")
+    func bitField64Bits() {
+        let allOnes: [UInt8] = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        #expect(decodeBitField(allOnes) == "18446744073709551615")
+        let halfPlusOne: [UInt8] = [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        #expect(decodeBitField(halfPlusOne) == "9223372036854775808")
+    }
+
+    @Test("bitFieldToString on an empty buffer returns 0")
+    func bitFieldEmptyBuffer() {
+        #expect(decodeBitField([]) == "0")
+    }
+
+    @Test("Data overload matches the raw-pointer overload")
+    func bitFieldDataOverload() {
+        let bytes: [UInt8] = [0x01, 0xff]
+        let dataResult = MariaDBFieldClassifier.bitFieldToString(Data(bytes))
+        #expect(dataResult == "511")
+        #expect(dataResult == decodeBitField(bytes))
+    }
+
+    private func decodeBitField(_ bytes: [UInt8]) -> String {
+        bytes.withUnsafeBytes { MariaDBFieldClassifier.bitFieldToString($0) }
+    }
+
 
     @Test("BLOB family with binary charset routes to binary")
     func blobFamilyBinary() {


### PR DESCRIPTION
## Summary
MySQL `bit(1)` fields were incorrectly treated as binary data, causing values like `0x01` to display as `^A` (control character).

## Root Cause
- `MariaDBFieldClassifier.isBinary()` returned `true` for `MYSQL_TYPE_BIT` (type code 16), treating bit fields as binary blobs
- Binary values were passed through `BlobFormattingService` and displayed as hex, showing control characters

## Fix
- Remove `MYSQL_TYPE_BIT` from binary classification in `MariaDBFieldClassifier`
- Add `isBit()` detection and `bitFieldToString()` to convert packed binary representation to decimal string
- Propagate `columnIsBit` through all three query execution paths (sync, prepared statements, streaming)

## Result
`del_flag` values now display as `0`/`1` instead of `^A`/`^@`

Fixes #1272