### PR TITLE
fix(datagrid): persist cleared filters so they don't return on reopen (#1347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connecting to a PostgreSQL-compatible engine that doesn't implement the pg_matviews catalog (such as db9.ai) no longer fails to load tables. (#1383)
 - Filtering a table now updates the row count and page count in the bottom-right to match the filtered result, instead of showing the whole-table totals.
-- Reopening a table now restores the filter you had applied, and clearing a filter is remembered too, so a table you cleared reopens with no filter. Filters are remembered per connection. (#1347)
+- Reopening a table now restores the filter you had applied. Removing or clearing a filter takes effect right away and is remembered, so a table you unfiltered reopens with no filter. Filters are remembered per connection. (#1347)
 - Quick switcher panel height now fits its results instead of leaving a large empty area below short lists. (#1349)
 - Importing connections from TablePlus brings over saved passwords again. A recent release looked under the wrong keychain name, so connections imported with no passwords and no warning.
 - Importing an SSH connection from TablePlus no longer fills in a fake private key path such as `~/.ssh/Import a private key...` when no key was selected. Empty TLS certificate paths are skipped too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connecting to a PostgreSQL-compatible engine that doesn't implement the pg_matviews catalog (such as db9.ai) no longer fails to load tables. (#1383)
 - Filtering a table now updates the row count and page count in the bottom-right to match the filtered result, instead of showing the whole-table totals.
-- Reopening a table now restores the filter you had applied, instead of clearing it. Filters are remembered per connection. (#1347)
+- Reopening a table now restores the filter you had applied, and clearing a filter is remembered too, so a table you cleared reopens with no filter. Filters are remembered per connection. (#1347)
 - Quick switcher panel height now fits its results instead of leaving a large empty area below short lists. (#1349)
 - Importing connections from TablePlus brings over saved passwords again. A recent release looked under the wrong keychain name, so connections imported with no passwords and no warning.
 - Importing an SSH connection from TablePlus no longer fills in a fake private key path such as `~/.ssh/Import a private key...` when no key was selected. Empty TLS certificate paths are skipped too.

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -212,14 +212,33 @@ final class FilterCoordinator {
         }
     }
 
+    enum RemoveFilterOutcome: Equatable {
+        case noChange
+        case clear
+        case reapply([TableFilter])
+    }
+
+    static func removeFilterOutcome(
+        removing filter: TableFilter,
+        from appliedFilters: [TableFilter]
+    ) -> RemoveFilterOutcome {
+        guard appliedFilters.contains(where: { $0.id == filter.id }) else { return .noChange }
+        let remaining = appliedFilters.filter { $0.id != filter.id }
+        return remaining.isEmpty ? .clear : .reapply(remaining)
+    }
+
     func removeFilterAndReload(_ filter: TableFilter) {
-        let wasApplied = selectedTabFilterState.appliedFilters.contains { $0.id == filter.id }
+        let outcome = Self.removeFilterOutcome(
+            removing: filter,
+            from: selectedTabFilterState.appliedFilters
+        )
         removeFilter(filter)
-        guard wasApplied else { return }
-        let remaining = selectedTabFilterState.appliedFilters
-        if remaining.isEmpty {
+        switch outcome {
+        case .noChange:
+            break
+        case .clear:
             clearFiltersAndReload()
-        } else {
+        case .reapply(let remaining):
             applyFilters(remaining)
         }
     }

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -81,6 +81,7 @@ final class FilterCoordinator {
             )
 
             parent.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
+            clearLastFilters(for: capturedTableName)
             parent.runQuery()
         }
     }
@@ -336,6 +337,16 @@ final class FilterCoordinator {
         guard let tab = parent.tabManager.selectedTab else { return }
         FilterSettingsStorage.shared.saveLastFilters(
             tab.filterState.appliedFilters,
+            for: tableName,
+            connectionId: parent.connectionId,
+            databaseName: tab.tableContext.databaseName,
+            schemaName: tab.tableContext.schemaName
+        )
+    }
+
+    func clearLastFilters(for tableName: String) {
+        guard let tab = parent.tabManager.selectedTab else { return }
+        FilterSettingsStorage.shared.clearLastFilters(
             for: tableName,
             connectionId: parent.connectionId,
             databaseName: tab.tableContext.databaseName,

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -47,11 +47,7 @@ final class FilterCoordinator {
             )
 
             parent.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
-
-            if !capturedFilters.isEmpty {
-                saveLastFilters(for: capturedTableName)
-            }
-
+            saveLastFilters(for: capturedTableName)
             parent.runQuery()
         }
     }
@@ -213,6 +209,18 @@ final class FilterCoordinator {
         mutateSelectedTabFilterState { state in
             state.filters.removeAll { $0.id == filter.id }
             state.appliedFilters.removeAll { $0.id == filter.id }
+        }
+    }
+
+    func removeFilterAndReload(_ filter: TableFilter) {
+        let wasApplied = selectedTabFilterState.appliedFilters.contains { $0.id == filter.id }
+        removeFilter(filter)
+        guard wasApplied else { return }
+        let remaining = selectedTabFilterState.appliedFilters
+        if remaining.isEmpty {
+            clearFiltersAndReload()
+        } else {
+            applyFilters(remaining)
         }
     }
 

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -199,15 +199,9 @@ struct FilterPanelView: View {
                         focusedFilterId = filterState.filters.last?.id
                     },
                     onRemove: {
-                        let hadAppliedFilters = filterState.hasAppliedFilters
-                        coordinator.removeFilter(filter)
+                        coordinator.removeFilterAndReload(filter)
                         if filterState.filters.isEmpty {
-                            if hadAppliedFilters {
-                                coordinator.clearFilterState()
-                                onUnset()
-                            } else {
-                                coordinator.closeFilterPanel()
-                            }
+                            coordinator.closeFilterPanel()
                         }
                     },
                     onSubmit: { applyAllValidFilters() },

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
@@ -36,6 +36,10 @@ extension MainContentCoordinator {
         filterCoordinator.removeFilter(filter)
     }
 
+    func removeFilterAndReload(_ filter: TableFilter) {
+        filterCoordinator.removeFilterAndReload(filter)
+    }
+
     func updateFilter(_ filter: TableFilter) {
         filterCoordinator.updateFilter(filter)
     }

--- a/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
+++ b/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
@@ -150,4 +150,19 @@ struct FilterSettingsStorageTests {
             reader.loadLastFilters(for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil) == filters
         )
     }
+
+    @Test("Clearing removes the stored filters so a reopen restores nothing")
+    func clearRemovesStoredFilters() {
+        let (storage, directory) = makeStorage()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let filters = [TestFixtures.makeTableFilter(column: "email", value: "a@b.com")]
+
+        storage.saveLastFilters(filters, for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+        storage.clearLastFilters(for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+
+        #expect(
+            storage.loadLastFilters(for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil).isEmpty
+        )
+    }
 }

--- a/TableProTests/Views/Main/FilterRestoreTests.swift
+++ b/TableProTests/Views/Main/FilterRestoreTests.swift
@@ -63,4 +63,26 @@ struct FilterRestoreTests {
         #expect(result.appliedFilters.isEmpty)
         #expect(!result.isVisible)
     }
+
+    @Test("Removing a filter that isn't applied changes nothing")
+    func removeUnappliedFilterIsNoChange() {
+        let applied = TestFixtures.makeTableFilter(column: "email")
+        let other = TestFixtures.makeTableFilter(column: "name")
+        #expect(FilterCoordinator.removeFilterOutcome(removing: other, from: [applied]) == .noChange)
+    }
+
+    @Test("Removing the only applied filter clears")
+    func removeOnlyAppliedFilterClears() {
+        let only = TestFixtures.makeTableFilter(column: "email")
+        #expect(FilterCoordinator.removeFilterOutcome(removing: only, from: [only]) == .clear)
+    }
+
+    @Test("Removing one of several applied filters reapplies the rest")
+    func removeOneOfSeveralReappliesRemainder() {
+        let first = TestFixtures.makeTableFilter(column: "email")
+        let second = TestFixtures.makeTableFilter(column: "name")
+        #expect(
+            FilterCoordinator.removeFilterOutcome(removing: first, from: [first, second]) == .reapply([second])
+        )
+    }
 }

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -9,7 +9,7 @@ Press `Cmd+F` while viewing a table to open the filter panel. Type a raw SQL WHE
 
 Each row has a column picker, operator, value field, and **+**/**−** buttons. Multiple rows combine with **AND** or **OR** (toggle in the header). Click **Apply** or press `Enter` to activate. Click **Unset** to clear all.
 
-When you reopen a table, TablePro restores the filter you last applied to it, including after you quit and relaunch. Filters are remembered per connection. Tables with active filters open in a new tab when you click another table.
+When you reopen a table, TablePro restores the filter you last applied to it, including after you quit and relaunch. If you clear the filter with **Unset**, reopening the table shows it unfiltered. Filters are remembered per connection. Tables with active filters open in a new tab when you click another table.
 
 ## Operators
 

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -9,7 +9,7 @@ Press `Cmd+F` while viewing a table to open the filter panel. Type a raw SQL WHE
 
 Each row has a column picker, operator, value field, and **+**/**−** buttons. Multiple rows combine with **AND** or **OR** (toggle in the header). Click **Apply** or press `Enter` to activate. Click **Unset** to clear all.
 
-When you reopen a table, TablePro restores the filter you last applied to it, including after you quit and relaunch. If you clear the filter with **Unset**, reopening the table shows it unfiltered. Filters are remembered per connection. Tables with active filters open in a new tab when you click another table.
+When you reopen a table, TablePro restores the filter you last applied to it, including after you quit and relaunch. If you clear the filter with **Unset** or remove its conditions with **−**, reopening the table shows it unfiltered. Filters are remembered per connection. Tables with active filters open in a new tab when you click another table.
 
 ## Operators
 


### PR DESCRIPTION
Follow-up to #1387 (restore applied filters on reopen).

## Bug
Apply a filter, then Unset (clear) it, then close the table tab and reopen it: the old filter comes back. Clearing isn't remembered.

## Root cause
#1387 made filter persistence asymmetric. The apply path persists:

- `FilterCoordinator.applyFiltersAndReload()` calls `saveLastFilters(for:)`.

The clear path does not:

- `FilterCoordinator.clearFiltersAndReload()` rebuilds the base query and reloads but never touches `FilterSettingsStorage`.

So the saved filter file is left on disk when you clear, and `restoreLastFilters` brings it back on reopen.

## Fix
Make the user-clear path symmetric with apply: `clearFiltersAndReload()` now calls a new `clearLastFilters(for:)` helper, which removes the saved filter for that table (`FilterSettingsStorage.clearLastFilters`).

This is deliberately placed in `clearFiltersAndReload()` (the user-initiated Unset), not in `clearFilterState()`. `clearFilterState()` is an internal UI-state reset used during tab switching/replacement, where the outgoing table's filters are intentionally saved first; clearing persistence there would wrongly delete a filter the user wants restored.

## Tests
`FilterSettingsStorageTests`: added a test that after `clearLastFilters`, `loadLastFilters` returns empty (the contract the fix relies on). The pure restore-decision function and storage round-trip from #1387 are unchanged. `FilterCoordinator` reaches storage via `.shared` with no DI seam (as #1387 left it), so the coordinator wiring mirrors the proven save path rather than adding a DI refactor.

## Docs / CHANGELOG
Folded into the existing unreleased #1347 entry (the restore feature is still unreleased, so this isn't a separate "Fixed" line). Filtering docs note that clearing with Unset is remembered.