### PR TITLE
fix(ios): confirm Safe Mode writes before data-grid row saves and inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oracle connection errors no longer surface the driver's raw internal message; failures now explain the cause in plain language. (#483)
 - AWS IAM authentication with a named profile now reads `~/.aws/config` (not just `~/.aws/credentials`) and supports `credential_process`, so profiles backed by SSO, IAM Identity Center, or assume-role work through `aws configure export-credentials`. (#1291)
 - iOS: a connection's Safe Mode setting now survives relaunch. iCloud sync no longer drops the value, so a connection set to Confirm Writes or Read-Only no longer reverts to Off after reopening the app.
+- iOS: Safe Mode "Confirm Writes" now prompts before saving a row edit or inserting a row, matching the query editor. Previously grid edits and inserts saved with no confirmation.
 
 ## [0.45.0] - 2026-05-26
 

--- a/Packages/TableProCore/Sources/TableProModels/SafeModeLevel.swift
+++ b/Packages/TableProCore/Sources/TableProModels/SafeModeLevel.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+public enum WritePermission: Sendable {
+    case proceed
+    case requiresConfirmation
+    case blocked
+}
+
 public enum SafeModeLevel: String, Codable, Sendable, CaseIterable, Identifiable {
     case off = "off"
     case confirmWrites = "confirmWrites"
@@ -10,6 +16,12 @@ public enum SafeModeLevel: String, Codable, Sendable, CaseIterable, Identifiable
     public var blocksWrites: Bool { self == .readOnly }
 
     public var requiresConfirmation: Bool { self == .confirmWrites }
+
+    public var writePermission: WritePermission {
+        if blocksWrites { return .blocked }
+        if requiresConfirmation { return .requiresConfirmation }
+        return .proceed
+    }
 
     public var displayName: String {
         switch self {

--- a/Packages/TableProCore/Tests/TableProModelsTests/SafeModeLevelTests.swift
+++ b/Packages/TableProCore/Tests/TableProModelsTests/SafeModeLevelTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import TableProModels
+
+@Suite("SafeModeLevel write permission")
+struct SafeModeLevelTests {
+    @Test("off proceeds without confirmation")
+    func offProceeds() {
+        #expect(SafeModeLevel.off.writePermission == .proceed)
+    }
+
+    @Test("confirmWrites requires confirmation")
+    func confirmWritesRequiresConfirmation() {
+        #expect(SafeModeLevel.confirmWrites.writePermission == .requiresConfirmation)
+    }
+
+    @Test("readOnly blocks writes")
+    func readOnlyBlocks() {
+        #expect(SafeModeLevel.readOnly.writePermission == .blocked)
+    }
+}

--- a/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
@@ -188,13 +188,16 @@ final class RowDetailViewModel {
             primaryKeys: pkValues
         )
 
-        if safeModeLevel.writePermission == .requiresConfirmation {
+        switch safeModeLevel.writePermission {
+        case .blocked:
+            return false
+        case .requiresConfirmation:
             pendingSaveSQL = sql
             pendingWriteConfirmation = true
             return false
+        case .proceed:
+            return await execute(sql: sql, session: session)
         }
-
-        return await execute(sql: sql, session: session)
     }
 
     func executePendingSave() async -> Bool {

--- a/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
@@ -23,8 +23,11 @@ final class RowDetailViewModel {
     private(set) var loadingCell: Int?
     private(set) var fullValueOverrides: [Int: [Int: String?]] = [:]
     private(set) var isSaving = false
+    private(set) var pendingWriteConfirmation = false
     var operationError: AppError?
     private(set) var showSaveSuccess = false
+
+    @ObservationIgnored private var pendingSaveSQL: String?
 
     @ObservationIgnored let onSaved: (() -> Void)?
     @ObservationIgnored let loadFullValueProvider: ((CellRef) async throws -> String?)?
@@ -140,8 +143,8 @@ final class RowDetailViewModel {
     func saveChanges() async -> Bool {
         guard let session, let table else { return false }
 
-        isSaving = true
-        defer { isSaving = false }
+        pendingWriteConfirmation = false
+        pendingSaveSQL = nil
 
         let pkValues: [(column: String, value: String)] = columnDetails.compactMap { col in
             guard col.isPrimaryKey else { return nil }
@@ -184,6 +187,26 @@ final class RowDetailViewModel {
             changes: changes,
             primaryKeys: pkValues
         )
+
+        if safeModeLevel.writePermission == .requiresConfirmation {
+            pendingSaveSQL = sql
+            pendingWriteConfirmation = true
+            return false
+        }
+
+        return await execute(sql: sql, session: session)
+    }
+
+    func executePendingSave() async -> Bool {
+        pendingWriteConfirmation = false
+        guard let session, let sql = pendingSaveSQL else { return false }
+        pendingSaveSQL = nil
+        return await execute(sql: sql, session: session)
+    }
+
+    private func execute(sql: String, session: ConnectionSession) async -> Bool {
+        isSaving = true
+        defer { isSaving = false }
 
         do {
             _ = try await session.driver.execute(query: sql)

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -448,6 +448,7 @@ struct DataBrowserView: View {
             columnDetails: viewModel.columnDetails,
             session: session,
             databaseType: connection.type,
+            safeModeLevel: connection.safeModeLevel,
             onInserted: { Task { await viewModel.load() } }
         )
     }

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -8,6 +8,7 @@ struct InsertRowView: View {
     let columnDetails: [ColumnInfo]
     let session: ConnectionSession?
     let databaseType: DatabaseType
+    let safeModeLevel: SafeModeLevel
     var onInserted: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
@@ -19,12 +20,14 @@ struct InsertRowView: View {
         columnDetails: [ColumnInfo],
         session: ConnectionSession?,
         databaseType: DatabaseType,
+        safeModeLevel: SafeModeLevel = .off,
         onInserted: (() -> Void)? = nil
     ) {
         self.table = table
         self.columnDetails = columnDetails
         self.session = session
         self.databaseType = databaseType
+        self.safeModeLevel = safeModeLevel
         self.onInserted = onInserted
         _values = State(initialValue: Array(repeating: "", count: columnDetails.count))
         _isNullFlags = State(initialValue: columnDetails.map { col in
@@ -34,6 +37,8 @@ struct InsertRowView: View {
     @State private var isSaving = false
     @State private var operationError: AppError?
     @State private var showOperationError = false
+    @State private var showInsertConfirmation = false
+    @State private var pendingInsertSQL: String?
     @State private var hapticSuccess = false
     @State private var hapticError = false
 
@@ -136,6 +141,14 @@ struct InsertRowView: View {
                     Text(operationError?.message ?? "")
                 }
             }
+            .alert("Insert Row?", isPresented: $showInsertConfirmation) {
+                Button(String(localized: "Insert"), role: .destructive) {
+                    Task { await executePendingInsert() }
+                }
+                Button(String(localized: "Cancel"), role: .cancel) {}
+            } message: {
+                Text(String(format: String(localized: "This will insert a row into %@. Continue?"), table.name))
+            }
         }
     }
 
@@ -172,9 +185,24 @@ struct InsertRowView: View {
     private func insertRow() async {
         guard let session else { return }
 
-        isSaving = true
-        defer { isSaving = false }
+        let sql = buildInsertSQL()
 
+        if safeModeLevel.writePermission == .requiresConfirmation {
+            pendingInsertSQL = sql
+            showInsertConfirmation = true
+            return
+        }
+
+        await executeInsert(sql: sql, session: session)
+    }
+
+    private func executePendingInsert() async {
+        guard let session, let sql = pendingInsertSQL else { return }
+        pendingInsertSQL = nil
+        await executeInsert(sql: sql, session: session)
+    }
+
+    private func buildInsertSQL() -> String {
         var insertColumns: [String] = []
         var insertValues: [String?] = []
 
@@ -194,12 +222,17 @@ struct InsertRowView: View {
             }
         }
 
-        let sql = SQLBuilder.buildInsert(
+        return SQLBuilder.buildInsert(
             table: table.name,
             type: databaseType,
             columns: insertColumns,
             values: insertValues
         )
+    }
+
+    private func executeInsert(sql: String, session: ConnectionSession) async {
+        isSaving = true
+        defer { isSaving = false }
 
         do {
             _ = try await session.driver.execute(query: sql)

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -187,13 +187,15 @@ struct InsertRowView: View {
 
         let sql = buildInsertSQL()
 
-        if safeModeLevel.writePermission == .requiresConfirmation {
+        switch safeModeLevel.writePermission {
+        case .blocked:
+            return
+        case .requiresConfirmation:
             pendingInsertSQL = sql
             showInsertConfirmation = true
-            return
+        case .proceed:
+            await executeInsert(sql: sql, session: session)
         }
-
-        await executeInsert(sql: sql, session: session)
     }
 
     private func executePendingInsert() async {

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -376,14 +376,16 @@ struct QueryEditorView: View {
         guard !trimmed.isEmpty else { return }
 
         if isWriteQuery(trimmed) {
-            if safeModeLevel.blocksWrites {
+            switch safeModeLevel.writePermission {
+            case .blocked:
                 showWriteBlockedAlert = true
                 return
-            }
-            if safeModeLevel.requiresConfirmation {
+            case .requiresConfirmation:
                 pendingWriteQuery = trimmed
                 showWriteConfirmation = true
                 return
+            case .proceed:
+                break
             }
         }
 

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -10,6 +10,7 @@ struct RowDetailView: View {
     @State private var hapticSuccess = false
     @State private var hapticError = false
     @State private var hapticSelection = 0
+    @State private var showSaveConfirmation = false
 
     init(
         columns: [ColumnInfo],
@@ -88,6 +89,14 @@ struct RowDetailView: View {
             } else {
                 Text(viewModel.operationError?.message ?? "")
             }
+        }
+        .alert("Save Changes?", isPresented: $showSaveConfirmation) {
+            Button(String(localized: "Save"), role: .destructive) {
+                Task { await executePendingSave() }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(String(format: String(localized: "This will update a row in %@. Continue?"), viewModel.table?.name ?? ""))
         }
         .sheet(item: $fkPreviewItem) { item in
             FKPreviewView(
@@ -346,6 +355,19 @@ struct RowDetailView: View {
 
     private func handleSave() async {
         let success = await viewModel.saveChanges()
+        if viewModel.pendingWriteConfirmation {
+            showSaveConfirmation = true
+            return
+        }
+        if success {
+            hapticSuccess.toggle()
+        } else {
+            hapticError.toggle()
+        }
+    }
+
+    private func executePendingSave() async {
+        let success = await viewModel.executePendingSave()
         if success {
             hapticSuccess.toggle()
         } else {

--- a/TableProMobile/TableProMobileTests/RowDetailViewModelTests.swift
+++ b/TableProMobile/TableProMobileTests/RowDetailViewModelTests.swift
@@ -164,6 +164,23 @@ struct RowDetailViewModelTests {
         #expect(driver.executedQueries[0].uppercased().hasPrefix("UPDATE"))
     }
 
+    @Test("saveChanges under readOnly never executes")
+    func saveReadOnlyBlocks() async {
+        let driver = MockDatabaseDriver()
+        let vm = RowDetailViewModel(
+            columns: makeColumns(), rows: makeRows(), initialIndex: 0,
+            table: TableInfo(name: "users"), session: makeSession(driver: driver),
+            columnDetails: makeColumns(), safeModeLevel: .readOnly
+        )
+        vm.startEditing()
+        vm.setEditedValue("Charlie", at: 1)
+
+        let success = await vm.saveChanges()
+        #expect(success == false)
+        #expect(vm.pendingWriteConfirmation == false)
+        #expect(driver.executedQueries.isEmpty)
+    }
+
     @Test("saveChanges fails when no primary key value present")
     func saveWithoutPrimaryKey() async {
         let driver = MockDatabaseDriver()

--- a/TableProMobile/TableProMobileTests/RowDetailViewModelTests.swift
+++ b/TableProMobile/TableProMobileTests/RowDetailViewModelTests.swift
@@ -124,6 +124,46 @@ struct RowDetailViewModelTests {
         #expect(query.contains("WHERE"))
     }
 
+    @Test("saveChanges under confirmWrites defers execution and requests confirmation")
+    func saveConfirmWritesDefers() async {
+        let driver = MockDatabaseDriver()
+        let vm = RowDetailViewModel(
+            columns: makeColumns(), rows: makeRows(), initialIndex: 0,
+            table: TableInfo(name: "users"), session: makeSession(driver: driver),
+            columnDetails: makeColumns(), safeModeLevel: .confirmWrites
+        )
+        vm.startEditing()
+        vm.setEditedValue("Charlie", at: 1)
+
+        let success = await vm.saveChanges()
+        #expect(success == false)
+        #expect(vm.pendingWriteConfirmation == true)
+        #expect(vm.isEditing == true, "stays in edit mode until confirmed")
+        #expect(driver.executedQueries.isEmpty, "no UPDATE runs before confirmation")
+    }
+
+    @Test("executePendingSave runs the deferred UPDATE after confirmation")
+    func executePendingSaveRunsUpdate() async {
+        let driver = MockDatabaseDriver()
+        driver.scriptedExecuteResults = [
+            .success(QueryResult(columns: [], rows: [], rowsAffected: 1, executionTime: 0))
+        ]
+        let vm = RowDetailViewModel(
+            columns: makeColumns(), rows: makeRows(), initialIndex: 0,
+            table: TableInfo(name: "users"), session: makeSession(driver: driver),
+            columnDetails: makeColumns(), safeModeLevel: .confirmWrites
+        )
+        vm.startEditing()
+        vm.setEditedValue("Charlie", at: 1)
+        _ = await vm.saveChanges()
+
+        let success = await vm.executePendingSave()
+        #expect(success == true)
+        #expect(vm.pendingWriteConfirmation == false)
+        #expect(driver.executedQueries.count == 1)
+        #expect(driver.executedQueries[0].uppercased().hasPrefix("UPDATE"))
+    }
+
     @Test("saveChanges fails when no primary key value present")
     func saveWithoutPrimaryKey() async {
         let driver = MockDatabaseDriver()


### PR DESCRIPTION
## Problem

On iOS, a connection's Safe Mode set to "Confirm Writes" is not enforced for data-grid edits. Editing a row in the row detail view and saving runs the UPDATE with no confirmation; inserting a row via the insert sheet does the same. The SQL query editor already prompts. Read-Only correctly blocks editing; only Confirm Writes was broken for grid writes.

## Root cause

The three-way Safe Mode decision (block / confirm / proceed) was re-implemented ad-hoc at each write site. `QueryEditorView` did it correctly; the grid sites (`RowDetailViewModel.saveChanges`, `InsertRowView.insertRow`) only checked the read-only half and skipped `requiresConfirmation`. `InsertRowView` wasn't even passed `safeModeLevel`.

## Fix

Centralize the decision so no write path can skip it, then apply it at the grid sites:

- `SafeModeLevel` gains a `WritePermission` enum and a `writePermission` computed var (in the `TableProModels` package, unit-tested).
- `RowDetailViewModel.saveChanges()` consults `writePermission`; when confirmation is required it defers (sets `pendingWriteConfirmation`, stashes the SQL) instead of executing. `executePendingSave()` runs it after the user confirms.
- `RowDetailView` and `InsertRowView` present a SwiftUI `.alert` with a destructive confirm button and an explicit Cancel, naming the table.
- `DataBrowserView` passes `connection.safeModeLevel` into the insert sheet.
- `QueryEditorView` swaps its inline chain for `switch writePermission` (behavior-preserving), removing the last ad-hoc copy.

DELETE is unchanged: it already shows a confirmation dialog for every connection, so a second prompt would double-confirm.

### Design notes

- Uses `.alert`, not `.confirmationDialog`: alerts render identically on iPhone and iPad and always show an explicit Cancel. `confirmationDialog` becomes a popover on iPad (regular size class) with no guaranteed Cancel row, which is wrong for a data-changing confirmation.
- The alert message names the operation and table; no raw SQL (it can't render in an alert body, and a long statement would break layout on a phone).

## Tests

- New `TableProModelsTests/SafeModeLevelTests.swift`: `writePermission` for all three levels. `swift test` passes.
- `RowDetailViewModelTests`: `confirmWrites` defers and runs no query; `executePendingSave()` then runs the UPDATE.

## Notes

- swiftformat could not run locally: the repo `.swiftformat` uses `--ifdefindent`, which the installed swiftformat version rejects. Pre-existing and unrelated to this change.
