### PR TITLE
Fix test target compilation (stale status bar init, missing imports)

### DIFF
--- a/TableProTests/AWS/AWSIAMAuthTests.swift
+++ b/TableProTests/AWS/AWSIAMAuthTests.swift
@@ -10,6 +10,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 import Testing
 
 @testable import TablePro

--- a/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
+++ b/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
@@ -4,10 +4,11 @@
 //
 
 import Foundation
-import TableProPluginKit
 import SwiftUI
-@testable import TablePro
+import TableProPluginKit
 import Testing
+
+@testable import TablePro
 
 @Suite("MainStatusBarView Layout")
 @MainActor
@@ -25,9 +26,9 @@ struct MainStatusBarLayoutTests {
             onPreviousPage: {},
             onNextPage: {},
             onLastPage: {},
-            onLimitChange: { _ in },
-            onOffsetChange: { _ in },
-            onPaginationGo: {},
+            onPageSizeChange: { _ in },
+            onShowAll: {},
+            onGoToPage: { _ in },
             onToggleColumn: { _ in },
             onShowAllColumns: {},
             onHideAllColumns: { _ in },

--- a/TableProTests/Views/Results/Extensions/FillColumnTests.swift
+++ b/TableProTests/Views/Results/Extensions/FillColumnTests.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import SwiftUI
 import TableProPluginKit
 import Testing
 


### PR DESCRIPTION
The TableProTests target does not compile on `main`, so the whole test bundle (and CI's test phase) fails. Three test files drifted out of sync with recent feature merges:

- `MainStatusBarLayoutTests` still calls `MainStatusBarView(...)` with the old pagination callbacks (`onLimitChange`/`onOffsetChange`/`onPaginationGo`). The #1364 pagination PRs (#1408, #1411) changed the initializer to `onPageSizeChange`/`onShowAll`/`onGoToPage`. Updated the call and sorted its imports.
- `AWSIAMAuthTests` reads `.id`/`.isSecure` on a `TableProPluginKit` type without importing the module (from the AWS IAM work, #1291). Added `import TableProPluginKit`.
- `FillColumnTests` uses `Binding.constant(...)` without importing SwiftUI (from Fill Column, #1304). Added `import SwiftUI`.

After these, the test target builds again and `MainStatusBarLayoutTests` passes. No production code changed.