### PR TITLE
ci(plugins): fix build-plugin.yml release-notes block scalar indentation

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -276,14 +276,14 @@ jobs:
 
           RELEASE_BODY="## $DISPLAY_NAME v$VERSION
 
-Plugin release for TablePro (PluginKit $PKV).
+          Plugin release for TablePro (PluginKit $PKV).
 
-### Installation
-TablePro will prompt you to install this plugin automatically when you select the database type. You can also install manually via Settings > Plugins > Browse.
+          ### Installation
+          TablePro will prompt you to install this plugin automatically when you select the database type. You can also install manually via Settings > Plugins > Browse.
 
-### SHA-256
-- ARM64: \`$ARM64_SHA\`
-- x86_64: \`$X86_SHA\`"
+          ### SHA-256
+          - ARM64: \`$ARM64_SHA\`
+          - x86_64: \`$X86_SHA\`"
 
           gh release delete "$TAG" --yes 2>/dev/null || true
           gh release create "$TAG" \


### PR DESCRIPTION
## Problem

`.github/workflows/build-plugin.yml` fails to parse: `Invalid workflow file ... You have an error in your yaml syntax on line 279`. Plugin releases (`plugin-*-v*` tags and `workflow_dispatch`) can't run.

The "Create GitHub Release" step builds `RELEASE_BODY` as a multi-line shell string inside a `run: |` block scalar (indented 10 spaces). The string's continuation lines sat at column 0. A non-empty line dedented below the block indent ends the block scalar, so YAML tried to parse `Plugin release for TablePro ...` as structure and errored at line 279.

Introduced by the pipeline rewrite in #1322 / #1343.

## Fix

Indent the continuation lines to the block's 10-space indent so they stay inside the scalar. YAML strips the 10-space prefix, so the shell still receives clean column-0 markdown for the release notes.

Verified by parsing the full workflow with `yaml.safe_load` (passes) and inspecting the rendered `run` block: the release-notes body has no leading whitespace.