### PR TITLE
refactor(datagrid): make Cmd+C and Cmd+Shift+C robust when focus left the grid

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -43,8 +43,12 @@ struct PasteboardCommands: Commands {
                     hasTableSelection: actions?.hasTableSelection ?? false
                 )
                 switch action {
-                case .textCopy, .copyRows:
+                case .textCopy:
                     NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+                case .copyRows:
+                    if !NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil) {
+                        actions?.copySelectedRows()
+                    }
                 case .copyTableNames:
                     actions?.copyTableNames()
                 }
@@ -52,7 +56,9 @@ struct PasteboardCommands: Commands {
             .optionalKeyboardShortcut(shortcut(for: .copy))
 
             Button("Copy Rows") {
-                NSApp.sendAction(#selector(KeyHandlingTableView.copyRowsAsTSV(_:)), to: nil, from: nil)
+                if !NSApp.sendAction(#selector(KeyHandlingTableView.copyRowsAsTSV(_:)), to: nil, from: nil) {
+                    actions?.copySelectedRows()
+                }
             }
             .optionalKeyboardShortcut(shortcut(for: .copyRowsExplicit))
             .disabled(!(actions?.hasRowSelection ?? false))

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -209,7 +209,8 @@ struct MainEditorContentView: View {
         case .createTable:
             CreateTableView(
                 connection: connection,
-                coordinator: coordinator
+                coordinator: coordinator,
+                selectionState: selectionState
             )
         case .erDiagram:
             erDiagramContent(tab: tab)

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -33,6 +33,7 @@ struct CreateTableView: View {
 
     let connection: DatabaseConnection
     var coordinator: MainContentCoordinator?
+    let selectionState: GridSelectionState
 
     @State private var structureChangeManager: StructureChangeManager
     @State private var wrappedChangeManager: AnyChangeManager
@@ -50,9 +51,14 @@ struct CreateTableView: View {
     @State private var sortState = SortState()
     @State private var columnLayout = ColumnLayoutState()
 
-    init(connection: DatabaseConnection, coordinator: MainContentCoordinator?) {
+    init(
+        connection: DatabaseConnection,
+        coordinator: MainContentCoordinator?,
+        selectionState: GridSelectionState
+    ) {
         self.connection = connection
         self.coordinator = coordinator
+        self.selectionState = selectionState
 
         let manager = StructureChangeManager()
         _structureChangeManager = State(wrappedValue: manager)
@@ -80,6 +86,8 @@ struct CreateTableView: View {
                 structureChangeManager.addNewColumn()
             }
         }
+        .onDisappear { selectionState.indices = [] }
+        .onChange(of: selectedRows) { _, newRows in selectionState.indices = newRows }
         .onChange(of: selectedTab) { updateGridDelegate() }
         .alert(String(localized: "Create Table Failed"), isPresented: $showError) {
             Button("OK") {}


### PR DESCRIPTION
## Summary

Follow-up to #1337. Two open items from the post-merge review of that PR:

1. **Responder-chain regression** for `.copyRows`. After #1337, both Cmd+C (when router resolves to `.copyRows`) and Cmd+Shift+C dispatch the action via `NSApp.sendAction(_:to:nil:from:)`. If the first responder isn't in a chain that reaches `KeyHandlingTableView` (e.g. focus moved to a different text field while a row selection persists in the grid), the action is silently lost. Before #1337, the menu button called `actions?.copySelectedRows()` directly, which didn't depend on responder chain.

2. **`CreateTableView`** has the same selection-mirror problem `TableStructureView` had: `@State selectedRows` never feeds `GridSelectionState.indices`, so `.disabled(!hasRowSelection)` on the new "Copy Rows" menu item stays true and Cmd+Shift+C is blocked.

## Changes

- `PasteboardCommands`: both the "Copy" `.copyRows` branch and the "Copy Rows" button now fall back to `actions?.copySelectedRows()` when `NSApp.sendAction` returns `false`. Responder chain stays the preferred path; the SwiftUI-side action is the safety net.
- `CreateTableView`: takes `selectionState: GridSelectionState`, mirrors `selectedRows` into it via `.onChange(of:)`, and clears it `.onDisappear`. Same pattern `TableStructureView` already uses.
- `MainEditorContentView`: passes `selectionState` into the `CreateTableView` call site.

## Why this is the right shape

- Native macOS pattern stays in place: menu items dispatch via the responder chain first. AppKit's `validateUserInterfaceItem` on `KeyHandlingTableView` continues to guard `copy:` and `copyRowsAsTSV:`.
- The fallback is the SwiftUI action that the prior pre-#1337 codebase already trusted as the single dispatch path. Not a new abstraction.
- For `.copyCellValue`, there's no fallback needed because cell-copy only fires when the user can see the focus border, which requires the table view to be the active emphasized responder, which means the responder chain will reach it.

## Test plan

- [ ] `xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginValidation`
- [ ] Select rows in data grid, click the SQL editor to move focus, press `Cmd+Shift+C` — clipboard contains the row TSV (was silently lost before this PR)
- [ ] Same setup, press `Cmd+C` — clipboard contains the row TSV
- [ ] Open Create Table tab, add columns, click rows in the columns grid, press `Cmd+Shift+C` — clipboard contains the structure-row payload
- [ ] Original scenarios still work: single row + cell focus + `Cmd+C` copies the cell, multi-row select + `Cmd+C` copies TSV