### PR TITLE
fix(datagrid): crash adding a row while a cell overlay is open (#1378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a crash when adding a row while a cell editor or value viewer was open (#1378)
+
 ## [0.43.2] - 2026-05-22
 
 ### Changed

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -3,8 +3,7 @@ import AppKit
 final class KeyHandlingTableView: NSTableView {
     weak var coordinator: TableViewCoordinator?
 
-    private var isRaisingOverlayEditor = false
-    private var isRaisingOverlayViewer = false
+    private var isRaisingOverlay = false
 
     override var acceptsFirstResponder: Bool {
         true
@@ -12,21 +11,21 @@ final class KeyHandlingTableView: NSTableView {
 
     override func didAddSubview(_ subview: NSView) {
         super.didAddSubview(subview)
-        raiseOverlayIfNeeded(coordinator?.overlayEditor, subview: subview, flag: &isRaisingOverlayEditor)
-        raiseOverlayIfNeeded(coordinator?.overlayViewer, subview: subview, flag: &isRaisingOverlayViewer)
+        guard !isRaisingOverlay else { return }
+        isRaisingOverlay = true
+        defer { isRaisingOverlay = false }
+        raiseOverlayIfNeeded(coordinator?.overlayEditor, subview: subview)
+        raiseOverlayIfNeeded(coordinator?.overlayViewer, subview: subview)
     }
 
-    private func raiseOverlayIfNeeded(_ overlay: CellOverlayBase?, subview: NSView, flag: inout Bool) {
-        guard !flag else { return }
+    private func raiseOverlayIfNeeded(_ overlay: CellOverlayBase?, subview: NSView) {
         guard let overlay,
               overlay.isActive,
               let container = overlay.containerView,
               container !== subview,
               container.superview === self,
               subviews.last !== container else { return }
-        flag = true
         overlay.raiseToFront()
-        flag = false
     }
 
     var selection = TableSelection() {

--- a/TableProTests/Views/Results/KeyHandlingTableViewOverlayTests.swift
+++ b/TableProTests/Views/Results/KeyHandlingTableViewOverlayTests.swift
@@ -1,0 +1,51 @@
+//
+//  KeyHandlingTableViewOverlayTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class StubColumnLayoutPersister: ColumnLayoutPersisting {
+    func load(for tableName: String, connectionId: UUID) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for tableName: String, connectionId: UUID) {}
+    func clear(for tableName: String, connectionId: UUID) {}
+}
+
+@Suite("KeyHandlingTableView overlay raise")
+@MainActor
+struct KeyHandlingTableViewOverlayTests {
+    private func makeCoordinator() -> TableViewCoordinator {
+        TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: StubColumnLayoutPersister()
+        )
+    }
+
+    @Test("adding a subview while an overlay is active raises it to front without trapping")
+    func addingSubviewRaisesActiveOverlay() {
+        let tableView = KeyHandlingTableView()
+        let coordinator = makeCoordinator()
+        tableView.coordinator = coordinator
+
+        let editor = CellOverlayEditor()
+        coordinator.overlayEditor = editor
+        let container = CellOverlayContainerView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        editor.install(in: tableView, row: 0, column: 0, columnIndex: 0, container: container)
+
+        tableView.addSubview(NSView(frame: NSRect(x: 0, y: 0, width: 10, height: 10)))
+
+        #expect(tableView.subviews.last === container)
+
+        editor.removeOverlay()
+    }
+}


### PR DESCRIPTION
Fixes #1378.

## Problem
Adding a row (Cmd+Shift+N) crashes when a cell editor or value viewer overlay is open. The trace is a Swift exclusive-access-to-memory violation (`swift_beginAccess` -> `AccessSet::insert` -> `_swift_runtime_on_report`), not a stack overflow.

## Cause
`KeyHandlingTableView.didAddSubview` passed the reentrancy guard as `inout` (`flag: &isRaisingOverlayEditor`), which holds an exclusive access for the whole call. Inside, `raiseToFront()` calls `addSubview`, which synchronously re-enters `didAddSubview` and tries to take a second overlapping access to the same property. The runtime traps. The `guard !flag` never gets to run because the conflict is detected when the `inout` argument is formed.

Regression from #1341, which refactored the prior inline guard into an `inout` helper. The version before that used a direct instance-property guard, which does not conflict.

## Fix
Drop the `inout` parameter. Use one `isRaisingOverlay` guard hoisted to the top of `didAddSubview`, reset with `defer`. Bool reads and writes are instantaneous accesses, so the reentrant call short-circuits cleanly. Editor and viewer are mutually exclusive (each `show` dismisses the other), so a single guard is correct.

## Test
`KeyHandlingTableViewOverlayTests` installs an active overlay, adds another subview to force the re-raise path, and asserts the overlay ends on top. This path traps before the fix and passes after. Verified locally with `** TEST SUCCEEDED **`.

## Not included
The reporter also mentioned "the plus button to add a new row is not visible." That has no trace and is not explained by this crash. Tracking separately.
