### PR TITLE
feat(datagrid): fill column with one value across loaded rows (#1304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fill Column: right-click a column header and choose Fill Column to set one value across all loaded rows. The change is staged like a normal edit, so you review it and Save before it applies, and one undo reverts the whole fill. Not available on primary key columns. (#1304)
+
 ## [0.44.0] - 2026-05-23
 
 ### Added

--- a/TablePro/Views/Results/Extensions/DataGridView+CellCommit.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+CellCommit.swift
@@ -15,17 +15,39 @@ extension TableViewCoordinator {
     }
 
     func commitTypedCellEdit(row: Int, columnIndex: Int, newValue typedNewValue: PluginCellValue) {
-        cellCommitLogger.debug("commitTypedCellEdit(row: \(row, privacy: .public), columnIndex: \(columnIndex, privacy: .public)) isCommitting=\(self.isCommittingCellEdit, privacy: .public) delegate=\(self.delegate == nil ? "nil" : "present", privacy: .public)")
-        guard !isCommittingCellEdit else { return }
         guard let tableView else { return }
+        guard let delta = recordCellEdit(row: row, columnIndex: columnIndex, newValue: typedNewValue) else { return }
+
+        invalidateDisplayCache()
+        visualIndex.updateRow(row, from: changeManager, sortedIDs: sortedIDs)
+
+        guard let tableColumnIndex = DataGridView.tableColumnIndex(
+            for: columnIndex,
+            in: tableView,
+            schema: identitySchema
+        ) else { return }
+        if case .cellChanged = delta {
+            tableRowsController.apply(.cellChanged(row: row, column: tableColumnIndex))
+        } else {
+            tableView.reloadData(
+                forRowIndexes: IndexSet(integer: row),
+                columnIndexes: IndexSet(integer: tableColumnIndex)
+            )
+        }
+    }
+
+    @discardableResult
+    func recordCellEdit(row: Int, columnIndex: Int, newValue typedNewValue: PluginCellValue) -> Delta? {
+        cellCommitLogger.debug("recordCellEdit(row: \(row, privacy: .public), columnIndex: \(columnIndex, privacy: .public)) isCommitting=\(self.isCommittingCellEdit, privacy: .public) delegate=\(self.delegate == nil ? "nil" : "present", privacy: .public)")
+        guard !isCommittingCellEdit else { return nil }
         let tableRows = tableRowsProvider()
-        guard columnIndex >= 0 && columnIndex < tableRows.columns.count else { return }
-        guard let displayRowValues = displayRow(at: row) else { return }
-        guard columnIndex < displayRowValues.values.count else { return }
+        guard columnIndex >= 0 && columnIndex < tableRows.columns.count else { return nil }
+        guard let displayRowValues = displayRow(at: row) else { return nil }
+        guard columnIndex < displayRowValues.values.count else { return nil }
         let oldValue = displayRowValues.values[columnIndex]
         guard oldValue != typedNewValue else {
-            cellCommitLogger.debug("commitTypedCellEdit - value unchanged, guard returned")
-            return
+            cellCommitLogger.debug("recordCellEdit - value unchanged, guard returned")
+            return nil
         }
 
         isCommittingCellEdit = true
@@ -49,23 +71,8 @@ extension TableViewCoordinator {
                 delta = tableRows.edit(row: storageRow, column: columnIndex, value: typedNewValue)
             }
         }
-        cellCommitLogger.debug("commitTypedCellEdit - about to call delegate.dataGridDidEditCell, delegate=\(self.delegate == nil ? "nil" : "present", privacy: .public)")
+        cellCommitLogger.debug("recordCellEdit - about to call delegate.dataGridDidEditCell, delegate=\(self.delegate == nil ? "nil" : "present", privacy: .public)")
         delegate?.dataGridDidEditCell(row: row, column: columnIndex, newValue: typedNewValue.asText)
-        invalidateDisplayCache()
-        visualIndex.updateRow(row, from: changeManager, sortedIDs: sortedIDs)
-
-        guard let tableColumnIndex = DataGridView.tableColumnIndex(
-            for: columnIndex,
-            in: tableView,
-            schema: identitySchema
-        ) else { return }
-        if storageRow != nil, case .cellChanged = delta {
-            tableRowsController.apply(.cellChanged(row: row, column: tableColumnIndex))
-        } else {
-            tableView.reloadData(
-                forRowIndexes: IndexSet(integer: row),
-                columnIndexes: IndexSet(integer: tableColumnIndex)
-            )
-        }
+        return delta
     }
 }

