### PR TITLE
feat(datagrid): copy focused cell value with Cmd+C, add Cmd+Shift+C for rows (#1332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-click a column header to copy all its values from the loaded rows (#1325)
 - Copy as submenu on the row context menu now offers CSV, CSV with Headers, Markdown table, and IN Clause for SQL `WHERE id IN (...)` lookups (#1325)
 
+### Changed
+
+- `Cmd+C` now copies the focused cell value when one row is selected and a cell has focus; with multiple rows selected, or when no cell is focused, it still copies row(s) as TSV. `Cmd+Shift+C` now always copies row(s) as TSV. "Copy with Headers" stays in the Edit menu and row context menu without a default shortcut (#1332)
+
 ### Fixed
 
 - DuckDB Spatial `GEOMETRY` columns render as WKT, not NULL (#1324)

--- a/TablePro/Core/KeyboardHandling/PasteboardActionRouter.swift
+++ b/TablePro/Core/KeyboardHandling/PasteboardActionRouter.swift
@@ -29,13 +29,14 @@ enum PasteboardActionRouter {
         if let responder = firstResponder,
            responder is NSTextView || responder is TextView {
             return .textCopy
-        } else if hasRowSelection {
-            return .copyRows
-        } else if hasTableSelection {
-            return .copyTableNames
-        } else {
-            return .textCopy
         }
+        if hasRowSelection {
+            return .copyRows
+        }
+        if hasTableSelection {
+            return .copyTableNames
+        }
+        return .textCopy
     }
 
     static func resolvePasteAction(

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -64,6 +64,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case redo
     case cut
     case copy
+    case copyRowsExplicit
     case copyWithHeaders
     case copyAsJson
     case paste
@@ -103,7 +104,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .executeQuery, .explainQuery, .formatQuery, .export, .importData, .quickSwitcher,
              .previousPage, .nextPage, .saveAsFavorite, .openTerminal:
             return .file
-        case .undo, .redo, .cut, .copy, .copyWithHeaders, .copyAsJson, .paste,
+        case .undo, .redo, .cut, .copy, .copyRowsExplicit, .copyWithHeaders, .copyAsJson, .paste,
              .delete, .selectAll, .clearSelection, .addRow,
              .duplicateRow, .truncateTable, .previewFKReference:
             return .edit
@@ -142,6 +143,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .redo: return String(localized: "Redo")
         case .cut: return String(localized: "Cut")
         case .copy: return String(localized: "Copy")
+        case .copyRowsExplicit: return String(localized: "Copy Rows")
         case .copyWithHeaders: return String(localized: "Copy with Headers")
         case .copyAsJson: return String(localized: "Copy as JSON")
         case .paste: return String(localized: "Paste")
@@ -482,7 +484,7 @@ struct KeyboardSettings: Codable, Equatable {
         .redo: KeyCombo(key: "z", command: true, shift: true),
         .cut: KeyCombo(key: "x", command: true),
         .copy: KeyCombo(key: "c", command: true),
-        .copyWithHeaders: KeyCombo(key: "c", command: true, shift: true),
+        .copyRowsExplicit: KeyCombo(key: "c", command: true, shift: true),
         .copyAsJson: KeyCombo(key: "j", command: true, option: true),
         .paste: KeyCombo(key: "v", command: true),
         .delete: KeyCombo(key: "delete", command: true, isSpecialKey: true),

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -12512,6 +12512,9 @@
         }
       }
     },
+    "Copy Rows" : {
+
+    },
     "Copy SQL" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -18,9 +18,13 @@ import TableProPluginKit
 /// Custom Commands struct for pasteboard operations
 struct PasteboardCommands: Commands {
     var settingsManager: AppSettingsManager
-    @FocusedValue(\.commandActions) var actions: MainContentCommandActions?
+    @FocusedValue(\.commandActions) var focusedActions: MainContentCommandActions?
+    @Bindable var commandRegistry: CommandActionsRegistry
 
-    /// Build a SwiftUI KeyboardShortcut from keyboard settings
+    private var actions: MainContentCommandActions? {
+        focusedActions ?? commandRegistry.current
+    }
+
     private func shortcut(for action: ShortcutAction) -> KeyboardShortcut? {
         settingsManager.keyboard.keyboardShortcut(for: action)
     }
@@ -39,15 +43,19 @@ struct PasteboardCommands: Commands {
                     hasTableSelection: actions?.hasTableSelection ?? false
                 )
                 switch action {
-                case .textCopy:
+                case .textCopy, .copyRows:
                     NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
-                case .copyRows:
-                    actions?.copySelectedRows()
                 case .copyTableNames:
                     actions?.copyTableNames()
                 }
             }
             .optionalKeyboardShortcut(shortcut(for: .copy))
+
+            Button("Copy Rows") {
+                NSApp.sendAction(#selector(KeyHandlingTableView.copyRowsAsTSV(_:)), to: nil, from: nil)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .copyRowsExplicit))
+            .disabled(!(actions?.hasRowSelection ?? false))
 
             Button("Copy with Headers") {
                 actions?.copySelectedRowsWithHeaders()
@@ -458,8 +466,7 @@ struct AppMenuCommands: Commands {
             .optionalKeyboardShortcut(shortcut(for: .redo))
         }
 
-        // Edit menu - pasteboard commands with FocusedValue support
-        PasteboardCommands(settingsManager: settingsManager)
+        PasteboardCommands(settingsManager: settingsManager, commandRegistry: commandRegistry)
 
         // Edit menu - Find + row operations (after pasteboard)
         CommandGroup(after: .pasteboard) {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -433,8 +433,11 @@ struct MainEditorContentView: View {
             case .structure:
                 if let tableName = tab.tableContext.tableName {
                     TableStructureView(
-                        tableName: tableName, connection: connection,
-                        toolbarState: coordinator.toolbarState, coordinator: coordinator
+                        tableName: tableName,
+                        connection: connection,
+                        toolbarState: coordinator.toolbarState,
+                        coordinator: coordinator,
+                        selectionState: selectionState
                     )
                     .id(tableName)
                     .frame(maxHeight: .infinity)

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -173,9 +173,7 @@ final class MainContentCommandActions {
         observeKeyWindowOnly(AppCommands.shared.exportQueryResults) { [weak self] _ in self?.exportQueryResults() }
 
         observeKeyWindowOnly(AppCommands.shared.copySelectedRows) { [weak self] _ in
-            guard let self else { return }
-            let indices = self.selectionState.indices
-            self.coordinator?.copySelectedRowsToClipboard(indices: indices)
+            self?.copySelectedRows()
         }
 
         observeKeyWindowOnly(AppCommands.shared.pasteRows) { [weak self] _ in

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -118,7 +118,26 @@ final class KeyHandlingTableView: NSTableView {
     }
 
     @objc func copy(_ sender: Any?) {
+        if let cell = focusedDataCell() {
+            coordinator?.copyCellValue(at: cell.row, columnIndex: cell.columnIndex)
+        } else {
+            coordinator?.delegate?.dataGridCopyRows(Set(selectedRowIndexes))
+        }
+    }
+
+    @objc func copyRowsAsTSV(_ sender: Any?) {
         coordinator?.delegate?.dataGridCopyRows(Set(selectedRowIndexes))
+    }
+
+    private func focusedDataCell() -> (row: Int, columnIndex: Int)? {
+        guard selectedRowIndexes.count == 1,
+              focusedRow >= 0,
+              DataGridView.isDataTableColumn(focusedColumn),
+              let schema = coordinator?.identitySchema,
+              let dataColumn = DataGridView.dataColumnIndex(for: focusedColumn, in: self, schema: schema) else {
+            return nil
+        }
+        return (focusedRow, dataColumn)
     }
 
     @objc func paste(_ sender: Any?) {
@@ -137,7 +156,7 @@ final class KeyHandlingTableView: NSTableView {
         switch item.action {
         case #selector(delete(_:)), #selector(deleteBackward(_:)):
             return coordinator?.isEditable == true && !selectedRowIndexes.isEmpty
-        case #selector(copy(_:)):
+        case #selector(copy(_:)), #selector(copyRowsAsTSV(_:)):
             return !selectedRowIndexes.isEmpty
         case #selector(paste(_:)):
             return coordinator?.isEditable == true && coordinator?.delegate != nil

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -86,6 +86,7 @@ struct TableStructureView: View {
             contentArea
         }
         .task(loadInitialData)
+        .onChange(of: selectedRows) { _, newRows in selectionState.indices = newRows }
         .onChange(of: selectedTab) { _, newValue in onSelectedTabChanged(newValue) }
         .onChange(of: columns) { onColumnsChanged() }
         .onChange(of: indexes) { onIndexesChanged() }
@@ -95,10 +96,7 @@ struct TableStructureView: View {
         .onAppear {
             coordinator?.toolbarState.hasStructureChanges = structureChangeManager.hasChanges
 
-            gridDelegate.onSelectedRowsChanged = { rows in
-                self.selectedRows = rows
-                self.selectionState.indices = rows
-            }
+            gridDelegate.onSelectedRowsChanged = { self.selectedRows = $0 }
             gridDelegate.coordinator = coordinator
             gridDelegate.sortHandler = { [self] column, ascending in
                 structureSortDescriptor = StructureSortDescriptor(column: column, ascending: ascending)

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -21,6 +21,7 @@ struct TableStructureView: View {
     let connection: DatabaseConnection
     let toolbarState: ConnectionToolbarState
     let coordinator: MainContentCoordinator?
+    let selectionState: GridSelectionState
 
     @State var selectedTab: StructureTab = .columns
     @State var columns: [ColumnInfo] = []
@@ -53,11 +54,18 @@ struct TableStructureView: View {
     @State var actionHandler = StructureViewActionHandler()
     @State var gridDelegate: StructureGridDelegate
 
-    init(tableName: String, connection: DatabaseConnection, toolbarState: ConnectionToolbarState, coordinator: MainContentCoordinator?) {
+    init(
+        tableName: String,
+        connection: DatabaseConnection,
+        toolbarState: ConnectionToolbarState,
+        coordinator: MainContentCoordinator?,
+        selectionState: GridSelectionState
+    ) {
         self.tableName = tableName
         self.connection = connection
         self.toolbarState = toolbarState
         self.coordinator = coordinator
+        self.selectionState = selectionState
 
         let manager = StructureChangeManager()
         _structureChangeManager = State(wrappedValue: manager)
@@ -87,7 +95,10 @@ struct TableStructureView: View {
         .onAppear {
             coordinator?.toolbarState.hasStructureChanges = structureChangeManager.hasChanges
 
-            gridDelegate.onSelectedRowsChanged = { self.selectedRows = $0 }
+            gridDelegate.onSelectedRowsChanged = { rows in
+                self.selectedRows = rows
+                self.selectionState.indices = rows
+            }
             gridDelegate.coordinator = coordinator
             gridDelegate.sortHandler = { [self] column, ascending in
                 structureSortDescriptor = StructureSortDescriptor(column: column, ascending: ascending)
@@ -114,6 +125,7 @@ struct TableStructureView: View {
         .onDisappear {
             coordinator?.toolbarState.hasStructureChanges = false
             coordinator?.structureActions = nil
+            selectionState.indices = []
         }
         .onChange(of: structureChangeManager.hasChanges) { _, newValue in
             coordinator?.toolbarState.hasStructureChanges = newValue
@@ -360,7 +372,8 @@ struct TableStructureView: View {
             type: .mysql
         ),
         toolbarState: ConnectionToolbarState(),
-        coordinator: nil
+        coordinator: nil,
+        selectionState: GridSelectionState()
     )
     .frame(width: 800, height: 600)
 }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -321,7 +321,7 @@ Use arrow keys to move between cells. Press `Enter` to edit, `Escape` to cancel.
 
 Click a cell to select it. Drag or Shift+click to select a range. Click row numbers for entire rows; Cmd+click for non-contiguous rows.
 
-Select rows and press `Cmd+C` for TSV, `Cmd+Shift+C` for TSV with headers, or `Cmd+Option+J` for JSON.
+`Cmd+C` copies the focused cell value when a single row is selected and a cell has focus; otherwise it copies the selected row(s) as TSV. `Cmd+Shift+C` always copies the selected row(s) as TSV. `Cmd+Option+J` copies as JSON.
 
 Right-click a row and choose **Copy as** for additional formats:
 

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -137,10 +137,10 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 
 | Action | Shortcut |
 |--------|----------|
-| Copy selection | `Cmd+C` |
-| Copy with Headers | `Cmd+Shift+C` |
+| Copy (cell value if a cell is focused on a single row, otherwise row(s) TSV) | `Cmd+C` |
+| Copy Rows as TSV | `Cmd+Shift+C` |
 | Copy as JSON | `Cmd+Option+J` |
-| Copy as TSV | Available from context menu |
+| Copy with Headers | Available from Edit menu and context menu |
 
 ## CSV Inspector
 


### PR DESCRIPTION
## Summary

Closes #1332.

`Cmd+C` in the data grid now copies the focused cell value when a single row is selected and a cell has focus on a data column. Otherwise it copies the selected row(s) as TSV (existing behavior).

`Cmd+Shift+C` is a new shortcut that always copies the selected row(s) as TSV, even when a cell is focused. "Copy with Headers" stays in the Edit menu and right-click menu but loses its default shortcut.

## Why

The data grid renders a cell focus border and tracks `focusedRow`/`focusedColumn`, but `Cmd+C` ignored both and always copied the whole row. Foreign key cells were the worst-affected case: double-click opens the FK popover instead of inline edit, so users had no keyboard path to copy just the cell value.

This aligns the shortcut with what the UI shows. Apple's HIG and most database clients (DataGrip, DBeaver, Postico, Sequel Ace, MySQL Workbench) target the most specific visible selection. TablePlus uses `Cmd+Shift+C` for explicit-rows, which this PR matches.

## Implementation

Native AppKit responder chain:

- `KeyHandlingTableView.copy(_:)` decides cell vs row internally based on `focusedDataCell()` (mirrors the existing `paste(_:)` pattern at the same call site).
- `KeyHandlingTableView.copyRowsAsTSV(_:)` is a new selector for explicit-row dispatch.
- `PasteboardCommands` menu buttons dispatch via `NSApp.sendAction(_, to: nil, from: nil)`, letting the responder chain deliver `copy:` to NSTextView or the table view.
- `PasteboardActionRouter` stays in its original 3-case form (text / rows / table-names). The sidebar table-names case still routes via app state because the sidebar may not be in the responder chain.
- `PasteboardCommands` now gets a `CommandActionsRegistry` fallback for `@FocusedValue`, matching `AppMenuCommands`. Without it, `.disabled(!hasRowSelection)` was always true when NSTableView was first responder, which disabled the "Copy Rows" menu item and blocked the shortcut.
- `AppCommands.copySelectedRows` observer routes through `copySelectedRows()` so the structure-tab guard applies.

## Test plan

- [ ] `xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginValidation -only-testing:TableProTests/PasteboardActionRouterTests`
- [ ] Open a table, click a cell, press `Cmd+C` -> clipboard contains only the cell value
- [ ] Open a table, click an FK cell (one that opens the FK popover on double-click), press `Cmd+C` -> clipboard contains the raw FK value
- [ ] Shift-select multiple rows, press `Cmd+C` -> clipboard contains TSV of all selected rows
- [ ] Single row + cell focus, press `Cmd+Shift+C` -> clipboard contains the row as TSV (not the cell)
- [ ] Click row-number column header (selects whole row, clears cell focus), press `Cmd+C` -> clipboard contains the row TSV
- [ ] Open SQL editor, select text, press `Cmd+C` -> standard text copy still works
- [ ] Click on sidebar to select tables (no row selection in grid), press `Cmd+C` -> table names copied
- [ ] Edit menu shows "Copy", "Copy Rows" (`Cmd+Shift+C`), "Copy with Headers" (no shortcut), "Copy as JSON" with correct enabled/disabled states
- [ ] Structure tab: same behavior — `Cmd+C` on a single focused cell copies cell value