### PR TITLE
fix(import): detect foreign apps via LaunchServices (#1305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Import from other apps now detects TablePlus, Sequel Ace, and DBeaver via LaunchServices instead of probing for data files, so newly installed apps are picked up even before they have been opened (#1305)
 - ClickHouse (and any HTTP-based driver) can now connect to plain-HTTP servers addressed by DNS hostname; previously App Transport Security blocked the request because only IP-addressed plain HTTP is exempt by default (#1316)
 - Import from TablePlus now reads passwords from the keychain correctly; previously it queried the wrong service name and silently returned empty passwords without prompting
 - Port numbers in the import preview, welcome screen linked-file list, and plugin details no longer render with a thousand separator (e.g. 3306 instead of 3.306) under Vietnamese, German, and other locales that use a dot as a digit separator

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import AppKit
 import CommonCrypto
 import Foundation
 import os
@@ -16,11 +17,23 @@ struct DBeaverImporter: ForeignAppImporter {
     let symbolName = "bird"
     let appBundleIdentifier = "org.jkiss.dbeaver.core.product"
 
+    /// All known DBeaver Eclipse product identifiers. Community, Enterprise,
+    /// Ultimate, Lite, and CloudBeaver desktop variants each register a
+    /// different bundle ID, but they all write to the same workspace.
+    private static let knownBundleIdentifiers = [
+        "org.jkiss.dbeaver.core.product",
+        "org.jkiss.dbeaver.ee.core.product",
+        "org.jkiss.dbeaver.ue.product",
+        "org.jkiss.dbeaver.lite.product"
+    ]
+
     var workspaceBaseURL: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/DBeaverData/workspace6")
 
     func isAvailable() -> Bool {
-        findDataSourcesFile() != nil
+        Self.knownBundleIdentifiers.contains { bundleId in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) != nil
+        }
     }
 
     func connectionCount() -> Int {

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -18,8 +18,8 @@ struct DBeaverImporter: ForeignAppImporter {
     let appBundleIdentifier = "org.jkiss.dbeaver.core.product"
 
     /// All known DBeaver Eclipse product identifiers. Community, Enterprise,
-    /// Ultimate, Lite, and CloudBeaver desktop variants each register a
-    /// different bundle ID, but they all write to the same workspace.
+    /// Ultimate, and Lite variants each register a different bundle ID, but
+    /// they all write to the same `~/Library/DBeaverData/workspace*`.
     private static let knownBundleIdentifiers = [
         "org.jkiss.dbeaver.core.product",
         "org.jkiss.dbeaver.ee.core.product",
@@ -27,13 +27,19 @@ struct DBeaverImporter: ForeignAppImporter {
         "org.jkiss.dbeaver.lite.product"
     ]
 
-    var workspaceBaseURL: URL = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent("Library/DBeaverData/workspace6")
+    /// Root directory containing DBeaver workspace folders. The actual
+    /// workspace path is discovered by scanning for `workspace*` subdirs so
+    /// future versions (workspace7, etc.) keep working without code changes.
+    var dbeaverDataRoot: URL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/DBeaverData")
 
-    func isAvailable() -> Bool {
-        Self.knownBundleIdentifiers.contains { bundleId in
-            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) != nil
+    func installedAppURL() -> URL? {
+        for bundleId in Self.knownBundleIdentifiers {
+            if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+                return url
+            }
         }
+        return nil
     }
 
     func connectionCount() -> Int {
@@ -113,18 +119,30 @@ struct DBeaverImporter: ForeignAppImporter {
 
     // MARK: - File Discovery
 
+    /// Scans `~/Library/DBeaverData/workspace*` for a project folder that
+    /// contains `.dbeaver/data-sources.json`. Supports any workspace version
+    /// (workspace6, workspace7, ...) by enumeration rather than hardcoding.
     private func findDataSourcesFile() -> URL? {
         let fm = FileManager.default
-        let basePath = workspaceBaseURL.path
-        guard fm.fileExists(atPath: basePath),
-              let contents = try? fm.contentsOfDirectory(atPath: basePath) else { return nil }
+        guard let workspaceDirs = try? fm.contentsOfDirectory(
+            at: dbeaverDataRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
 
-        for dirName in contents {
-            let candidate = workspaceBaseURL
-                .appendingPathComponent(dirName)
-                .appendingPathComponent(".dbeaver/data-sources.json")
-            if fm.fileExists(atPath: candidate.path) {
-                return candidate
+        let workspaces = workspaceDirs
+            .filter { $0.lastPathComponent.hasPrefix("workspace") }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+        for workspace in workspaces {
+            guard let projects = try? fm.contentsOfDirectory(atPath: workspace.path) else { continue }
+            for projectName in projects {
+                let candidate = workspace
+                    .appendingPathComponent(projectName)
+                    .appendingPathComponent(".dbeaver/data-sources.json")
+                if fm.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
             }
         }
         return nil

--- a/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
@@ -14,19 +14,26 @@ protocol ForeignAppImporter {
     var id: String { get }
     var displayName: String { get }
     var symbolName: String { get }
+    /// Canonical bundle identifier of the source app. Importers whose source
+    /// app ships in multiple editions (e.g. DBeaver Community / Enterprise)
+    /// should override `installedAppURL()` to look those up as well.
     var appBundleIdentifier: String { get }
-    func isAvailable() -> Bool
+    func installedAppURL() -> URL?
     func connectionCount() -> Int
     func importConnections(includePasswords: Bool) throws -> ForeignAppImportResult
 }
 
 extension ForeignAppImporter {
-    /// Default detection via LaunchServices: returns true if any app with the
-    /// declared bundle identifier is installed and registered with macOS,
-    /// regardless of whether the user has opened it or created any data.
-    /// Importers with a sharper notion of "available" can override.
+    /// LaunchServices lookup for the source app. Returns the URL on disk if
+    /// the app is registered with macOS, regardless of whether the user has
+    /// opened it or created any data. Override to consider multiple editions.
+    func installedAppURL() -> URL? {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: appBundleIdentifier)
+    }
+
+    /// Convenience: true when the source app is installed.
     func isAvailable() -> Bool {
-        NSWorkspace.shared.urlForApplication(withBundleIdentifier: appBundleIdentifier) != nil
+        installedAppURL() != nil
     }
 }
 

--- a/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import AppKit
 import Foundation
 import os
 import Security
@@ -17,6 +18,16 @@ protocol ForeignAppImporter {
     func isAvailable() -> Bool
     func connectionCount() -> Int
     func importConnections(includePasswords: Bool) throws -> ForeignAppImportResult
+}
+
+extension ForeignAppImporter {
+    /// Default detection via LaunchServices: returns true if any app with the
+    /// declared bundle identifier is installed and registered with macOS,
+    /// regardless of whether the user has opened it or created any data.
+    /// Importers with a sharper notion of "available" can override.
+    func isAvailable() -> Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: appBundleIdentifier) != nil
+    }
 }
 
 // MARK: - Result

--- a/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
@@ -20,10 +20,6 @@ struct SequelAceImporter: ForeignAppImporter {
                 + "Sequel Ace/Data/Favorites.plist"
         )
 
-    func isAvailable() -> Bool {
-        FileManager.default.fileExists(atPath: favoritesFileURL.path)
-    }
-
     func connectionCount() -> Int {
         guard let root = loadRootDict() else { return 0 }
         guard let favoritesRoot = root["Favorites Root"] as? [String: Any],

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -21,10 +21,6 @@ struct TablePlusImporter: ForeignAppImporter {
     var groupsFileURL: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/Application Support/com.tinyapp.TablePlus/Data/ConnectionGroups.plist")
 
-    func isAvailable() -> Bool {
-        FileManager.default.fileExists(atPath: connectionsFileURL.path)
-    }
-
     func connectionCount() -> Int {
         guard let data = try? Data(contentsOf: connectionsFileURL),
               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),

--- a/TablePro/Views/Connection/ImportFromApp/ImportFromAppSourcePicker.swift
+++ b/TablePro/Views/Connection/ImportFromApp/ImportFromAppSourcePicker.swift
@@ -96,9 +96,8 @@ struct ImportFromAppSourcePicker: View {
 
     @ViewBuilder
     private func appIcon(for importer: any ForeignAppImporter) -> some View {
-        let icon = resolveAppIcon(bundleId: importer.appBundleIdentifier)
-        if let icon {
-            Image(nsImage: icon)
+        if let appURL = importer.installedAppURL() {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
                 .resizable()
                 .aspectRatio(contentMode: .fit)
         } else {
@@ -173,8 +172,4 @@ struct ImportFromAppSourcePicker: View {
         onSelect(state.importer, includePasswords)
     }
 
-    private func resolveAppIcon(bundleId: String) -> NSImage? {
-        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) else { return nil }
-        return NSWorkspace.shared.icon(forFile: appURL.path)
-    }
 }


### PR DESCRIPTION
## Summary

Fixes #1305. DBeaver (and TablePlus, Sequel Ace) were shown as "not installed" in the import dialog even when the app was clearly installed in `/Applications/`.

## Root cause

All three importers' \`isAvailable()\` checks were probing for data files instead of the app itself:

- **TablePlus**: \`fileExists(connectionsFileURL)\` — false until user opens TablePlus once
- **Sequel Ace**: \`fileExists(favoritesFileURL)\` — false until user has a favorite
- **DBeaver**: \`findDataSourcesFile() != nil\` — false until user opens a workspace

For DBeaver this was especially bad because the path was also hardcoded to \`~/Library/DBeaverData/workspace6\` and would miss any user with a non-default workspace path or DBeaver Enterprise/Lite installation.

## Fix

Move \`isAvailable()\` to a default protocol-extension implementation that uses LaunchServices via \`NSWorkspace.urlForApplication(withBundleIdentifier:)\`. This is Apple's documented API for asking "is an app with this bundle id installed", and it returns true as long as macOS knows about the app, regardless of whether the user has launched it or created any data.

DBeaver overrides the default to also check the Enterprise, Ultimate, and Lite product identifiers, since all DBeaver variants share the same workspace format.

The data-file check is preserved inside \`importConnections\` so users who click Import without data still get a clear "Could not find data files" error message instead of silent failure.

## Test plan

- [ ] Install fresh DBeaver, do not open it → appears as available in the import dialog
- [ ] Install fresh TablePlus, do not open it → appears as available
- [ ] Install fresh Sequel Ace, do not open it → appears as available
- [ ] Uninstall all three → all hidden from import dialog
- [ ] DBeaver Enterprise / Ultimate installed → still detected