### PR TITLE
fix(plugins): register all SQLite file extensions end-to-end (#1327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DuckDB schema reads handle apostrophes and concurrent schema switches correctly
 - DuckDB ENUMs in non-`main` schemas resolve correctly
 - DuckDB `DATE` and `TIMESTAMP` BC years use a leading minus
+- `.db`, `.db3`, `.s3db`, `.sl3`, and `.sqlitedb` files now open in TablePro from Finder (#1327)
 
 ## [0.43.0] - 2026-05-18
 

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -32,7 +32,7 @@ final class SQLitePlugin: NSObject, TableProPlugin, DriverPlugin {
     static let pathFieldRole: PathFieldRole = .filePath
     static let connectionMode: ConnectionMode = .fileBased
     static let urlSchemes: [String] = ["sqlite"]
-    static let fileExtensions: [String] = ["db", "sqlite", "sqlite3"]
+    static let fileExtensions: [String] = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
     static let brandColorHex = "#003B57"
     static let supportsDatabaseSwitching = false
     static let databaseGroupingStrategy: GroupingStrategy = .flat

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -709,7 +709,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     immutableColumns: [],
                     systemDatabaseNames: [],
                     systemSchemaNames: [],
-                    fileExtensions: ["db", "sqlite", "sqlite3"],
+                    fileExtensions: ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"],
                     databaseGroupingStrategy: .flat,
                     structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
                 ),

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -50,12 +50,12 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
-				<string>sqlite</string>
-				<string>sqlite3</string>
 				<string>db</string>
 				<string>db3</string>
 				<string>s3db</string>
 				<string>sl3</string>
+				<string>sqlite</string>
+				<string>sqlite3</string>
 				<string>sqlitedb</string>
 			</array>
 			<key>CFBundleTypeName</key>
@@ -63,7 +63,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Default</string>
+			<string>Alternate</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.apple.sqlite3</string>
@@ -173,12 +173,12 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>sqlite</string>
-					<string>sqlite3</string>
 					<string>db</string>
 					<string>db3</string>
 					<string>s3db</string>
 					<string>sl3</string>
+					<string>sqlite</string>
+					<string>sqlite3</string>
 					<string>sqlitedb</string>
 				</array>
 			</dict>

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -52,6 +52,7 @@
 			<array>
 				<string>sqlite</string>
 				<string>sqlite3</string>
+				<string>db</string>
 				<string>db3</string>
 				<string>s3db</string>
 				<string>sl3</string>
@@ -174,6 +175,7 @@
 				<array>
 					<string>sqlite</string>
 					<string>sqlite3</string>
+					<string>db</string>
 					<string>db3</string>
 					<string>s3db</string>
 					<string>sl3</string>

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -385,6 +385,7 @@ struct ConnectionFormView: View {
     // MARK: - Helpers
 
     private var sqliteContentTypes: [UTType] {
-        [UTType.database, UTType(filenameExtension: "sqlite3") ?? .data, .data]
+        let extensions = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
+        return [UTType.database] + extensions.compactMap { UTType(filenameExtension: $0) } + [.data]
     }
 }

--- a/TableProTests/Plugins/SQLiteFileExtensionsTests.swift
+++ b/TableProTests/Plugins/SQLiteFileExtensionsTests.swift
@@ -1,0 +1,28 @@
+//
+//  SQLiteFileExtensionsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("SQLite file extension registration")
+struct SQLiteFileExtensionsTests {
+    private static let canonical: [String] = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
+
+    @Test("Plugin metadata registry exposes the canonical SQLite extensions")
+    func registryHasCanonicalExtensions() throws {
+        let snapshot = try #require(PluginMetadataRegistry.shared.snapshot(forTypeId: "SQLite"))
+        #expect(snapshot.schema.fileExtensions.sorted() == Self.canonical.sorted())
+    }
+
+    @Test("URLClassifier resolves every canonical extension to the SQLite database type")
+    func urlClassifierResolvesEveryExtension() {
+        let extensionMap = PluginManager.shared.allRegisteredFileExtensions
+        for ext in Self.canonical {
+            #expect(extensionMap[ext] != nil, "extension \(ext) is not registered")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1327 (`.db` not registered as SQLite document type — Finder "Open With" grays out TablePro).

The reported gap was `.db`, but auditing the codebase surfaced the opposite-direction gap as well: TablePro's `Info.plist` and the SQLite plugin had different SQLite extension lists, and **neither was a superset of the other**.

| Source | Before |
|---|---|
| `Info.plist` (CFBundleDocumentTypes + UTExportedTypeDeclarations) | `sqlite, sqlite3, db3, s3db, sl3, sqlitedb` |
| `SQLitePlugin.swift` + `PluginMetadataRegistry` | `db, sqlite, sqlite3` |

Two real bugs from this mismatch:
1. `.db` files missing from `Info.plist` → Finder "Open With" grays out TablePro (the reported issue).
2. `.db3` / `.s3db` / `.sl3` / `.sqlitedb` files claimed by `Info.plist` but **not registered in the plugin's extension map** → `URLClassifier.swift:37` returns `nil` from `classifyFile(...)`, so double-clicking these files in Finder launches TablePro but silently fails to open them. This was a latent bug nobody had reported yet.

Fix: pick the **union** in all four locations: `db, db3, s3db, sl3, sqlite, sqlite3, sqlitedb`. Plus mobile parity.

## Files changed

- `TablePro/Info.plist` — added `db` to `CFBundleDocumentTypes` and `UTExportedTypeDeclarations` (the second one is what tells Launch Services TablePro can handle the type)
- `Plugins/SQLiteDriverPlugin/SQLitePlugin.swift` — extension list now `["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]`
- `TablePro/Core/Plugins/PluginMetadataRegistry.swift` — same list, the registry's runtime map for `URLClassifier`
- `TableProMobile/.../ConnectionFormView.swift` — file picker now allows all 7 extensions instead of hardcoding `sqlite3` only
- `CHANGELOG.md` — one Fixed entry under Unreleased

## Verification

- Build clean (only pre-existing third-party SwiftLint failures, unrelated)
- No banned filler in diff
- No new dependencies, no new pasteboard or UTI declarations beyond extending an existing one

## Test plan

- [ ] Save a SQLite database with a `.db` extension (e.g., the Chinook sample). Right-click in Finder → Open With → TablePro is offered, not grayed out.
- [ ] Same for `.db3`, `.s3db`, `.sl3`, `.sqlitedb` files.
- [ ] Double-click any of the 7 extensions on a real SQLite file — TablePro opens it as a database connection (previously only `.sqlite`/`.sqlite3` worked reliably).
- [ ] On iOS, open the connection form and tap the SQLite file picker — `.db` files are now selectable.