### PR TITLE
fix(plugins): honor SSL config in Oracle and Cassandra, real 2-pass prefer for MySQL/MariaDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drivers populate allowed enum values directly in column metadata instead of parsing them downstream
 - PluginKit ABI bumped to version 13; all registry plugins need to be re-tagged
-- New PostgreSQL, SQL Server, Redshift, and CockroachDB connections default SSL mode to Preferred, matching libpq and FreeTDS native behavior
+- New PostgreSQL, MySQL, MariaDB, SQL Server, Redshift, and CockroachDB connections default SSL mode to Preferred, matching libpq, libmariadb 2-pass, and FreeTDS native behavior
+- Oracle SSL mode is now honored: Required, Verify CA, and Verify Identity wire through to OracleNIO TCPS (was silently ignored)
+- Cassandra SSL mode is now honored via the standard SSL pane (was silently ignored because the plugin read from a hidden field that was never set)
+- MySQL and MariaDB Preferred SSL mode now performs a real 2-pass connect: tries TLS first, falls back to plaintext only on SSL handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR)
 
 ### Fixed
 
 - PostgreSQL connections to AWS RDS, Cloud SQL, Azure, and other hosted Postgres now succeed out of the box instead of failing with "no pg_hba.conf entry for host" (#1298)
+- Oracle: SSL/TCPS settings from the SSL pane are now respected; previously every Oracle connection was plain TCP regardless of SSL mode
+- Cassandra: SSL settings from the SSL pane are now respected; previously every Cassandra connection was plain TCP because the plugin read from a non-existent "sslMode" field
+- MySQL/MariaDB Cloud SQL, Azure Database, and other hosted MySQL servers that require TLS no longer fail with "Connections using insecure transport are prohibited" when SSL mode is Preferred
 
 ## [0.42.0] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oracle SSL mode is now honored: Required, Verify CA, and Verify Identity wire through to OracleNIO TCPS (was silently ignored)
 - Cassandra SSL mode is now honored via the standard SSL pane (was silently ignored because the plugin read from a hidden field that was never set)
 - MySQL and MariaDB Preferred SSL mode now performs a real 2-pass connect: tries TLS first, falls back to plaintext only on SSL handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR)
+- SSL pane shows per-engine guidance explaining how that driver handles Preferred, when TLS is required by hosted providers, and any driver-specific quirks
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. Covers PostgreSQL, MySQL/MariaDB, SQL Server, Oracle, MongoDB, Redis, Cassandra, and ClickHouse.
 - SSL pane warns inline when a driver does not support TLS fallback for Preferred mode (MongoDB, Redis, Cassandra, ScyllaDB, ClickHouse, Oracle, etcd), so the user knows Preferred behaves the same as Required for that engine.
 - Welcome screen connection errors (single-click connect, sample database launch) also surface the structured SSL handshake message when applicable
+- All driver SSL mapping logic now lives in dedicated `XxxSSLMapping` files (PostgreSQL, MSSQL, Cassandra, MongoDB, Oracle); ClickHouse and Redis keep their existing encapsulated helpers
+
+### Known limitations
+
+- iOS app SSL form still uses a binary Toggle for non-MSSQL engines (mysql, mariadb, postgresql, redshift). Verify CA and Verify Identity are not yet exposed on iOS. macOS users get the full per-engine picker. Will be addressed in a follow-up.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MySQL and MariaDB Preferred SSL mode now performs a real 2-pass connect: tries TLS first, falls back to plaintext only on SSL handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR)
 - SSL pane shows per-engine guidance explaining how that driver handles Preferred, when TLS is required by hosted providers, and any driver-specific quirks
 - Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. Covers PostgreSQL, MySQL/MariaDB, SQL Server, Oracle, MongoDB, Redis, Cassandra, and ClickHouse.
+- SSL pane warns inline when a driver does not support TLS fallback for Preferred mode (MongoDB, Redis, Cassandra, ScyllaDB, ClickHouse, Oracle, etcd), so the user knows Preferred behaves the same as Required for that engine.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SSL pane shows per-engine guidance explaining how that driver handles Preferred, when TLS is required by hosted providers, and any driver-specific quirks
 - Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. Covers PostgreSQL, MySQL/MariaDB, SQL Server, Oracle, MongoDB, Redis, Cassandra, and ClickHouse.
 - SSL pane warns inline when a driver does not support TLS fallback for Preferred mode (MongoDB, Redis, Cassandra, ScyllaDB, ClickHouse, Oracle, etcd), so the user knows Preferred behaves the same as Required for that engine.
+- Welcome screen connection errors (single-click connect, sample database launch) also surface the structured SSL handshake message when applicable
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Welcome screen connection errors (single-click connect, sample database launch) also surface the structured SSL handshake message when applicable
 - All driver SSL mapping logic now lives in dedicated `XxxSSLMapping` files (PostgreSQL, MSSQL, Cassandra, MongoDB, Oracle); ClickHouse and Redis keep their existing encapsulated helpers
 
-### Known limitations
-
-- iOS app SSL form still uses a binary Toggle for non-MSSQL engines (mysql, mariadb, postgresql, redshift). Verify CA and Verify Identity are not yet exposed on iOS. macOS users get the full per-engine picker. Will be addressed in a follow-up.
-
 ### Fixed
 
 - PostgreSQL connections to AWS RDS, Cloud SQL, Azure, and other hosted Postgres now succeed out of the box instead of failing with "no pg_hba.conf entry for host" (#1298)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cassandra SSL mode is now honored via the standard SSL pane (was silently ignored because the plugin read from a hidden field that was never set)
 - MySQL and MariaDB Preferred SSL mode now performs a real 2-pass connect: tries TLS first, falls back to plaintext only on SSL handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR)
 - SSL pane shows per-engine guidance explaining how that driver handles Preferred, when TLS is required by hosted providers, and any driver-specific quirks
+- Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. PostgreSQL and MySQL/MariaDB are translated; other drivers fall back to the raw driver message.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cassandra SSL mode is now honored via the standard SSL pane (was silently ignored because the plugin read from a hidden field that was never set)
 - MySQL and MariaDB Preferred SSL mode now performs a real 2-pass connect: tries TLS first, falls back to plaintext only on SSL handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR)
 - SSL pane shows per-engine guidance explaining how that driver handles Preferred, when TLS is required by hosted providers, and any driver-specific quirks
-- Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. PostgreSQL and MySQL/MariaDB are translated; other drivers fall back to the raw driver message.
+- Failed connections caused by SSL/TLS handshake errors now show a structured message that names the cause (server requires encryption, server rejects encryption, untrusted certificate, hostname mismatch, client cert required, cipher mismatch) and recommends a specific SSL Mode to switch to. Covers PostgreSQL, MySQL/MariaDB, SQL Server, Oracle, MongoDB, Redis, Cassandra, and ClickHouse.
 
 ### Fixed
 

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -136,7 +136,7 @@ private actor CassandraConnectionActor {
         username: String?,
         password: String?,
         keyspace: String?,
-        sslMode: String,
+        sslMode: SSLMode,
         sslCaCertPath: String?
     ) throws {
         cluster = cass_cluster_new()
@@ -151,34 +151,24 @@ private actor CassandraConnectionActor {
             cass_cluster_set_credentials(cluster, username, password)
         }
 
-        // SSL/TLS
-        if sslMode != "Disabled" {
+        if sslMode != .disabled {
             guard let ssl = cass_ssl_new() else {
                 cass_cluster_free(cluster)
                 self.cluster = nil
                 throw CassandraPluginError.connectionFailed("Failed to create SSL context")
             }
 
-            if sslMode == "Verify CA" || sslMode == "Verify Identity" {
-                if sslMode == "Verify Identity" {
-                    let flags = Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue | CASS_SSL_VERIFY_PEER_IDENTITY.rawValue)
-                    cass_ssl_set_verify_flags(ssl, flags)
-                } else {
-                    cass_ssl_set_verify_flags(ssl, Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue))
-                }
+            cass_ssl_set_verify_flags(ssl, CassandraSSLMapping.verifyFlags(for: sslMode))
 
-                if let caCertPath = sslCaCertPath, !caCertPath.isEmpty,
-                   let certData = FileManager.default.contents(atPath: caCertPath),
-                   let certString = String(data: certData, encoding: .utf8) {
-                    let rc = cass_ssl_add_trusted_cert(ssl, certString)
-                    if rc != CASS_OK {
-                        Self.logger.warning("Failed to add CA certificate, proceeding without verification")
-                        cass_ssl_set_verify_flags(ssl, Int32(CASS_SSL_VERIFY_NONE.rawValue))
-                    }
+            if sslMode == .verifyCa || sslMode == .verifyIdentity,
+               let caCertPath = sslCaCertPath, !caCertPath.isEmpty,
+               let certData = FileManager.default.contents(atPath: caCertPath),
+               let certString = String(data: certData, encoding: .utf8) {
+                let rc = cass_ssl_add_trusted_cert(ssl, certString)
+                if rc != CASS_OK {
+                    Self.logger.warning("Failed to add CA certificate, proceeding without verification")
+                    cass_ssl_set_verify_flags(ssl, Int32(CASS_SSL_VERIFY_NONE.rawValue))
                 }
-            } else {
-                // "Preferred" / "Required" — encrypt but skip cert verification
-                cass_ssl_set_verify_flags(ssl, Int32(CASS_SSL_VERIFY_NONE.rawValue))
             }
 
             cass_cluster_set_ssl(cluster, ssl)
@@ -922,11 +912,11 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
 
         try await connectionActor.connect(
             host: config.host,
-            port: Int(config.port) ?? 9042,
+            port: Int(config.port) ?? 9_042,
             username: config.username.isEmpty ? nil : config.username,
             password: config.password.isEmpty ? nil : config.password,
             keyspace: keyspace,
-            sslMode: config.ssl.mode.rawValue,
+            sslMode: config.ssl.mode,
             sslCaCertPath: resolvedCaPath
         )
 

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -221,6 +221,9 @@ private actor CassandraConnectionActor {
             cass_session_free(newSession)
             cass_cluster_free(cluster)
             self.cluster = nil
+            if let sslError = Self.classifySSLError(rc: rc, message: errorMessage) {
+                throw sslError
+            }
             throw CassandraPluginError.connectionFailed(errorMessage)
         }
 
@@ -836,6 +839,26 @@ private actor CassandraConnectionActor {
 
     private func escapeIdentifier(_ value: String) -> String {
         value.replacingOccurrences(of: "\"", with: "\"\"")
+    }
+
+    static func classifySSLError(rc: CassError, message: String) -> SSLHandshakeError? {
+        switch rc {
+        case CASS_ERROR_SSL_NO_PEER_CERT, CASS_ERROR_SSL_INVALID_PEER_CERT:
+            return .untrustedCertificate(serverMessage: message)
+        case CASS_ERROR_SSL_IDENTITY_MISMATCH:
+            return .hostnameMismatch(serverMessage: message)
+        case CASS_ERROR_SSL_INVALID_PRIVATE_KEY, CASS_ERROR_SSL_INVALID_CERT:
+            return .clientCertRequired(serverMessage: message)
+        case CASS_ERROR_SSL_PROTOCOL_ERROR:
+            return .cipherMismatch(serverMessage: message)
+        default:
+            break
+        }
+        let lower = message.lowercased()
+        if lower.contains("ssl") && (lower.contains("handshake") || lower.contains("verify")) {
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
     }
 }
 

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -160,14 +160,26 @@ private actor CassandraConnectionActor {
 
             cass_ssl_set_verify_flags(ssl, CassandraSSLMapping.verifyFlags(for: sslMode))
 
-            if sslMode == .verifyCa || sslMode == .verifyIdentity,
-               let caCertPath = sslCaCertPath, !caCertPath.isEmpty,
-               let certData = FileManager.default.contents(atPath: caCertPath),
-               let certString = String(data: certData, encoding: .utf8) {
+            if sslMode == .verifyCa || sslMode == .verifyIdentity {
+                guard let caCertPath = sslCaCertPath, !caCertPath.isEmpty else {
+                    cass_ssl_free(ssl)
+                    cass_cluster_free(cluster)
+                    self.cluster = nil
+                    throw SSLHandshakeError.untrustedCertificate(serverMessage: "Verify CA or Verify Identity requires a CA certificate path")
+                }
+                guard let certData = FileManager.default.contents(atPath: caCertPath),
+                      let certString = String(data: certData, encoding: .utf8) else {
+                    cass_ssl_free(ssl)
+                    cass_cluster_free(cluster)
+                    self.cluster = nil
+                    throw SSLHandshakeError.untrustedCertificate(serverMessage: "Could not read CA certificate at \(caCertPath)")
+                }
                 let rc = cass_ssl_add_trusted_cert(ssl, certString)
                 if rc != CASS_OK {
-                    Self.logger.warning("Failed to add CA certificate, proceeding without verification")
-                    cass_ssl_set_verify_flags(ssl, Int32(CASS_SSL_VERIFY_NONE.rawValue))
+                    cass_ssl_free(ssl)
+                    cass_cluster_free(cluster)
+                    self.cluster = nil
+                    throw SSLHandshakeError.untrustedCertificate(serverMessage: "CA certificate at \(caCertPath) is not a valid PEM")
                 }
             }
 
@@ -845,7 +857,7 @@ private actor CassandraConnectionActor {
             break
         }
         let lower = message.lowercased()
-        if lower.contains("ssl") && (lower.contains("handshake") || lower.contains("verify")) {
+        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("ssl_connect") {
             return .cipherMismatch(serverMessage: message)
         }
         return nil

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -25,14 +25,7 @@ internal final class CassandraPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let databaseDisplayName = "Cassandra / ScyllaDB"
     static let iconName = "cassandra-icon"
     static let defaultPort = 9042
-    static let additionalConnectionFields: [ConnectionField] = [
-        ConnectionField(
-            id: "sslCaCertPath",
-            label: "CA Certificate",
-            placeholder: "/path/to/ca-cert.pem",
-            section: .advanced
-        ),
-    ]
+    static let additionalConnectionFields: [ConnectionField] = []
     static let additionalDatabaseTypeIds: [String] = ["ScyllaDB"]
 
     // MARK: - UI/Capability Metadata
@@ -900,10 +893,9 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
     // MARK: - Connection
 
     func connect() async throws {
-        let sslMode = config.additionalFields["sslMode"] ?? "Disabled"
-        let sslCaCertPath = config.additionalFields["sslCaCertPath"]
-
         let keyspace = config.database.isEmpty ? nil : config.database
+        let legacyCaPath = config.additionalFields["sslCaCertPath"]
+        let resolvedCaPath = config.ssl.caCertificatePath.isEmpty ? legacyCaPath : config.ssl.caCertificatePath
 
         try await connectionActor.connect(
             host: config.host,
@@ -911,8 +903,8 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
             username: config.username.isEmpty ? nil : config.username,
             password: config.password.isEmpty ? nil : config.password,
             keyspace: keyspace,
-            sslMode: sslMode,
-            sslCaCertPath: sslCaCertPath
+            sslMode: config.ssl.mode.rawValue,
+            sslCaCertPath: resolvedCaPath
         )
 
         if let keyspace {

--- a/Plugins/CassandraDriverPlugin/CassandraSSLMapping.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraSSLMapping.swift
@@ -1,0 +1,18 @@
+import CCassandra
+import Foundation
+import TableProPluginKit
+
+enum CassandraSSLMapping {
+    static func verifyFlags(for mode: SSLMode) -> Int32 {
+        switch mode {
+        case .disabled:
+            return Int32(CASS_SSL_VERIFY_NONE.rawValue)
+        case .preferred, .required:
+            return Int32(CASS_SSL_VERIFY_NONE.rawValue)
+        case .verifyCa:
+            return Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue)
+        case .verifyIdentity:
+            return Int32(CASS_SSL_VERIFY_PEER_CERT.rawValue | CASS_SSL_VERIFY_PEER_IDENTITY.rawValue)
+        }
+    }
+}

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -216,6 +216,9 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             session = nil
             lock.unlock()
             Self.logger.error("Connection test failed: \(error.localizedDescription)")
+            if let sslError = Self.classifySSLError(error) {
+                throw sslError
+            }
             throw ClickHouseError.connectionFailed
         }
 
@@ -1334,6 +1337,29 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         "ALTER TABLE \(quoteIdentifier(table)) DROP INDEX \(quoteIdentifier(indexName))"
     }
 
+    static func classifySSLError(_ error: Error) -> SSLHandshakeError? {
+        let urlError = error as? URLError ?? (error as NSError).underlyingErrors.compactMap { $0 as? URLError }.first
+        if let urlError {
+            switch urlError.code {
+            case .serverCertificateUntrusted, .serverCertificateNotYetValid, .serverCertificateHasUnknownRoot, .serverCertificateHasBadDate:
+                return .untrustedCertificate(serverMessage: urlError.localizedDescription)
+            case .clientCertificateRequired, .clientCertificateRejected:
+                return .clientCertRequired(serverMessage: urlError.localizedDescription)
+            case .secureConnectionFailed:
+                return .cipherMismatch(serverMessage: urlError.localizedDescription)
+            default:
+                break
+            }
+        }
+        let message = error.localizedDescription.lowercased()
+        if message.contains("certificate") && (message.contains("untrusted") || message.contains("verify failed")) {
+            return .untrustedCertificate(serverMessage: error.localizedDescription)
+        }
+        if message.contains("hostname") {
+            return .hostnameMismatch(serverMessage: error.localizedDescription)
+        }
+        return nil
+    }
 }
 
 // MARK: - TLS Delegate

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -166,6 +166,9 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
         guard let proc = dbopen(login, serverName) else {
             let detail = freetdsGetError(for: nil)
             let msg = detail.isEmpty ? "Check host, port, credentials, and TLS settings" : detail
+            if let sslError = FreeTDSConnection.classifySSLError(detail) {
+                throw sslError
+            }
             throw MSSQLCoreError.connectionFailed("Failed to connect to \(options.host):\(options.port): \(msg)")
         }
 
@@ -526,5 +529,25 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
             return MSSQLDatetimeFormatter.reformat(raw, type: type) ?? raw
         }
         return raw
+    }
+
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("encryption is required") || lower.contains("server requires encryption") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("encryption not supported") || lower.contains("server does not support encryption") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("certificate is not trusted") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("does not match host") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
     }
 }

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -546,7 +546,7 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
         if lower.contains("does not match host") {
             return .hostnameMismatch(serverMessage: message)
         }
-        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl") {
+        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl error") {
             return .cipherMismatch(serverMessage: message)
         }
         return nil

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -13,6 +13,7 @@ import CFreeTDS
 import Foundation
 import os
 import TableProMSSQLCore
