### PR TITLE
fix(coordinator): restore CodeEditTextView import dropped in #1340

### DIFF
--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -5,6 +5,7 @@
 //  Created by Ngo Quoc Dat on 16/12/25.
 //
 
+import CodeEditTextView
 import Combine
 import Observation
 import os


### PR DESCRIPTION
## Summary
PR #1340 removed `import CodeEditTextView` from `TableProApp.swift` along with the deleted `PasteboardActionRouter`, but the Undo/Redo command buttons still reference `TextView` (from `CodeEditTextView`) at lines 443 and 454. This left `main` failing to compile with `Cannot find type 'TextView' in scope`.

Restores the import. The `is TextView` responder checks route undo/redo to the AppKit responder chain for CodeEdit-backed text views.

## Test plan
- [ ] Build the TablePro scheme — compiles without the `Cannot find type 'TextView'` error