### PR TITLE
fix(datagrid): Esc in the filter suggestions or a search field no longer exits fullscreen (#1403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Installing or updating a plugin right after updating TablePro now refetches the current plugin list first, so it no longer fails against a stale cached list (the error a restart used to clear). (#1380)
+- Pressing Esc to close the Raw SQL filter suggestions, or to clear a search field, no longer also exits fullscreen. (#1403)
 
 ## [0.44.0] - 2026-05-23
 

--- a/TablePro/Views/Filter/FilterValueTextField.swift
+++ b/TablePro/Views/Filter/FilterValueTextField.swift
@@ -38,6 +38,24 @@ struct FilterValueTextField: NSViewRepresentable {
         return (ns.replacingCharacters(in: range, with: insertText), caret)
     }
 
+    enum SuggestionKeyOutcome: Equatable {
+        case moveSelection(Int)
+        case accept(submitting: Bool)
+        case dismiss
+        case passThrough
+    }
+
+    static func suggestionKeyOutcome(for key: KeyCode?, submitsOnAccept: Bool) -> SuggestionKeyOutcome {
+        switch key {
+        case .downArrow: return .moveSelection(1)
+        case .upArrow: return .moveSelection(-1)
+        case .return: return .accept(submitting: submitsOnAccept)
+        case .tab: return .accept(submitting: false)
+        case .escape: return .dismiss
+        default: return .passThrough
+        }
+    }
+
     func makeNSView(context: Context) -> NSTextField {
         let textField = SubstitutionDisabledTextField()
         textField.bezelStyle = .roundedBezel
@@ -176,6 +194,10 @@ struct FilterValueTextField: NSViewRepresentable {
                 text.wrappedValue = textView.string
                 return true
             }
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                dismissSuggestions()
+                return true
+            }
             return false
         }
 
@@ -291,25 +313,20 @@ struct FilterValueTextField: NSViewRepresentable {
                           nsEvent.window?.firstResponder === textField.currentEditor()
                     else { return nsEvent }
 
-                    switch nsEvent.semanticKeyCode {
-                    case .downArrow:
-                        self.moveSelection(by: 1)
-                        return nil
-                    case .upArrow:
-                        self.moveSelection(by: -1)
-                        return nil
-                    case .return:
-                        self.acceptCurrentSelection(submitting: self.submitsOnAccept)
-                        return nil
-                    case .tab:
-                        self.acceptCurrentSelection(submitting: false)
-                        return nil
-                    case .escape:
+                    switch FilterValueTextField.suggestionKeyOutcome(
+                        for: nsEvent.semanticKeyCode,
+                        submitsOnAccept: self.submitsOnAccept
+                    ) {
+                    case .moveSelection(let delta):
+                        self.moveSelection(by: delta)
+                    case .accept(let submitting):
+                        self.acceptCurrentSelection(submitting: submitting)
+                    case .dismiss:
                         self.dismissSuggestions()
-                        return nsEvent
-                    default:
+                    case .passThrough:
                         return nsEvent
                     }
+                    return nil
                 }
             }
         }

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -98,9 +98,8 @@ struct NativeSearchField: NSViewRepresentable {
                 if !field.stringValue.isEmpty {
                     field.stringValue = ""
                     text.wrappedValue = ""
-                    return true
                 }
-                return false
+                return true
             }
             if commandSelector == #selector(NSResponder.moveUp(_:)), let onMoveUp {
                 onMoveUp()

--- a/TableProTests/Views/Filter/FilterValueTextFieldTests.swift
+++ b/TableProTests/Views/Filter/FilterValueTextFieldTests.swift
@@ -113,4 +113,24 @@ struct FilterValueTextFieldTests {
         )
         #expect(result == nil)
     }
+
+    @Test("Escape dismisses the suggestions and is consumed, not passed through")
+    func testKeyOutcome_escapeDismisses() {
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .escape, submitsOnAccept: true) == .dismiss)
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .escape, submitsOnAccept: false) == .dismiss)
+    }
+
+    @Test("Arrow and accept keys map to consuming outcomes")
+    func testKeyOutcome_navigationAndAccept() {
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .downArrow, submitsOnAccept: false) == .moveSelection(1))
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .upArrow, submitsOnAccept: false) == .moveSelection(-1))
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .return, submitsOnAccept: true) == .accept(submitting: true))
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .tab, submitsOnAccept: true) == .accept(submitting: false))
+    }
+
+    @Test("Unhandled keys pass through unchanged")
+    func testKeyOutcome_passThrough() {
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: .space, submitsOnAccept: true) == .passThrough)
+        #expect(FilterValueTextField.suggestionKeyOutcome(for: nil, submitsOnAccept: true) == .passThrough)
+    }
 }


### PR DESCRIPTION
## What

In macOS fullscreen, pressing Esc to dismiss the Raw SQL filter's autocomplete popup also exited fullscreen. Closes #1403. The same leak affected search fields. Esc now stays in fullscreen.

## Root cause

The Esc key (`cancelOperation:`) reached SwiftUI's `NSHostingView`, which exits fullscreen on an unhandled exit command. The trace:

```
NSTextView.keyDown -> interpretKeyEvents -> doCommandBySelector(cancelOperation:)
  -> SwiftUI NSHostingView.doCommand(by:) -> _NSFullScreenSpace exit transition
```

So the exit happens at the SwiftUI hosting layer, not at the window. Standard window fullscreen is not exited by Esc natively; that is the green button or Ctrl+Cmd+F. The exit here was `NSHostingView` reacting to an unconsumed exit command.

Two text fields let Esc through to the hosting view:
- The Raw SQL filter's suggestion monitor handled Esc but returned the event instead of consuming it.
- `NativeSearchField` returned `false` from its delegate when the field was empty, so Esc propagated.

## Fix

Consume `cancelOperation:` at the text field's delegate (`control(_:textView:doCommandBy:)` returning `true`), so it never reaches `NSHostingView`. This is the same mechanism `NativeSearchField` already used for the non-empty case (clearing a search without exiting fullscreen).

- `FilterValueTextField`: the delegate now consumes Esc, dismissing the suggestion popup if it is shown. The popup monitor also consumes Esc instead of passing it through. Extracted a pure, testable `suggestionKeyOutcome(for:submitsOnAccept:)`.
- `NativeSearchField`: an empty-field Esc is now consumed instead of propagating.

## Tests

`FilterValueTextFieldTests` asserts `escape -> .dismiss` (a consuming outcome) plus the arrow/return/tab/pass-through mappings.

## Verify (in fullscreen)

- Raw SQL filter: type a value to open the popup, Esc closes the popup and stays fullscreen. Esc again with no popup stays fullscreen.
- Search field: Esc with text clears it and stays fullscreen; Esc on an empty field stays fullscreen.
- Regression: green button and Ctrl+Cmd+F still exit fullscreen.

## Scope

This consumes Esc in the filter and search fields (the reported case and the related search-field case). Any other SwiftUI-hosted text field would use the same one-line delegate consume.
