### PR TITLE
fix(plugin-oracle): log connection target string instead of service enum

### DIFF
--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -186,7 +186,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
                 current.isConnected = true
             }
 
-            osLogger.debug("Connected to Oracle \(self.host):\(self.port)/\(service)")
+            let target = useSID ? "\(self.host):\(self.port):\(identifier)" : "\(self.host):\(self.port)/\(identifier)"
+            osLogger.debug("Connected to Oracle \(target)")
         } catch let sqlError as OracleSQLError {
             let detail = sqlError.serverInfo?.message ?? sqlError.description
             osLogger.error("Oracle connection failed: \(detail)")


### PR DESCRIPTION
## What

`OracleConnection.connect()` interpolated the OracleNIO `OracleServiceMethod` enum into an OSLog debug line. That type conforms to none of OSLog's supported interpolation types, so the build failed with:

```
Instance method 'appendInterpolation(_:align:privacy:)' requires that 'OracleServiceMethod' conform to 'CustomStringConvertible'
```

## Fix

Log the connection identifier string instead of the enum, using Oracle's Easy Connect separators so the line stays accurate for both modes the SID option (#1431) introduced:

- service name: `host:port/service`
- SID: `host:port:sid`

No retroactive `CustomStringConvertible` conformance on the third-party type, and the identifier is what's actually useful when debugging a connection.

## Notes

Follow-up to #1431 (still unreleased), so no CHANGELOG entry per the unreleased-fix rule.