### PR TITLE
fix(mcp): return plain HTTP 404 for unknown paths so OAuth clients get a clear error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Installing or updating a plugin right after updating TablePro now refetches the current plugin list first, so it no longer fails against a stale cached list (the error a restart used to clear). (#1380)
 - Pressing Esc to close the Raw SQL filter suggestions, or to clear a search field, no longer also exits fullscreen. (#1403)
-- Connecting an OAuth-capable MCP client like Claude Code with an invalid or expired token now shows a clear error instead of a confusing "Invalid OAuth error response".
+- Connecting an OAuth-capable MCP client like Claude Code with an invalid or expired token now shows a clear error instead of a confusing "Invalid OAuth error response". (#1409)
 
 ## [0.44.0] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Installing or updating a plugin right after updating TablePro now refetches the current plugin list first, so it no longer fails against a stale cached list (the error a restart used to clear). (#1380)
 - Pressing Esc to close the Raw SQL filter suggestions, or to clear a search field, no longer also exits fullscreen. (#1403)
+- Connecting an OAuth-capable MCP client like Claude Code with an invalid or expired token now shows a clear error instead of a confusing "Invalid OAuth error response".
 
 ## [0.44.0] - 2026-05-23
 

--- a/TablePro/Core/MCP/Transport/MCPHttpConnectionContext.swift
+++ b/TablePro/Core/MCP/Transport/MCPHttpConnectionContext.swift
@@ -147,12 +147,13 @@ actor HttpConnectionContext {
         await send(payload)
     }
 
-    func writePlainJsonResponse(status: HttpStatus, body: Data) async {
+    func writePlainJsonResponse(status: HttpStatus, body: Data, extraHeaders: [(String, String)] = []) async {
         if cancelled { return }
         var headers: [(String, String)] = [
             ("Content-Type", "application/json"),
             ("Connection", "close")
         ]
+        headers.append(contentsOf: extraHeaders)
         headers.append(contentsOf: self.corsHeaders())
         let head = HttpResponseHead(status: status, headers: HttpHeaders(headers))
         let payload = HttpResponseEncoder.encode(head, body: body)
@@ -165,7 +166,12 @@ actor HttpConnectionContext {
         await writePlainJsonResponse(status: status, body: payload)
     }
 
-    func writePlainJsonError(status: HttpStatus, error: String, errorDescription: String) async {
+    func writePlainJsonError(
+        status: HttpStatus,
+        error: String,
+        errorDescription: String,
+        extraHeaders: [(String, String)] = []
+    ) async {
         struct ErrorBody: Encodable {
             let error: String
             let errorDescription: String
@@ -176,7 +182,7 @@ actor HttpConnectionContext {
         }
         let body = ErrorBody(error: error, errorDescription: errorDescription)
         let payload = (try? JSONEncoder().encode(body)) ?? Data()
-        await writePlainJsonResponse(status: status, body: payload)
+        await writePlainJsonResponse(status: status, body: payload, extraHeaders: extraHeaders)
     }
 
     func writeOptions204() async {

--- a/TablePro/Core/MCP/Transport/MCPHttpConnectionContext.swift
+++ b/TablePro/Core/MCP/Transport/MCPHttpConnectionContext.swift
@@ -165,6 +165,20 @@ actor HttpConnectionContext {
         await writePlainJsonResponse(status: status, body: payload)
     }
 
+    func writePlainJsonError(status: HttpStatus, error: String, errorDescription: String) async {
+        struct ErrorBody: Encodable {
+            let error: String
+            let errorDescription: String
+            enum CodingKeys: String, CodingKey {
+                case error
+                case errorDescription = "error_description"
+            }
+        }
+        let body = ErrorBody(error: error, errorDescription: errorDescription)
+        let payload = (try? JSONEncoder().encode(body)) ?? Data()
+        await writePlainJsonResponse(status: status, body: payload)
+    }
+
     func writeOptions204() async {
         if cancelled { return }
         var headers: [(String, String)] = [("Connection", "close")]

--- a/TablePro/Core/MCP/Transport/MCPHttpRequestRouter.swift
+++ b/TablePro/Core/MCP/Transport/MCPHttpRequestRouter.swift
@@ -42,15 +42,7 @@ struct MCPHttpRequestRouter: Sendable {
         case .delete:
             await handleDeleteMcp(head: head, context: context, clientAddress: clientAddress)
         default:
-            await respondTopLevel(
-                context: context,
-                error: MCPProtocolError(
-                    code: JsonRpcErrorCode.methodNotFound,
-                    message: "Method not allowed",
-                    httpStatus: .methodNotAllowed
-                ),
-                requestId: nil
-            )
+            await respondHttpMethodNotAllowed(context: context)
         }
     }
 
@@ -177,15 +169,7 @@ struct MCPHttpRequestRouter: Sendable {
         clientAddress: MCPClientAddress
     ) async {
         guard pathMatchesMcp(head.path) else {
-            await respondTopLevel(
-                context: context,
-                error: MCPProtocolError(
-                    code: JsonRpcErrorCode.methodNotFound,
-                    message: "Method not found",
-                    httpStatus: .notFound
-                ),
-                requestId: nil
-            )
+            await respondHttpNotFound(context: context)
             return
         }
 
@@ -242,15 +226,7 @@ struct MCPHttpRequestRouter: Sendable {
         now: Date
     ) async {
         guard pathMatchesMcp(head.path) else {
-            await respondTopLevel(
-                context: context,
-                error: MCPProtocolError(
-                    code: JsonRpcErrorCode.methodNotFound,
-                    message: "Method not found",
-                    httpStatus: .notFound
-                ),
-                requestId: nil
-            )
+            await respondHttpNotFound(context: context)
             return
         }
 
@@ -344,15 +320,7 @@ struct MCPHttpRequestRouter: Sendable {
         clientAddress: MCPClientAddress
     ) async {
         guard pathMatchesMcp(head.path) else {
-            await respondTopLevel(
-                context: context,
-                error: MCPProtocolError(
-                    code: JsonRpcErrorCode.methodNotFound,
-                    message: "Method not found",
-                    httpStatus: .notFound
-                ),
-                requestId: nil
-            )
+            await respondHttpNotFound(context: context)
             return
         }
 
@@ -443,6 +411,24 @@ struct MCPHttpRequestRouter: Sendable {
             status: error.httpStatus,
             sessionId: nil,
             extraHeaders: error.extraHeaders
+        )
+        await context.cancel()
+    }
+
+    private func respondHttpNotFound(context: HttpConnectionContext) async {
+        await context.writePlainJsonError(
+            status: .notFound,
+            error: "not_found",
+            errorDescription: "TablePro's MCP server does not provide this endpoint."
+        )
+        await context.cancel()
+    }
+
+    private func respondHttpMethodNotAllowed(context: HttpConnectionContext) async {
+        await context.writePlainJsonError(
+            status: .methodNotAllowed,
+            error: "method_not_allowed",
+            errorDescription: "This HTTP method is not supported."
         )
         await context.cancel()
     }

--- a/TablePro/Core/MCP/Transport/MCPHttpRequestRouter.swift
+++ b/TablePro/Core/MCP/Transport/MCPHttpRequestRouter.swift
@@ -42,7 +42,11 @@ struct MCPHttpRequestRouter: Sendable {
         case .delete:
             await handleDeleteMcp(head: head, context: context, clientAddress: clientAddress)
         default:
-            await respondHttpMethodNotAllowed(context: context)
+            if pathMatchesMcp(head.path) {
+                await respondHttpMethodNotAllowed(context: context)
+            } else {
+                await respondHttpNotFound(context: context)
+            }
         }
     }
 
@@ -428,7 +432,8 @@ struct MCPHttpRequestRouter: Sendable {
         await context.writePlainJsonError(
             status: .methodNotAllowed,
             error: "method_not_allowed",
-            errorDescription: "This HTTP method is not supported."
+            errorDescription: "This HTTP method is not supported.",
+            extraHeaders: [("Allow", "GET, POST, DELETE, OPTIONS")]
         )
         await context.cancel()
     }

--- a/TableProTests/Core/MCP/Transport/MCPHttpServerTransportTests.swift
+++ b/TableProTests/Core/MCP/Transport/MCPHttpServerTransportTests.swift
@@ -113,6 +113,42 @@ struct MCPHttpServerTransportTests {
         return (envelope.id, envelope.error.code, envelope.error.message)
     }
 
+    private func makeRequest(port: UInt16, path: String, method: String, body: Data? = nil) -> URLRequest {
+        guard let url = URL(string: "http://127.0.0.1:\(port)\(path)") else {
+            fatalError("Failed to construct test URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer test", forHTTPHeaderField: "Authorization")
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        return request
+    }
+
+    private func decodeJsonObject(_ data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw TestError.malformedJsonBody
+        }
+        return object
+    }
+
+    private func expectPlainError(
+        data: Data,
+        response: URLResponse?,
+        status: Int,
+        error: String,
+        label: String
+    ) throws {
+        let http = try #require(response as? HTTPURLResponse, "\(label): expected an HTTP response")
+        #expect(http.statusCode == status, "\(label): expected status \(status)")
+        let object = try decodeJsonObject(data)
+        #expect(object["jsonrpc"] == nil, "\(label): must not be a JSON-RPC envelope")
+        #expect((object["error"] as? String) == error, "\(label): error must be the string \"\(error)\"")
+        #expect((object["error_description"] as? String)?.isEmpty == false, "\(label): needs an error_description")
+    }
+
     private func runEchoLoop(
         transport: MCPHttpServerTransport,
         consumer: StubExchangeConsumer,
@@ -336,8 +372,8 @@ struct MCPHttpServerTransportTests {
         #expect(http.statusCode == 413)
     }
 
-    @Test("Method not found at unknown path returns 404 with JSON-RPC error envelope")
-    func unknownPathReturns404() async throws {
+    @Test("Unknown HTTP paths return a plain 404, not a JSON-RPC envelope, so OAuth clients get a clear error")
+    func unknownPathsReturnPlainNotFound() async throws {
         let auth = StubAlwaysAllowAuthenticator()
         let (transport, _, port) = try await startedTransport(authenticator: auth)
         defer { Task { await transport.stop() } }
@@ -346,19 +382,47 @@ struct MCPHttpServerTransportTests {
         await runEchoLoop(transport: transport, consumer: consumer)
         defer { Task { await consumer.stop() } }
 
-        guard let url = URL(string: "http://127.0.0.1:\(port)/foo") else {
-            Issue.record("Failed to construct URL")
-            return
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer test", forHTTPHeaderField: "Authorization")
-        let (data, response) = try await URLSession.shared.data(for: request)
-        let http = try #require(response as? HTTPURLResponse)
+        let cases: [(path: String, method: String, body: Data?)] = [
+            ("/foo", "GET", nil),
+            ("/foo", "POST", Data("{}".utf8)),
+            ("/foo", "DELETE", nil),
+            ("/.well-known/oauth-protected-resource", "GET", nil),
+            ("/.well-known/oauth-authorization-server", "GET", nil),
+            ("/register", "POST", Data("{}".utf8))
+        ]
 
-        #expect(http.statusCode == 404)
-        let parsed = try parseJsonRpcError(data)
-        #expect(parsed.code == JsonRpcErrorCode.methodNotFound)
+        for testCase in cases {
+            let request = makeRequest(port: port, path: testCase.path, method: testCase.method, body: testCase.body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try expectPlainError(
+                data: data,
+                response: response,
+                status: 404,
+                error: "not_found",
+                label: "\(testCase.method) \(testCase.path)"
+            )
+        }
+    }
+
+    @Test("Unsupported HTTP method returns a plain 405, not a JSON-RPC envelope")
+    func unsupportedMethodReturnsPlain405() async throws {
+        let auth = StubAlwaysAllowAuthenticator()
+        let (transport, _, port) = try await startedTransport(authenticator: auth)
+        defer { Task { await transport.stop() } }
+
+        let consumer = StubExchangeConsumer()
+        await runEchoLoop(transport: transport, consumer: consumer)
+        defer { Task { await consumer.stop() } }
+
+        let request = makeRequest(port: port, path: "/mcp", method: "PUT", body: Data("{}".utf8))
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try expectPlainError(
+            data: data,
+            response: response,
+            status: 405,
+            error: "method_not_allowed",
+            label: "PUT /mcp"
+        )
     }
 
     @Test("OPTIONS request returns 204 with CORS headers reflecting allowed origin")
@@ -589,4 +653,5 @@ struct MCPHttpServerTransportTests {
 private enum TestError: Error {
     case serverDidNotStart
     case expectedErrorEnvelope
+    case malformedJsonBody
 }

--- a/TableProTests/Core/MCP/Transport/MCPHttpServerTransportTests.swift
+++ b/TableProTests/Core/MCP/Transport/MCPHttpServerTransportTests.swift
@@ -386,6 +386,7 @@ struct MCPHttpServerTransportTests {
             ("/foo", "GET", nil),
             ("/foo", "POST", Data("{}".utf8)),
             ("/foo", "DELETE", nil),
+            ("/foo", "PUT", Data("{}".utf8)),
             ("/.well-known/oauth-protected-resource", "GET", nil),
             ("/.well-known/oauth-authorization-server", "GET", nil),
             ("/register", "POST", Data("{}".utf8))
@@ -423,6 +424,10 @@ struct MCPHttpServerTransportTests {
             error: "method_not_allowed",
             label: "PUT /mcp"
         )
+        let http = try #require(response as? HTTPURLResponse)
+        let allow = http.value(forHTTPHeaderField: "Allow")
+        #expect(allow?.contains("POST") == true)
+        #expect(allow?.contains("GET") == true)
     }
 
     @Test("OPTIONS request returns 204 with CORS headers reflecting allowed origin")


### PR DESCRIPTION
## Problem

Connecting an OAuth-capable MCP client (Claude Code's `http` transport) with an invalid or expired bearer token failed with a cryptic error:

```
SDK auth failed: HTTP 404: Invalid OAuth error response: ZodError ...
Raw body: {"id":null,"error":{"message":"Method not found","code":-32601},"jsonrpc":"2.0"}
```

The real cause (a bad token) was hidden, and the offered "Authenticate" / "Reconnect" actions could not succeed because TablePro is not an OAuth server.

## Root cause

The HTTP router returned a JSON-RPC error envelope for any path that is not `/mcp` or `/v1/integrations/exchange`. JSON-RPC errors are a transport-protocol concept that should only apply to the MCP endpoint. An unknown HTTP path is an HTTP-layer 404.

Traced through the MCP TypeScript SDK:

1. The SDK starts the OAuth flow on any 401 when an authProvider exists (`if (response.status === 401 && this._authProvider)`), regardless of the `WWW-Authenticate` header.
2. It probes `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` (404s, swallowed), then POSTs Dynamic Client Registration to `/register`.
3. `/register` returned our JSON-RPC body. The SDK validates it with `OAuthErrorResponseSchema.parse`, where `error` must be a string. Our `error` was an object, so it threw the ZodError.

## Fix

Separate HTTP-layer errors from JSON-RPC protocol errors:

- Unknown HTTP paths return a plain HTTP 404 with `{"error":"not_found","error_description":"..."}` (a string `error`, the shape the SDK accepts).
- Unsupported HTTP methods on `/mcp` return a plain 405.
- The JSON-RPC `-32601` envelope still applies to unknown JSON-RPC methods dispatched on `/mcp`.

`WWW-Authenticate` is unchanged: it does not gate the SDK's OAuth trigger, so changing it would have no effect.

After the fix, a bad token in Claude Code ends with a clear error instead of the ZodError.

## Tests

- `unknownPathsReturnPlainNotFound`: GET, POST, and DELETE on unknown paths, both `.well-known` OAuth probes, and `POST /register` all return a plain 404 with a string `error` and no JSON-RPC envelope.
- `unsupportedMethodReturnsPlain405`: `PUT /mcp` returns a plain 405.
- SwiftLint `--strict` clean.