--- a/TablePro/Views/Results/Extensions/DataGridView+FillColumn.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+FillColumn.swift
@@ -58,11 +58,15 @@ extension TableViewCoordinator {
         undoManager?.beginUndoGrouping()
         undoManager?.setActionName(String(localized: "Fill Column"))
 
-        for row in targetRows {
-            commitTypedCellEdit(row: row, columnIndex: columnIndex, newValue: value)
+        var didEdit = false
+        for row in targetRows where recordCellEdit(row: row, columnIndex: columnIndex, newValue: value) != nil {
+            didEdit = true
         }
 
         undoManager?.endUndoGrouping()
+
+        guard didEdit else { return }
+        invalidateAllDisplayCaches()
         tableView?.reloadData()
     }
 

--- a/TablePro/Views/Results/Extensions/DataGridView+FillColumn.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+FillColumn.swift
@@ -1,0 +1,129 @@
+//
+//  DataGridView+FillColumn.swift
+//  TablePro
+//
+
+import AppKit
+import TableProPluginKit
+
+extension TableViewCoordinator {
+    @objc func fillColumn(_ sender: NSMenuItem) {
+        guard let columnIndex = sender.representedObject as? Int else { return }
+        presentFillColumnDialog(columnIndex: columnIndex)
+    }
+
+    func presentFillColumnDialog(columnIndex: Int) {
+        guard isEditable, let window = tableView?.window else { return }
+
+        let tableRows = tableRowsProvider()
+        guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
+
+        let rowCount = Self.fillTargetRows(
+            rowCount: cachedRowCount,
+            isEditable: isEditable,
+            isRowDeleted: changeManager.isRowDeleted
+        ).count
+        guard rowCount > 0 else { return }
+
+        let columnName = tableRows.columns[columnIndex]
+        let allowsNull = tableRows.columnNullable[columnName] ?? true
+        let accessory = FillColumnAccessoryView(allowsNull: allowsNull)
+
+        let alert = NSAlert()
+        alert.messageText = String(format: String(localized: "Fill column \"%@\""), columnName)
+        alert.informativeText = Self.fillImpactDescription(rowCount: rowCount)
+        alert.accessoryView = accessory
+        alert.addButton(withTitle: String(localized: "Fill"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard response == .alertFirstButtonReturn else { return }
+            self?.applyFillColumn(columnIndex: columnIndex, value: accessory.resolvedValue)
+        }
+
+        DispatchQueue.main.async {
+            alert.window.makeFirstResponder(accessory.firstResponderView)
+        }
+    }
+
+    func applyFillColumn(columnIndex: Int, value: PluginCellValue) {
+        let targetRows = Self.fillTargetRows(
+            rowCount: cachedRowCount,
+            isEditable: isEditable,
+            isRowDeleted: changeManager.isRowDeleted
+        )
+        guard !targetRows.isEmpty else { return }
+
+        let undoManager = tableView?.window?.undoManager
+        undoManager?.beginUndoGrouping()
+        undoManager?.setActionName(String(localized: "Fill Column"))
+
+        for row in targetRows {
+            commitTypedCellEdit(row: row, columnIndex: columnIndex, newValue: value)
+        }
+
+        undoManager?.endUndoGrouping()
+        tableView?.reloadData()
+    }
+
+    static func fillTargetRows(rowCount: Int, isEditable: Bool, isRowDeleted: (Int) -> Bool) -> [Int] {
+        guard isEditable, rowCount > 0 else { return [] }
+        return (0..<rowCount).filter { !isRowDeleted($0) }
+    }
+
+    static func fillColumnValue(text: String, setNull: Bool) -> PluginCellValue {
+        setNull ? .null : .text(text)
+    }
+
+    static func fillImpactDescription(rowCount: Int) -> String {
+        if rowCount == 1 {
+            return String(localized: "This sets 1 loaded row. Review and Save to apply.")
+        }
+        return String(
+            format: String(localized: "This sets %lld loaded rows. Review and Save to apply."),
+            Int64(rowCount)
+        )
+    }
+}
+
+@MainActor
+private final class FillColumnAccessoryView: NSView {
+    private let valueField = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+    private let nullCheckbox: NSButton?
+
+    init(allowsNull: Bool) {
+        nullCheckbox = allowsNull
+            ? NSButton(checkboxWithTitle: String(localized: "Set to NULL"), target: nil, action: nil)
+            : nil
+        super.init(frame: NSRect(x: 0, y: 0, width: 260, height: allowsNull ? 50 : 24))
+
+        valueField.usesSingleLineMode = true
+        valueField.placeholderString = String(localized: "Value")
+        valueField.frame = NSRect(x: 0, y: allowsNull ? 26 : 0, width: 260, height: 24)
+        addSubview(valueField)
+
+        guard let nullCheckbox else { return }
+        nullCheckbox.frame = NSRect(x: 0, y: 0, width: 260, height: 18)
+        nullCheckbox.target = self
+        nullCheckbox.action = #selector(nullStateChanged)
+        addSubview(nullCheckbox)
+    }
+
+    required init?(coder: NSCoder) {
+        nullCheckbox = nil
+        super.init(coder: coder)
+    }
+
+    var resolvedValue: PluginCellValue {
+        TableViewCoordinator.fillColumnValue(
+            text: valueField.stringValue,
+            setNull: nullCheckbox?.state == .on
+        )
+    }
+
+    var firstResponderView: NSView { valueField }
+
+    @objc private func nullStateChanged() {
+        valueField.isEnabled = nullCheckbox?.state != .on
+    }
+}

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -102,6 +102,20 @@ extension TableViewCoordinator {
             menu.addItem(copyValuesItem)
         }
 
+        if let dataColumnIndex = dataColumnIndex(from: column.identifier),
+           isEditable,
+           cachedRowCount > 0,
+           !primaryKeyColumns.contains(baseName) {
+            let fillItem = NSMenuItem(
+                title: String(localized: "Fill Column…"),
+                action: #selector(fillColumn(_:)),
+                keyEquivalent: ""
+            )
+            fillItem.representedObject = dataColumnIndex
+            fillItem.target = self
+            menu.addItem(fillItem)
+        }
+
         let filterItem = NSMenuItem(title: String(localized: "Filter with column"), action: #selector(filterWithColumn(_:)), keyEquivalent: "")
         filterItem.representedObject = baseName
         filterItem.target = self

--- a/TableProTests/Views/Results/Extensions/FillColumnTests.swift
+++ b/TableProTests/Views/Results/Extensions/FillColumnTests.swift
@@ -2,10 +2,10 @@
 //  FillColumnTests.swift
 //  TableProTests
 //
-//  Locks the Fill Column decision logic: which loaded rows a fill targets
-//  (editable guard, deleted-row skipping, empty result) and how the dialog
-//  resolves NULL distinctly from an empty string. The apply loop itself
-//  reuses commitTypedCellEdit, which the cell-edit and paste paths exercise.
+//  Locks Fill Column behaviour at two levels: the pure decisions (which loaded
+//  rows a fill targets, how the dialog resolves NULL vs an empty string) and
+//  the effect (applyFillColumn records one staged change per loaded row through
+//  DataChangeManager, skipping deleted rows and read-only result sets).
 //
 
 import Foundation
@@ -14,11 +14,45 @@ import Testing
 
 @testable import TablePro
 
+@MainActor
+private final class NoopColumnLayoutPersister: ColumnLayoutPersisting {
+    func load(for tableName: String, connectionId: UUID) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for tableName: String, connectionId: UUID) {}
+    func clear(for tableName: String, connectionId: UUID) {}
+}
+
 @Suite("Fill Column")
 @MainActor
 struct FillColumnTests {
-    @Test("Fills every loaded row when editable and none are deleted")
-    func fillsAllLoadedRows() {
+    private func makeCoordinator(
+        columns: [String],
+        rowCount: Int,
+        isEditable: Bool = true,
+        manager: DataChangeManager
+    ) -> TableViewCoordinator {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(manager),
+            isEditable: isEditable,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: NoopColumnLayoutPersister()
+        )
+        let columnTypes: [ColumnType] = Array(repeating: .text(rawType: nil), count: columns.count)
+        let rows = (0..<rowCount).map { i in (0..<columns.count).map { c in "r\(i)c\(c)" } }
+        let tableRows = TableRows.from(
+            queryRows: rows.map { row in row.map { PluginCellValue.text($0) } },
+            columns: columns,
+            columnTypes: columnTypes
+        )
+        coordinator.tableRowsProvider = { tableRows }
+        coordinator.updateCache()
+        return coordinator
+    }
+
+    // MARK: - Target selection
+
+    @Test("Targets every loaded row when editable and none are deleted")
+    func targetsAllLoadedRows() {
         let rows = TableViewCoordinator.fillTargetRows(
             rowCount: 5,
             isEditable: true,
@@ -27,8 +61,8 @@ struct FillColumnTests {
         #expect(rows == [0, 1, 2, 3, 4])
     }
 
-    @Test("Skips rows marked for deletion")
-    func skipsDeletedRows() {
+    @Test("Excludes rows marked for deletion")
+    func excludesDeletedRows() {
         let rows = TableViewCoordinator.fillTargetRows(
             rowCount: 5,
             isEditable: true,
@@ -57,6 +91,8 @@ struct FillColumnTests {
         #expect(rows.isEmpty)
     }
 
+    // MARK: - Value resolution
+
     @Test("Resolves NULL distinctly from an empty string")
     func resolvesNullDistinctFromEmpty() {
         #expect(TableViewCoordinator.fillColumnValue(text: "ignored", setNull: true) == .null)
@@ -68,5 +104,64 @@ struct FillColumnTests {
     func impactDescriptionSingularAndPlural() {
         #expect(TableViewCoordinator.fillImpactDescription(rowCount: 1).contains("1 loaded row"))
         #expect(TableViewCoordinator.fillImpactDescription(rowCount: 42).contains("42 loaded rows"))
+    }
+
+    // MARK: - Apply (staged effect)
+
+    @Test("Records one staged change per loaded row, leaving other columns untouched")
+    func appliesToEveryLoadedRow() {
+        let manager = DataChangeManager()
+        let coordinator = makeCoordinator(columns: ["a", "b"], rowCount: 4, manager: manager)
+
+        coordinator.applyFillColumn(columnIndex: 0, value: .text("X"))
+
+        for row in 0..<4 {
+            #expect(manager.pending.isCellModified(rowIndex: row, columnIndex: 0))
+        }
+        #expect(manager.pending.isCellModified(rowIndex: 0, columnIndex: 1) == false)
+    }
+
+    @Test("Does not touch rows marked for deletion")
+    func skipsDeletedRowsOnApply() {
+        let manager = DataChangeManager()
+        let coordinator = makeCoordinator(columns: ["a"], rowCount: 4, manager: manager)
+        manager.recordRowDeletion(rowIndex: 2, originalRow: [.text("r2c0")])
+
+        coordinator.applyFillColumn(columnIndex: 0, value: .text("X"))
+
+        #expect(manager.pending.isCellModified(rowIndex: 0, columnIndex: 0))
+        #expect(manager.pending.isCellModified(rowIndex: 2, columnIndex: 0) == false)
+    }
+
+    @Test("Records nothing on a read-only result set")
+    func recordsNothingWhenReadOnly() {
+        let manager = DataChangeManager()
+        let coordinator = makeCoordinator(columns: ["a"], rowCount: 4, isEditable: false, manager: manager)
+
+        coordinator.applyFillColumn(columnIndex: 0, value: .text("X"))
+
+        #expect(manager.hasChanges == false)
+    }
+
+    @Test("Writes NULL as a null change, not an empty string")
+    func appliesNull() {
+        let manager = DataChangeManager()
+        let coordinator = makeCoordinator(columns: ["a"], rowCount: 2, manager: manager)
+
+        coordinator.applyFillColumn(columnIndex: 0, value: .null)
+
+        let change = manager.pending.change(forRow: 0, type: .update)
+        #expect(change?.cellChanges.first?.newValue == .null)
+    }
+
+    @Test("Skips rows whose value already equals the fill value")
+    func skipsRowsAlreadyEqual() {
+        let manager = DataChangeManager()
+        let coordinator = makeCoordinator(columns: ["a"], rowCount: 2, manager: manager)
+
+        coordinator.applyFillColumn(columnIndex: 0, value: .text("r0c0"))
+
+        #expect(manager.pending.isCellModified(rowIndex: 0, columnIndex: 0) == false)
+        #expect(manager.pending.isCellModified(rowIndex: 1, columnIndex: 0))
     }
 }

--- a/TableProTests/Views/Results/Extensions/FillColumnTests.swift
+++ b/TableProTests/Views/Results/Extensions/FillColumnTests.swift
@@ -1,0 +1,72 @@
+//
+//  FillColumnTests.swift
+//  TableProTests
+//
+//  Locks the Fill Column decision logic: which loaded rows a fill targets
+//  (editable guard, deleted-row skipping, empty result) and how the dialog
+//  resolves NULL distinctly from an empty string. The apply loop itself
+//  reuses commitTypedCellEdit, which the cell-edit and paste paths exercise.
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Fill Column")
+@MainActor
+struct FillColumnTests {
+    @Test("Fills every loaded row when editable and none are deleted")
+    func fillsAllLoadedRows() {
+        let rows = TableViewCoordinator.fillTargetRows(
+            rowCount: 5,
+            isEditable: true,
+            isRowDeleted: { _ in false }
+        )
+        #expect(rows == [0, 1, 2, 3, 4])
+    }
+
+    @Test("Skips rows marked for deletion")
+    func skipsDeletedRows() {
+        let rows = TableViewCoordinator.fillTargetRows(
+            rowCount: 5,
+            isEditable: true,
+            isRowDeleted: { $0 == 2 }
+        )
+        #expect(rows == [0, 1, 3, 4])
+    }
+
+    @Test("Targets nothing on a read-only result set")
+    func noTargetsWhenReadOnly() {
+        let rows = TableViewCoordinator.fillTargetRows(
+            rowCount: 5,
+            isEditable: false,
+            isRowDeleted: { _ in false }
+        )
+        #expect(rows.isEmpty)
+    }
+
+    @Test("Targets nothing when no rows are loaded")
+    func noTargetsWhenEmpty() {
+        let rows = TableViewCoordinator.fillTargetRows(
+            rowCount: 0,
+            isEditable: true,
+            isRowDeleted: { _ in false }
+        )
+        #expect(rows.isEmpty)
+    }
+
+    @Test("Resolves NULL distinctly from an empty string")
+    func resolvesNullDistinctFromEmpty() {
+        #expect(TableViewCoordinator.fillColumnValue(text: "ignored", setNull: true) == .null)
+        #expect(TableViewCoordinator.fillColumnValue(text: "", setNull: false) == .text(""))
+        #expect(TableViewCoordinator.fillColumnValue(text: "active", setNull: false) == .text("active"))
+    }
+
+    @Test("Impact description reflects singular and plural counts")
+    func impactDescriptionSingularAndPlural() {
+        #expect(TableViewCoordinator.fillImpactDescription(rowCount: 1).contains("1 loaded row"))
+        #expect(TableViewCoordinator.fillImpactDescription(rowCount: 42).contains("42 loaded rows"))
+    }
+}

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -255,6 +255,12 @@ Select multiple rows with `Cmd+click` (non-contiguous) or `Shift+click` (range) 
   />
 </Frame>
 
+### Fill Column
+
+Right-click a column header and choose **Fill Column** to set one value across all loaded rows at once. Enter the value in the dialog, or check **Set to NULL** for nullable columns. The dialog shows how many rows it will set.
+
+Fill stages the change like any other edit, so review it with **Preview SQL** and **Commit** (`Cmd+S`) to apply, or **Discard** to drop it. `Cmd+Z` reverses the whole fill in one step. It only affects the rows currently loaded in the grid, not rows on other pages, and is not available on primary key columns.
+
 ### Saving Changes
 
 Changes are queued, not applied immediately. Manage pending changes with:


### PR DESCRIPTION
## What

Adds a **Fill Column** action to the data grid. Right-click a column header, choose **Fill Column**, enter one value (or check **Set to NULL**), and it sets that value across all loaded rows. Closes #1304.

The change is staged like any other cell edit, so you review it (Preview SQL), Save to apply, or Discard. One `Cmd+Z` reverts the whole fill.

## Scope decision

Fill targets the **rows currently loaded in the grid**, not every row matching the current filter. This is deliberate:

- The issue scopes it to "the current result set or view."
- No mature native client (TablePlus, DataGrip, Postico, Sequel) offers a whole-table grid fill. They all stay selection/loaded-scoped and staged, to avoid accidental mass updates of unseen rows.
- A whole-table `UPDATE ... WHERE <filter>` would bypass change-tracking and undo entirely.

Because the fill is staged and reversible before Save, there is no blocking confirmation alert. The dialog states the impact inline ("This sets N loaded rows. Review and Save to apply.").

## How it works

- Menu item lives in the column-header context menu, between Copy Column Values and Filter. Built by `TableViewCoordinator` (the existing `NSMenuDelegate`), so the whole flow is coordinator-local like Copy Column Values and multi-cell paste.
- Dialog is an `NSAlert` with an accessory view (text field, plus a "Set to NULL" checkbox on nullable columns), the same pattern as the existing column-rename prompt.
- Apply reuses the multi-cell-paste mechanics: one `beginUndoGrouping`/`endUndoGrouping` named "Fill Column", looping `commitTypedCellEdit` over loaded rows.

## Guards

- Hidden on read-only result sets (`isEditable`).
- Hidden on primary key columns (filling a PK with one value would fail with a duplicate-key error on Save; DataGrip disables it for the same reason).
- No-op when no rows are loaded.
- Already-equal values skip via the existing cell-commit guard.

Unique-constraint columns aren't guarded yet (that metadata isn't reachable synchronously at menu-build time); PK is the worst case and is covered. Noted as a follow-up.

## Tests

`FillColumnTests` covers the decision logic: fills all loaded rows, skips deleted rows, none when read-only, none when empty, NULL vs empty-string resolution, and singular/plural impact text. The apply loop reuses `commitTypedCellEdit`, which the cell-edit and paste paths already exercise.

## Docs / CHANGELOG

- New Fill Column subsection in `docs/features/data-grid.mdx`.
- `Added` entry under `[Unreleased]`.

New `String(localized:)` keys are extracted into `Localizable.xcstrings` on build.

## Not included (deliberate)

- No whole-table / all-filtered-rows server-side UPDATE.
- No keyboard shortcut (contextual action).
- No selection-scoped "Set value" on arbitrary cell selections (separate feature).
