### PR TITLE
refactor(hig): bind .defaultAction/.cancelAction and confirm Remove Provider

### DIFF
--- a/TablePro/Views/Backup/BackupResultSheet.swift
+++ b/TablePro/Views/Backup/BackupResultSheet.swift
@@ -48,7 +48,7 @@ struct BackupResultSheet: View {
                     onClose()
                 }
                 .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.return)
+                .keyboardShortcut(.defaultAction)
             }
         }
         .padding(24)

--- a/TablePro/Views/Connection/ConnectionGroupPicker.swift
+++ b/TablePro/Views/Connection/ConnectionGroupPicker.swift
@@ -153,13 +153,14 @@ struct CreateGroupSheet: View {
                 Button("Cancel") {
                     dismiss()
                 }
+                .keyboardShortcut(.cancelAction)
 
                 Button("Create") {
                     onSave(groupName, groupColor, selectedParentId)
                     dismiss()
                 }
-                .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
                 .disabled(groupName.trimmingCharacters(in: .whitespaces).isEmpty)
             }
         }

--- a/TablePro/Views/Connection/ConnectionTagEditor.swift
+++ b/TablePro/Views/Connection/ConnectionTagEditor.swift
@@ -157,13 +157,14 @@ private struct CreateTagSheet: View {
 
             HStack {
                 Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button("Create") {
                     onSave(tagName, tagColor)
                     dismiss()
                 }
-                .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
                 .disabled(tagName.trimmingCharacters(in: .whitespaces).isEmpty)
             }
             .padding(12)

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -27,6 +27,8 @@ struct AIProviderDetailSheet: View {
     @State private var copilotService = CopilotService.shared
     @State private var copilotErrorMessage: String?
 
+    @State private var showRemoveConfirmation = false
+
     enum TestResult: Equatable {
         case success
         case failure(String)
@@ -89,6 +91,18 @@ struct AIProviderDetailSheet: View {
             }
         }
         .frame(minWidth: 520, minHeight: 480)
+        .confirmationDialog(
+            String(format: String(localized: "Remove “%@”?"), draft.displayName),
+            isPresented: $showRemoveConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Remove Provider"), role: .destructive) {
+                onDelete?()
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(String(localized: "The provider configuration and stored API key will be deleted."))
+        }
     }
 
     private var navigationTitle: String {
@@ -461,7 +475,7 @@ struct AIProviderDetailSheet: View {
     private func deleteSection(onDelete: @escaping () -> Void) -> some View {
         Section {
             Button(role: .destructive) {
-                onDelete()
+                showRemoveConfirmation = true
             } label: {
                 Label(String(localized: "Remove Provider"), systemImage: "trash")
                     .frame(maxWidth: .infinity)

--- a/TablePro/Views/Settings/LicenseActivationSheet.swift
+++ b/TablePro/Views/Settings/LicenseActivationSheet.swift
@@ -73,7 +73,6 @@ struct LicenseActivationSheet: View {
                         dismiss()
                     }
                     .keyboardShortcut(.cancelAction)
-                    .keyboardShortcut(.cancelAction)
                 }
             }
             .padding(.top, 20)

--- a/TablePro/Views/Settings/Sections/PairingApprovalSheet.swift
+++ b/TablePro/Views/Settings/Sections/PairingApprovalSheet.swift
@@ -220,6 +220,8 @@ struct PairingApprovalSheet: View {
                 )
                 onComplete(.success(approval))
             }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
             .disabled(approveDisabled)
         }
     }


### PR DESCRIPTION
## Summary

Round 2 of macOS HIG cleanup, addressing remaining issues found while reviewing the broader codebase:

- **Cancel buttons** in `ConnectionTagEditor`, `ConnectionGroupPicker` — added `.keyboardShortcut(.cancelAction)`.
- **Primary buttons** using `.keyboardShortcut(.return)` in `ConnectionTagEditor`, `ConnectionGroupPicker`, `BackupResultSheet` — changed to `.keyboardShortcut(.defaultAction)`, which also auto-tints the button as the platform default action.
- **`PairingApprovalSheet`** — added `.buttonStyle(.borderedProminent)` + `.keyboardShortcut(.defaultAction)` on the Approve button. Previously plain styled despite being the primary action.
- **`AIProviderDetailSheet`** — "Remove Provider" no longer deletes immediately on click; now triggers a native `.confirmationDialog` with a typed message. Destructive actions should always confirm.
- **`LicenseActivationSheet`** — removed a duplicate `.keyboardShortcut(.cancelAction)` modifier left over from a previous edit.

## Test plan

- [ ] `ConnectionTagEditor`: Esc dismisses, Return creates tag, primary button shows accent tint
- [ ] `ConnectionGroupPicker`: Esc dismisses, Return creates group, primary button shows accent tint
- [ ] `BackupResultSheet`: Return dismisses the Done button correctly
- [ ] `PairingApprovalSheet`: Approve button visually prominent (blue), Return triggers it, Esc denies
- [ ] `AIProviderDetailSheet`: clicking "Remove Provider" now shows a confirmation dialog before deleting; cancel keeps the provider intact
- [ ] `LicenseActivationSheet`: Esc still dismisses the sheet (only one cancelAction binding now)