### PR TITLE
feat(datagrid): toggle filter with Cmd+F when grid is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Cmd+C` now copies the focused cell value when one row is selected and a cell has focus; with multiple rows selected, or when no cell is focused, it still copies row(s) as TSV. `Cmd+Shift+C` now always copies row(s) as TSV. "Copy with Headers" stays in the Edit menu and row context menu without a default shortcut (#1332)
+- `Cmd+F` toggles the data-grid filter panel when the grid is focused; the SQL editor's Find panel still opens with `Cmd+F` when the editor is focused. The old `Cmd+Shift+F` shortcut for filters is removed
 
 ### Fixed
 

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -499,7 +499,6 @@ struct KeyboardSettings: Codable, Equatable {
         // View
         .toggleTableBrowser: KeyCombo(key: "0", command: true),
         .toggleInspector: KeyCombo(key: "i", command: true, option: true),
-        .toggleFilters: KeyCombo(key: "f", command: true, shift: true),
         .toggleHistory: KeyCombo(key: "y", command: true),
         .toggleResults: KeyCombo(key: "r", command: true, option: true),
         .previousResultTab: KeyCombo(key: "[", command: true, option: true),

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -481,6 +481,9 @@ struct AppMenuCommands: Commands {
             Button(String(localized: "Find...")) {
                 if keyWindowIsInspector {
                     NSApp.sendAction(#selector(InspectorViewController.toggleInspectorFilter(_:)), to: nil, from: nil)
+                } else if NSApp.keyWindow?.firstResponder is KeyHandlingTableView,
+                          actions?.isTableTab == true {
+                    actions?.toggleFilterPanel()
                 } else {
                     EditorEventRouter.shared.showFindPanelForKeyWindow()
                 }

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -5,7 +5,7 @@ description: Filter table data with 18 operators, raw SQL, and saved presets
 
 # Filtering
 
-Press `Cmd+Shift+F` to open the filter panel. Type a raw SQL WHERE clause and press `Enter` to filter. Raw SQL is the default mode.
+Press `Cmd+F` with the data grid focused to open the filter panel. Type a raw SQL WHERE clause and press `Enter` to filter. Raw SQL is the default mode.
 
 Each row has a column picker, operator, value field, and **+**/**−** buttons. Multiple rows combine with **AND** or **OR** (toggle in the header). Click **Apply** or press `Enter` to activate. Click **Unset** to clear all.
 

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -71,7 +71,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 
 | Action | Shortcut |
 |--------|----------|
-| Find | `Cmd+F` |
+| Find (SQL editor focused) | `Cmd+F` |
 | Find and replace | `Cmd+Option+F` |
 | Find next | `Cmd+G` |
 | Find previous | `Cmd+Shift+G` |
@@ -255,7 +255,7 @@ Vim keys only apply in the SQL editor. The data grid and other panels keep their
 
 | Action | Shortcut |
 |--------|----------|
-| Toggle filter panel | `Cmd+Shift+F` |
+| Toggle filter panel (data grid focused) | `Cmd+F` |
 | Apply filters | `Enter` (in value field) |
 
 ## Table Structure


### PR DESCRIPTION
## Summary

`Cmd+F` is now context-aware:

- **Data grid focused** (table tab): toggles the filter panel
- **SQL editor focused**: opens the standard Find panel
- **Inspector window focused**: toggles the inspector filter (existing behavior)

`Cmd+Shift+F` is removed as the default shortcut for "Toggle Filters". The Edit menu "Toggle Filters" item stays accessible without a default binding; users can rebind in Settings → Keyboard Shortcuts if they want their old habit back.

## Why

The previous `Cmd+Shift+F` for filters added a modifier where most users expect a Filter shortcut to match the native Find-style `Cmd+F`. Inspector windows already routed `Cmd+F` to filter; this PR extends the same logic to the main data grid.

## Changes

- `TableProApp.swift` "Find..." menu button: adds a branch for `firstResponder is KeyHandlingTableView && actions?.isTableTab == true` → `toggleFilterPanel()`. Editor branch unchanged.
- `KeyboardShortcutModels.swift`: removes the `.toggleFilters` default keymap entry. The action stays in the enum so users keep their saved customizations; only the factory default is gone.
- Docs updated: `docs/features/filtering.mdx`, `docs/features/keyboard-shortcuts.mdx`.
- CHANGELOG entry under `Changed`.

## Test plan

- [ ] `xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginValidation`
- [ ] Open a table → click the data grid → press `Cmd+F` → filter panel toggles
- [ ] Open a query tab → click the SQL editor → press `Cmd+F` → editor Find panel opens
- [ ] Open the Inspector → press `Cmd+F` → inspector filter toggles
- [ ] On a non-table tab (welcome, ER diagram) → press `Cmd+F` → editor Find panel fallback (or no-op if no editor)
- [ ] Settings → Keyboard Shortcuts: `.toggleFilters` shows up with no default and can be assigned to any combo by the user