### PR TITLE
feat(sidebar): show BigQuery datasets as an expandable tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- BigQuery: switching to another table now loads its data right away, instead of leaving the grid empty until you close and reopen the tab.
 - Custom and OpenAI-compatible AI providers now work when the base URL already ends in `/v1`, instead of building a doubled `/v1/v1/` path that failed. (#1400)
 - MongoDB: opening a collection no longer crashes when a document contains a NaN or infinite number. (#1418)
 - Opening a saved connection that fails now shows the detailed troubleshooting dialog with suggested fixes, the same one Test Connection shows, instead of a generic error alert. (#1425, #483)

--- a/Packages/TableProCore/Sources/TableProPluginKit/GroupingStrategy.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/GroupingStrategy.swift
@@ -4,4 +4,5 @@ public enum GroupingStrategy: String, Codable, Sendable {
     case byDatabase
     case bySchema
     case flat
+    case hierarchicalSchema
 }

--- a/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/PluginDatabaseDriver.swift
@@ -112,6 +112,24 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
         limit: Int,
         offset: Int
     ) -> String?
+    func buildBrowseQuery(
+        table: String,
+        schema: String?,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String?
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String?
     // Filtered row count (optional, for NoSQL plugins; SQL plugins use COUNT(*) WHERE)
     func fetchFilteredRowCount(
         table: String,
@@ -177,6 +195,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
 
     // Default export query (optional)
     func defaultExportQuery(table: String) -> String?
+    func defaultExportQuery(table: String, schema: String?) -> String?
 
     // Streaming row fetch for export
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error>
@@ -305,6 +324,28 @@ public extension PluginDatabaseDriver {
         limit: Int,
         offset: Int
     ) -> String? { nil }
+    func buildBrowseQuery(
+        table: String,
+        schema: String?,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String? {
+        buildBrowseQuery(table: table, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset)
+    }
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String? {
+        buildFilteredQuery(table: table, filters: filters, logicMode: logicMode, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset)
+    }
     func fetchFilteredRowCount(
         table: String,
         filters: [(column: String, op: String, value: String)],
@@ -356,6 +397,7 @@ public extension PluginDatabaseDriver {
     func castColumnToText(_ column: String) -> String { column }
     func allTablesMetadataSQL(schema: String?) -> String? { nil }
     func defaultExportQuery(table: String) -> String? { nil }
+    func defaultExportQuery(table: String, schema: String?) -> String? { defaultExportQuery(table: table) }
 
     func quoteIdentifier(_ name: String) -> String {
         let escaped = name.replacingOccurrences(of: "\"", with: "\"\"")

--- a/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
@@ -43,7 +43,7 @@ final class BigQueryPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let tableEntityName = "Tables"
     static let supportsForeignKeyDisable = false
     static let supportsReadOnlyMode = true
-    static let databaseGroupingStrategy: GroupingStrategy = .bySchema
+    static let databaseGroupingStrategy: GroupingStrategy = .hierarchicalSchema
     static let defaultGroupName = "default"
     static let defaultPrimaryKeyColumn: String? = nil
     static let structureColumnFields: [StructureColumnField] = [.name, .type, .nullable, .comment]

--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -81,8 +81,12 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
     }
 
     func defaultExportQuery(table: String) -> String? {
+        defaultExportQuery(table: table, schema: nil)
+    }
+
+    func defaultExportQuery(table: String, schema: String?) -> String? {
         guard let conn = connection else { return nil }
-        let dataset = lock.withLock { _currentDataset } ?? ""
+        let dataset = schema ?? (lock.withLock { _currentDataset }) ?? ""
         return "SELECT * FROM `\(conn.projectId).\(dataset).\(table)`"
     }
 
@@ -495,8 +499,22 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         limit: Int,
         offset: Int
     ) -> String? {
+        buildBrowseQuery(
+            table: table, schema: nil, sortColumns: sortColumns,
+            columns: columns, limit: limit, offset: offset
+        )
+    }
+
+    func buildBrowseQuery(
+        table: String,
+        schema: String?,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String? {
         let dataset: String = lock.withLock {
-            let ds = _currentDataset ?? ""
+            let ds = schema ?? _currentDataset ?? ""
             _columnCache["\(ds).\(table)"] = columns
             return ds
         }
@@ -515,8 +533,24 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         limit: Int,
         offset: Int
     ) -> String? {
+        buildFilteredQuery(
+            table: table, schema: nil, filters: filters, logicMode: logicMode,
+            sortColumns: sortColumns, columns: columns, limit: limit, offset: offset
+        )
+    }
+
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String? {
         let dataset: String = lock.withLock {
-            let ds = _currentDataset ?? ""
+            let ds = schema ?? _currentDataset ?? ""
             _columnCache["\(ds).\(table)"] = columns
             return ds
         }

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/TableProPluginKit/GroupingStrategy.swift
+++ b/Plugins/TableProPluginKit/GroupingStrategy.swift
@@ -7,4 +7,5 @@ public enum GroupingStrategy: String, Codable, Sendable {
     case byDatabase
     case bySchema
     case flat
+    case hierarchicalSchema
 }

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -88,6 +88,8 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     // Query building (optional, for NoSQL plugins)
     func buildBrowseQuery(table: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
     func buildFilteredQuery(table: String, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
+    func buildBrowseQuery(table: String, schema: String?, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
+    func buildFilteredQuery(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
     // Filtered row count (optional, for NoSQL plugins; SQL plugins use COUNT(*) WHERE)
     func fetchFilteredRowCount(table: String, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int?
     // Statement generation (optional, for NoSQL plugins)
@@ -141,6 +143,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
 
     // Default export query (optional — returns nil to use app-level fallback)
     func defaultExportQuery(table: String) -> String?
+    func defaultExportQuery(table: String, schema: String?) -> String?
 
     // Streaming row fetch for export
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error>
@@ -251,6 +254,12 @@ public extension PluginDatabaseDriver {
 
     func buildBrowseQuery(table: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? { nil }
     func buildFilteredQuery(table: String, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? { nil }
+    func buildBrowseQuery(table: String, schema: String?, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? {
+        buildBrowseQuery(table: table, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset)
+    }
+    func buildFilteredQuery(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? {
+        buildFilteredQuery(table: table, filters: filters, logicMode: logicMode, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset)
+    }
     func fetchFilteredRowCount(table: String, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int? { nil }
     func generateStatements(table: String, columns: [String], primaryKeyColumns: [String], changes: [PluginRowChange], insertedRowData: [Int: [PluginCellValue]], deletedRowIndices: Set<Int>, insertedRowIndices: Set<Int>) -> [(statement: String, parameters: [PluginCellValue])]? { nil }
 
@@ -284,6 +293,7 @@ public extension PluginDatabaseDriver {
     func castColumnToText(_ column: String) -> String { column }
     func allTablesMetadataSQL(schema: String?) -> String? { nil }
     func defaultExportQuery(table: String) -> String? { nil }
+    func defaultExportQuery(table: String, schema: String?) -> String? { defaultExportQuery(table: table) }
 
     func quoteIdentifier(_ name: String) -> String {
         let escaped = name.replacingOccurrences(of: "\"", with: "\"\"")

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>15</integer>
+	<integer>16</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
+++ b/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
@@ -23,7 +23,7 @@ final class ExportDataSourceAdapter: PluginExportDataSource, @unchecked Sendable
     func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         let query: String
         if let pluginDriver = (driver as? PluginDriverAdapter)?.schemaPluginDriver,
-           let customQuery = pluginDriver.defaultExportQuery(table: table) {
+           let customQuery = pluginDriver.defaultExportQuery(table: table, schema: databaseName.isEmpty ? nil : databaseName) {
             query = customQuery
         } else {
             let tableRef = qualifiedTableRef(table: table, databaseName: databaseName)

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -13,7 +13,7 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager()
-    static let currentPluginKitVersion = 15
+    static let currentPluginKitVersion = 16
     static let currentInspectorKitVersion = 1
     private static let disabledPluginsKey = "com.TablePro.disabledPlugins"
     private static let legacyDisabledPluginsKey = "disabledPlugins"

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
@@ -187,7 +187,7 @@ extension PluginMetadataRegistry {
                     systemDatabaseNames: [],
                     systemSchemaNames: ["INFORMATION_SCHEMA"],
                     fileExtensions: [],
-                    databaseGroupingStrategy: .bySchema,
+                    databaseGroupingStrategy: .hierarchicalSchema,
                     structureColumnFields: [.name, .type, .nullable, .comment]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -6,6 +6,7 @@
 import Combine
 import Foundation
 import os
+import TableProPluginKit
 
 @MainActor
 @Observable
@@ -16,11 +17,18 @@ final class SchemaService {
     private(set) var procedures: [UUID: [RoutineInfo]] = [:]
     private(set) var functions: [UUID: [RoutineInfo]] = [:]
     private(set) var schemasInOrder: [UUID: [String]] = [:]
+    private(set) var perSchemaStates: [UUID: [String: SchemaState]] = [:]
 
     @ObservationIgnored private let loadDedup = OnceTask<UUID, [TableInfo]>()
     @ObservationIgnored private let procedureDedup = OnceTask<UUID, [RoutineInfo]>()
     @ObservationIgnored private let functionDedup = OnceTask<UUID, [RoutineInfo]>()
     @ObservationIgnored private let schemasDedup = OnceTask<UUID, [String]>()
+    @ObservationIgnored private let perSchemaDedup = OnceTask<SchemaKey, [TableInfo]>()
+
+    struct SchemaKey: Hashable, Sendable {
+        let connectionId: UUID
+        let schema: String
+    }
     @ObservationIgnored private var schemaChangeCancellable: AnyCancellable?
     @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaService")
 
@@ -58,6 +66,53 @@ final class SchemaService {
 
     func schemas(for connectionId: UUID) -> [String] {
         schemasInOrder[connectionId] ?? []
+    }
+
+    func schemaState(for connectionId: UUID, schema: String) -> SchemaState {
+        perSchemaStates[connectionId]?[schema] ?? .idle
+    }
+
+    func tables(for connectionId: UUID, schema: String) -> [TableInfo] {
+        if case .loaded(let tables) = schemaState(for: connectionId, schema: schema) {
+            return tables
+        }
+        return []
+    }
+
+    func loadSchemaTables(connectionId: UUID, schema: String, driver: DatabaseDriver) async {
+        if case .loaded = schemaState(for: connectionId, schema: schema) { return }
+        setPerSchemaState(.loading, connectionId: connectionId, schema: schema)
+        do {
+            let tables = try await perSchemaDedup.execute(key: SchemaKey(connectionId: connectionId, schema: schema)) {
+                try await driver.fetchTables(schema: schema)
+            }
+            setPerSchemaState(.loaded(tables), connectionId: connectionId, schema: schema)
+        } catch is CancellationError {
+            return
+        } catch {
+            Self.logger.warning(
+                "[schema] per-schema load failed connId=\(connectionId, privacy: .public) schema=\(schema, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+            setPerSchemaState(.failed(error.localizedDescription), connectionId: connectionId, schema: schema)
+        }
+    }
+
+    func reloadSchemaTables(connectionId: UUID, schema: String, driver: DatabaseDriver) async {
+        await perSchemaDedup.cancel(key: SchemaKey(connectionId: connectionId, schema: schema))
+        clearPerSchemaState(connectionId: connectionId, schema: schema)
+        await loadSchemaTables(connectionId: connectionId, schema: schema, driver: driver)
+    }
+
+    private func setPerSchemaState(_ state: SchemaState, connectionId: UUID, schema: String) {
+        var inner = perSchemaStates[connectionId] ?? [:]
+        inner[schema] = state
+        perSchemaStates[connectionId] = inner
+    }
+
+    private func clearPerSchemaState(connectionId: UUID, schema: String) {
+        guard var inner = perSchemaStates[connectionId] else { return }
+        inner.removeValue(forKey: schema)
+        perSchemaStates[connectionId] = inner
     }
 
     func load(connectionId: UUID, driver: DatabaseDriver, connection: DatabaseConnection) async {
@@ -108,10 +163,16 @@ final class SchemaService {
         await procedureDedup.cancel(key: connectionId)
         await functionDedup.cancel(key: connectionId)
         await schemasDedup.cancel(key: connectionId)
+        if let schemas = perSchemaStates[connectionId]?.keys {
+            for schema in schemas {
+                await perSchemaDedup.cancel(key: SchemaKey(connectionId: connectionId, schema: schema))
+            }
+        }
         states.removeValue(forKey: connectionId)
         procedures.removeValue(forKey: connectionId)
         functions.removeValue(forKey: connectionId)
         schemasInOrder.removeValue(forKey: connectionId)
+        perSchemaStates.removeValue(forKey: connectionId)
     }
 
     func refresh(connectionId: UUID) async {
@@ -131,6 +192,12 @@ final class SchemaService {
         let supportsSchemas = PluginManager.shared.supportsSchemaSwitching(for: connection.type)
         if !supportsSchemas {
             schemasInOrder.removeValue(forKey: connectionId)
+        }
+
+        let grouping = PluginManager.shared.databaseGroupingStrategy(for: connection.type)
+        if grouping == .hierarchicalSchema {
+            await runHierarchicalLoad(connectionId: connectionId, driver: driver)
+            return
         }
 
         async let tablesTask: [TableInfo] = loadDedup.execute(key: connectionId) {
@@ -168,6 +235,29 @@ final class SchemaService {
             )
             states[connectionId] = .failed(error.localizedDescription)
         }
+    }
+
+    private func runHierarchicalLoad(connectionId: UUID, driver: DatabaseDriver) async {
+        async let proceduresTask: [RoutineInfo] = Self.fetchRoutinesSafely(
+            connectionId: connectionId,
+            kind: .procedure,
+            dedup: procedureDedup,
+            fetch: { try await driver.fetchProcedures(schema: nil) }
+        )
+        async let functionsTask: [RoutineInfo] = Self.fetchRoutinesSafely(
+            connectionId: connectionId,
+            kind: .function,
+            dedup: functionDedup,
+            fetch: { try await driver.fetchFunctions(schema: nil) }
+        )
+
+        let loadedProcedures = await proceduresTask
+        let loadedFunctions = await functionsTask
+        await loadSchemaList(connectionId: connectionId, driver: driver)
+
+        procedures[connectionId] = loadedProcedures
+        functions[connectionId] = loadedFunctions
+        states[connectionId] = .loaded([])
     }
 
     private func loadSchemaList(connectionId: UUID, driver: DatabaseDriver) async {

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -71,7 +71,7 @@ struct TableQueryBuilder {
         if let pluginDriver {
             let sortCols = sortColumnsAsTuples(sortState)
             if let result = pluginDriver.buildBrowseQuery(
-                table: tableName, sortColumns: sortCols,
+                table: tableName, schema: schemaName, sortColumns: sortCols,
                 columns: selectColumns ?? columns, limit: limit, offset: offset
             ) {
                 return result
@@ -106,7 +106,7 @@ struct TableQueryBuilder {
                 .filter { $0.isEnabled && !$0.columnName.isEmpty }
                 .map(\.asPluginFilterTuple)
             if let result = pluginDriver.buildFilteredQuery(
-                table: tableName, filters: filterTuples,
+                table: tableName, schema: schemaName, filters: filterTuples,
                 logicMode: logicMode == .and ? "and" : "or",
                 sortColumns: sortCols, columns: selectColumns ?? columns, limit: limit, offset: offset
             ) {

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -234,7 +234,7 @@ final class ConnectionToolbarState {
                 return schema
             }
             return currentDatabase
-        case .byDatabase, .flat:
+        case .byDatabase, .flat, .hierarchicalSchema:
             return currentDatabase
         }
     }

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -102,7 +102,7 @@ struct QueryTab: Identifiable, Equatable {
 
         if let pluginDriver = PluginManager.shared.queryBuildingDriver(for: databaseType),
            let pluginQuery = pluginDriver.buildBrowseQuery(
-               table: tableName, sortColumns: [], columns: [], limit: pageSize, offset: 0
+               table: tableName, schema: schemaName, sortColumns: [], columns: [], limit: pageSize, offset: 0
            ) {
             return pluginQuery
         }

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -569,7 +569,7 @@ struct ExportDialog: View {
             let dbType = connection.type
             let grouping = PluginManager.shared.databaseGroupingStrategy(for: dbType)
             switch grouping {
-            case .bySchema:
+            case .bySchema, .hierarchicalSchema:
                 let schemas = try await driver.fetchSchemas()
                 let defaultSchema = PluginManager.shared.defaultSchemaName(for: dbType)
                 for schema in schemas {

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -744,6 +744,11 @@ final class MainContentCoordinator {
         guard let (tab, index) = tabManager.selectedTabAndIndex,
               !tab.execution.isExecuting else { return }
 
+        if tab.tabType == .table {
+            executeTableTabQueryDirectly()
+            return
+        }
+
         let fullQuery = tab.content.query
 
         let sql: String

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import TableProPluginKit
+
+struct SidebarTreeView: View {
+    @Bindable private var schemaService = SchemaService.shared
+
+    let connectionId: UUID
+    let viewModel: SidebarViewModel
+    let windowState: WindowSidebarState
+    @Binding var pendingTruncates: Set<String>
+    @Binding var pendingDeletes: Set<String>
+    var onDoubleClick: ((TableInfo) -> Void)?
+    weak var coordinator: MainContentCoordinator?
+
+    @State private var expandedSchemas: Set<String> = []
+
+    private var systemSchemas: Set<String> {
+        Set(PluginManager.shared.systemSchemaNames(for: viewModel.databaseType))
+    }
+
+    private var schemas: [String] {
+        schemaService.schemas(for: connectionId).filter { !systemSchemas.contains($0) }
+    }
+
+    private var searchText: String {
+        viewModel.searchText
+    }
+
+    private var visibleSchemas: [String] {
+        guard !searchText.isEmpty else { return schemas }
+        return schemas.filter { schemaIsVisibleDuringSearch($0) }
+    }
+
+    private var selectedTablesBinding: Binding<Set<TableInfo>> {
+        Binding(
+            get: { windowState.selectedTables },
+            set: { windowState.selectedTables = $0 }
+        )
+    }
+
+    var body: some View {
+        Group {
+            if schemas.isEmpty {
+                emptyDatasetsState
+            } else if !searchText.isEmpty && visibleSchemas.isEmpty {
+                noMatchState
+            } else {
+                treeList
+            }
+        }
+        .onChange(of: searchText) { _, newValue in
+            guard !newValue.isEmpty else { return }
+            for schema in schemas {
+                loadTables(for: schema)
+            }
+        }
+    }
+
+    private var treeList: some View {
+        List(selection: selectedTablesBinding) {
+            ForEach(visibleSchemas, id: \.self) { schema in
+                Section(isExpanded: expansionBinding(for: schema)) {
+                    datasetContent(for: schema)
+                } header: {
+                    datasetHeader(schema)
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .scrollContentBackground(.hidden)
+        .contextMenu(forSelectionType: TableInfo.self) { _ in
+            EmptyView()
+        } primaryAction: { selection in
+            guard let table = selection.first else { return }
+            onDoubleClick?(table)
+        }
+        .onExitCommand {
+            windowState.selectedTables.removeAll()
+        }
+    }
+
+    @ViewBuilder
+    private func datasetContent(for schema: String) -> some View {
+        switch schemaService.schemaState(for: connectionId, schema: schema) {
+        case .idle, .loading:
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, alignment: .center)
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        case .loaded:
+            let tables = tablesToShow(for: schema)
+            if tables.isEmpty {
+                Text("No tables")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(tables) { table in
+                    tableRow(table)
+                }
+            }
+        }
+    }
+
+    private func tableRow(_ table: TableInfo) -> some View {
+        TableRow(
+            table: table,
+            isPendingTruncate: pendingTruncates.contains(table.name),
+            isPendingDelete: pendingDeletes.contains(table.name)
+        )
+        .tag(table)
+        .contextMenu {
+            SidebarContextMenu(
+                clickedTable: table,
+                selectedTables: windowState.selectedTables,
+                isReadOnly: coordinator?.safeModeLevel.blocksAllWrites ?? false,
+                onBatchToggleTruncate: { viewModel.batchToggleTruncate(tableNames: $0) },
+                onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
+                coordinator: coordinator
+            )
+        }
+    }
+
+    private func datasetHeader(_ schema: String) -> some View {
+        Label(schema, systemImage: "tablecells.badge.ellipsis")
+            .contextMenu {
+                Button(String(localized: "Refresh")) {
+                    reloadTables(for: schema)
+                }
+            }
+    }
+
+    private var emptyDatasetsState: some View {
+        ContentUnavailableView(
+            String(localized: "No Datasets"),
+            systemImage: "tablecells",
+            description: Text("This project has no datasets yet.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var noMatchState: some View {
+        ContentUnavailableView.search(text: searchText)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func expansionBinding(for schema: String) -> Binding<Bool> {
+        Binding(
+            get: { !searchText.isEmpty || expandedSchemas.contains(schema) },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedSchemas.insert(schema)
+                    loadTables(for: schema)
+                } else {
+                    expandedSchemas.remove(schema)
+                }
+            }
+        )
+    }
+
+    private func tablesToShow(for schema: String) -> [TableInfo] {
+        let tables = schemaService.tables(for: connectionId, schema: schema)
+        guard !searchText.isEmpty, !schema.localizedCaseInsensitiveContains(searchText) else {
+            return tables
+        }
+        return tables.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private func schemaIsVisibleDuringSearch(_ schema: String) -> Bool {
+        if schema.localizedCaseInsensitiveContains(searchText) { return true }
+        switch schemaService.schemaState(for: connectionId, schema: schema) {
+        case .loaded:
+            return !tablesToShow(for: schema).isEmpty
+        case .idle, .loading, .failed:
+            return true
+        }
+    }
+
+    private func loadTables(for schema: String) {
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
+        Task {
+            await schemaService.loadSchemaTables(connectionId: connectionId, schema: schema, driver: driver)
+        }
+    }
+
+    private func reloadTables(for schema: String) {
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
+        Task {
+            await schemaService.reloadSchemaTables(connectionId: connectionId, schema: schema, driver: driver)
+        }
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -83,20 +83,27 @@ struct SidebarTreeView: View {
     private func datasetContent(for schema: String) -> some View {
         switch schemaService.schemaState(for: connectionId, schema: schema) {
         case .idle, .loading:
-            ProgressView()
-                .controlSize(.small)
-                .frame(maxWidth: .infinity, alignment: .center)
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading tables\u{2026}")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
         case .failed(let message):
             Label(message, systemImage: "exclamationmark.triangle")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
+                .padding(.vertical, 4)
         case .loaded:
             let tables = tablesToShow(for: schema)
             if tables.isEmpty {
                 Text("No tables")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .padding(.vertical, 4)
             } else {
                 ForEach(tables) { table in
                     tableRow(table)
@@ -125,7 +132,7 @@ struct SidebarTreeView: View {
     }
 
     private func datasetHeader(_ schema: String) -> some View {
-        Label(schema, systemImage: "tablecells.badge.ellipsis")
+        Text(schema)
             .contextMenu {
                 Button(String(localized: "Refresh")) {
                     reloadTables(for: schema)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -39,8 +39,13 @@ struct SidebarView: View {
         }
     }
 
+    private var groupingStrategy: GroupingStrategy {
+        PluginManager.shared.databaseGroupingStrategy(for: viewModel.databaseType)
+    }
+
     private var supportsSchemaFooter: Bool {
-        PluginManager.shared.supportsSchemaSwitching(for: viewModel.databaseType)
+        guard PluginManager.shared.supportsSchemaSwitching(for: viewModel.databaseType) else { return false }
+        return groupingStrategy != .hierarchicalSchema
     }
 
     private var selectedTablesBinding: Binding<Set<TableInfo>> {
@@ -144,6 +149,35 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var tablesContent: some View {
+        if groupingStrategy == .hierarchicalSchema {
+            hierarchicalContent
+        } else {
+            flatContent
+        }
+    }
+
+    @ViewBuilder
+    private var hierarchicalContent: some View {
+        switch schemaService.state(for: connectionId) {
+        case .idle, .loading:
+            loadingState
+        case .failed(let message):
+            errorState(message: message)
+        case .loaded:
+            SidebarTreeView(
+                connectionId: connectionId,
+                viewModel: viewModel,
+                windowState: windowState,
+                pendingTruncates: $pendingTruncates,
+                pendingDeletes: $pendingDeletes,
+                onDoubleClick: onDoubleClick,
+                coordinator: coordinator
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var flatContent: some View {
         switch schemaService.state(for: connectionId) {
         case .loading where tables.isEmpty:
             loadingState

--- a/TablePro/Views/Toolbar/ConnectionStatusView.swift
+++ b/TablePro/Views/Toolbar/ConnectionStatusView.swift
@@ -89,7 +89,7 @@ struct ConnectionStatusView: View {
     private var chipKindLabel: String {
         switch databaseGroupingStrategy {
         case .bySchema: return String(localized: "Schema")
-        case .byDatabase, .flat: return String(localized: "Database")
+        case .byDatabase, .flat, .hierarchicalSchema: return String(localized: "Database")
         }
     }
 
@@ -100,7 +100,7 @@ struct ConnectionStatusView: View {
     private var switchableChipTooltip: String {
         let switchVerb: String = switch databaseGroupingStrategy {
         case .bySchema: String(localized: "switch schema")
-        case .byDatabase, .flat: String(localized: "switch database")
+        case .byDatabase, .flat, .hierarchicalSchema: String(localized: "switch database")
         }
         if safeModeLevel == .readOnly {
             return String(

--- a/TableProTests/Core/Plugins/DriverPluginMetadataTests.swift
+++ b/TableProTests/Core/Plugins/DriverPluginMetadataTests.swift
@@ -125,11 +125,12 @@ struct GroupingStrategyTests {
         #expect(GroupingStrategy.byDatabase.rawValue == "byDatabase")
         #expect(GroupingStrategy.bySchema.rawValue == "bySchema")
         #expect(GroupingStrategy.flat.rawValue == "flat")
+        #expect(GroupingStrategy.hierarchicalSchema.rawValue == "hierarchicalSchema")
     }
 
     @Test("Codable round-trip")
     func codable() throws {
-        for strategy in [GroupingStrategy.byDatabase, .bySchema, .flat] {
+        for strategy in [GroupingStrategy.byDatabase, .bySchema, .flat, .hierarchicalSchema] {
             let data = try JSONEncoder().encode(strategy)
             let decoded = try JSONDecoder().decode(GroupingStrategy.self, from: data)
             #expect(decoded == strategy)

--- a/TableProTests/Models/MultiRowEditStateTests.swift
+++ b/TableProTests/Models/MultiRowEditStateTests.swift
@@ -41,7 +41,7 @@ struct MultiRowEditStateTests {
         func hasEditFalseWhenNoPendingChanges() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: false, isPendingDefault: false
             )
             #expect(field.hasEdit == false)
@@ -51,7 +51,7 @@ struct MultiRowEditStateTests {
         func hasEditTrueWhenPendingValueSet() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: "2", isPendingNull: false, isPendingDefault: false
             )
             #expect(field.hasEdit == true)
@@ -61,7 +61,7 @@ struct MultiRowEditStateTests {
         func hasEditTrueWhenPendingNull() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: true, isPendingDefault: false
             )
             #expect(field.hasEdit == true)
@@ -71,7 +71,7 @@ struct MultiRowEditStateTests {
         func hasEditTrueWhenPendingDefault() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: false, isPendingDefault: true
             )
             #expect(field.hasEdit == true)
@@ -81,7 +81,7 @@ struct MultiRowEditStateTests {
         func effectiveValueReturnsPendingValue() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: "updated", isPendingNull: false, isPendingDefault: false
             )
             #expect(field.effectiveValue == "updated")
@@ -91,7 +91,7 @@ struct MultiRowEditStateTests {
         func effectiveValueReturnsNilWhenPendingNull() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: true, isPendingDefault: false
             )
             #expect(field.effectiveValue == nil)
@@ -101,7 +101,7 @@ struct MultiRowEditStateTests {
         func effectiveValueReturnsDefaultWhenPendingDefault() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: false, isPendingDefault: true
             )
             #expect(field.effectiveValue == "__DEFAULT__")
@@ -111,7 +111,7 @@ struct MultiRowEditStateTests {
         func effectiveValueReturnsNilWhenNoEdit() {
             let field = FieldEditState(
                 columnIndex: 0, columnName: "id", columnTypeEnum: .text(rawType: nil),
-                isLongText: false, originalValue: "1", hasMultipleValues: false,
+                isLongText: false, isJson: false, originalValue: "1", hasMultipleValues: false,
                 pendingValue: nil, isPendingNull: false, isPendingDefault: false
             )
             #expect(field.effectiveValue == nil)

--- a/TableProTests/Models/TableInfoTests.swift
+++ b/TableProTests/Models/TableInfoTests.swift
@@ -47,6 +47,22 @@ struct TableInfoTests {
         #expect(table.id != view.id)
     }
 
+    @Test("Schema-qualified id includes the schema")
+    func testSchemaQualifiedId() {
+        let info = TableInfo(name: "events", type: .table, rowCount: nil, schema: "analytics")
+        #expect(info.id == "analytics.events_TABLE")
+    }
+
+    @Test("Same table name in different schemas has distinct id, equality, and hash")
+    func testCrossSchemaDistinctIdentity() {
+        let a = TableInfo(name: "orders", type: .table, rowCount: nil, schema: "dataset_a")
+        let b = TableInfo(name: "orders", type: .table, rowCount: nil, schema: "dataset_b")
+        #expect(a.id != b.id)
+        #expect(a != b)
+        let set: Set<TableInfo> = [a, b]
+        #expect(set.count == 2)
+    }
+
     // MARK: - Equatable
 
     @Test("Same name and type are equal even with different rowCount")

--- a/TableProTests/Services/SchemaServiceHierarchicalTests.swift
+++ b/TableProTests/Services/SchemaServiceHierarchicalTests.swift
@@ -1,0 +1,179 @@
+//
+//  SchemaServiceHierarchicalTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+private final class HierarchicalMockDriver: DatabaseDriver, @unchecked Sendable {
+    let connection: DatabaseConnection
+    var status: ConnectionStatus = .connected
+    var serverVersion: String? { nil }
+
+    var schemasToReturn: [String] = []
+    var tablesBySchema: [String: [TableInfo]] = [:]
+    var fetchTablesCallCount: [String: Int] = [:]
+    var fetchSchemasCallCount = 0
+
+    init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
+        self.connection = connection
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func testConnection() async throws -> Bool { true }
+    func applyQueryTimeout(_ seconds: Int) async throws {}
+
+    func execute(query: String) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeParameterized(query: String, parameters: [Any?]) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func executeUserQuery(query: String, rowCap: Int?, parameters: [Any?]?) async throws -> QueryResult {
+        QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)
+    }
+
+    func fetchSchemas() async throws -> [String] {
+        fetchSchemasCallCount += 1
+        return schemasToReturn
+    }
+
+    func fetchTables() async throws -> [TableInfo] { [] }
+
+    func fetchTables(schema: String?) async throws -> [TableInfo] {
+        let key = schema ?? ""
+        fetchTablesCallCount[key, default: 0] += 1
+        return tablesBySchema[key] ?? []
+    }
+
+    func fetchColumns(table: String) async throws -> [ColumnInfo] { [] }
+    func fetchIndexes(table: String) async throws -> [IndexInfo] { [] }
+    func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo] { [] }
+    func fetchApproximateRowCount(table: String) async throws -> Int? { nil }
+    func fetchTableDDL(table: String) async throws -> String { "" }
+    func fetchViewDefinition(view: String) async throws -> String { "" }
+
+    func fetchTableMetadata(tableName: String) async throws -> TableMetadata {
+        TableMetadata(
+            tableName: tableName, dataSize: nil, indexSize: nil, totalSize: nil,
+            avgRowLength: nil, rowCount: nil, comment: nil, engine: nil,
+            collation: nil, createTime: nil, updateTime: nil
+        )
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> DatabaseMetadata {
+        DatabaseMetadata(
+            id: database, name: database, tableCount: nil, sizeBytes: nil,
+            lastAccessed: nil, isSystemDatabase: false, icon: "cylinder"
+        )
+    }
+
+    func cancelQuery() throws {}
+    func beginTransaction() async throws {}
+    func commitTransaction() async throws {}
+    func rollbackTransaction() async throws {}
+}
+
+@Suite("SchemaService hierarchical schema")
+@MainActor
+struct SchemaServiceHierarchicalTests {
+    private func bigQueryTable(_ name: String, schema: String) -> TableInfo {
+        TableInfo(name: name, type: .table, rowCount: nil, schema: schema)
+    }
+
+    @Test("BigQuery resolves to hierarchicalSchema grouping while Postgres stays bySchema")
+    func groupingStrategyResolution() {
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: .bigQuery) == .hierarchicalSchema)
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: .postgresql) == .bySchema)
+    }
+
+    @Test("loadSchemaTables stores tables per schema without touching other schemas")
+    func perSchemaStorage() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let driver = HierarchicalMockDriver()
+        driver.tablesBySchema = [
+            "analytics": [bigQueryTable("events", schema: "analytics"), bigQueryTable("sessions", schema: "analytics")],
+            "marketing": [bigQueryTable("campaigns", schema: "marketing")]
+        ]
+
+        await service.loadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+
+        #expect(service.tables(for: connectionId, schema: "analytics").map(\.name) == ["events", "sessions"])
+        #expect(service.tables(for: connectionId, schema: "marketing").isEmpty)
+        #expect(driver.fetchTablesCallCount["analytics"] == 1)
+        #expect(driver.fetchTablesCallCount["marketing"] == nil)
+    }
+
+    @Test("loadSchemaTables is idempotent once a schema is loaded")
+    func loadIsIdempotent() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let driver = HierarchicalMockDriver()
+        driver.tablesBySchema = ["analytics": [bigQueryTable("events", schema: "analytics")]]
+
+        await service.loadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+        await service.loadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+
+        #expect(driver.fetchTablesCallCount["analytics"] == 1)
+    }
+
+    @Test("reloadSchemaTables refetches a single schema")
+    func reloadRefetches() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let driver = HierarchicalMockDriver()
+        driver.tablesBySchema = ["analytics": [bigQueryTable("events", schema: "analytics")]]
+
+        await service.loadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+        driver.tablesBySchema["analytics"] = [
+            bigQueryTable("events", schema: "analytics"),
+            bigQueryTable("clicks", schema: "analytics")
+        ]
+        await service.reloadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+
+        #expect(driver.fetchTablesCallCount["analytics"] == 2)
+        #expect(service.tables(for: connectionId, schema: "analytics").map(\.name) == ["events", "clicks"])
+    }
+
+    @Test("hierarchical load fills the schema list and leaves the flat table list empty")
+    func hierarchicalLoadPopulatesSchemasOnly() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .bigQuery)
+        let driver = HierarchicalMockDriver(connection: connection)
+        driver.schemasToReturn = ["analytics", "marketing", "staging"]
+        driver.tablesBySchema = ["analytics": [bigQueryTable("events", schema: "analytics")]]
+
+        await service.load(connectionId: connectionId, driver: driver, connection: connection)
+
+        #expect(service.schemas(for: connectionId) == ["analytics", "marketing", "staging"])
+        #expect(service.tables(for: connectionId).isEmpty)
+        #expect(driver.fetchTablesCallCount.isEmpty)
+        if case .loaded = service.state(for: connectionId) {} else {
+            Issue.record("expected loaded state for hierarchical connection")
+        }
+    }
+
+    @Test("invalidate clears per-schema state")
+    func invalidateClearsPerSchema() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let driver = HierarchicalMockDriver()
+        driver.tablesBySchema = ["analytics": [bigQueryTable("events", schema: "analytics")]]
+
+        await service.loadSchemaTables(connectionId: connectionId, schema: "analytics", driver: driver)
+        #expect(!service.tables(for: connectionId, schema: "analytics").isEmpty)
+
+        await service.invalidate(connectionId: connectionId)
+
+        #expect(service.tables(for: connectionId, schema: "analytics").isEmpty)
+    }
+}

--- a/docs/databases/bigquery.mdx
+++ b/docs/databases/bigquery.mdx
@@ -48,7 +48,7 @@ OAuth tokens are session-only. You'll need to re-authorize after disconnecting. 
 
 ## Features
 
-**Dataset Browsing**: The first dataset is auto-selected on connect. Switch datasets with ⌘K or the database switcher. Datasets show as schemas in the sidebar.
+**Dataset Browsing**: The sidebar lists every dataset as an expandable node. Click a dataset to load its tables; they load the first time you open it. Search filters across the datasets you have open.
 
 **Table Structure**: Columns with full BigQuery types: `STRUCT<name STRING, age INT64>`, `ARRAY<STRING>`, nullable status, field descriptions. Clustering and partitioning info in the Indexes tab.
 
@@ -113,7 +113,7 @@ Minimum roles:
 
 **Cost**: Use `LIMIT`, select specific columns, prefer partitioned tables. Set **Max Bytes Billed** to prevent expensive queries. Table browsing caps rows automatically.
 
-**No tables after connect**: Switch datasets with ⌘K. The first dataset is auto-selected, but if it's empty, switch to one with tables.
+**No tables after connect**: Expand a dataset node in the sidebar to load its tables. Empty datasets stay empty; open another dataset that has tables.
 
 ## Limitations
 


### PR DESCRIPTION
## Problem

A BigQuery project with 7 datasets and 242 tables showed only a fraction of its tables in the sidebar. It is not a count bug: dataset and table listing both paginate correctly. TablePro rendered one dataset's tables at a time behind the `.bySchema` schema picker (the same model it uses for Postgres and MSSQL), so you only ever saw one dataset's slice. BigQuery has no "current schema" concept, and every BigQuery client (the web console, DataGrip, DBeaver, Postico) uses an expandable tree instead.

## Change

Adds a hierarchical sidebar tree and enables it for BigQuery. Postgres, MSSQL, and Oracle keep the picker.

- New `GroupingStrategy.hierarchicalSchema`. BigQuery's plugin and the cloud defaults declare it.
- `SchemaService` stores tables per (connection, dataset) and loads a dataset's tables the first time you expand its node. `tables.list` is a free metadata API, so this avoids listing all datasets up front.
- `SidebarTreeView` renders datasets as expandable nodes, reusing the existing table row, context menu, double-click, and multi-select. The schema picker footer is hidden in tree mode.
- Browsing a table from any dataset now threads that dataset through the query builders. `buildBrowseQuery`, `buildFilteredQuery`, and `defaultExportQuery` gained a `schema` parameter, with a default that delegates to the existing signature so only BigQuery is affected. This fixes browsing tables across several datasets at once, which the single shared `_currentDataset` could not express.

## ABI

The query-builder signature change is a `PluginDatabaseDriver` protocol change, so `currentPluginKitVersion` goes 15 to 16 and every plugin `Info.plist` is bumped to match. After merge, run `scripts/release-all-plugins.sh 16` to rebuild every registry plugin against kit-16.

## Tests

- `SchemaServiceHierarchicalTests`: per-dataset lazy storage, idempotent load, reload, and that a hierarchical connection populates the dataset list with an empty flat table list.
- `TableInfoTests`: a table name reused across datasets stays distinct by id, equality, and hash.
- `GroupingStrategy` raw value and Codable round-trip cover the new case.

## Notes

- BigQueryDriverPlugin is registry-only, so it is validated by plugin CI, not the app scheme.
