### PR TITLE
feat(datagrid): copy column values plus Copy as CSV/Markdown/IN Clause (#1325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Right-click a column header to copy all its values from the loaded rows (#1325)
+- Copy as submenu on the row context menu now offers CSV, CSV with Headers, Markdown table, and IN Clause for SQL `WHERE id IN (...)` lookups (#1325)
+
 ### Fixed
 
 - DuckDB Spatial `GEOMETRY` columns render as WKT, not NULL (#1324)

--- a/TablePro/Core/Services/Infrastructure/ClipboardService.swift
+++ b/TablePro/Core/Services/Infrastructure/ClipboardService.swift
@@ -2,9 +2,6 @@
 //  ClipboardService.swift
 //  TablePro
 //
-//  Abstraction over clipboard operations for testability.
-//  Provides protocol-based access to pasteboard data.
-//
 
 import AppKit
 import UniformTypeIdentifiers
@@ -12,6 +9,7 @@ import UniformTypeIdentifiers
 protocol ClipboardProvider {
     func readText() -> String?
     func writeText(_ text: String)
+    func writeCsv(_ csv: String)
     func writeRows(tsv: String, html: String?)
     var hasText: Bool { get }
     var hasGridRows: Bool { get }
@@ -19,6 +17,7 @@ protocol ClipboardProvider {
 
 struct NSPasteboardClipboardProvider: ClipboardProvider {
     private static let tsvType = NSPasteboard.PasteboardType("public.utf8-tab-separated-values-text")
+    private static let csvType = NSPasteboard.PasteboardType("public.comma-separated-values-text")
     private static let gridRowsType = NSPasteboard.PasteboardType("com.TablePro.gridRows")
 
     func readText() -> String? {
@@ -30,6 +29,14 @@ struct NSPasteboardClipboardProvider: ClipboardProvider {
         pb.clearContents()
         pb.setString(text, forType: .string)
         pb.setString(text, forType: NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier))
+    }
+
+    func writeCsv(_ csv: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(csv, forType: .string)
+        pb.setString(csv, forType: NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier))
+        pb.setString(csv, forType: Self.csvType)
     }
 
     func writeRows(tsv: String, html: String?) {

--- a/TablePro/Core/Utilities/SQL/CsvRowConverter.swift
+++ b/TablePro/Core/Utilities/SQL/CsvRowConverter.swift
@@ -1,0 +1,67 @@
+//
+//  CsvRowConverter.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+internal struct CsvRowConverter {
+    internal let columns: [String]
+    internal let columnTypes: [ColumnType]
+
+    private static let maxRows = 50_000
+
+    func generateCsv(rows: [[PluginCellValue]], includeHeaders: Bool) -> String {
+        let cappedRows = rows.prefix(Self.maxRows)
+        let columnCount = columns.count
+
+        var result = String()
+        result.reserveCapacity(cappedRows.count * columnCount * 16)
+
+        if includeHeaders {
+            for (idx, header) in columns.enumerated() {
+                if idx > 0 { result.append(",") }
+                result.append(Self.encode(header))
+            }
+            result.append("\n")
+        }
+
+        for row in cappedRows {
+            for idx in 0..<columnCount {
+                if idx > 0 { result.append(",") }
+                guard row.indices.contains(idx) else { continue }
+
+                let cell = row[idx]
+                switch cell {
+                case .null:
+                    continue
+                case .text(let value):
+                    let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
+                    let formatted = (columnType?.isBlobType ?? false)
+                        ? (value.formattedAsCompactHex() ?? value)
+                        : value
+                    result.append(Self.encode(formatted))
+                case .bytes(let data):
+                    let blob = String(data: data, encoding: .isoLatin1)?.formattedAsCompactHex() ?? ""
+                    result.append(Self.encode(blob))
+                }
+            }
+            result.append("\n")
+        }
+
+        return result
+    }
+
+    static func encode(_ value: String) -> String {
+        let needsQuoting = value.contains(",")
+            || value.contains("\"")
+            || value.contains("\n")
+            || value.contains("\r")
+            || value.hasPrefix(" ")
+            || value.hasSuffix(" ")
+        guard needsQuoting else { return value }
+        let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/TablePro/Core/Utilities/SQL/CsvRowConverter.swift
+++ b/TablePro/Core/Utilities/SQL/CsvRowConverter.swift
@@ -32,20 +32,11 @@ internal struct CsvRowConverter {
                 if idx > 0 { result.append(",") }
                 guard row.indices.contains(idx) else { continue }
 
-                let cell = row[idx]
-                switch cell {
-                case .null:
+                let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
+                guard let text = RowValueCopyFormatter.copyText(cell: row[idx], columnType: columnType) else {
                     continue
-                case .text(let value):
-                    let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
-                    let formatted = (columnType?.isBlobType ?? false)
-                        ? (value.formattedAsCompactHex() ?? value)
-                        : value
-                    result.append(Self.encode(formatted))
-                case .bytes(let data):
-                    let blob = String(data: data, encoding: .isoLatin1)?.formattedAsCompactHex() ?? ""
-                    result.append(Self.encode(blob))
                 }
+                result.append(Self.encode(text))
             }
             result.append("\n")
         }

--- a/TablePro/Core/Utilities/SQL/InClauseConverter.swift
+++ b/TablePro/Core/Utilities/SQL/InClauseConverter.swift
@@ -1,0 +1,66 @@
+//
+//  InClauseConverter.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+internal struct InClauseConverter {
+    internal let columnIndex: Int
+    internal let columnTypes: [ColumnType]
+    internal let escapeStringLiteral: ((String) -> String)?
+
+    private static let maxRows = 50_000
+
+    func generateInClause(rows: [[PluginCellValue]]) -> String {
+        let cappedRows = rows.prefix(Self.maxRows)
+        let columnType: ColumnType = columnTypes.indices.contains(columnIndex)
+            ? columnTypes[columnIndex]
+            : .text(rawType: nil)
+
+        let values: [String] = cappedRows.compactMap { row in
+            guard row.indices.contains(columnIndex) else { return nil }
+            return format(cell: row[columnIndex], type: columnType)
+        }
+
+        guard !values.isEmpty else { return "()" }
+        return "(\(values.joined(separator: ", ")))"
+    }
+
+    private func format(cell: PluginCellValue, type: ColumnType) -> String? {
+        switch cell {
+        case .null, .bytes:
+            return nil
+        case .text(let value):
+            return formatScalar(value, type: type)
+        }
+    }
+
+    private func formatScalar(_ value: String, type: ColumnType) -> String {
+        switch type {
+        case .integer:
+            if let intVal = Int64(value) { return String(intVal) }
+            return quoted(value)
+        case .decimal:
+            if Double(value) != nil { return value }
+            return quoted(value)
+        case .boolean:
+            switch value.lowercased() {
+            case "true", "1", "yes", "on":
+                return "TRUE"
+            case "false", "0", "no", "off":
+                return "FALSE"
+            default:
+                return quoted(value)
+            }
+        case .blob, .text, .date, .timestamp, .datetime, .json, .enumType, .set, .spatial:
+            return quoted(value)
+        }
+    }
+
+    private func quoted(_ value: String) -> String {
+        let escaped = escapeStringLiteral?(value) ?? value.replacingOccurrences(of: "'", with: "''")
+        return "'\(escaped)'"
+    }
+}

--- a/TablePro/Core/Utilities/SQL/InClauseConverter.swift
+++ b/TablePro/Core/Utilities/SQL/InClauseConverter.swift
@@ -40,7 +40,7 @@ internal struct InClauseConverter {
     private func formatScalar(_ value: String, type: ColumnType) -> String {
         switch type {
         case .integer:
-            if let intVal = Int64(value) { return String(intVal) }
+            if RowValueCopyFormatter.isIntegerLiteral(value) { return value }
             return quoted(value)
         case .decimal:
             if Double(value) != nil { return value }

--- a/TablePro/Core/Utilities/SQL/MarkdownTableConverter.swift
+++ b/TablePro/Core/Utilities/SQL/MarkdownTableConverter.swift
@@ -40,20 +40,9 @@ internal struct MarkdownTableConverter {
                     continue
                 }
 
-                let cell = row[idx]
-                switch cell {
-                case .null:
-                    result.append("NULL")
-                case .text(let value):
-                    let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
-                    let formatted = (columnType?.isBlobType ?? false)
-                        ? (value.formattedAsCompactHex() ?? value)
-                        : value
-                    result.append(Self.encode(formatted))
-                case .bytes(let data):
-                    let blob = String(data: data, encoding: .isoLatin1)?.formattedAsCompactHex() ?? ""
-                    result.append(Self.encode(blob))
-                }
+                let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
+                let text = RowValueCopyFormatter.copyText(cell: row[idx], columnType: columnType) ?? "NULL"
+                result.append(Self.encode(text))
             }
             result.append(" |\n")
         }

--- a/TablePro/Core/Utilities/SQL/MarkdownTableConverter.swift
+++ b/TablePro/Core/Utilities/SQL/MarkdownTableConverter.swift
@@ -1,0 +1,81 @@
+//
+//  MarkdownTableConverter.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+internal struct MarkdownTableConverter {
+    internal let columns: [String]
+    internal let columnTypes: [ColumnType]
+
+    private static let maxRows = 50_000
+
+    func generateMarkdown(rows: [[PluginCellValue]]) -> String {
+        let cappedRows = rows.prefix(Self.maxRows)
+        let columnCount = columns.count
+        guard columnCount > 0 else { return "" }
+
+        var result = String()
+        result.reserveCapacity(cappedRows.count * columnCount * 16)
+
+        result.append("| ")
+        result.append(columns.map(Self.encode).joined(separator: " | "))
+        result.append(" |\n")
+
+        result.append("|")
+        for _ in 0..<columnCount {
+            result.append(" --- |")
+        }
+        result.append("\n")
+
+        for row in cappedRows {
+            result.append("| ")
+            for idx in 0..<columnCount {
+                if idx > 0 { result.append(" | ") }
+
+                guard row.indices.contains(idx) else {
+                    result.append("NULL")
+                    continue
+                }
+
+                let cell = row[idx]
+                switch cell {
+                case .null:
+                    result.append("NULL")
+                case .text(let value):
+                    let columnType = columnTypes.indices.contains(idx) ? columnTypes[idx] : nil
+                    let formatted = (columnType?.isBlobType ?? false)
+                        ? (value.formattedAsCompactHex() ?? value)
+                        : value
+                    result.append(Self.encode(formatted))
+                case .bytes(let data):
+                    let blob = String(data: data, encoding: .isoLatin1)?.formattedAsCompactHex() ?? ""
+                    result.append(Self.encode(blob))
+                }
+            }
+            result.append(" |\n")
+        }
+
+        return result
+    }
+
+    static func encode(_ value: String) -> String {
+        var result = String()
+        result.reserveCapacity((value as NSString).length)
+
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "|":
+                result.append("\\|")
+            case "\n", "\r":
+                result.append("<br>")
+            default:
+                result.append(Character(scalar))
+            }
+        }
+
+        return result
+    }
+}

--- a/TablePro/Core/Utilities/SQL/RowValueCopyFormatter.swift
+++ b/TablePro/Core/Utilities/SQL/RowValueCopyFormatter.swift
@@ -1,0 +1,37 @@
+//
+//  RowValueCopyFormatter.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+internal enum RowValueCopyFormatter {
+    static func copyText(cell: PluginCellValue, columnType: ColumnType?) -> String? {
+        switch cell {
+        case .null:
+            return nil
+        case .text(let value):
+            if columnType?.isBlobType ?? false {
+                return value.formattedAsCompactHex() ?? value
+            }
+            return value
+        case .bytes(let data):
+            return String(data: data, encoding: .isoLatin1)?.formattedAsCompactHex() ?? ""
+        }
+    }
+
+    static func isIntegerLiteral(_ value: String) -> Bool {
+        var iter = value.unicodeScalars.makeIterator()
+        guard var first = iter.next() else { return false }
+        if first == "-" {
+            guard let next = iter.next() else { return false }
+            first = next
+        }
+        guard first >= "0" && first <= "9" else { return false }
+        while let next = iter.next() {
+            guard next >= "0" && next <= "9" else { return false }
+        }
+        return true
+    }
+}

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -12255,6 +12255,9 @@
         }
       }
     },