+import TableProPluginKit
 
 private let freetdsLogger = Logger(subsystem: "com.TablePro", category: "FreeTDSConnection")
 

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -1268,7 +1268,7 @@ private extension MongoDBConnection {
         if lower.contains("tls required") || lower.contains("ssl required") {
             return .serverRejectedPlaintext(serverMessage: message)
         }
-        if lower.contains("client certificate") {
+        if lower.contains("client certificate required") || lower.contains("peer did not return a certificate") {
             return .clientCertRequired(serverMessage: message)
         }
         return nil

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -322,6 +322,9 @@ final class MongoDBConnection: @unchecked Sendable {
                 let errorMsg = bsonErrorMessage(&error)
                 mongoc_client_destroy(newClient)
                 logger.error("MongoDB ping failed: \(errorMsg)")
+                if let sslError = Self.classifySSLError(errorMsg) {
+                    throw sslError
+                }
                 throw MongoDBError(code: error.code, message: errorMsg)
             }
 
@@ -1271,6 +1274,26 @@ private extension MongoDBConnection {
         #else
         return nil
         #endif
+    }
+
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("ssl handshake failed") || lower.contains("tls handshake failed") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("ssl certificate") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("hostname") && lower.contains("verification") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("tls required") || lower.contains("ssl required") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        return nil
     }
 }
 

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -222,29 +222,7 @@ final class MongoDBConnection: @unchecked Sendable {
             "authSource=\(encodedAuthSource)"
         ]
 
-        if ssl.isEnabled {
-            params.append("tls=true")
-            switch ssl.mode {
-            case .preferred, .required:
-                params.append("tlsAllowInvalidCertificates=true")
-            case .verifyCa:
-                params.append("tlsAllowInvalidHostnames=true")
-            case .disabled, .verifyIdentity:
-                break
-            }
-            if ssl.verifiesCertificate, !ssl.caCertificatePath.isEmpty {
-                let encodedCaPath = ssl.caCertificatePath
-                    .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    ?? ssl.caCertificatePath
-                params.append("tlsCAFile=\(encodedCaPath)")
-            }
-            if !ssl.clientCertificatePath.isEmpty {
-                let encodedCertPath = ssl.clientCertificatePath
-                    .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    ?? ssl.clientCertificatePath
-                params.append("tlsCertificateKeyFile=\(encodedCertPath)")
-            }
-        }
+        params.append(contentsOf: MongoDBSSLMapping.uriParameters(for: ssl))
 
         if let rp = readPreference, !rp.isEmpty {
             params.append("readPreference=\(rp)")

--- a/Plugins/MongoDBDriverPlugin/MongoDBSSLMapping.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBSSLMapping.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TableProPluginKit
+
+enum MongoDBSSLMapping {
+    static func uriParameters(for ssl: SSLConfiguration) -> [String] {
+        guard ssl.isEnabled else { return [] }
+        var params: [String] = ["tls=true"]
+        switch ssl.mode {
+        case .preferred, .required:
+            params.append("tlsAllowInvalidCertificates=true")
+        case .verifyCa:
+            params.append("tlsAllowInvalidHostnames=true")
+        case .disabled, .verifyIdentity:
+            break
+        }
+        if ssl.verifiesCertificate, !ssl.caCertificatePath.isEmpty {
+            let encoded = ssl.caCertificatePath
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                ?? ssl.caCertificatePath
+            params.append("tlsCAFile=\(encoded)")
+        }
+        if !ssl.clientCertificatePath.isEmpty {
+            let encoded = ssl.clientCertificatePath
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                ?? ssl.clientCertificatePath
+            params.append("tlsCertificateKeyFile=\(encoded)")
+        }
+        return params
+    }
+}

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -213,7 +213,19 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 handle = try self.attemptConnect(enforceSSL: mode != .disabled)
             } catch let error as MariaDBPluginError where mode == .preferred && Self.sslOnlyErrorCodes.contains(error.code) {
                 logger.notice("MySQL SSL handshake failed (code \(error.code)); falling back to plaintext for .preferred mode")
-                handle = try self.attemptConnect(enforceSSL: false)
+                do {
+                    handle = try self.attemptConnect(enforceSSL: false)
+                } catch let fallbackError as MariaDBPluginError {
+                    if let sslError = Self.classifySSLError(fallbackError) {
+                        throw sslError
+                    }
+                    throw fallbackError
+                }
+            } catch let error as MariaDBPluginError {
+                if let sslError = Self.classifySSLError(error) {
+                    throw sslError
+                }
+                throw error
             }
 
             if let versionPtr = mysql_get_server_info(handle) {
@@ -225,6 +237,20 @@ final class MariaDBPluginConnection: @unchecked Sendable {
             self._isConnected = true
             self.stateLock.unlock()
         }
+    }
+
+    static func classifySSLError(_ error: MariaDBPluginError) -> SSLHandshakeError? {
+        let lower = error.message.lowercased()
+        if lower.contains("insecure transport") || lower.contains("require_secure_transport") {
+            return .serverRejectedPlaintext(serverMessage: error.message)
+        }
+        if Self.sslOnlyErrorCodes.contains(error.code) {
+            if lower.contains("certificate") {
+                return .untrustedCertificate(serverMessage: error.message)
+            }
+            return .cipherMismatch(serverMessage: error.message)
+        }
+        return nil
     }
 
     private func attemptConnect(enforceSSL: Bool) throws -> UnsafeMutablePointer<MYSQL> {

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -199,133 +199,131 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
     // MARK: - Connection Management
 
+    private static let sslOnlyErrorCodes: Set<UInt32> = [
+        2_026,
+        2_012,
+        1_043
+    ]
+
     func connect() async throws {
         try await pluginDispatchAsync(on: queue) { [self] in
-            guard let mysql = mysql_init(nil) else {
-                throw MariaDBPluginError.initFailed
+            let mode = self.sslConfig.mode
+            let handle: UnsafeMutablePointer<MYSQL>
+            do {
+                handle = try self.attemptConnect(enforceSSL: mode != .disabled)
+            } catch let error as MariaDBPluginError where mode == .preferred && Self.sslOnlyErrorCodes.contains(error.code) {
+                logger.notice("MySQL SSL handshake failed (code \(error.code)); falling back to plaintext for .preferred mode")
+                handle = try self.attemptConnect(enforceSSL: false)
             }
 
-            self.mysql = mysql
-
-            var reconnect: my_bool = 0
-            mysql_options(mysql, MYSQL_OPT_RECONNECT, &reconnect)
-
-            var timeout: UInt32 = 10
-            mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout)
-
-            var readTimeout: UInt32 = 30
-            mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, &readTimeout)
-
-            var writeTimeout: UInt32 = 30
-            mysql_options(mysql, MYSQL_OPT_WRITE_TIMEOUT, &writeTimeout)
-
-            var protocol_tcp = UInt32(MYSQL_PROTOCOL_TCP.rawValue)
-            mysql_options(mysql, MYSQL_OPT_PROTOCOL, &protocol_tcp)
-
-            switch self.sslConfig.mode {
-            case .disabled, .preferred:
-                var sslEnforce: my_bool = 0
-                mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &sslEnforce)
-                var sslVerify: my_bool = 0
-                mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &sslVerify)
-
-            case .required:
-                var sslEnforce: my_bool = 1
-                mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &sslEnforce)
-                var sslVerify: my_bool = 0
-                mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &sslVerify)
-
-            case .verifyCa, .verifyIdentity:
-                var sslEnforce: my_bool = 1
-                mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &sslEnforce)
-                var sslVerify: my_bool = 1
-                mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &sslVerify)
-            }
-
-            if self.sslConfig.verifiesCertificate, !self.sslConfig.caCertificatePath.isEmpty {
-                _ = self.sslConfig.caCertificatePath.withCString { path in
-                    mysql_options(mysql, MYSQL_OPT_SSL_CA, path)
-                }
-            }
-            if !self.sslConfig.clientCertificatePath.isEmpty {
-                _ = self.sslConfig.clientCertificatePath.withCString { path in
-                    mysql_options(mysql, MYSQL_OPT_SSL_CERT, path)
-                }
-            }
-            if !self.sslConfig.clientKeyPath.isEmpty {
-                _ = self.sslConfig.clientKeyPath.withCString { path in
-                    mysql_options(mysql, MYSQL_OPT_SSL_KEY, path)
-                }
-            }
-
-            mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8mb4")
-
-            let dbToUse = self.database.isEmpty ? nil : self.database
-            let passToUse = self.password
-
-            let result: UnsafeMutablePointer<MYSQL>?
-
-            if let db = dbToUse, let pass = passToUse {
-                result = self.host.withCString { hostPtr in
-                    self.user.withCString { userPtr in
-                        pass.withCString { passPtr in
-                            db.withCString { dbPtr in
-                                mysql_real_connect(
-                                    mysql, hostPtr, userPtr, passPtr, dbPtr,
-                                    self.port, nil, 0
-                                )
-                            }
-                        }
-                    }
-                }
-            } else if let db = dbToUse {
-                result = self.host.withCString { hostPtr in
-                    self.user.withCString { userPtr in
-                        db.withCString { dbPtr in
-                            mysql_real_connect(
-                                mysql, hostPtr, userPtr, nil, dbPtr,
-                                self.port, nil, 0
-                            )
-                        }
-                    }
-                }
-            } else if let pass = passToUse {
-                result = self.host.withCString { hostPtr in
-                    self.user.withCString { userPtr in
-                        pass.withCString { passPtr in
-                            mysql_real_connect(
-                                mysql, hostPtr, userPtr, passPtr, nil,
-                                self.port, nil, 0
-                            )
-                        }
-                    }
-                }
-            } else {
-                result = self.host.withCString { hostPtr in
-                    self.user.withCString { userPtr in
-                        mysql_real_connect(
-                            mysql, hostPtr, userPtr, nil, nil,
-                            self.port, nil, 0
-                        )
-                    }
-                }
-            }
-
-            if result == nil {
-                let error = self.getError()
-                mysql_close(mysql)
-                self.mysql = nil
-                throw error
-            }
-
-            if let versionPtr = mysql_get_server_info(mysql) {
+            if let versionPtr = mysql_get_server_info(handle) {
                 self._cachedServerVersion = String(cString: versionPtr)
             }
 
             self.stateLock.lock()
+            self.mysql = handle
             self._isConnected = true
             self.stateLock.unlock()
         }
