### PR TITLE
feat(plugin-oracle): add SID connection option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BigQuery: the sidebar now shows every dataset as an expandable node, with each dataset's tables loading when you open it, instead of showing one dataset at a time behind a picker.
 - OpenCode Zen as an AI provider. Add it from the provider list and paste an OpenCode key, or leave the key blank to use the free models; the model list loads automatically, covering the Claude, GPT, Gemini, and open models Zen serves. (#1400)
 - Oracle Database 11g (11.1 and 11.2) now connects. Previously only 12c and later worked, so 11g servers failed with a "Server Version Not Supported" error. (#1425)
+- Oracle connections can now use a SID instead of a service name. Set Connection Type to SID in the connection form and enter the SID. (#1425)
 - Cmd-click a foreign key arrow to open the referenced table in a new tab instead of the current one. The right-click menu has the same Open in New Tab option. (#1421)
 
 ### Changed

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -117,6 +117,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     private let password: String
     private let database: String
     private let serviceName: String
+    private let useSID: Bool
     private let sslConfig: SSLConfiguration
 
     private struct LockedState: Sendable {
@@ -140,6 +141,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         password: String,
         database: String,
         serviceName: String = "",
+        useSID: Bool = false,
         sslConfig: SSLConfiguration = SSLConfiguration()
     ) {
         self.host = host
@@ -148,18 +150,20 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         self.password = password
         self.database = database
         self.serviceName = serviceName
+        self.useSID = useSID
         self.sslConfig = sslConfig
     }
 
     // MARK: - Connection
 
     func connect() async throws {
-        let service = serviceName.isEmpty ? database : serviceName
+        let identifier = serviceName.isEmpty ? database : serviceName
+        let service: OracleServiceMethod = useSID ? .sid(identifier) : .serviceName(identifier)
         let tls = try OracleSSLMapping.tls(for: sslConfig)
         let config = OracleNIO.OracleConnection.Configuration(
             host: host,
             port: port,
-            service: .serviceName(service),
+            service: service,
             username: user,
             password: password,
             tls: tls

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -18,7 +18,27 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
     static let iconName = "oracle-icon"
     static let defaultPort = 1_521
     static let additionalConnectionFields: [ConnectionField] = [
-        ConnectionField(id: "oracleServiceName", label: "Service Name", placeholder: "ORCL")
+        ConnectionField(
+            id: "oracleConnectionType",
+            label: "Connection Type",
+            defaultValue: "service",
+            fieldType: .dropdown(options: [
+                ConnectionField.DropdownOption(value: "service", label: "Service Name"),
+                ConnectionField.DropdownOption(value: "sid", label: "SID")
+            ])
+        ),
+        ConnectionField(
+            id: "oracleServiceName",
+            label: "Service Name",
+            placeholder: "ORCL",
+            visibleWhen: FieldVisibilityRule(fieldId: "oracleConnectionType", values: ["service"])
+        ),
+        ConnectionField(
+            id: "oracleSID",
+            label: "SID",
+            placeholder: "XE",
+            visibleWhen: FieldVisibilityRule(fieldId: "oracleConnectionType", values: ["sid"])
+        )
     ]
 
     // MARK: - UI/Capability Metadata
@@ -185,14 +205,18 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Connection
 
     func connect() async throws {
-        let serviceName = config.additionalFields["oracleServiceName"] ?? ""
+        let useSID = config.additionalFields["oracleConnectionType"] == "sid"
+        let identifier = useSID
+            ? config.additionalFields["oracleSID"] ?? ""
+            : config.additionalFields["oracleServiceName"] ?? ""
         let conn = OracleConnectionWrapper(
             host: config.host,
             port: config.port,
             user: config.username,
             password: config.password,
             database: config.database,
-            serviceName: serviceName,
+            serviceName: identifier,
+            useSID: useSID,
             sslConfig: config.ssl
         )
         try await conn.connect()

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -36,7 +36,7 @@ The Oracle driver is available as a downloadable plugin. When you select Oracle 
 |-------|---------|-------|
 | **Host** | `localhost` | |
 | **Port** | `1521` | Listener port |
-| **Service Name** | - | **Required**. Use service name not SID. Check `tnsnames.ora` if unclear. |
+| **Service Name** | - | **Required**. Check `tnsnames.ora` if unclear. To connect by SID instead, set **Connection Type** to SID and enter the SID. |
 | **Username** | - | Requires username/password auth (no OS auth) |
 
 ## Example Configurations


### PR DESCRIPTION
Follow-up to #1425. Oracle connections can now connect by SID, not just service name. DataGrip and older 11g setups commonly use SID (`jdbc:oracle:thin:@host:port:SID`), so imported connections that used a SID previously had no way to connect.

## Changes

- New **Connection Type** dropdown (Service Name / SID, defaults to Service Name) in the Oracle connection form. The Service Name and SID fields show based on the selection.
- The driver passes `.sid(...)` or `.serviceName(...)` to OracleNIO accordingly. Validated against a live Oracle 11.2.0.2 XE instance using its SID.

## Compatibility

Existing connections default to Service Name, so they are unaffected. The connection-type field falls back to its default for connections saved before this change.