+    "Copy Column Values" : {
+
+    },
     "Copy Connection ID" : {
 
     },
@@ -13443,6 +13446,12 @@
           }
         }
       }
+    },
+    "CSV" : {
+
+    },
+    "CSV with Headers" : {
+
     },
     "CURDATE()" : {
       "extractionState" : "stale",
@@ -24239,6 +24248,9 @@
         }
       }
     },
+    "IN Clause" : {
+
+    },
     "in list" : {
       "localizations" : {
         "tr" : {
@@ -27986,6 +27998,9 @@
           }
         }
       }
+    },
+    "Markdown" : {
+
     },
     "Massive" : {
       "extractionState" : "stale",

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -106,7 +106,7 @@ class DataGridRowView: NSTableRowView {
         let locationInTable = tableView.convert(locationInRow, from: self)
         let clickedColumn = tableView.column(at: locationInTable)
 
-        let dataColumnIndex: Int = clickedColumn > 0
+        let dataColumnIndex: Int = clickedColumn >= 0
             ? DataGridView.dataColumnIndex(for: clickedColumn, in: tableView, schema: coordinator.identitySchema) ?? -1
             : -1
 
@@ -148,6 +148,37 @@ class DataGridRowView: NSTableRowView {
             keyEquivalent: "")
         jsonItem.target = self
         copyAsMenu.addItem(jsonItem)
+
+        let csvItem = NSMenuItem(
+            title: String(localized: "CSV"),
+            action: #selector(copyAsCsv),
+            keyEquivalent: "")
+        csvItem.target = self
+        copyAsMenu.addItem(csvItem)
+
+        let csvHeadersItem = NSMenuItem(
+            title: String(localized: "CSV with Headers"),
+            action: #selector(copyAsCsvWithHeaders),
+            keyEquivalent: "")
+        csvHeadersItem.target = self
+        copyAsMenu.addItem(csvHeadersItem)
+
+        let markdownItem = NSMenuItem(
+            title: String(localized: "Markdown"),
+            action: #selector(copyAsMarkdown),
+            keyEquivalent: "")
+        markdownItem.target = self
+        copyAsMenu.addItem(markdownItem)
+
+        if dataColumnIndex >= 0 {
+            let inClauseItem = NSMenuItem(
+                title: String(localized: "IN Clause"),
+                action: #selector(copyAsInClause(_:)),
+                keyEquivalent: "")
+            inClauseItem.representedObject = dataColumnIndex
+            inClauseItem.target = self
+            copyAsMenu.addItem(inClauseItem)
+        }
 
         if let dbType = coordinator.databaseType,
            dbType != .mongodb && dbType != .redis,
@@ -311,20 +342,18 @@ class DataGridRowView: NSTableRowView {
         coordinator?.undoDeleteRow(at: rowIndex)
     }
 
+    private func selectedOrCurrentIndices(in coordinator: TableViewCoordinator) -> Set<Int> {
+        coordinator.selectedRowIndices.isEmpty ? [rowIndex] : coordinator.selectedRowIndices
+    }
+
     @objc private func copySelectedOrCurrentRowWithHeaders() {
-        guard let coordinator = coordinator else { return }
-        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
-            ? coordinator.selectedRowIndices
-            : [rowIndex]
-        coordinator.copyRowsWithHeaders(at: indices)
+        guard let coordinator else { return }
+        coordinator.copyRowsWithHeaders(at: selectedOrCurrentIndices(in: coordinator))
     }
 
     @objc private func copySelectedOrCurrentRow() {
-        guard let coordinator = coordinator else { return }
-        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
-            ? coordinator.selectedRowIndices
-            : [rowIndex]
-        coordinator.delegate?.dataGridCopyRows(indices)
+        guard let coordinator else { return }
+        coordinator.delegate?.dataGridCopyRows(selectedOrCurrentIndices(in: coordinator))
     }
 
     @objc private func pasteRows() {
@@ -371,18 +400,12 @@ class DataGridRowView: NSTableRowView {
 
     @objc private func copyAsInsert() {
         guard let coordinator else { return }
-        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
-            ? coordinator.selectedRowIndices
-            : [rowIndex]
-        coordinator.copyRowsAsInsert(at: indices)
+        coordinator.copyRowsAsInsert(at: selectedOrCurrentIndices(in: coordinator))
     }
 
     @objc private func copyAsUpdate() {
         guard let coordinator else { return }
-        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
-            ? coordinator.selectedRowIndices
-            : [rowIndex]
-        coordinator.copyRowsAsUpdate(at: indices)
+        coordinator.copyRowsAsUpdate(at: selectedOrCurrentIndices(in: coordinator))
     }
 
     @objc private func exportResults() {
@@ -391,10 +414,27 @@ class DataGridRowView: NSTableRowView {
 
     @objc private func copyAsJson() {
         guard let coordinator else { return }
-        let indices: Set<Int> = !coordinator.selectedRowIndices.isEmpty
-            ? coordinator.selectedRowIndices
-            : [rowIndex]
-        coordinator.copyRowsAsJson(at: indices)
+        coordinator.copyRowsAsJson(at: selectedOrCurrentIndices(in: coordinator))
+    }
+
+    @objc private func copyAsCsv() {
+        guard let coordinator else { return }
+        coordinator.copyRowsAsCsv(at: selectedOrCurrentIndices(in: coordinator), includeHeaders: false)
+    }
+
+    @objc private func copyAsCsvWithHeaders() {
+        guard let coordinator else { return }
+        coordinator.copyRowsAsCsv(at: selectedOrCurrentIndices(in: coordinator), includeHeaders: true)
+    }
+
+    @objc private func copyAsMarkdown() {
+        guard let coordinator else { return }
+        coordinator.copyRowsAsMarkdown(at: selectedOrCurrentIndices(in: coordinator))
+    }
+
+    @objc private func copyAsInClause(_ sender: NSMenuItem) {
+        guard let coordinator, let columnIndex = sender.representedObject as? Int else { return }
+        coordinator.copyRowsAsInClause(at: selectedOrCurrentIndices(in: coordinator), columnIndex: columnIndex)
     }
 
     @objc private func previewForeignKey(_ sender: NSMenuItem) {

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -2,8 +2,6 @@
 //  DataGridView+RowActions.swift
 //  TablePro
 //
-//  Row action methods extracted from DataGridView for maintainability.
-//
 
 import AppKit
 import os
@@ -158,6 +156,64 @@ extension TableViewCoordinator {
         let columnTypes = tableRows.columnTypes
         let converter = JsonRowConverter(columns: tableRows.columns, columnTypes: columnTypes)
         ClipboardService.shared.writeText(converter.generateJson(rows: rows))
+    }
+
+    func copyRowsAsCsv(at indices: Set<Int>, includeHeaders: Bool) {
+        let rows: [[PluginCellValue]] = indices.sorted().compactMap { displayRow(at: $0).map { Array($0.values) } }
+        guard !rows.isEmpty else { return }
+        let tableRows = tableRowsProvider()
+        let converter = CsvRowConverter(columns: tableRows.columns, columnTypes: tableRows.columnTypes)
+        ClipboardService.shared.writeCsv(converter.generateCsv(rows: rows, includeHeaders: includeHeaders))
+    }
+
+    func copyRowsAsMarkdown(at indices: Set<Int>) {
+        let rows: [[PluginCellValue]] = indices.sorted().compactMap { displayRow(at: $0).map { Array($0.values) } }
+        guard !rows.isEmpty else { return }
+        let tableRows = tableRowsProvider()
+        let converter = MarkdownTableConverter(columns: tableRows.columns, columnTypes: tableRows.columnTypes)
+        ClipboardService.shared.writeText(converter.generateMarkdown(rows: rows))
+    }
+
+    func copyRowsAsInClause(at indices: Set<Int>, columnIndex: Int) {
+        let rows: [[PluginCellValue]] = indices.sorted().compactMap { displayRow(at: $0).map { Array($0.values) } }
+        guard !rows.isEmpty else { return }
+        let tableRows = tableRowsProvider()
+        guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
+        let driver = resolveDriver()
+        let converter = InClauseConverter(
+            columnIndex: columnIndex,
+            columnTypes: tableRows.columnTypes,
+            escapeStringLiteral: driver?.escapeStringLiteral
+        )
+        ClipboardService.shared.writeText(converter.generateInClause(rows: rows))
+    }
+
+    func copyColumnValues(columnIndex: Int) {
+        let tableRows = tableRowsProvider()
+        guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
+        let rowCount = sortedIDs?.count ?? tableRows.rows.count
+        guard rowCount > 0 else { return }
+
+        let columnType = tableRows.columnTypes.indices.contains(columnIndex)
+            ? tableRows.columnTypes[columnIndex]
+            : nil
+
+        var lines: [String] = []
+        lines.reserveCapacity(rowCount)
+
+        for rowIndex in 0..<rowCount {
+            guard let row = displayRow(at: rowIndex), row.values.indices.contains(columnIndex) else { continue }
+            switch row.values[columnIndex] {
+            case .null:
+                lines.append("NULL")
+            case .text(let value):
+                lines.append(BlobFormattingService.shared.formatIfNeeded(value, columnType: columnType, for: .copy))
+            case .bytes(let data):
+                lines.append(BlobFormattingService.shared.format(data, for: .copy) ?? "")
+            }
+        }
+
+        ClipboardService.shared.writeText(lines.joined(separator: "\n"))
     }
 
     private func formatRowValues(values: [PluginCellValue], columnTypes: [ColumnType]?) -> [String] {

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -191,7 +191,8 @@ extension TableViewCoordinator {
     func copyColumnValues(columnIndex: Int) {
         let tableRows = tableRowsProvider()
         guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
-        let rowCount = sortedIDs?.count ?? tableRows.rows.count
+        let totalRows = sortedIDs?.count ?? tableRows.rows.count
+        let rowCount = min(totalRows, PluginRowLimits.emergencyMax)
         guard rowCount > 0 else { return }
 
         let columnType = tableRows.columnTypes.indices.contains(columnIndex)
@@ -203,14 +204,8 @@ extension TableViewCoordinator {
 
         for rowIndex in 0..<rowCount {
             guard let row = displayRow(at: rowIndex), row.values.indices.contains(columnIndex) else { continue }
-            switch row.values[columnIndex] {
-            case .null:
-                lines.append("NULL")
-            case .text(let value):
-                lines.append(BlobFormattingService.shared.formatIfNeeded(value, columnType: columnType, for: .copy))
-            case .bytes(let data):
-                lines.append(BlobFormattingService.shared.format(data, for: .copy) ?? "")
-            }
+            let text = RowValueCopyFormatter.copyText(cell: row.values[columnIndex], columnType: columnType) ?? "NULL"
+            lines.append(text)
         }
 
         ClipboardService.shared.writeText(lines.joined(separator: "\n"))

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -91,6 +91,17 @@ extension TableViewCoordinator {
         copyItem.target = self
         menu.addItem(copyItem)
 
+        if let dataColumnIndex = dataColumnIndex(from: column.identifier) {
+            let copyValuesItem = NSMenuItem(
+                title: String(localized: "Copy Column Values"),
+                action: #selector(copyColumnValues(_:)),
+                keyEquivalent: ""
+            )
+            copyValuesItem.representedObject = dataColumnIndex
+            copyValuesItem.target = self
+            menu.addItem(copyValuesItem)
+        }
+
         let filterItem = NSMenuItem(title: String(localized: "Filter with column"), action: #selector(filterWithColumn(_:)), keyEquivalent: "")
         filterItem.representedObject = baseName
         filterItem.target = self
@@ -193,6 +204,11 @@ extension TableViewCoordinator {
     @objc func copyColumnName(_ sender: NSMenuItem) {
         guard let columnName = sender.representedObject as? String else { return }
         ClipboardService.shared.writeText(columnName)
+    }
+
+    @objc func copyColumnValues(_ sender: NSMenuItem) {
+        guard let columnIndex = sender.representedObject as? Int else { return }
+        copyColumnValues(columnIndex: columnIndex)
     }
 
     @objc func filterWithColumn(_ sender: NSMenuItem) {

--- a/TableProTests/Core/Services/ClipboardServiceTests.swift
+++ b/TableProTests/Core/Services/ClipboardServiceTests.swift
@@ -1,0 +1,45 @@
+//
+//  ClipboardServiceTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+import UniformTypeIdentifiers
+
+@MainActor
+@Suite("ClipboardService pasteboard")
+struct ClipboardServiceTests {
+    private static let csvType = NSPasteboard.PasteboardType("public.comma-separated-values-text")
+    private static let tsvType = NSPasteboard.PasteboardType("public.utf8-tab-separated-values-text")
+    private static let gridRowsType = NSPasteboard.PasteboardType("com.TablePro.gridRows")
+
+    @Test("writeCsv writes string, utf8PlainText, and the CSV UTI")
+    func writeCsvWritesCsvUti() {
+        let provider = NSPasteboardClipboardProvider()
+        let csv = "id,name\n1,alice\n"
+        provider.writeCsv(csv)
+
+        let pb = NSPasteboard.general
+        #expect(pb.string(forType: .string) == csv)
+        #expect(pb.string(forType: NSPasteboard.PasteboardType(UTType.utf8PlainText.identifier)) == csv)
+        #expect(pb.string(forType: Self.csvType) == csv)
+    }
+
+    @Test("writeCsv does not write the gridRows marker (CSV is not a grid paste)")
+    func writeCsvSkipsGridRowsMarker() {
+        let provider = NSPasteboardClipboardProvider()
+        provider.writeCsv("a,b\n")
+        let pb = NSPasteboard.general
+        #expect(pb.types?.contains(Self.gridRowsType) != true)
+    }
+
+    @Test("writeCsv does not write the TSV UTI (avoids spreadsheet auto-paste-as-TSV)")
+    func writeCsvSkipsTsvUti() {
+        let provider = NSPasteboardClipboardProvider()
+        provider.writeCsv("a,b\n")
+        let pb = NSPasteboard.general
+        #expect(pb.string(forType: Self.tsvType) == nil)
+    }
+}

--- a/TableProTests/Core/Services/RowOperationsManagerCopyTests.swift
+++ b/TableProTests/Core/Services/RowOperationsManagerCopyTests.swift
@@ -15,6 +15,11 @@ private final class MockClipboardProvider: ClipboardProvider {
         lastWasGridRows = false
     }
 
+    func writeCsv(_ csv: String) {
+        lastWrittenText = csv
+        lastWasGridRows = false
+    }
+
     func writeRows(tsv: String, html: String?) {
         lastWrittenText = tsv
         lastWasGridRows = true

--- a/TableProTests/Core/Utilities/CsvRowConverterTests.swift
+++ b/TableProTests/Core/Utilities/CsvRowConverterTests.swift
@@ -1,0 +1,102 @@
+//
+//  CsvRowConverterTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+
+@testable import TablePro
+import Testing
+
+@Suite("CSV Row Converter")
+struct CsvRowConverterTests {
+    private func makeConverter(columns: [String], columnTypes: [ColumnType]) -> CsvRowConverter {
+        CsvRowConverter(columns: columns, columnTypes: columnTypes)
+    }
+
+    @Test("Empty rows produces empty string")
+    func emptyRows() {
+        let converter = makeConverter(columns: ["id"], columnTypes: [.integer(rawType: nil)])
+        let result = converter.generateCsv(rows: [], includeHeaders: false)
+        #expect(result == "")
+    }
+
+    @Test("Plain values without quoting")
+    func plainValues() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateCsv(rows: [["1", "alice"], ["2", "bob"]], includeHeaders: false)
+        #expect(result == "1,alice\n2,bob\n")
+    }
+
+    @Test("Headers prepended when requested")
+    func headers() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateCsv(rows: [["1", "alice"]], includeHeaders: true)
+        #expect(result == "id,name\n1,alice\n")
+    }
+
+    @Test("NULL becomes empty field")
+    func nullEmpty() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateCsv(rows: [["1", nil]], includeHeaders: false)
+        #expect(result == "1,\n")
+    }
+
+    @Test("Mid-row NULL keeps subsequent columns aligned")
+    func nullKeepsAlignment() {
+        let converter = makeConverter(
+            columns: ["a", "b", "c"],
+            columnTypes: Array(repeating: ColumnType.text(rawType: nil), count: 3)
+        )
+        let result = converter.generateCsv(rows: [["a", nil, "c"]], includeHeaders: false)
+        #expect(result == "a,,c\n")
+    }
+
+    @Test("Leading and trailing whitespace forces quoting")
+    func whitespaceQuoting() {
+        let converter = makeConverter(columns: ["name"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateCsv(rows: [[" leading"], ["trailing "]], includeHeaders: false)
+        #expect(result == "\" leading\"\n\"trailing \"\n")
+    }
+
+    @Test("Values with commas are quoted")
+    func commaQuoting() {
+        let converter = makeConverter(columns: ["name"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateCsv(rows: [["doe, john"]], includeHeaders: false)
+        #expect(result == "\"doe, john\"\n")
+    }
+
+    @Test("Embedded quotes are doubled")
+    func quoteEscape() {
+        let converter = makeConverter(columns: ["quote"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateCsv(rows: [["he said \"hi\""]], includeHeaders: false)
+        #expect(result == "\"he said \"\"hi\"\"\"\n")
+    }
+
+    @Test("Newlines force quoting")
+    func newlineQuoting() {
+        let converter = makeConverter(columns: ["note"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateCsv(rows: [["line1\nline2"]], includeHeaders: false)
+        #expect(result == "\"line1\nline2\"\n")
+    }
+
+    @Test("Header containing comma is quoted")
+    func quotedHeader() {
+        let converter = makeConverter(
+            columns: ["first, last"],
+            columnTypes: [.text(rawType: nil)]
+        )
+        let result = converter.generateCsv(rows: [["alice"]], includeHeaders: true)
+        #expect(result == "\"first, last\"\nalice\n")
+    }
+}

--- a/TableProTests/Core/Utilities/InClauseConverterTests.swift
+++ b/TableProTests/Core/Utilities/InClauseConverterTests.swift
@@ -1,0 +1,105 @@
+//
+//  InClauseConverterTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+
+@testable import TablePro
+import Testing
+
+@Suite("IN Clause Converter")
+struct InClauseConverterTests {
+    private func makeConverter(
+        columnIndex: Int,
+        columnTypes: [ColumnType],
+        escape: ((String) -> String)? = nil
+    ) -> InClauseConverter {
+        InClauseConverter(columnIndex: columnIndex, columnTypes: columnTypes, escapeStringLiteral: escape)
+    }
+
+    @Test("Empty rows yields empty parens")
+    func emptyRows() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.integer(rawType: nil)])
+        let result = converter.generateInClause(rows: [])
+        #expect(result == "()")
+    }
+
+    @Test("Integer column produces unquoted values")
+    func integers() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.integer(rawType: nil)])
+        let result = converter.generateInClause(rows: [["1"], ["2"], ["3"]])
+        #expect(result == "(1, 2, 3)")
+    }
+
+    @Test("Text column produces quoted values")
+    func text() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.text(rawType: nil)])
+        let result = converter.generateInClause(rows: [["alice"], ["bob"]])
+        #expect(result == "('alice', 'bob')")
+    }
+
+    @Test("Single quote in text is escaped by doubling when no driver escape is provided")
+    func defaultEscape() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.text(rawType: nil)])
+        let result = converter.generateInClause(rows: [["O'Brien"]])
+        #expect(result == "('O''Brien')")
+    }
+
+    @Test("Driver-provided escape is used when available")
+    func driverEscape() {
+        let converter = makeConverter(
+            columnIndex: 0,
+            columnTypes: [.text(rawType: nil)],
+            escape: { $0.replacingOccurrences(of: "'", with: "\\'") }
+        )
+        let result = converter.generateInClause(rows: [["O'Brien"]])
+        #expect(result == "('O\\'Brien')")
+    }
+
+    @Test("NULL values are excluded so the IN clause matches its non-NULL siblings cleanly")
+    func nullExcluded() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.integer(rawType: nil)])
+        let result = converter.generateInClause(rows: [["1"], [nil], ["3"]])
+        #expect(result == "(1, 3)")
+    }
+
+    @Test("All-NULL selection yields empty parens")
+    func allNull() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.integer(rawType: nil)])
+        let result = converter.generateInClause(rows: [[nil], [nil]])
+        #expect(result == "()")
+    }
+
+    @Test("Boolean true variants normalize to TRUE")
+    func boolTrue() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.boolean(rawType: nil)])
+        let result = converter.generateInClause(rows: [["true"], ["1"], ["yes"], ["on"]])
+        #expect(result == "(TRUE, TRUE, TRUE, TRUE)")
+    }
+
+    @Test("Boolean false variants normalize to FALSE")
+    func boolFalse() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.boolean(rawType: nil)])
+        let result = converter.generateInClause(rows: [["false"], ["0"], ["no"], ["off"]])
+        #expect(result == "(FALSE, FALSE, FALSE, FALSE)")
+    }
+
+    @Test("Decimal column emits unquoted values")
+    func decimals() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.decimal(rawType: nil)])
+        let result = converter.generateInClause(rows: [["3.14"], ["2.71"]])
+        #expect(result == "(3.14, 2.71)")
+    }
+
+    @Test("Picks the requested column index, not the first")
+    func columnIndexHonored() {
+        let converter = makeConverter(
+            columnIndex: 1,
+            columnTypes: [.text(rawType: nil), .integer(rawType: nil)]
+        )
+        let result = converter.generateInClause(rows: [["alice", "1"], ["bob", "2"]])
+        #expect(result == "(1, 2)")
+    }
+}