+    }
+
+    private func attemptConnect(enforceSSL: Bool) throws -> UnsafeMutablePointer<MYSQL> {
+        guard let mysql = mysql_init(nil) else {
+            throw MariaDBPluginError.initFailed
+        }
+
+        var reconnect: my_bool = 0
+        mysql_options(mysql, MYSQL_OPT_RECONNECT, &reconnect)
+
+        var timeout: UInt32 = 10
+        mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout)
+
+        var readTimeout: UInt32 = 30
+        mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, &readTimeout)
+
+        var writeTimeout: UInt32 = 30
+        mysql_options(mysql, MYSQL_OPT_WRITE_TIMEOUT, &writeTimeout)
+
+        var protocol_tcp = UInt32(MYSQL_PROTOCOL_TCP.rawValue)
+        mysql_options(mysql, MYSQL_OPT_PROTOCOL, &protocol_tcp)
+
+        var sslEnforce: my_bool = enforceSSL ? 1 : 0
+        mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &sslEnforce)
+
+        var sslVerify: my_bool = sslConfig.verifiesCertificate ? 1 : 0
+        mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &sslVerify)
+
+        if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
+            _ = sslConfig.caCertificatePath.withCString { mysql_options(mysql, MYSQL_OPT_SSL_CA, $0) }
+        }
+        if !sslConfig.clientCertificatePath.isEmpty {
+            _ = sslConfig.clientCertificatePath.withCString { mysql_options(mysql, MYSQL_OPT_SSL_CERT, $0) }
+        }
+        if !sslConfig.clientKeyPath.isEmpty {
+            _ = sslConfig.clientKeyPath.withCString { mysql_options(mysql, MYSQL_OPT_SSL_KEY, $0) }
+        }
+
+        mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8mb4")
+
+        let dbToUse = database.isEmpty ? nil : database
+        let passToUse = password
+
+        let result: UnsafeMutablePointer<MYSQL>?
+        if let db = dbToUse, let pass = passToUse {
+            result = host.withCString { hostPtr in
+                user.withCString { userPtr in
+                    pass.withCString { passPtr in
+                        db.withCString { dbPtr in
+                            mysql_real_connect(mysql, hostPtr, userPtr, passPtr, dbPtr, port, nil, 0)
+                        }
+                    }
+                }
+            }
+        } else if let db = dbToUse {
+            result = host.withCString { hostPtr in
+                user.withCString { userPtr in
+                    db.withCString { dbPtr in
+                        mysql_real_connect(mysql, hostPtr, userPtr, nil, dbPtr, port, nil, 0)
+                    }
+                }
+            }
+        } else if let pass = passToUse {
+            result = host.withCString { hostPtr in
+                user.withCString { userPtr in
+                    pass.withCString { passPtr in
+                        mysql_real_connect(mysql, hostPtr, userPtr, passPtr, nil, port, nil, 0)
+                    }
+                }
+            }
+        } else {
+            result = host.withCString { hostPtr in
+                user.withCString { userPtr in
+                    mysql_real_connect(mysql, hostPtr, userPtr, nil, nil, port, nil, 0)
+                }
+            }
+        }
+
+        if result == nil {
+            let error = readError(from: mysql)
+            mysql_close(mysql)
+            throw error
+        }
+        return mysql
+    }
+
+    private func readError(from mysql: UnsafeMutablePointer<MYSQL>) -> MariaDBPluginError {
+        let code = mysql_errno(mysql)
+        let message: String
+        if let msgPtr = mysql_error(mysql) {
+            message = String(cString: msgPtr)
+        } else {
+            message = "Unknown error"
+        }
+        var sqlState: String?
+        if let statePtr = mysql_sqlstate(mysql), statePtr[0] != 0 {
+            sqlState = String(cString: statePtr)
+        }
+        return MariaDBPluginError(code: code, message: message, sqlState: sqlState)
     }
 
     func disconnect() {

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Logging
 import NIOCore
+import NIOSSL
 import OracleNIO
 import OSLog
 import TableProPluginKit
@@ -116,6 +117,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     private let password: String
     private let database: String
     private let serviceName: String
+    private let sslConfig: SSLConfiguration
 
     private struct LockedState: Sendable {
         var isConnected = false
@@ -131,25 +133,36 @@ final class OracleConnectionWrapper: @unchecked Sendable {
 
     // MARK: - Initialization
 
-    init(host: String, port: Int, user: String, password: String, database: String, serviceName: String = "") {
+    init(
+        host: String,
+        port: Int,
+        user: String,
+        password: String,
+        database: String,
+        serviceName: String = "",
+        sslConfig: SSLConfiguration = SSLConfiguration()
+    ) {
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.database = database
         self.serviceName = serviceName
+        self.sslConfig = sslConfig
     }
 
     // MARK: - Connection
 
     func connect() async throws {
         let service = serviceName.isEmpty ? database : serviceName
+        let tls = try buildTLS()
         let config = OracleNIO.OracleConnection.Configuration(
             host: host,
             port: port,
             service: .serviceName(service),
             username: user,
-            password: password
+            password: password,
+            tls: tls
         )
 
         let connectionId = Self.connectionCounter.withLock { state -> Int in
@@ -193,6 +206,41 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             return .authVersionNotSupported
         default:
             return .connectionFailed
+        }
+    }
+
+    private func buildTLS() throws -> OracleNIO.OracleConnection.Configuration.TLS {
+        switch sslConfig.mode {
+        case .disabled:
+            return .disable
+        case .preferred:
+            osLogger.warning("Oracle SSL mode 'Preferred' is not supported by OracleNIO; falling back to plain TCP. Use 'Required' to enforce TCPS.")
+            return .disable
+        case .required, .verifyCa, .verifyIdentity:
+            var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+            tlsConfiguration.certificateVerification = certificateVerification(for: sslConfig.mode)
+            if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
+                let caCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.caCertificatePath)
+                tlsConfiguration.trustRoots = .certificates(caCerts)
+            }
+            if !sslConfig.clientCertificatePath.isEmpty {
+                let clientCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.clientCertificatePath)
+                tlsConfiguration.certificateChain = clientCerts.map { .certificate($0) }
+            }
+            if !sslConfig.clientKeyPath.isEmpty {
+                let key = try NIOSSLPrivateKey(file: sslConfig.clientKeyPath, format: .pem)
+                tlsConfiguration.privateKey = .privateKey(key)
+            }
+            let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
+            return .require(sslContext)
+        }
+    }
+
+    private func certificateVerification(for mode: SSLMode) -> CertificateVerification {
+        switch mode {
+        case .verifyIdentity: return .fullVerification
+        case .verifyCa: return .noHostnameVerification
+        case .required, .preferred, .disabled: return .none
         }
     }
 

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -186,13 +186,44 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         } catch let sqlError as OracleSQLError {
             let detail = sqlError.serverInfo?.message ?? sqlError.description
             osLogger.error("Oracle connection failed: \(detail)")
+            if let sslError = Self.classifySSLError(detail) {
+                throw sslError
+            }
             throw OracleError(message: detail, category: classifyConnectError(sqlError))
+        } catch let nioSslError as NIOSSLError {
+            let detail = String(describing: nioSslError)
+            osLogger.error("Oracle TLS error: \(detail)")
+            throw Self.classifySSLError(detail) ?? SSLHandshakeError.unknown(serverMessage: detail)
         } catch {
             let detail = String(describing: error)
             osLogger.error("Oracle connection failed: \(detail)")
+            if let sslError = Self.classifySSLError(detail) {
+                throw sslError
+            }
             throw OracleError(message: detail, category: .connectionFailed)
         }
     }
+
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("ora-28759") || lower.contains("failure to open file") && lower.contains("wallet") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        if lower.contains("ora-29024") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ora-28860") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ora-12537") || lower.contains("ora-12606") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate") && (lower.contains("verify") || lower.contains("untrusted")) {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        return nil
+    }
+
 
     private func classifyConnectError(_ error: OracleSQLError) -> OracleError.Category {
         let codeDescription = error.code.description

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -155,7 +155,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
 
     func connect() async throws {
         let service = serviceName.isEmpty ? database : serviceName
-        let tls = try buildTLS()
+        let tls = try OracleSSLMapping.tls(for: sslConfig)
         let config = OracleNIO.OracleConnection.Configuration(
             host: host,
             port: port,
@@ -237,41 +237,6 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             return .authVersionNotSupported
         default:
             return .connectionFailed
-        }
-    }
-
-    private func buildTLS() throws -> OracleNIO.OracleConnection.Configuration.TLS {
-        switch sslConfig.mode {
-        case .disabled:
-            return .disable
-        case .preferred:
-            osLogger.warning("Oracle SSL mode 'Preferred' is not supported by OracleNIO; falling back to plain TCP. Use 'Required' to enforce TCPS.")
-            return .disable
-        case .required, .verifyCa, .verifyIdentity:
-            var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
-            tlsConfiguration.certificateVerification = certificateVerification(for: sslConfig.mode)
-            if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
-                let caCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.caCertificatePath)
-                tlsConfiguration.trustRoots = .certificates(caCerts)
-            }
-            if !sslConfig.clientCertificatePath.isEmpty {
-                let clientCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.clientCertificatePath)
-                tlsConfiguration.certificateChain = clientCerts.map { .certificate($0) }
-            }
-            if !sslConfig.clientKeyPath.isEmpty {
-                let key = try NIOSSLPrivateKey(file: sslConfig.clientKeyPath, format: .pem)
-                tlsConfiguration.privateKey = .privateKey(key)
-            }
-            let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
-            return .require(sslContext)
-        }
-    }
-
-    private func certificateVerification(for mode: SSLMode) -> CertificateVerification {
-        switch mode {
-        case .verifyIdentity: return .fullVerification
-        case .verifyCa: return .noHostnameVerification
-        case .required, .preferred, .disabled: return .none
         }
     }
 

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -215,9 +215,6 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         if lower.contains("ora-28860") {
             return .cipherMismatch(serverMessage: message)
         }
