### PR TITLE
fix(connections): close SSH tunnel when a pending connection is cancelled (#1369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reassigning the Execute Query, Execute All Statements, and Cancel Query shortcuts now takes effect, and the Query menu shows the new keys (#1357)
 - Custom shortcuts now require a modifier key, so a plain key like Space is no longer accepted and then silently ignored (#1357)
 - Cancelling a pending connection no longer lets the abandoned attempt overwrite or drop a later successful connection to the same database (#1358)
+- Cancelling a pending SSH connection now closes its tunnel instead of leaving the local forward port open (#1369)
 - Importing connections from DBeaver now brings over the username (#1355)
 
 ## [0.43.1] - 2026-05-20

--- a/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
+++ b/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 
 extension DatabaseManager {
     func ensureConnected(_ connection: DatabaseConnection) async throws {
@@ -16,6 +17,13 @@ extension DatabaseManager {
     func cancelEnsureConnected(_ connectionId: UUID) async {
         await ensureConnectedDedup.cancel(key: connectionId)
         if let session = activeSessions[connectionId], session.driver == nil {
+            if session.connection.resolvedSSHConfig.enabled {
+                do {
+                    try await SSHTunnelManager.shared.closeTunnel(connectionId: connectionId)
+                } catch {
+                    Self.logger.warning("SSH tunnel cleanup failed for \(connectionId): \(error.localizedDescription)")
+                }
+            }
             removeSessionEntry(for: connectionId)
             if currentSessionId == connectionId {
                 currentSessionId = nil


### PR DESCRIPTION
Fixes #1369.

Cancelling a tunnelled connection while it was connecting could leave the SSH tunnel (local forward port + keep-alive task) open if the user did not retry. `cancelEnsureConnected` removed the session but never closed the tunnel, and the cancelled connect task deliberately leaves the connectionId-keyed tunnel alone so it cannot tear down a retry's tunnel (per #1367).

## Change
`cancelEnsureConnected` now closes the SSH tunnel when the cancelled session has no driver, i.e. no live connection is using it.

## Race safety
`SSHTunnelManager` is an actor and `closeTunnel` runs as a single atomic step (`removeValue` + `close()`, no suspension). The cancel path is scheduled the moment the connection is cancelled, before any retry starts its slower tunnel handshake, and a retry's `createTunnel` closes and replaces the tunnel for the same id anyway. So the cancel closes only the abandoned attempt's tunnel and cannot drop a newer one.

## Tests
The teardown is a side effect on the `SSHTunnelManager` actor singleton with no injection seam, so it is not unit-tested here, consistent with the existing SSH tunnel code. Verified by build. Session-removal behaviour is unchanged and still covered by the #1358 tests.