### PR TITLE
fix(plugin-postgresql): probe catalog presence so compatible engines without pg_matviews load (#1383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connecting to a PostgreSQL-compatible engine that doesn't implement the pg_matviews catalog (such as db9.ai) no longer fails to load tables. (#1383)
 - Reopening a table now restores the filter you had applied, instead of clearing it. Filters are remembered per connection. (#1347)
 - Importing connections from TablePlus brings over saved passwords again. A recent release looked under the wrong keychain name, so connections imported with no passwords and no warning.
 - Importing an SSH connection from TablePlus no longer fills in a fake private key path such as `~/.ssh/Import a private key...` when no key was selected. Empty TLS certificate paths are skipped too.

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift
@@ -1,0 +1,33 @@
+//
+//  PostgreSQLCatalogPresence.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+
+struct PostgreSQLCatalogPresence: Sendable, Equatable {
+    var hasMaterializedViews: Bool
+    var hasForeignTables: Bool
+    var hasSequences: Bool
+
+    static let probeQuery = """
+        SELECT c.relname
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pg_catalog'
+          AND c.relname IN ('pg_matviews', 'pg_foreign_table', 'pg_sequences')
+        """
+
+    init(hasMaterializedViews: Bool, hasForeignTables: Bool, hasSequences: Bool) {
+        self.hasMaterializedViews = hasMaterializedViews
+        self.hasForeignTables = hasForeignTables
+        self.hasSequences = hasSequences
+    }
+
+    init(relationNames: [String]) {
+        let names = Set(relationNames)
+        self.hasMaterializedViews = names.contains("pg_matviews")
+        self.hasForeignTables = names.contains("pg_foreign_table")
+        self.hasSequences = names.contains("pg_sequences")
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift
@@ -6,9 +6,9 @@
 import Foundation
 
 struct PostgreSQLCatalogPresence: Sendable, Equatable {
-    var hasMaterializedViews: Bool
-    var hasForeignTables: Bool
-    var hasSequences: Bool
+    let hasMaterializedViews: Bool
+    let hasForeignTables: Bool
+    let hasSequences: Bool
 
     static let probeQuery = """
         SELECT c.relname
@@ -17,12 +17,6 @@ struct PostgreSQLCatalogPresence: Sendable, Equatable {
         WHERE n.nspname = 'pg_catalog'
           AND c.relname IN ('pg_matviews', 'pg_foreign_table', 'pg_sequences')
         """
-
-    init(hasMaterializedViews: Bool, hasForeignTables: Bool, hasSequences: Bool) {
-        self.hasMaterializedViews = hasMaterializedViews
-        self.hasForeignTables = hasForeignTables
-        self.hasSequences = hasSequences
-    }
 
     init(relationNames: [String]) {
         let names = Set(relationNames)

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -15,6 +15,10 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     private static let logger = Logger(subsystem: "com.TablePro.PostgreSQLDriver", category: "PostgreSQLPluginDriver")
 
+    private static let undefinedTableSQLState = "42P01"
+
+    private var catalogPresence: PostgreSQLCatalogPresence?
+
     var serverVersionNumber: Int32 { core.serverVersionNumber }
     var versionedCapabilities: PostgreSQLCapabilities {
         PostgreSQLCapabilities(serverVersion: core.serverVersionNumber)
@@ -37,6 +41,33 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     init(config: DriverConnectionConfig) {
         self.core = LibPQDriverCore(config: config)
+    }
+
+    // MARK: - Connection
+
+    func connect() async throws {
+        try await core.connect()
+        await probeCatalogPresence()
+    }
+
+    private func probeCatalogPresence() async {
+        guard let result = try? await core.execute(query: PostgreSQLCatalogPresence.probeQuery) else {
+            return
+        }
+        let relationNames = result.rows.compactMap { $0.first?.asText }
+        catalogPresence = PostgreSQLCatalogPresence(relationNames: relationNames)
+    }
+
+    private func includesMaterializedViews() -> Bool {
+        catalogPresence?.hasMaterializedViews ?? versionedCapabilities.hasMaterializedViewsCatalog
+    }
+
+    private func includesForeignTables() -> Bool {
+        catalogPresence?.hasForeignTables ?? versionedCapabilities.hasForeignTablesCatalog
+    }
+
+    private func includesSequencesCatalog() -> Bool {
+        catalogPresence?.hasSequences ?? versionedCapabilities.hasSequencesCatalog
     }
 
     // MARK: - EXPLAIN
@@ -101,40 +132,24 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
-        let caps = versionedCapabilities
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: schemaLiteral,
+            includeMaterializedViews: includesMaterializedViews(),
+            includeForeignTables: includesForeignTables()
+        )
 
-        var unions: [String] = [
-            """
-            SELECT table_name, table_type FROM information_schema.tables
-            WHERE table_schema = '\(schemaLiteral)'
-              AND table_type IN ('BASE TABLE', 'VIEW')
-            """
-        ]
-
-        if caps.hasMaterializedViewsCatalog {
-            unions.append(
-                """
-                SELECT matviewname AS table_name, 'MATERIALIZED VIEW' AS table_type
-                FROM pg_matviews
-                WHERE schemaname = '\(schemaLiteral)'
-                """
+        let result: PluginQueryResult
+        do {
+            result = try await execute(query: query)
+        } catch let error as LibPQPluginError where error.sqlState == Self.undefinedTableSQLState {
+            let baseQuery = PostgreSQLSchemaQueries.fetchTables(
+                schemaLiteral: schemaLiteral,
+                includeMaterializedViews: false,
+                includeForeignTables: false
             )
+            result = try await execute(query: baseQuery)
         }
 
-        if caps.hasForeignTablesCatalog {
-            unions.append(
-                """
-                SELECT c.relname AS table_name, 'FOREIGN TABLE' AS table_type
-                FROM pg_foreign_table ft
-                JOIN pg_class c ON c.oid = ft.ftrelid
-                JOIN pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '\(schemaLiteral)'
-                """
-            )
-        }
-
-        let query = unions.joined(separator: "\nUNION ALL\n") + "\nORDER BY table_name"
-        let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginTableInfo? in
             guard let name = row[0].asText else { return nil }
             let typeStr = row[1].asText ?? "BASE TABLE"
@@ -533,7 +548,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchDependentSequences(table: String, schema: String?) async throws -> [(name: String, ddl: String)] {
-        guard versionedCapabilities.hasSequencesCatalog else { return [] }
+        guard includesSequencesCatalog() else { return [] }
         let safeTable = escapeLiteral(table)
         let query = """
             SELECT s.sequencename,

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -51,11 +51,13 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     private func probeCatalogPresence() async {
-        guard let result = try? await core.execute(query: PostgreSQLCatalogPresence.probeQuery) else {
-            return
+        do {
+            let result = try await core.execute(query: PostgreSQLCatalogPresence.probeQuery)
+            let relationNames = result.rows.compactMap { $0.first?.asText }
+            catalogPresence = PostgreSQLCatalogPresence(relationNames: relationNames)
+        } catch {
+            Self.logger.debug("Catalog presence probe failed; using version-based capabilities: \(error.localizedDescription)")
         }
-        let relationNames = result.rows.compactMap { $0.first?.asText }
-        catalogPresence = PostgreSQLCatalogPresence(relationNames: relationNames)
     }
 
     private func includesMaterializedViews() -> Bool {

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -32,4 +32,47 @@ enum PostgreSQLSchemaQueries {
           AND has_schema_privilege(current_user, nspname, 'USAGE')
         ORDER BY nspname
         """
+
+    /// Lists tables and views, optionally including materialized views and
+    /// foreign tables. The optional unions reference `pg_matviews` and
+    /// `pg_foreign_table`, which some PostgreSQL-compatible engines do not
+    /// implement; the caller passes `false` when those catalogs are absent so
+    /// the whole query does not fail with `relation does not exist`.
+    static func fetchTables(
+        schemaLiteral: String,
+        includeMaterializedViews: Bool,
+        includeForeignTables: Bool
+    ) -> String {
+        var unions: [String] = [
+            """
+            SELECT table_name, table_type FROM information_schema.tables
+            WHERE table_schema = '\(schemaLiteral)'
+              AND table_type IN ('BASE TABLE', 'VIEW')
+            """
+        ]
+
+        if includeMaterializedViews {
+            unions.append(
+                """
+                SELECT matviewname AS table_name, 'MATERIALIZED VIEW' AS table_type
+                FROM pg_matviews
+                WHERE schemaname = '\(schemaLiteral)'
+                """
+            )
+        }
+
+        if includeForeignTables {
+            unions.append(
+                """
+                SELECT c.relname AS table_name, 'FOREIGN TABLE' AS table_type
+                FROM pg_foreign_table ft
+                JOIN pg_class c ON c.oid = ft.ftrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = '\(schemaLiteral)'
+                """
+            )
+        }
+
+        return unions.joined(separator: "\nUNION ALL\n") + "\nORDER BY table_name"
+    }
 }

--- a/TableProTests/PluginTestSources/PostgreSQLCatalogPresence.swift
+++ b/TableProTests/PluginTestSources/PostgreSQLCatalogPresence.swift
@@ -1,0 +1,1 @@
+../../Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift

--- a/TableProTests/Plugins/PostgreSQLCatalogCompatibilityTests.swift
+++ b/TableProTests/Plugins/PostgreSQLCatalogCompatibilityTests.swift
@@ -1,0 +1,98 @@
+//
+//  PostgreSQLCatalogCompatibilityTests.swift
+//  TableProTests
+//
+//  Regression cover for #1383: PostgreSQL-compatible engines (e.g. db9.ai)
+//  report a recent Postgres version but lack optional catalogs like
+//  pg_matviews. fetchTables must omit those unions when the catalog is absent,
+//  and the catalog probe must parse presence from pg_class relation names.
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("PostgreSQLSchemaQueries.fetchTables")
+struct PostgreSQLFetchTablesQueryTests {
+    @Test("Always selects base tables and views from information_schema")
+    func alwaysIncludesBaseTables() {
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: "public",
+            includeMaterializedViews: true,
+            includeForeignTables: true
+        )
+        #expect(query.contains("information_schema.tables"))
+    }
+
+    @Test("Omits the pg_matviews union when materialized views are unavailable")
+    func omitsMatviewsWhenAbsent() {
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: "public",
+            includeMaterializedViews: false,
+            includeForeignTables: true
+        )
+        #expect(!query.contains("pg_matviews"))
+    }
+
+    @Test("Includes the pg_matviews union when materialized views are available")
+    func includesMatviewsWhenPresent() {
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: "public",
+            includeMaterializedViews: true,
+            includeForeignTables: false
+        )
+        #expect(query.contains("pg_matviews"))
+    }
+
+    @Test("Omits the pg_foreign_table union when foreign tables are unavailable")
+    func omitsForeignTablesWhenAbsent() {
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: "public",
+            includeMaterializedViews: true,
+            includeForeignTables: false
+        )
+        #expect(!query.contains("pg_foreign_table"))
+    }
+
+    @Test("With no optional catalogs, only the base query remains")
+    func baseOnlyWhenNoOptionalCatalogs() {
+        let query = PostgreSQLSchemaQueries.fetchTables(
+            schemaLiteral: "public",
+            includeMaterializedViews: false,
+            includeForeignTables: false
+        )
+        #expect(query.contains("information_schema.tables"))
+        #expect(!query.contains("pg_matviews"))
+        #expect(!query.contains("pg_foreign_table"))
+        #expect(!query.contains("UNION ALL"))
+    }
+}
+
+@Suite("PostgreSQLCatalogPresence")
+struct PostgreSQLCatalogPresenceTests {
+    @Test("Parses a single present catalog")
+    func parsesSingleCatalog() {
+        let presence = PostgreSQLCatalogPresence(relationNames: ["pg_matviews"])
+        #expect(presence.hasMaterializedViews)
+        #expect(!presence.hasForeignTables)
+        #expect(!presence.hasSequences)
+    }
+
+    @Test("Parses all catalogs present")
+    func parsesAllCatalogs() {
+        let presence = PostgreSQLCatalogPresence(
+            relationNames: ["pg_matviews", "pg_foreign_table", "pg_sequences"]
+        )
+        #expect(presence.hasMaterializedViews)
+        #expect(presence.hasForeignTables)
+        #expect(presence.hasSequences)
+    }
+
+    @Test("Empty probe result means no optional catalogs")
+    func parsesEmpty() {
+        let presence = PostgreSQLCatalogPresence(relationNames: [])
+        #expect(!presence.hasMaterializedViews)
+        #expect(!presence.hasForeignTables)
+        #expect(!presence.hasSequences)
+    }
+}

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -107,6 +107,8 @@ Supports `jsonb` (formatted JSON), `array`, `uuid`, `inet` (IP), `timestamp with
 
 **SSL/TLS**: New connections default to **Preferred** (libpq `sslmode=prefer`), which tries TLS first and falls back to plain. Works for both local Postgres and hosted providers (AWS RDS, Cloud SQL, Heroku, Supabase, Neon). Pick **Verify CA** when you need to validate the server certificate. See [SSL/TLS](/features/ssl) for details.
 
+**Postgres-compatible engines**: Connect wire-compatible engines (such as db9.ai) using the PostgreSQL type. TablePro checks which system catalogs each server actually provides, so engines that omit catalogs like `pg_matviews` still load their tables; materialized views or foreign tables just won't appear if the server doesn't expose them.
+
 ## Advanced Configuration
 
 **Startup Commands** (Advanced tab): Set session variables like `SET timezone = 'UTC'; SET search_path TO myschema, public;` to apply automatically on connect.


### PR DESCRIPTION
Fixes #1383.

## Problem
Connecting to a PostgreSQL wire-compatible engine (the reporter used db9.ai) fails with `ERROR: relation "pg_matviews" does not exist`, and tables don't load.

## Root cause
`PostgreSQLCapabilities` infers catalog presence purely from the server version: `hasMaterializedViewsCatalog { serverVersion >= 90_300 }`. Compatible engines report a real-looking Postgres version (>= 9.3) but don't implement the `pg_matviews` catalog. The version guard in `fetchTables` therefore passes, the `pg_matviews` UNION runs, and because it sits in the same compound query as the base tables/views, the whole query fails and schema loading breaks. The same version-only assumption affects `pg_foreign_table` and `pg_sequences`. A server version reflects the dialect target, not which system catalogs are actually implemented (CockroachDB and Redshift have hit this same class of bug).

## Approach
Stop inferring catalog existence from the version. Probe it.

- **Connect-time probe** (`PostgreSQLPluginDriver.connect()` override, mirroring `CockroachPluginDriver`): one portable query against `pg_catalog.pg_class`/`pg_namespace` returns which of `pg_matviews` / `pg_foreign_table` / `pg_sequences` the server actually has. Result cached on the driver. `pg_class`/`pg_namespace` are the lowest common denominator (an engine without them can't be used at all), so this avoids depending on `to_regclass`, which a minimal engine may also lack. Relation resolution is parse-time, so the probe and the catalog query must be separate statements.
- **Gate on probed presence, fall back to version** when the probe didn't run.
- **Safety net**: if the table query still hits `undefined_table` (SQLSTATE `42P01`, matched by code not message), retry with the base `information_schema.tables` query so a missing catalog can never abort the whole schema load.

## Changes
- `PostgreSQLCatalogPresence.swift` (new): presence model + probe SQL + a pure parser from `pg_class` relation names. Symlinked into `TableProTests/PluginTestSources` for tests.
- `PostgreSQLSchemaQueries.swift`: `fetchTables(schemaLiteral:includeMaterializedViews:includeForeignTables:)` query builder (pure, testable; lives with the other schema queries).
- `PostgreSQLPluginDriver.swift`: `connect()` override + catalog probe + presence-gated unions and sequences, plus the `42P01` fallback in `fetchTables`.

No PluginKit ABI change (internal driver logic). PostgreSQL is a bundled plugin, so it ships with the next app release; no registry update.

## Tests
`PostgreSQLCatalogCompatibilityTests`: the `fetchTables` builder includes/omits the `pg_matviews` and `pg_foreign_table` unions per flag (and base-only contains no `UNION ALL`); `PostgreSQLCatalogPresence` parses probe rows into the right flags.

## Docs
CHANGELOG (Fixed) and a Postgres-compatible-engines note in `docs/databases/postgresql.mdx`.