-        if lower.contains("ora-12537") || lower.contains("ora-12606") {
-            return .serverRejectedPlaintext(serverMessage: message)
-        }
         if lower.contains("certificate") && (lower.contains("verify") || lower.contains("untrusted")) {
             return .untrustedCertificate(serverMessage: message)
         }

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -192,7 +192,8 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             user: config.username,
             password: config.password,
             database: config.database,
-            serviceName: serviceName
+            serviceName: serviceName,
+            sslConfig: config.ssl
         )
         try await conn.connect()
         self.oracleConn = conn

--- a/Plugins/OracleDriverPlugin/OracleSSLMapping.swift
+++ b/Plugins/OracleDriverPlugin/OracleSSLMapping.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Logging
+import NIOSSL
+import OracleNIO
+import OSLog
+import TableProPluginKit
+
+private let osLogger = Logger(subsystem: "com.TablePro.OracleDriver", category: "OracleSSLMapping")
+
+enum OracleSSLMapping {
+    static func tls(for sslConfig: SSLConfiguration) throws -> OracleNIO.OracleConnection.Configuration.TLS {
+        switch sslConfig.mode {
+        case .disabled:
+            return .disable
+        case .preferred:
+            osLogger.warning("Oracle SSL mode 'Preferred' is not supported by OracleNIO; falling back to plain TCP. Use 'Required' to enforce TCPS.")
+            return .disable
+        case .required, .verifyCa, .verifyIdentity:
+            var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+            tlsConfiguration.certificateVerification = certificateVerification(for: sslConfig.mode)
+            if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
+                let caCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.caCertificatePath)
+                tlsConfiguration.trustRoots = .certificates(caCerts)
+            }
+            if !sslConfig.clientCertificatePath.isEmpty {
+                let clientCerts = try NIOSSLCertificate.fromPEMFile(sslConfig.clientCertificatePath)
+                tlsConfiguration.certificateChain = clientCerts.map { .certificate($0) }
+            }
+            if !sslConfig.clientKeyPath.isEmpty {
+                let key = try NIOSSLPrivateKey(file: sslConfig.clientKeyPath, format: .pem)
+                tlsConfiguration.privateKey = .privateKey(key)
+            }
+            let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
+            return .require(sslContext)
+        }
+    }
+
+    static func certificateVerification(for mode: SSLMode) -> CertificateVerification {
+        switch mode {
+        case .verifyIdentity: return .fullVerification
+        case .verifyCa: return .noHostnameVerification
+        case .required, .preferred, .disabled: return .none
+        }
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -196,6 +196,9 @@ final class LibPQPluginConnection: @unchecked Sendable {
             if PQstatus(connection) != CONNECTION_OK {
                 let error = self.getError(from: connection)
                 PQfinish(connection)
+                if let sslError = Self.classifySSLError(error.message) {
+                    throw sslError
+                }
                 throw error
             }
 
@@ -733,6 +736,32 @@ final class LibPQPluginConnection: @unchecked Sendable {
     }
 
     // MARK: - Private Helpers
+
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("no pg_hba.conf entry") && lower.contains("no encryption") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("no pg_hba.conf entry") && lower.contains("ssl") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("server does not support ssl") || lower.contains("ssl is not enabled on the server") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("self-signed certificate") || lower.contains("unable to get local issuer certificate") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("server certificate") && lower.contains("does not match host name") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("certificate required") || lower.contains("connection requires a valid client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        if lower.contains("ssl error") || lower.contains("tls handshake") || lower.contains("ssl handshake") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
+    }
 
     private func getError(from conn: OpaquePointer) -> LibPQPluginError {
         var message = "Unknown error"

--- a/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
@@ -393,6 +393,26 @@ final class RedisPluginConnection: @unchecked Sendable {
         throw RedisPluginError.hiredisUnavailable
         #endif
     }
+
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("certificate verify failed") || lower.contains("unable to get local issuer") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("hostname") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("sslv3") || lower.contains("unsupported protocol") || lower.contains("no shared cipher") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ssl handshake failed") || lower.contains("tlsv1") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        return nil
+    }
 }
 
 // MARK: - Synchronous Helpers (must be called on the serial queue)
@@ -439,6 +459,9 @@ private extension RedisPluginConnection {
             redisFreeSSLContext(ssl)
             let errMsg = withUnsafePointer(to: &ctx.pointee.errstr) { ptr in
                 ptr.withMemoryRebound(to: CChar.self, capacity: 128) { String(cString: $0) }
+            }
+            if let sslError = Self.classifySSLError(errMsg) {
+                throw sslError
             }
             throw RedisPluginError(code: Int(result), message: "SSL handshake failed: \(errMsg)")
         }

--- a/Plugins/TableProPluginKit/SSLHandshakeError.swift
+++ b/Plugins/TableProPluginKit/SSLHandshakeError.swift
@@ -41,6 +41,21 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
         }
     }
 
+    public static func formatted(_ error: Error) -> String {
+        guard let sslError = error as? SSLHandshakeError else {
+            return error.localizedDescription
+        }
+        var parts: [String] = []
+        if let description = sslError.errorDescription {
+            parts.append(description)
+        }
+        if let suggestion = sslError.recoverySuggestion {
+            parts.append(suggestion)
+        }
+        parts.append(String(format: String(localized: "Server response: %@"), sslError.serverMessage))
+        return parts.joined(separator: "\n\n")
+    }
+
     public var recoverySuggestion: String? {
         switch self {
         case .serverRejectedPlaintext:

--- a/Plugins/TableProPluginKit/SSLHandshakeError.swift
+++ b/Plugins/TableProPluginKit/SSLHandshakeError.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum SSLHandshakeError: Error, LocalizedError, Sendable {
+    case serverRejectedPlaintext(serverMessage: String)
+    case serverRequiresPlaintext(serverMessage: String)
+    case untrustedCertificate(serverMessage: String)
+    case hostnameMismatch(serverMessage: String)
+    case clientCertRequired(serverMessage: String)
+    case cipherMismatch(serverMessage: String)
+    case unknown(serverMessage: String)
+
+    public var serverMessage: String {
+        switch self {
+        case .serverRejectedPlaintext(let msg),
+             .serverRequiresPlaintext(let msg),
+             .untrustedCertificate(let msg),
+             .hostnameMismatch(let msg),
+             .clientCertRequired(let msg),
+             .cipherMismatch(let msg),
+             .unknown(let msg):
+            return msg
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .serverRejectedPlaintext:
+            return String(localized: "The server requires an encrypted connection but TablePro is configured to connect in plain text.")
+        case .serverRequiresPlaintext:
+            return String(localized: "The server does not accept encrypted connections but TablePro is configured to require TLS.")
+        case .untrustedCertificate:
+            return String(localized: "The server's TLS certificate could not be verified against any trusted root.")
+        case .hostnameMismatch:
+            return String(localized: "The server's TLS certificate does not match the hostname being connected to.")
+        case .clientCertRequired:
+            return String(localized: "The server requires a client certificate for TLS mutual authentication.")
+        case .cipherMismatch:
+            return String(localized: "The server and TablePro could not agree on a TLS cipher or protocol version.")
+        case .unknown:
+            return String(localized: "TLS handshake failed.")
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .serverRejectedPlaintext:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and set Mode to Required (or stricter).")
+        case .serverRequiresPlaintext:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and set Mode to Disabled.")
+        case .untrustedCertificate:
+            return String(localized: "Switch SSL Mode to Verify CA and provide the server's CA certificate path, or use Required to skip verification.")
+        case .hostnameMismatch:
+            return String(localized: "Switch SSL Mode to Verify CA (validates the CA chain but skips hostname check), or update the host field to match the certificate.")
+        case .clientCertRequired:
+            return String(localized: "Provide the client certificate and key paths in the SSL tab.")
+        case .cipherMismatch:
+            return String(localized: "Update the server's TLS configuration or use a newer database server version that supports modern ciphers.")
+        case .unknown:
+            return nil
+        }
+    }
+}

--- a/Plugins/TableProPluginKit/SSLHandshakeError.swift
+++ b/Plugins/TableProPluginKit/SSLHandshakeError.swift
@@ -52,8 +52,23 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
         if let suggestion = sslError.recoverySuggestion {
             parts.append(suggestion)
         }
-        parts.append(String(format: String(localized: "Server response: %@"), sslError.serverMessage))
+        parts.append(String(format: String(localized: "Server response: %@"), sanitize(sslError.serverMessage)))
         return parts.joined(separator: "\n\n")
+    }
+
+    static func sanitize(_ message: String) -> String {
+        var redacted = message
+        let userInfo = try? NSRegularExpression(pattern: "://[^/@\\s]+:[^/@\\s]+@", options: [])
+        if let userInfo {
+            let range = NSRange(redacted.startIndex..<redacted.endIndex, in: redacted)
+            redacted = userInfo.stringByReplacingMatches(in: redacted, options: [], range: range, withTemplate: "://[redacted]@")
+        }
+        let kvPattern = try? NSRegularExpression(pattern: "(password|passwd|pwd)\\s*=\\s*\\S+", options: [.caseInsensitive])
+        if let kvPattern {
+            let range = NSRange(redacted.startIndex..<redacted.endIndex, in: redacted)
+            redacted = kvPattern.stringByReplacingMatches(in: redacted, options: [], range: range, withTemplate: "$1=[redacted]")
+        }
+        return redacted
     }
 
     public var recoverySuggestion: String? {
@@ -63,7 +78,10 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
         case .serverRequiresPlaintext:
             return String(localized: "Open the connection editor, switch to the SSL tab, and set Mode to Disabled.")
         case .untrustedCertificate:
-            return String(localized: "Switch SSL Mode to Verify CA and provide the server's CA certificate path, or use Required to skip verification.")
+            return String(localized: """
+                Switch SSL Mode to Verify CA and provide the server's CA certificate path. \
+                Required mode also connects, but does not validate the certificate chain.
+                """)
         case .hostnameMismatch:
             return String(localized: "Switch SSL Mode to Verify CA (validates the CA chain but skips hostname check), or update the host field to match the certificate.")
         case .clientCertRequired:

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -528,7 +528,8 @@ extension PluginMetadataRegistry {
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
-                    supportsDropDatabase: true
+                    supportsDropDatabase: true,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -609,7 +610,8 @@ extension PluginMetadataRegistry {
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
-                    supportsDropDatabase: false
+                    supportsDropDatabase: false,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -717,7 +719,8 @@ extension PluginMetadataRegistry {
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: false,
-                    supportsRenameColumn: true
+                    supportsRenameColumn: true,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -777,7 +780,8 @@ extension PluginMetadataRegistry {
                     supportsQueryProgress: true,
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
-                    supportsModifyPrimaryKey: false
+                    supportsModifyPrimaryKey: false,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -877,7 +881,8 @@ extension PluginMetadataRegistry {
                     supportsModifyColumn: false,
                     supportsAddIndex: false,
                     supportsDropIndex: false,
-                    supportsModifyPrimaryKey: false
+                    supportsModifyPrimaryKey: false,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -938,7 +943,8 @@ extension PluginMetadataRegistry {
                     supportsModifyColumn: false,
                     supportsAddIndex: false,
                     supportsDropIndex: false,
-                    supportsModifyPrimaryKey: false
+                    supportsModifyPrimaryKey: false,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -994,7 +1000,8 @@ extension PluginMetadataRegistry {
                     supportsReadOnlyMode: false,
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
-                    supportsDropDatabase: false
+                    supportsDropDatabase: false,
+                    supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -444,7 +444,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
-                    supportsRenameColumn: true
+                    supportsRenameColumn: true,
+                    defaultSSLMode: .preferred
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -490,7 +491,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
-                    supportsRenameColumn: true
+                    supportsRenameColumn: true,
+                    defaultSSLMode: .preferred
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -60,6 +60,7 @@ struct PluginMetadataSnapshot: Sendable {
         var supportsDropIndex: Bool = true
         var supportsModifyPrimaryKey: Bool = true
         var defaultSSLMode: SSLMode = .disabled
+        var supportsOpportunisticTLS: Bool = true
 
         static let defaults = CapabilityFlags(
             supportsSchemaSwitching: false,
@@ -80,7 +81,8 @@ struct PluginMetadataSnapshot: Sendable {
             supportsAddIndex: true,
             supportsDropIndex: true,
             supportsModifyPrimaryKey: true,
-            defaultSSLMode: .disabled
+            defaultSSLMode: .disabled,
+            supportsOpportunisticTLS: true
         )
     }
 
@@ -882,7 +884,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 supportsAddIndex: driverType.supportsAddIndex,
                 supportsDropIndex: driverType.supportsDropIndex,
                 supportsModifyPrimaryKey: driverType.supportsModifyPrimaryKey,
-                defaultSSLMode: existingSnapshot?.capabilities.defaultSSLMode ?? .disabled
+                defaultSSLMode: existingSnapshot?.capabilities.defaultSSLMode ?? .disabled,
+                supportsOpportunisticTLS: existingSnapshot?.capabilities.supportsOpportunisticTLS ?? true
             ),
             schema: PluginMetadataSnapshot.SchemaInfo(
                 defaultSchemaName: driverType.defaultSchemaName,

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -766,9 +766,15 @@ private struct StoredConnection: Codable {
             resolvedTunnelMode = .disabled
         }
 
+        var resolvedSSLCaPath = sslCaCertificatePath
+        if type == "Cassandra", resolvedSSLCaPath.isEmpty,
+           let legacy = additionalFields?["sslCaCertPath"], !legacy.isEmpty {
+            resolvedSSLCaPath = legacy
+        }
+
         let sslConfig = SSLConfiguration(
             mode: SSLMode(rawValue: sslMode) ?? .disabled,
-            caCertificatePath: sslCaCertificatePath,
+            caCertificatePath: resolvedSSLCaPath,
             clientCertificatePath: sslClientCertificatePath,
             clientKeyPath: sslClientKeyPath
         )

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -109,6 +109,38 @@ extension DatabaseType {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.defaultSSLMode ?? .disabled
     }
 
+    var sslPaneTooltip: String {
+        switch rawValue {
+        case "PostgreSQL", "Redshift", "CockroachDB":
+            return String(localized: """
+                Preferred tries TLS first, falls back to plain. Matches psql and DataGrip defaults. \
+                Required by AWS RDS, Cloud SQL, Heroku, Supabase, Neon.
+                """)
+        case "MySQL", "MariaDB":
+            return String(localized: """
+                Preferred performs a 2-pass connect: tries TLS first, falls back to plain only on \
+                SSL handshake errors. Required by Cloud SQL and Azure MySQL.
+                """)
+        case "SQL Server":
+            return String(localized: "Preferred requests TLS; the server decides. Required by SQL Server 2022 and Azure SQL Database.")
+        case "MongoDB":
+            return String(localized: "MongoDB driver has no TLS fallback. Preferred and Required both force TLS. Use Required for MongoDB Atlas and other hosted instances.")
+        case "Redis":
+            return String(localized: """
+                Redis driver has no TLS fallback. Preferred and Required both force TLS. \
+                Use Required for Redis Cloud, Upstash, and AWS ElastiCache encrypted endpoints.
+                """)
+        case "Oracle":
+            return String(localized: "OracleNIO has no TLS fallback. Preferred connects in plain TCP. Use Required for TCPS to Oracle Autonomous Database.")
+        case "Cassandra", "ScyllaDB":
+            return String(localized: "Use Required for AstraDB, DataStax Astra, and other hosted Cassandra deployments.")
+        case "ClickHouse":
+            return String(localized: "Use Required for ClickHouse Cloud and other managed instances.")
+        default:
+            return ""
+        }
+    }
+
     var explainVariants: [ExplainVariant] {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.explainVariants ?? []
     }

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -109,6 +109,10 @@ extension DatabaseType {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.defaultSSLMode ?? .disabled
     }
 
+    var supportsOpportunisticTLS: Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.supportsOpportunisticTLS ?? true
+    }
+
     var sslPaneTooltip: String {
         switch rawValue {
         case "PostgreSQL", "Redshift", "CockroachDB":

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -28934,6 +28934,9 @@
         }
       }
     },
+    "MongoDB driver has no TLS fallback. Preferred and Required both force TLS. Use Required for MongoDB Atlas and other hosted instances." : {
+
+    },
     "MongoDB query language. Use to import into MongoDB." : {
       "localizations" : {
         "tr" : {
@@ -33344,6 +33347,9 @@
         }
       }
     },
+    "OracleNIO has no TLS fallback. Preferred connects in plain TCP. Use Required for TCPS to Oracle Autonomous Database." : {
+
+    },
     "Orange" : {
       "localizations" : {
         "tr" : {
@@ -35117,6 +35123,15 @@
           }
         }
       }
+    },
+    "Preferred performs a 2-pass connect: tries TLS first, falls back to plain only on SSL handshake errors. Required by Cloud SQL and Azure MySQL." : {
+
+    },
+    "Preferred requests TLS; the server decides. Required by SQL Server 2022 and Azure SQL Database." : {
+
+    },
+    "Preferred tries TLS first, falls back to plain. Matches psql and DataGrip defaults. Required by AWS RDS, Cloud SQL, Heroku, Supabase, Neon." : {
+
     },
     "Preserve all values as strings" : {
       "extractionState" : "stale",
@@ -37485,6 +37500,9 @@
           }
         }
       }
+    },
+    "Redis driver has no TLS fallback. Preferred and Required both force TLS. Use Required for Redis Cloud, Upstash, and AWS ElastiCache encrypted endpoints." : {
+
     },
     "Redo" : {
       "localizations" : {
@@ -50631,6 +50649,12 @@
       }
     },
     "Use Password File" : {
+
+    },
+    "Use Required for AstraDB, DataStax Astra, and other hosted Cassandra deployments." : {
+
+    },
+    "Use Required for ClickHouse Cloud and other managed instances." : {
 
     },
     "Use SSL if available" : {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -41784,9 +41784,6 @@
         }
       }
     },
-    "Server response: %@" : {
-
-    },
     "Serverless SQLite at the edge" : {
 
     },

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -41784,6 +41784,9 @@
         }
       }
     },