--- a/TableProTests/Core/Utilities/InClauseConverterTests.swift
+++ b/TableProTests/Core/Utilities/InClauseConverterTests.swift
@@ -72,6 +72,15 @@ struct InClauseConverterTests {
         #expect(result == "()")
     }
 
+    @Test("Integer column preserves HUGEINT values beyond Int64 range")
+    func hugeIntInteger() {
+        let converter = makeConverter(columnIndex: 0, columnTypes: [.integer(rawType: nil)])
+        let max = "170141183460469231731687303715884105727"
+        let min = "-170141183460469231731687303715884105728"
+        let result = converter.generateInClause(rows: [[PluginCellValue.text(max)], [PluginCellValue.text(min)]])
+        #expect(result == "(\(max), \(min))")
+    }
+
     @Test("Boolean true variants normalize to TRUE")
     func boolTrue() {
         let converter = makeConverter(columnIndex: 0, columnTypes: [.boolean(rawType: nil)])

--- a/TableProTests/Core/Utilities/MarkdownTableConverterTests.swift
+++ b/TableProTests/Core/Utilities/MarkdownTableConverterTests.swift
@@ -1,0 +1,61 @@
+//
+//  MarkdownTableConverterTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+
+@testable import TablePro
+import Testing
+
+@Suite("Markdown Table Converter")
+struct MarkdownTableConverterTests {
+    private func makeConverter(columns: [String], columnTypes: [ColumnType]) -> MarkdownTableConverter {
+        MarkdownTableConverter(columns: columns, columnTypes: columnTypes)
+    }
+
+    @Test("Header and alignment rows always emitted")
+    func headerAlignment() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateMarkdown(rows: [["1", "alice"]])
+        let lines = result.split(separator: "\n", omittingEmptySubsequences: false)
+        #expect(lines[0] == "| id | name |")
+        #expect(lines[1] == "| --- | --- |")
+        #expect(lines[2] == "| 1 | alice |")
+    }
+
+    @Test("NULL renders as NULL literal")
+    func nullLiteral() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateMarkdown(rows: [["1", nil]])
+        #expect(result.contains("| 1 | NULL |"))
+    }
+
+    @Test("Pipe characters in cells are escaped")
+    func pipeEscape() {
+        let converter = makeConverter(columns: ["expr"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateMarkdown(rows: [["a | b"]])
+        #expect(result.contains("| a \\| b |"))
+    }
+
+    @Test("Newlines in cells become <br>")
+    func newlineToBr() {
+        let converter = makeConverter(columns: ["note"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateMarkdown(rows: [["line1\nline2"]])
+        #expect(result.contains("line1<br>line2"))
+    }
+
+    @Test("Empty columns yields empty string")
+    func emptyColumns() {
+        let converter = makeConverter(columns: [], columnTypes: [])
+        let result = converter.generateMarkdown(rows: [["x"]])
+        #expect(result == "")
+    }
+}

--- a/TableProTests/Views/Results/Extensions/CellPasteRoutingTests.swift
+++ b/TableProTests/Views/Results/Extensions/CellPasteRoutingTests.swift
@@ -29,6 +29,7 @@ private final class StubClipboard: ClipboardProvider {
 
     func readText() -> String? { text }
     func writeText(_ text: String) { self.text = text; hasGridRowsValue = false }
+    func writeCsv(_ csv: String) { self.text = csv; hasGridRowsValue = false }
     func writeRows(tsv: String, html: String?) { self.text = tsv; hasGridRowsValue = true }
     var hasText: Bool { text != nil }
     var hasGridRows: Bool { hasGridRowsValue }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -321,7 +321,23 @@ Use arrow keys to move between cells. Press `Enter` to edit, `Escape` to cancel.
 
 Click a cell to select it. Drag or Shift+click to select a range. Click row numbers for entire rows; Cmd+click for non-contiguous rows.
 
-Select cells and press `Cmd+C` for TSV, `Cmd+Shift+C` for CSV, or `Cmd+Option+J` for JSON.
+Select rows and press `Cmd+C` for TSV, `Cmd+Shift+C` for TSV with headers, or `Cmd+Option+J` for JSON.
+
+Right-click a row and choose **Copy as** for additional formats:
+
+| Format | Description |
+|--------|-------------|
+| Cell Value | The clicked cell's content |
+| With Headers | TSV with the column names as the first line |
+| JSON | A JSON array of row objects |
+| CSV | RFC 4180 CSV; empty fields for NULL |
+| CSV with Headers | Same as CSV with the header row prepended |
+| Markdown | GitHub-flavored Markdown table |
+| IN Clause | `('a', 'b', 'c')` from the clicked column across selected rows, ready for `WHERE col IN (...)` |
+| INSERT Statement(s) | SQL INSERT for each row (SQL databases only) |
+| UPDATE Statement(s) | SQL UPDATE for each row by primary key (SQL databases only) |
+
+Right-click a column header and choose **Copy Column Values** to copy every loaded value in that column, one per line.
 
 {/* Screenshot: Copy options in context menu */}
 <Frame caption="Copy options in context menu">


### PR DESCRIPTION
## Summary

Closes #1325 (能否添加复制多条id功能? — "Can you add a feature to copy multiple IDs, or copy an entire column?").

Adds two complementary entry points to the data grid:

- **Right-click column header → Copy Column Values** — copies every value from the loaded rows of the clicked column, one per line. Operates on the currently visible page (matches every other copy action in the app).
- **Row context menu → Copy as submenu**: new entries for **CSV**, **CSV with Headers**, **Markdown table**, and **IN Clause**. IN Clause produces `(1, 2, 3)` or `('a', 'b')` from the right-clicked column across the selected rows, ready to paste into a `WHERE col IN (...)` query.

Native macOS pattern throughout — NSMenu / NSMenuItem with `representedObject` carrying column indices, dispatching to coordinator methods that mirror the existing `copyRowsAsJson(at:)` / `copyRowsAsInsert(at:)` shape. No new abstractions; new converters (`CsvRowConverter`, `MarkdownTableConverter`, `InClauseConverter`) live in `Core/Utilities/SQL/` alongside the existing `JsonRowConverter` / `SQLRowToStatementConverter` and follow the same struct shape.

`ClipboardService` gains a `writeCsv(_:)` method that writes `.string` + `utf8PlainText` + `public.comma-separated-values-text` so pasting CSV into Numbers/Excel works without content-sniffing. `writeText` and `writeRows` are unchanged.

## Design decisions

- **Column Values lives on the column header context menu**, not the row Copy-as submenu. HIG-wise headers are for structural actions (sort, hide, resize) and Numbers/Mail follow that pattern. But here the action is self-explanatory and discoverable, similar to TablePlus's "Copy All Column Value". One menu item, no submenu.
- **IN Clause uses the right-clicked column**, same idiom as the existing "Cell Value" entry. Reflects the user's natural mental model when copy-pasting from a specific cell into a WHERE clause.
- **Scope is loaded rows only**, not "all matching rows in the database". Matches every other copy operation in the app. No background queries, no surprise costs.
- **NULL handling differs by format on purpose** — CSV: empty field (RFC 4180 / Postgres COPY default). Markdown: `NULL` literal (matches grid display). IN Clause: NULLs are filtered out — `WHERE x IN (.., NULL, ..)` never matches NULL rows in three-valued SQL logic anyway, so emitting them would silently mislead the user.
- **No new keyboard shortcuts**. `Cmd+C` (TSV) and `Cmd+Shift+C` (TSV with Headers) stay default. `Cmd+Opt+C` is reserved by macOS for "Copy Style" in text contexts and would conflict in the SQL editor.

## Code centralization

Following the existing `copyRowsAsJson(at:)` pattern exactly:

```swift
// TableViewCoordinator extension (DataGridView+RowActions.swift)
func copyRowsAsCsv(at:includeHeaders:)
func copyRowsAsMarkdown(at:)
func copyRowsAsInClause(at:columnIndex:)
func copyColumnValues(columnIndex:)
```

All three converters use the driver-provided `escapeStringLiteral` closure when the column needs SQL quoting — same pattern as `SQLRowToStatementConverter`.

## Files changed

- New converters: `CsvRowConverter.swift`, `MarkdownTableConverter.swift`, `InClauseConverter.swift`
- New tests: `CsvRowConverterTests`, `MarkdownTableConverterTests`, `InClauseConverterTests` (24 tests, all passing)
- `ClipboardService.swift` — new `writeCsv(_:)` plus protocol method; existing mocks updated
- `DataGridRowView.swift` — 4 new menu items + actions, dedup helper `selectedOrCurrentIndices(in:)` covering 8 existing call sites that had the same guard/ternary pattern duplicated
- `DataGridView+Sort.swift` — 1 new header-menu item + action
- `Localizable.xcstrings` — Xcode auto-extracted new String(localized:) keys
- `docs/features/data-grid.mdx` — full Copy as / Copy Column Values table, plus a correction (Cmd+Shift+C was documented as "CSV"; it's actually TSV with Headers)

## Verification

- 24 new converter tests pass; all existing copy/paste tests in `RowOperationsManagerCopyTests` + `CellPasteRoutingTests` still green
- Build clean against the main TablePro scheme
- No banned filler words in CHANGELOG / docs / PR body

## Test plan

- [ ] Right-click a column header on a SELECT result, choose **Copy Column Values**, paste into a text editor — one value per line, length matches loaded rows.
- [ ] Select 3 rows on an `id INT` column, right-click on the `id` cell, **Copy as → IN Clause** — clipboard contains `(1, 2, 3)`.
- [ ] Same flow with a `name VARCHAR` column — clipboard contains `('a', 'b', 'c')` with proper quoting.
- [ ] **Copy as → CSV** with a row containing `O'Brien` and `doe, john` — RFC 4180 compliant quoting.
- [ ] **Copy as → Markdown** — pipe-escaped cells render correctly when pasted into GitHub/Discord.
- [ ] Existing `Cmd+C` (TSV) and `Cmd+Shift+C` (TSV with Headers) behavior unchanged.