### PR TITLE
fix(plugins): publish each ABI as a new plugin version, verify built kit matches label (#1380)

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -252,19 +252,21 @@ jobs:
         run: |
           BUNDLE_NAME="${{ steps.plugin.outputs.bundleName }}"
           EXPECTED="${{ matrix.pluginKitVersion }}"
-          WORK=$(mktemp -d)
-          unzip -oq "build/Plugins/${BUNDLE_NAME}-arm64.zip" -d "$WORK"
-          PLIST=$(find "$WORK" -path '*.tableplugin/Contents/Info.plist' | head -1)
-          if [ -z "$PLIST" ]; then
-            echo "::error::Could not find Info.plist in the built ${BUNDLE_NAME} bundle."
-            exit 1
-          fi
-          ACTUAL=$(plutil -extract TableProPluginKitVersion raw "$PLIST")
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "::error::${BUNDLE_NAME} was built for PluginKit $ACTUAL but this release is labeled PluginKit $EXPECTED. Refusing to publish a mislabeled binary. Re-release from a commit whose plugin Info.plist matches the target PluginKit version."
-            exit 1
-          fi
-          echo "Verified ${BUNDLE_NAME}: built PluginKit $ACTUAL matches the release label."
+          for ARCH in arm64 x86_64; do
+            WORK=$(mktemp -d)
+            unzip -oq "build/Plugins/${BUNDLE_NAME}-${ARCH}.zip" -d "$WORK"
+            PLIST=$(find "$WORK" -path '*.tableplugin/Contents/Info.plist' | head -1)
+            if [ -z "$PLIST" ]; then
+              echo "::error::Could not find Info.plist in the built ${BUNDLE_NAME}-${ARCH} bundle."
+              exit 1
+            fi
+            ACTUAL=$(plutil -extract TableProPluginKitVersion raw "$PLIST")
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::${BUNDLE_NAME}-${ARCH} was built for PluginKit $ACTUAL but this release is labeled PluginKit $EXPECTED. Refusing to publish a mislabeled binary. Re-release from a commit whose plugin Info.plist matches the target PluginKit version."
+              exit 1
+            fi
+            echo "Verified ${BUNDLE_NAME}-${ARCH}: built PluginKit $ACTUAL matches the release label."
+          done
 
       - name: Read checksums
         id: sha
@@ -307,6 +309,13 @@ jobs:
           ### SHA-256
           - ARM64: \`$ARM64_SHA\`
           - x86_64: \`$X86_SHA\`"
+
+          EXISTING_PKV=$(gh release view "$TAG" --json body --jq .body 2>/dev/null \
+            | grep -oiE 'PluginKit [0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+          if [ -n "$EXISTING_PKV" ] && [ "$EXISTING_PKV" != "$PKV" ]; then
+            echo "::error::Release $TAG already exists for PluginKit $EXISTING_PKV. Refusing to overwrite it with PluginKit $PKV; publish the new ABI under a new plugin version."
+            exit 1
+          fi
 
           gh release delete "$TAG" --yes 2>/dev/null || true
           gh release create "$TAG" \

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -248,6 +248,24 @@ jobs:
           ./scripts/build-plugin.sh "${{ steps.plugin.outputs.target }}" arm64 "${{ steps.plugin.outputs.version }}"
           ./scripts/build-plugin.sh "${{ steps.plugin.outputs.target }}" x86_64 "${{ steps.plugin.outputs.version }}"
 
+      - name: Verify built PluginKit version matches the release label
+        run: |
+          BUNDLE_NAME="${{ steps.plugin.outputs.bundleName }}"
+          EXPECTED="${{ matrix.pluginKitVersion }}"
+          WORK=$(mktemp -d)
+          unzip -oq "build/Plugins/${BUNDLE_NAME}-arm64.zip" -d "$WORK"
+          PLIST=$(find "$WORK" -path '*.tableplugin/Contents/Info.plist' | head -1)
+          if [ -z "$PLIST" ]; then
+            echo "::error::Could not find Info.plist in the built ${BUNDLE_NAME} bundle."
+            exit 1
+          fi
+          ACTUAL=$(plutil -extract TableProPluginKitVersion raw "$PLIST")
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::${BUNDLE_NAME} was built for PluginKit $ACTUAL but this release is labeled PluginKit $EXPECTED. Refusing to publish a mislabeled binary. Re-release from a commit whose plugin Info.plist matches the target PluginKit version."
+            exit 1
+          fi
+          echo "Verified ${BUNDLE_NAME}: built PluginKit $ACTUAL matches the release label."
+
       - name: Read checksums
         id: sha
         run: |

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -4,9 +4,13 @@
 # Usage: ./scripts/release-all-plugins.sh <pluginKitVersion>
 # Example: ./scripts/release-all-plugins.sh 14
 #
-# Reads the latest tag for each plugin from git, pairs it with the given
-# pluginKitVersion, and fires one workflow_dispatch on build-plugin.yml so all
-# plugins build in parallel as a single matrix run.
+# Reads the latest tag for each plugin, bumps the patch version, and pairs the
+# NEW version with the given pluginKitVersion, then fires one workflow_dispatch
+# on build-plugin.yml so all plugins build in parallel as a single matrix run.
+#
+# An ABI bump must publish fresh binaries at a NEW release tag. Reusing the
+# existing tag overwrites that release's assets, which breaks the previous ABI's
+# consumers and serves stale copies from the GitHub release CDN.
 #
 # Prerequisites: gh CLI authenticated, run from repo root.
 
@@ -59,16 +63,20 @@ for PLUGIN in "${PLUGINS[@]}"; do
     done
 done
 
+git fetch --tags --quiet origin 2>/dev/null || true
+
 TAG_LIST=""
 FIRST=true
-echo "Resolving latest tag for each plugin:"
+echo "Resolving next release version for each plugin (PluginKit $PKV):"
 for PLUGIN in "${PLUGINS[@]}"; do
     LATEST_TAG=$(git tag -l "plugin-${PLUGIN}-v*" | sort -V | tail -1)
     if [ -z "$LATEST_TAG" ]; then
         echo "  WARNING: No tag found for plugin-${PLUGIN}-v*. Skipping."
         continue
     fi
-    PAIR="${LATEST_TAG}:${PKV}"
+    LATEST_VER="${LATEST_TAG#plugin-${PLUGIN}-v}"
+    NEW_TAG="plugin-${PLUGIN}-v${LATEST_VER%.*}.$(( ${LATEST_VER##*.} + 1 ))"
+    PAIR="${NEW_TAG}:${PKV}"
     if [ "$FIRST" = true ]; then
         TAG_LIST="$PAIR"
         FIRST=false

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -63,15 +63,14 @@ for PLUGIN in "${PLUGINS[@]}"; do
     done
 done
 
-git fetch --tags --quiet origin 2>/dev/null || true
-
 TAG_LIST=""
 FIRST=true
 echo "Resolving next release version for each plugin (PluginKit $PKV):"
 for PLUGIN in "${PLUGINS[@]}"; do
-    LATEST_TAG=$(git tag -l "plugin-${PLUGIN}-v*" | sort -V | tail -1)
+    LATEST_TAG=$(git ls-remote --tags --refs origin "plugin-${PLUGIN}-v*" \
+        | sed 's#.*/##' | sort -V | tail -1)
     if [ -z "$LATEST_TAG" ]; then
-        echo "  WARNING: No tag found for plugin-${PLUGIN}-v*. Skipping."
+        echo "  WARNING: No remote tag found for plugin-${PLUGIN}-v*. Skipping."
         continue
     fi
     LATEST_VER="${LATEST_TAG#plugin-${PLUGIN}-v}"


### PR DESCRIPTION
## Problem (#1380, also the residual of #1322)

After the PluginKit ABI bump to 15 shipped in v0.44.0, users still could not install or update registry plugins (Cloudflare D1, and in fact all 10). The app correctly reported "Plugin was built for PluginKit version 14; this release needs version 15".

## Root cause: the bulk re-release reused existing tags

`release-all-plugins.sh` paired each plugin's **latest existing tag** (e.g. `plugin-cloudflare-d1-v1.0.22`) with the new PluginKit version, and the build workflow does `gh release delete` + `gh release create` on that same tag. Reusing one tag/asset URL for two different ABIs has two failure modes:

1. The download URL never changes, so the GitHub release CDN serves the previously cached (kit 14) asset for an unpredictable window after the asset is replaced. Users who updated in that window downloaded a kit 14 binary even though the release now held kit 15.
2. The previous ABI's binary at that URL gets overwritten, so consumers on the older app version (kit 14) start downloading the kit 15 binary and break too.

`--keep-kit-versions 2` only works if each ABI is a distinct artifact at a distinct URL. Reusing the tag collapsed both ABIs onto one URL.

## Fix

- **`release-all-plugins.sh`** now bumps the patch version (e.g. `v1.0.22` to `v1.0.23`) and dispatches the new tag, so each ABI publishes fresh binaries at a new release URL. No overwrite, no CDN staleness, and the two retained ABIs stay distinct. Also fetches tags first so the latest version is read correctly.
- **`build-plugin.yml`** gains a guard: after building, it reads the bundle's `TableProPluginKitVersion` and fails the job if it does not match the `pluginKitVersion` the release is labeled with. A mislabeled binary can no longer reach the registry.

## Follow-up to unblock users

Run `./scripts/release-all-plugins.sh 15` (with this fix) to publish all 10 registry plugins at new versions with genuine kit 15 binaries.

No app code changes; the app already shows the correct, actionable message.