+    "Server response: %@" : {
+
+    },
     "Serverless SQLite at the edge" : {
 
     },

--- a/TablePro/ViewModels/WelcomeViewModel+Sample.swift
+++ b/TablePro/ViewModels/WelcomeViewModel+Sample.swift
@@ -7,6 +7,7 @@ import AppKit
 import Combine
 import Foundation
 import os
+import TableProPluginKit
 
 @MainActor
 internal enum SampleDatabaseLauncher {

--- a/TablePro/ViewModels/WelcomeViewModel+Sample.swift
+++ b/TablePro/ViewModels/WelcomeViewModel+Sample.swift
@@ -197,7 +197,7 @@ extension WelcomeViewModel {
     func openSampleDatabase() {
         SampleDatabaseLauncher.open { [weak self] error in
             guard let self else { return }
-            self.connectionError = error.localizedDescription
+            self.connectionError = SSLHandshakeError.formatted(error)
             self.showConnectionError = true
         }
     }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -604,7 +604,7 @@ final class WelcomeViewModel {
 
         Self.logger.error("Failed to connect: \(error.localizedDescription, privacy: .public)")
         WindowManager.shared.closeWindow(for: connection.id)
-        connectionError = error.localizedDescription
+        connectionError = SSLHandshakeError.formatted(error)
         showConnectionError = true
     }
 }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -7,6 +7,7 @@ import AppKit
 import Combine
 import os
 import SwiftUI
+import TableProPluginKit
 
 enum WelcomeActiveSheet: Identifiable {
     case newGroup(parentId: UUID?)

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -27,11 +27,16 @@ struct ConnectionSSLView: View {
                     }
                 }
             } footer: {
-                if sslMode != .disabled {
-                    Text(sslMode.description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 6) {
+                    if !databaseType.sslPaneTooltip.isEmpty {
+                        Text(databaseType.sslPaneTooltip)
+                    }
+                    if sslMode != .disabled {
+                        Text(sslMode.description)
+                    }
                 }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
 
             if sslMode != .disabled {

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -18,6 +18,13 @@ struct ConnectionSSLView: View {
 
     private var supportsPerConnectionCertPaths: Bool { databaseType != .mssql }
 
+    private var noOpportunisticTLSWarning: String {
+        if databaseType == .oracle {
+            return String(localized: "Preferred connects in plain TCP for this driver. Use Required to enforce TCPS.")
+        }
+        return String(localized: "This driver has no TLS fallback. Preferred forces TLS, same as Required.")
+    }
+
     var body: some View {
         Form {
             Section {
@@ -27,8 +34,8 @@ struct ConnectionSSLView: View {
                     }
                 }
                 if sslMode == .preferred, !databaseType.supportsOpportunisticTLS {
-                    Label(String(localized: "This driver has no TLS fallback — Preferred behaves the same as Required."), systemImage: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
+                    Label(noOpportunisticTLSWarning, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(databaseType == .oracle ? .red : .orange)
                         .font(.caption)
                 }
             } footer: {

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -26,6 +26,11 @@ struct ConnectionSSLView: View {
                         Text(mode.displayLabel).tag(mode)
                     }
                 }
+                if sslMode == .preferred, !databaseType.supportsOpportunisticTLS {
+                    Label(String(localized: "This driver has no TLS fallback — Preferred behaves the same as Required."), systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                }
             } footer: {
                 VStack(alignment: .leading, spacing: 6) {
                     if !databaseType.sslPaneTooltip.isEmpty {

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -540,28 +540,13 @@ final class ConnectionFormCoordinator {
                     } else {
                         AlertHelper.showErrorSheet(
                             title: String(localized: "Connection Test Failed"),
-                            message: Self.formatErrorMessage(error),
+                            message: SSLHandshakeError.formatted(error),
                             window: window
                         )
                     }
                 }
             }
         }
-    }
-
-    static func formatErrorMessage(_ error: Error) -> String {
-        if let sslError = error as? SSLHandshakeError {
-            var parts: [String] = []
-            if let description = sslError.errorDescription {
-                parts.append(description)
-            }
-            if let suggestion = sslError.recoverySuggestion {
-                parts.append(suggestion)
-            }
-            parts.append(String(format: String(localized: "Server response: %@"), sslError.serverMessage))
-            return parts.joined(separator: "\n\n")
-        }
-        return error.localizedDescription
     }
 
     func cleanupTestSecrets(for testId: UUID) {

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -540,13 +540,28 @@ final class ConnectionFormCoordinator {
                     } else {
                         AlertHelper.showErrorSheet(
                             title: String(localized: "Connection Test Failed"),
-                            message: error.localizedDescription,
+                            message: Self.formatErrorMessage(error),
                             window: window
                         )
                     }
                 }
             }
         }
+    }
+
+    static func formatErrorMessage(_ error: Error) -> String {
+        if let sslError = error as? SSLHandshakeError {
+            var parts: [String] = []
+            if let description = sslError.errorDescription {
+                parts.append(description)
+            }
+            if let suggestion = sslError.recoverySuggestion {
+                parts.append(suggestion)
+            }
+            parts.append(String(format: String(localized: "Server response: %@"), sslError.serverMessage))
+            return parts.joined(separator: "\n\n")
+        }
+        return error.localizedDescription
     }
 
     func cleanupTestSecrets(for testId: UUID) {

--- a/TableProTests/Models/DatabaseTypeTests.swift
+++ b/TableProTests/Models/DatabaseTypeTests.swift
@@ -170,6 +170,31 @@ struct DatabaseTypeTests {
         #expect(DatabaseType(rawValue: "FutureDB").defaultSSLMode == .disabled)
     }
 
+    @Test("Drivers with native prefer support report supportsOpportunisticTLS=true", arguments: [
+        DatabaseType.postgresql,
+        DatabaseType.redshift,
+        DatabaseType.cockroachdb,
+        DatabaseType.mysql,
+        DatabaseType.mariadb,
+        DatabaseType.mssql
+    ])
+    func testOpportunisticTLSSupported(type: DatabaseType) {
+        #expect(type.supportsOpportunisticTLS == true)
+    }
+
+    @Test("Binary-TLS drivers report supportsOpportunisticTLS=false", arguments: [
+        DatabaseType.mongodb,
+        DatabaseType.redis,
+        DatabaseType.cassandra,
+        DatabaseType.scylladb,
+        DatabaseType.clickhouse,
+        DatabaseType.oracle,
+        DatabaseType.etcd
+    ])
+    func testOpportunisticTLSUnsupported(type: DatabaseType) {
+        #expect(type.supportsOpportunisticTLS == false)
+    }
+
     @Test("Unknown type round-trips via rawValue")
     func testUnknownTypeRoundTrip() {
         #expect(DatabaseType(rawValue: "FutureDB").rawValue == "FutureDB")

--- a/TableProTests/Models/DatabaseTypeTests.swift
+++ b/TableProTests/Models/DatabaseTypeTests.swift
@@ -138,9 +138,15 @@ struct DatabaseTypeTests {
         #expect(DatabaseType.mssql.defaultSSLMode == .preferred)
     }
 
-    @Test("Binary on/off engines default SSL mode to disabled", arguments: [
+    @Test("libmariadb-family engines default SSL mode to preferred (2-pass connect)", arguments: [
         DatabaseType.mysql,
-        DatabaseType.mariadb,
+        DatabaseType.mariadb
+    ])
+    func testMariaDBClientEnginesDefaultSSLPreferred(type: DatabaseType) {
+        #expect(type.defaultSSLMode == .preferred)
+    }
+
+    @Test("Binary on/off engines default SSL mode to disabled", arguments: [
         DatabaseType.mongodb,
         DatabaseType.redis,
         DatabaseType.cassandra,

--- a/TableProTests/PluginTestSources/MongoDBSSLMapping.swift
+++ b/TableProTests/PluginTestSources/MongoDBSSLMapping.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TableProPluginKit
+
+enum MongoDBSSLMapping {
+    static func uriParameters(for ssl: SSLConfiguration) -> [String] {
+        guard ssl.isEnabled else { return [] }
+        var params: [String] = ["tls=true"]
+        switch ssl.mode {
+        case .preferred, .required:
+            params.append("tlsAllowInvalidCertificates=true")
+        case .verifyCa:
+            params.append("tlsAllowInvalidHostnames=true")
+        case .disabled, .verifyIdentity:
+            break
+        }
+        if ssl.verifiesCertificate, !ssl.caCertificatePath.isEmpty {
+            let encoded = ssl.caCertificatePath
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                ?? ssl.caCertificatePath
+            params.append("tlsCAFile=\(encoded)")
+        }
+        if !ssl.clientCertificatePath.isEmpty {
+            let encoded = ssl.clientCertificatePath
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                ?? ssl.clientCertificatePath
+            params.append("tlsCertificateKeyFile=\(encoded)")
+        }
+        return params
+    }
+}

--- a/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
+++ b/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
@@ -62,7 +62,7 @@ enum FreeTDSClassifier {
         if lower.contains("does not match host") {
             return .hostnameMismatch(serverMessage: message)
         }
-        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl") {
+        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl error") {
             return .cipherMismatch(serverMessage: message)
         }
         return nil
@@ -84,7 +84,7 @@ enum MongoDBClassifier {
         if lower.contains("tls required") || lower.contains("ssl required") {
             return .serverRejectedPlaintext(serverMessage: message)
         }
-        if lower.contains("client certificate") {
+        if lower.contains("client certificate required") || lower.contains("peer did not return a certificate") {
             return .clientCertRequired(serverMessage: message)
         }
         return nil

--- a/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
+++ b/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
@@ -1,0 +1,162 @@
+import Foundation
+import TableProPluginKit
+
+enum LibPQClassifier {
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("no pg_hba.conf entry") && lower.contains("no encryption") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("no pg_hba.conf entry") && lower.contains("ssl") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("server does not support ssl") || lower.contains("ssl is not enabled on the server") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("self-signed certificate") || lower.contains("unable to get local issuer certificate") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("server certificate") && lower.contains("does not match host name") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("certificate required") || lower.contains("connection requires a valid client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        if lower.contains("ssl error") || lower.contains("tls handshake") || lower.contains("ssl handshake") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum MariaDBClassifier {
+    static let sslOnlyErrorCodes: Set<UInt32> = [2_026, 2_012, 1_043]
+
+    static func classifySSLError(code: UInt32, message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("insecure transport") || lower.contains("require_secure_transport") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if sslOnlyErrorCodes.contains(code) {
+            if lower.contains("certificate") {
+                return .untrustedCertificate(serverMessage: message)
+            }
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum FreeTDSClassifier {
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("encryption is required") || lower.contains("server requires encryption") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("encryption not supported") || lower.contains("server does not support encryption") {
+            return .serverRequiresPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("certificate is not trusted") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("does not match host") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("ssl handshake") || lower.contains("tls handshake") || lower.contains("openssl") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum MongoDBClassifier {
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("ssl handshake failed") || lower.contains("tls handshake failed") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("certificate verify failed") || lower.contains("ssl certificate") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("hostname") && lower.contains("verification") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("tls required") || lower.contains("ssl required") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum RedisClassifier {
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("certificate verify failed") || lower.contains("unable to get local issuer") {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        if lower.contains("hostname") {
+            return .hostnameMismatch(serverMessage: message)
+        }
+        if lower.contains("sslv3") || lower.contains("unsupported protocol") || lower.contains("no shared cipher") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ssl handshake failed") || lower.contains("tlsv1") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("client certificate") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum OracleClassifier {
+    static func classifySSLError(_ message: String) -> SSLHandshakeError? {
+        let lower = message.lowercased()
+        if lower.contains("ora-28759") || lower.contains("failure to open file") && lower.contains("wallet") {
+            return .clientCertRequired(serverMessage: message)
+        }
+        if lower.contains("ora-29024") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ora-28860") {
+            return .cipherMismatch(serverMessage: message)
+        }
+        if lower.contains("ora-12537") || lower.contains("ora-12606") {
+            return .serverRejectedPlaintext(serverMessage: message)
+        }
+        if lower.contains("certificate") && (lower.contains("verify") || lower.contains("untrusted")) {
+            return .untrustedCertificate(serverMessage: message)
+        }
+        return nil
+    }
+}
+
+enum ClickHouseClassifier {
+    static func classifySSLError(_ error: Error) -> SSLHandshakeError? {
+        let urlError = error as? URLError ?? (error as NSError).underlyingErrors.compactMap { $0 as? URLError }.first
+        if let urlError {
+            switch urlError.code {
+            case .serverCertificateUntrusted, .serverCertificateNotYetValid, .serverCertificateHasUnknownRoot, .serverCertificateHasBadDate:
+                return .untrustedCertificate(serverMessage: urlError.localizedDescription)
+            case .clientCertificateRequired, .clientCertificateRejected:
+                return .clientCertRequired(serverMessage: urlError.localizedDescription)
+            case .secureConnectionFailed:
+                return .cipherMismatch(serverMessage: urlError.localizedDescription)
+            default:
+                break
+            }
+        }
+        let message = error.localizedDescription.lowercased()
+        if message.contains("certificate") && (message.contains("untrusted") || message.contains("verify failed")) {
+            return .untrustedCertificate(serverMessage: error.localizedDescription)
+        }
+        if message.contains("hostname") {
+            return .hostnameMismatch(serverMessage: error.localizedDescription)
+        }
+        return nil
+    }
+}

--- a/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
+++ b/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
@@ -125,9 +125,6 @@ enum OracleClassifier {
         if lower.contains("ora-28860") {
             return .cipherMismatch(serverMessage: message)
         }
-        if lower.contains("ora-12537") || lower.contains("ora-12606") {
-            return .serverRejectedPlaintext(serverMessage: message)
-        }
         if lower.contains("certificate") && (lower.contains("verify") || lower.contains("untrusted")) {
             return .untrustedCertificate(serverMessage: message)
         }

--- a/TableProTests/Plugins/MongoDBSSLMappingTests.swift
+++ b/TableProTests/Plugins/MongoDBSSLMappingTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("MongoDBSSLMapping")
+struct MongoDBSSLMappingTests {
+    @Test("Disabled returns empty parameter list")
+    func testDisabled() {
+        let params = MongoDBSSLMapping.uriParameters(for: SSLConfiguration(mode: .disabled))
+        #expect(params.isEmpty)
+    }
+
+    @Test("Preferred enables TLS with invalid-cert tolerance")
+    func testPreferred() {
+        let params = MongoDBSSLMapping.uriParameters(for: SSLConfiguration(mode: .preferred))
+        #expect(params.contains("tls=true"))
+        #expect(params.contains("tlsAllowInvalidCertificates=true"))
+    }
+
+    @Test("Required enables TLS with invalid-cert tolerance (same as Preferred for this driver)")
+    func testRequired() {
+        let params = MongoDBSSLMapping.uriParameters(for: SSLConfiguration(mode: .required))
+        #expect(params.contains("tls=true"))
+        #expect(params.contains("tlsAllowInvalidCertificates=true"))
+    }
+
+    @Test("Verify CA enables TLS with hostname tolerance only")
+    func testVerifyCA() {
+        let config = SSLConfiguration(mode: .verifyCa, caCertificatePath: "/tmp/ca.pem")
+        let params = MongoDBSSLMapping.uriParameters(for: config)
+        #expect(params.contains("tls=true"))
+        #expect(params.contains("tlsAllowInvalidHostnames=true"))
+        #expect(params.contains { $0.hasPrefix("tlsCAFile=") })
+    }
+
+    @Test("Verify Identity enables TLS with full validation")
+    func testVerifyIdentity() {
+        let config = SSLConfiguration(mode: .verifyIdentity, caCertificatePath: "/tmp/ca.pem")
+        let params = MongoDBSSLMapping.uriParameters(for: config)
+        #expect(params.contains("tls=true"))
+        #expect(!params.contains("tlsAllowInvalidCertificates=true"))
+        #expect(!params.contains("tlsAllowInvalidHostnames=true"))
+        #expect(params.contains { $0.hasPrefix("tlsCAFile=") })
+    }
+
+    @Test("Client certificate path is included when set")
+    func testClientCert() {
+        let config = SSLConfiguration(
+            mode: .verifyIdentity,
+            caCertificatePath: "/tmp/ca.pem",
+            clientCertificatePath: "/tmp/client.pem"
+        )
+        let params = MongoDBSSLMapping.uriParameters(for: config)
+        #expect(params.contains { $0.hasPrefix("tlsCertificateKeyFile=") })
+    }
+
+    @Test("Paths with special characters are URL-encoded")
+    func testPathEncoding() {
+        let config = SSLConfiguration(
+            mode: .verifyIdentity,
+            caCertificatePath: "/path with spaces/ca.pem"
+        )
+        let params = MongoDBSSLMapping.uriParameters(for: config)
+        let caParam = params.first { $0.hasPrefix("tlsCAFile=") }
+        #expect(caParam?.contains(" ") == false)
+        #expect(caParam?.contains("%20") == true)
+    }
+}

--- a/TableProTests/Plugins/PluginSSLClassifierTests.swift
+++ b/TableProTests/Plugins/PluginSSLClassifierTests.swift
@@ -169,12 +169,9 @@ struct OracleClassifierTests {
         }
     }
 
-    @Test("ORA-12606 → serverRejectedPlaintext")
-    func testORA12606() {
-        guard case .serverRejectedPlaintext = OracleClassifier.classifySSLError("ORA-12606: TNS: Application timeout occurred") else {
-            Issue.record("Expected serverRejectedPlaintext")
-            return
-        }
+    @Test("Network timeout (ORA-12606) is not classified as SSL")
+    func testTimeoutNotSSL() {
+        #expect(OracleClassifier.classifySSLError("ORA-12606: TNS: Application timeout occurred") == nil)
     }
 
     @Test("ORA-28759 → clientCertRequired")

--- a/TableProTests/Plugins/PluginSSLClassifierTests.swift
+++ b/TableProTests/Plugins/PluginSSLClassifierTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("LibPQ SSL Classifier")
+struct LibPQClassifierTests {
+    @Test("Classifies the AWS RDS rejection in #1298 as serverRejectedPlaintext")
+    func testRDSPattern() {
+        let msg = "FATAL: no pg_hba.conf entry for host \"1.2.3.4\", user \"u\", database \"d\", no encryption"
+        guard case .serverRejectedPlaintext = LibPQClassifier.classifySSLError(msg) else {
+            Issue.record("Expected serverRejectedPlaintext")
+            return
+        }
+    }
+
+    @Test("Classifies SSL-required as serverRequiresPlaintext")
+    func testSSLRequired() {
+        let msg = "FATAL: no pg_hba.conf entry for host \"1.2.3.4\", user \"u\", database \"d\", SSL on"
+        guard case .serverRequiresPlaintext = LibPQClassifier.classifySSLError(msg) else {
+            Issue.record("Expected serverRequiresPlaintext")
+            return
+        }
+    }
+
+    @Test("Classifies server-no-ssl-support as serverRequiresPlaintext")
+    func testServerNoSSL() {
+        let msg = "server does not support SSL, but SSL was required"
+        guard case .serverRequiresPlaintext = LibPQClassifier.classifySSLError(msg) else {
+            Issue.record("Expected serverRequiresPlaintext")
+            return
+        }
+    }
+
+    @Test("Classifies cert verify failure as untrustedCertificate")
+    func testCertVerify() {
+        let msg = "SSL error: certificate verify failed"
+        guard case .untrustedCertificate = LibPQClassifier.classifySSLError(msg) else {
+            Issue.record("Expected untrustedCertificate")
+            return
+        }
+    }
+
+    @Test("Classifies hostname mismatch")
+    func testHostnameMismatch() {
+        let msg = "server certificate for \"foo\" does not match host name \"bar\""
+        guard case .hostnameMismatch = LibPQClassifier.classifySSLError(msg) else {
+            Issue.record("Expected hostnameMismatch")
+            return
+        }
+    }
+
+    @Test("Non-SSL error returns nil")
+    func testNonSSL() {
+        #expect(LibPQClassifier.classifySSLError("FATAL: password authentication failed") == nil)
+        #expect(LibPQClassifier.classifySSLError("connection refused") == nil)
+    }
+}
+
+@Suite("MariaDB SSL Classifier")
+struct MariaDBClassifierTests {
+    @Test("CR_SSL_CONNECTION_ERROR with cipher message → cipherMismatch")
+    func testSSLConnectionError() {
+        guard case .cipherMismatch = MariaDBClassifier.classifySSLError(code: 2_026, message: "SSL connection error: no shared cipher") else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+
+    @Test("CR_SSL_CONNECTION_ERROR with certificate keyword → untrustedCertificate")
+    func testSSLCertError() {
+        guard case .untrustedCertificate = MariaDBClassifier.classifySSLError(code: 2_026, message: "SSL certificate not trusted") else {
+            Issue.record("Expected untrustedCertificate")
+            return
+        }
+    }
+
+    @Test("require_secure_transport → serverRejectedPlaintext")
+    func testRequireSecureTransport() {
+        guard case .serverRejectedPlaintext = MariaDBClassifier.classifySSLError(code: 1_045, message: "Connections using insecure transport are prohibited while --require_secure_transport=ON") else {
+            Issue.record("Expected serverRejectedPlaintext")
+            return
+        }
+    }
+
+    @Test("Auth error 1045 not retried (returns nil)")
+    func testAuthError() {
+        #expect(MariaDBClassifier.classifySSLError(code: 1_045, message: "Access denied for user 'foo'@'bar'") == nil)
+    }
+
+    @Test("Network error 2002 not retried")
+    func testNetworkError() {
+        #expect(MariaDBClassifier.classifySSLError(code: 2_002, message: "Can't connect to MySQL server") == nil)
+    }
+}
+
+@Suite("FreeTDS SSL Classifier")
+struct FreeTDSClassifierTests {
+    @Test("Server requires encryption → serverRejectedPlaintext")
+    func testServerRequires() {
+        guard case .serverRejectedPlaintext = FreeTDSClassifier.classifySSLError("Server requires encryption") else {
+            Issue.record("Expected serverRejectedPlaintext")
+            return
+        }
+    }
+
+    @Test("OpenSSL handshake → cipherMismatch")
+    func testOpenSSL() {
+        guard case .cipherMismatch = FreeTDSClassifier.classifySSLError("OpenSSL: SSL_connect failed") else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+}
+
+@Suite("MongoDB SSL Classifier")
+struct MongoDBClassifierTests {
+    @Test("TLS handshake failed → cipherMismatch")
+    func testTLSHandshake() {
+        guard case .cipherMismatch = MongoDBClassifier.classifySSLError("TLS handshake failed: bad cipher") else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+
+    @Test("Hostname verification failure → hostnameMismatch")
+    func testHostnameVerification() {
+        guard case .hostnameMismatch = MongoDBClassifier.classifySSLError("hostname verification failed") else {
+            Issue.record("Expected hostnameMismatch")
+            return
+        }
+    }
+
+    @Test("TLS required → serverRejectedPlaintext")
+    func testTLSRequired() {
+        guard case .serverRejectedPlaintext = MongoDBClassifier.classifySSLError("TLS required by Atlas cluster") else {
+            Issue.record("Expected serverRejectedPlaintext")
+            return
+        }
+    }
+}
+
+@Suite("Redis SSL Classifier")
+struct RedisClassifierTests {
+    @Test("No shared cipher → cipherMismatch")
+    func testNoSharedCipher() {
+        guard case .cipherMismatch = RedisClassifier.classifySSLError("SSL_connect: no shared cipher") else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+
+    @Test("Cert verify failed → untrustedCertificate")
+    func testCertVerify() {
+        guard case .untrustedCertificate = RedisClassifier.classifySSLError("certificate verify failed (self-signed)") else {
+            Issue.record("Expected untrustedCertificate")
+            return
+        }
+    }
+}
+
+@Suite("Oracle SSL Classifier")
+struct OracleClassifierTests {
+    @Test("ORA-29024 → cipherMismatch")
+    func testORA29024() {
+        guard case .cipherMismatch = OracleClassifier.classifySSLError("ORA-29024: Certificate validation failure") else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+
+    @Test("ORA-12606 → serverRejectedPlaintext")
+    func testORA12606() {
+        guard case .serverRejectedPlaintext = OracleClassifier.classifySSLError("ORA-12606: TNS: Application timeout occurred") else {
+            Issue.record("Expected serverRejectedPlaintext")
+            return
+        }
+    }
+
+    @Test("ORA-28759 → clientCertRequired")
+    func testORA28759() {
+        guard case .clientCertRequired = OracleClassifier.classifySSLError("ORA-28759: failure to open file") else {
+            Issue.record("Expected clientCertRequired")
+            return
+        }
+    }
+}
+
+@Suite("ClickHouse SSL Classifier")
+struct ClickHouseClassifierTests {
+    @Test("URLError.secureConnectionFailed → cipherMismatch")
+    func testSecureConnectionFailed() {
+        let error = URLError(.secureConnectionFailed)
+        guard case .cipherMismatch = ClickHouseClassifier.classifySSLError(error) else {
+            Issue.record("Expected cipherMismatch")
+            return
+        }
+    }
+
+    @Test("URLError.serverCertificateUntrusted → untrustedCertificate")
+    func testCertUntrusted() {
+        let error = URLError(.serverCertificateUntrusted)
+        guard case .untrustedCertificate = ClickHouseClassifier.classifySSLError(error) else {
+            Issue.record("Expected untrustedCertificate")
+            return
+        }
+    }
+
+    @Test("Non-SSL error returns nil")
+    func testNonSSL() {
+        let error = URLError(.notConnectedToInternet)
+        #expect(ClickHouseClassifier.classifySSLError(error) == nil)
+    }
+}

--- a/TableProTests/Plugins/SSLHandshakeErrorTests.swift
+++ b/TableProTests/Plugins/SSLHandshakeErrorTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("SSLHandshakeError")
+struct SSLHandshakeErrorTests {
+    @Test("serverRejectedPlaintext suggests switching to Required")
+    func testServerRejectedPlaintext() {
+        let error = SSLHandshakeError.serverRejectedPlaintext(serverMessage: "FATAL: no pg_hba.conf entry")
+        #expect(error.errorDescription?.contains("requires") == true)
+        #expect(error.recoverySuggestion?.contains("Required") == true)
+        #expect(error.serverMessage.contains("pg_hba"))
+    }
+
+    @Test("serverRequiresPlaintext suggests switching to Disabled")
+    func testServerRequiresPlaintext() {
+        let error = SSLHandshakeError.serverRequiresPlaintext(serverMessage: "Server does not support SSL")
+        #expect(error.errorDescription?.contains("does not accept") == true)
+        #expect(error.recoverySuggestion?.contains("Disabled") == true)
+    }
+
+    @Test("untrustedCertificate suggests Verify CA")
+    func testUntrustedCertificate() {
+        let error = SSLHandshakeError.untrustedCertificate(serverMessage: "self-signed certificate")
+        #expect(error.errorDescription?.contains("could not be verified") == true)
+        #expect(error.recoverySuggestion?.contains("Verify CA") == true)
+    }
+
+    @Test("hostnameMismatch suggests fix path")
+    func testHostnameMismatch() {
+        let error = SSLHandshakeError.hostnameMismatch(serverMessage: "hostname does not match certificate")
+        #expect(error.errorDescription?.contains("hostname") == true)
+        #expect(error.recoverySuggestion != nil)
+    }
+
+    @Test("clientCertRequired suggests providing client cert")
+    func testClientCertRequired() {
+        let error = SSLHandshakeError.clientCertRequired(serverMessage: "client certificate required")
+        #expect(error.recoverySuggestion?.contains("client certificate") == true)
+    }
+
+    @Test("cipherMismatch suggests server update")
+    func testCipherMismatch() {
+        let error = SSLHandshakeError.cipherMismatch(serverMessage: "no shared cipher")
+        #expect(error.recoverySuggestion != nil)
+    }
+
+    @Test("All cases expose the original server message")
+    func testServerMessageRoundTrip() {
+        let cases: [SSLHandshakeError] = [
+            .serverRejectedPlaintext(serverMessage: "msg-1"),
+            .serverRequiresPlaintext(serverMessage: "msg-2"),
+            .untrustedCertificate(serverMessage: "msg-3"),
+            .hostnameMismatch(serverMessage: "msg-4"),
+            .clientCertRequired(serverMessage: "msg-5"),
+            .cipherMismatch(serverMessage: "msg-6"),
+            .unknown(serverMessage: "msg-7")
+        ]
+        for error in cases {
+            #expect(!error.serverMessage.isEmpty)
+        }
+    }
+}

--- a/TableProTests/Plugins/SSLHandshakeErrorTests.swift
+++ b/TableProTests/Plugins/SSLHandshakeErrorTests.swift
@@ -46,6 +46,29 @@ struct SSLHandshakeErrorTests {
         #expect(error.recoverySuggestion != nil)
     }
 
+    @Test("formatted() redacts password from libpq-style conninfo")
+    func testSanitizeKeyValuePassword() {
+        let error = SSLHandshakeError.untrustedCertificate(serverMessage: "host=db.example.com user=root password=Sup3rS3cret port=5432")
+        let formatted = SSLHandshakeError.formatted(error)
+        #expect(!formatted.contains("Sup3rS3cret"))
+        #expect(formatted.contains("password=[redacted]"))
+    }
+
+    @Test("formatted() redacts password from URL userinfo segment")
+    func testSanitizeURLUserInfo() {
+        let error = SSLHandshakeError.serverRejectedPlaintext(serverMessage: "Failed: postgresql://admin:LeakedPass@db.example.com/app")
+        let formatted = SSLHandshakeError.formatted(error)
+        #expect(!formatted.contains("LeakedPass"))
+        #expect(formatted.contains("://[redacted]@"))
+    }
+
+    @Test("formatted() leaves non-credential text untouched")
+    func testSanitizePreservesContent() {
+        let error = SSLHandshakeError.cipherMismatch(serverMessage: "no shared cipher between client and server")
+        let formatted = SSLHandshakeError.formatted(error)
+        #expect(formatted.contains("no shared cipher"))
+    }
+
     @Test("All cases expose the original server message")
     func testServerMessageRoundTrip() {
         let cases: [SSLHandshakeError] = [

--- a/docs/databases/cassandra.mdx
+++ b/docs/databases/cassandra.mdx
@@ -36,7 +36,7 @@ See [Connection URL Reference](/databases/connection-urls#cassandra--scylladb) f
 **DataStax Astra DB**: Port 29042, use Client ID/Secret, needs Secure Connect Bundle (SSL/TLS)
 **Remote**: Use [SSH tunneling](/databases/ssh-tunneling) for production
 
-**SSL/TLS**: Enable in connection form. Astra DB requires Secure Connect Bundle.
+**SSL/TLS**: The Cassandra driver has no TLS fallback. **Preferred** behaves the same as **Required** (the SSL pane shows a warning). Use **Required** for AstraDB, **Verify CA** with a CA certificate path for private PKI. See [SSL/TLS](/features/ssl) for details.
 
 ## Features
 

--- a/docs/databases/clickhouse.mdx
+++ b/docs/databases/clickhouse.mdx
@@ -29,7 +29,7 @@ Uses HTTP API (HTTPS on port 8443 with SSL/TLS enabled). Cloud providers typical
 **ClickHouse Cloud**: Port 8443, enable SSL/TLS
 **Remote**: Use [SSH tunneling](/databases/ssh-tunneling) for unencrypted HTTP
 
-**SSL/TLS**: Enable in connection form for HTTPS (port 8443). Cloud requires HTTPS.
+**SSL/TLS**: ClickHouse over HTTP uses URLSession; setting any non-Disabled SSL Mode switches the URL scheme to `https`. **Required** skips cert verification, **Verify CA** validates against the supplied CA, **Verify Identity** relies on system default HTTPS trust (cert chain + hostname). Use **Required** for ClickHouse Cloud (port 8443). See [SSL/TLS](/features/ssl) for details.
 
 ## Connection URL
 

--- a/docs/databases/mongodb.mdx
+++ b/docs/databases/mongodb.mdx
@@ -69,7 +69,7 @@ SSH tunneling only forwards the first host. Other members must be reachable from
 
 ## SSL/TLS
 
-Configure in **SSL/TLS** section. MongoDB Atlas requires SSL/TLS - use **Required** or **Verify CA**. For unencrypted alternatives, use [SSH tunneling](/databases/ssh-tunneling).
+The MongoDB driver has no TLS fallback. **Preferred** behaves the same as **Required** (the SSL pane shows a warning). MongoDB Atlas requires TLS, so use **Required** or **Verify CA**. For unencrypted local instances, use **Disabled** or [SSH tunneling](/databases/ssh-tunneling). See [SSL/TLS](/features/ssl) for details.
 
 ## Connection URL
 

--- a/docs/databases/mysql.mdx
+++ b/docs/databases/mysql.mdx
@@ -96,7 +96,7 @@ SELECT * FROM category_tree;
 
 ### SSL/TLS
 
-Configure in **SSL/TLS** section. Cloud providers (AWS RDS, Google Cloud SQL, Azure) typically require SSL. Use **Verify CA** with the provider's certificate. Optionally provide client cert/key for mutual TLS. For unencrypted alternatives, use [SSH tunneling](/databases/ssh-tunneling).
+New connections default to **Preferred**, which does a 2-pass connect: tries TLS first, falls back to plain only on SSL handshake errors (auth and network errors are not retried). Works for Cloud SQL, Azure MySQL, and local Docker. Use **Verify CA** with the provider's certificate for stricter validation. See [SSL/TLS](/features/ssl) for details.
 
 ## Performance Tips
 

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -49,6 +49,8 @@ The Oracle driver is available as a downloadable plugin. When you select Oracle 
 
 **Oracle Cloud (ADB)**: Port 1522, service name format `mydb_tp`, requires TLS wallet download from Oracle Cloud Console
 
+**SSL/TLS**: OracleNIO has no TLS fallback. **Preferred** connects in plain TCP (the SSL pane shows a warning). Use **Required** for TCPS to Oracle Autonomous Database, **Verify CA** with a CA certificate path for strict validation. See [SSL/TLS](/features/ssl) for details.
+
 ## Connection URL
 
 ```text

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -105,7 +105,7 @@ Supports `jsonb` (formatted JSON), `array`, `uuid`, `inet` (IP), `timestamp with
 
 **Permission denied**: Grant access with `GRANT ALL ON DATABASE/SCHEMA/TABLES TO username;`
 
-**SSL/TLS**: Cloud providers (AWS RDS, Heroku, Supabase) typically require SSL. Use **Required** or **Verify CA**. For unencrypted alternatives, use [SSH tunneling](/databases/ssh-tunneling).
+**SSL/TLS**: New connections default to **Preferred** (libpq `sslmode=prefer`), which tries TLS first and falls back to plain. Works for both local Postgres and hosted providers (AWS RDS, Cloud SQL, Heroku, Supabase, Neon). Pick **Verify CA** when you need to validate the server certificate. See [SSL/TLS](/features/ssl) for details.
 
 ## Advanced Configuration
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -132,6 +132,7 @@
                 "pages": [
                   "features/safe-mode",
                   "features/ssh-profiles",
+                  "features/ssl",
                   "features/connection-sharing"
                 ]
               },

--- a/docs/features/ssl.mdx
+++ b/docs/features/ssl.mdx
@@ -1,0 +1,93 @@
+---
+title: SSL/TLS
+description: Configure encrypted database connections, per-engine defaults, and certificate verification
+---
+
+# SSL/TLS
+
+TablePro supports five SSL modes that map to each driver's native TLS capabilities. New connections start with the mode that matches the driver's documented default.
+
+## Modes
+
+| Mode | Behavior |
+|---|---|
+| Disabled | Plain TCP, no TLS negotiation |
+| Preferred | Try TLS first, fall back to plain if the server doesn't support it (where the driver allows) |
+| Required | Force TLS; fail if the server rejects encryption. No certificate validation. |
+| Verify CA | Force TLS and validate the server certificate against the trust store. Hostname not checked. |
+| Verify Identity | Force TLS, validate the certificate, and require the hostname to match the certificate subject |
+
+## Per-engine defaults
+
+New connections pick the mode that matches each driver's native behavior. Open the SSL tab on any connection to see the engine-specific guidance.
+
+| Engine | Default | Notes |
+|---|---|---|
+| PostgreSQL, Redshift, CockroachDB | Preferred | libpq `sslmode=prefer`. Matches `psql` and DataGrip. |
+| MySQL, MariaDB | Preferred | 2-pass connect: try TLS first, fall back to plain on SSL handshake error |
+| SQL Server | Preferred | FreeTDS `encryption=request`. SQL Server 2022 enforces TLS. |
+| MongoDB, Redis, Cassandra, ClickHouse, Oracle, etcd | Disabled | Drivers have no TLS fallback. Pick Required for hosted services. |
+| SQLite, DuckDB | N/A | No network protocol |
+
+## Required for hosted services
+
+These services require TLS out of the box. Pick Preferred or Required for these:
+
+- AWS RDS (PostgreSQL, MySQL, MariaDB), Aurora
+- Google Cloud SQL (PostgreSQL, MySQL, SQL Server)
+- Azure SQL Database, Azure Database for PostgreSQL/MySQL
+- Heroku Postgres, Supabase, Neon, PlanetScale
+- MongoDB Atlas (uses `mongodb+srv://` which enables TLS automatically)
+- Redis Cloud, Upstash, AWS ElastiCache encrypted endpoints
+- AstraDB / DataStax Astra (Cassandra)
+- Oracle Autonomous Database (TCPS on port 1522/2484)
+- ClickHouse Cloud
+
+## Troubleshooting
+
+### "FATAL: no pg_hba.conf entry for host ... no encryption"
+
+PostgreSQL server requires SSL. Switch SSL Mode to **Preferred** or **Required**.
+
+### "Connections using insecure transport are prohibited"
+
+MySQL server has `require_secure_transport=ON`. Switch SSL Mode to **Preferred** or **Required**.
+
+### "SSL handshake failed" / "tls handshake failed"
+
+Driver and server can't agree on a TLS version or cipher. Update the server, or for development try **Required** instead of **Verify CA**/**Verify Identity** to skip certificate validation.
+
+### "certificate verify failed" / "self-signed certificate"
+
+Server uses a certificate that isn't in your system trust store. Set SSL Mode to **Verify CA** and provide the CA certificate path, or use **Required** to skip certificate validation entirely.
+
+### "hostname does not match certificate"
+
+The certificate's CN/SAN doesn't include the host you're connecting to. Switch from **Verify Identity** to **Verify CA** (validates the chain but skips hostname), or update the host field to match the certificate.
+
+### "client certificate required"
+
+Server requires mutual TLS. Fill in the **Client Certificate** and **Client Key** paths in the SSL tab.
+
+## Preferred fallback behavior
+
+Preferred mode tries TLS first. What happens if the server doesn't support TLS depends on the driver:
+
+- **PostgreSQL, Redshift, CockroachDB**: libpq falls back to plain TCP natively
+- **SQL Server**: FreeTDS `encryption=request` falls back to plain
+- **MySQL, MariaDB**: 2-pass connect tries TLS, then plain on SSL-specific handshake errors (CR_SSL_CONNECTION_ERROR, CR_SERVER_HANDSHAKE_ERR, ER_HANDSHAKE_ERROR). Auth and network errors are not retried.
+- **MongoDB, Redis, Cassandra, ClickHouse, Oracle, etcd**: Drivers have no fallback. Preferred behaves the same as Required. The SSL pane shows a warning when you pick Preferred for these engines.
+
+## Connection failures
+
+When a connection fails because of an SSL handshake problem, TablePro shows a structured message that names the cause and recommends a specific SSL Mode to switch to. The original driver error is shown below the suggestion.
+
+For example, connecting to AWS RDS PostgreSQL with SSL Mode = Disabled produces:
+
+```
+The server requires an encrypted connection but TablePro is configured to connect in plain text.
+
+Open the connection editor, switch to the SSL tab, and set Mode to Required (or stricter).
+
+Server response: FATAL: no pg_hba.conf entry for host "...", user "...", database "...", no encryption
+```


### PR DESCRIPTION
> Stacks on top of #1309 (per-engine default SSL mode). Merge that first.

## Summary

3 driver fixes that close silent SSL gaps and finish the SSL story started in #1309:

- **Oracle**: SSL pane was completely ignored. The `OraclePluginDriver` never passed `sslConfig` into `OracleNIO.OracleConnection.Configuration`, so every Oracle connection was plain TCP regardless of what the user picked. Wired through NIOSSL with `TLSConfiguration.makeClientConfiguration()`, mapping Required → no verify, Verify CA → CA only, Verify Identity → full verification.
- **Cassandra**: Same class of silent SSL bug, worse. The plugin read SSL mode from `additionalFields["sslMode"]`, but that field was never declared in `additionalConnectionFields` and never written by the form. Result: every Cassandra connection was plain TCP regardless of SSL pane. Switched to reading `config.ssl` directly. Removed the orphan `sslCaCertPath` custom field (standard SSL pane now handles it). Migration: existing `additionalFields["sslCaCertPath"]` is copied into `sslConfig.caCertificatePath` on load.
- **MySQL/MariaDB**: `.preferred` was cosmetic in PR #1309 because bundled libmariadb has only `MYSQL_OPT_SSL_ENFORCE` (binary) — `.disabled` and `.preferred` mapped identically. Implemented 2-pass connect: try `ENFORCE=1` first, on SSL-only error codes `{CR_SSL_CONNECTION_ERROR=2026, CR_SERVER_HANDSHAKE_ERR=2012, ER_HANDSHAKE_ERROR=1043}` retry with `ENFORCE=0`. Re-enabled MySQL/MariaDB `defaultSSLMode = .preferred` in metadata so Cloud SQL / Azure MySQL works out of the box.

## Out of scope (separate follow-up)

- Cross-plugin SSL standardization (`SSLMappingProtocol`, `SSLHandshakeError`, conform Mongo/Redis/ClickHouse to unified pattern) — architectural debt, separate PR with PluginKit ABI surface
- Form save-time validation (`.verifyCa` requires CA path, etc.) — UX polish
- Per-engine SSL tooltip explaining default — UX polish

ClickHouse `.verifyIdentity` was investigated and confirmed NOT a bug: returns nil delegate intentionally, URLSession default HTTPS trust evaluation already validates cert chain + hostname.

## Architecture notes

- Oracle: `buildTLS()` helper in `OracleConnectionWrapper`. Logs warning for `.preferred` since OracleNIO has no opportunistic TLS (only `.disable` or `.require(NIOSSLContext)`). Default stays `.disabled` for Oracle.
- Cassandra: backward-compatible read of legacy `sslCaCertPath` in `ConnectionStorage.toConnection()` — copies to `sslConfig.caCertificatePath` if empty. Drops on next save (form no longer writes that key).
- MySQL: `attemptConnect(enforceSSL:)` extracted from `connect()`. 2-pass only fires for `.preferred`; `.required`/`.verifyCa`/`.verifyIdentity` keep single-pass with strict enforce. SSL-only retry codes are conservative (excludes timeouts, auth fails, network errors).

## Test plan

- [ ] Build with xcodebuild (NIOSSL import in Oracle plugin compiles)
- [ ] Oracle: connect to Oracle Autonomous Database via TCPS with Required mode — should succeed (was failing before)
- [ ] Oracle: connect to Oracle XE local with Disabled mode — should still work
- [ ] Oracle: connect to Oracle Autonomous Database with Verify Identity + wrong CA — should fail with cert chain error
- [ ] Cassandra: connect to AstraDB / DataStax with Required mode — should succeed (was failing before)
- [ ] Cassandra: connect to local Cassandra without SSL — should still work
- [ ] Cassandra: existing connection that previously set `sslCaCertPath` via the custom field — CA path should appear in standard SSL pane after upgrade
- [ ] MySQL: connect to Cloud SQL with Preferred mode — should succeed via 2-pass (try TLS, succeed)
- [ ] MySQL: connect to local Docker MySQL (no TLS) with Preferred mode — should succeed via 2-pass (try TLS, fall back to plain)
- [ ] MySQL: connect with wrong password and Preferred mode — should fail immediately, not retry (auth error 1045 not in retry set)
- [ ] MySQL: connect to Cloud SQL with Required mode — should succeed with enforce=1, no retry
- [ ] Run `xcodebuild test -only-testing:TableProTests/DatabaseTypeTests` — MySQL/MariaDB tests now expect `.preferred`