### PR TITLE
fix(ios): prevent keychain precondition crash on unsigned and test builds

### DIFF
--- a/TableProMobile/TableProMobile/AppState.swift
+++ b/TableProMobile/TableProMobile/AppState.swift
@@ -52,7 +52,7 @@ final class AppState {
         )
         loadPersistedData()
 
-        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
+        guard !TestRuntime.isActive else { return }
 
         secureStore.cleanOrphanedCredentials(validConnectionIds: Set(connections.map(\.id)))
         Task {

--- a/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
+++ b/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
@@ -1,24 +1,24 @@
 import Foundation
+import os
 import Security
 import TableProDatabase
 
 final class KeychainSecureStore: SecureStore {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "KeychainSecureStore")
+
     private let serviceName = "com.TablePro"
-    private let accessGroup: String
+    private let accessGroup: String?
 
     private static var cachedAccessGroup: String?
 
-    private static func resolveAccessGroup() -> String {
+    private static func resolveAccessGroup() -> String? {
         if let cached = cachedAccessGroup { return cached }
 
         guard let prefix = Bundle.main.infoDictionary?["AppIdentifierPrefix"] as? String,
               !prefix.isEmpty,
               !prefix.hasPrefix("$(") else {
-            preconditionFailure(
-                "AppIdentifierPrefix missing from Info.plist. Add `<key>AppIdentifierPrefix</key>"
-                + "<string>$(AppIdentifierPrefix)</string>` so Xcode substitutes the team ID prefix "
-                + "at build time. Without it, keychain access fails with errSecMissingEntitlement (-34018)."
-            )
+            logger.warning("AppIdentifierPrefix unavailable; using the app-local keychain without a shared access group (expected for unsigned or test builds; in a signed build, widget keychain sharing is off).")
+            return nil
         }
 
         let group = "\(prefix)com.TablePro.shared"
@@ -30,6 +30,13 @@ final class KeychainSecureStore: SecureStore {
         self.accessGroup = Self.resolveAccessGroup()
     }
 
+    private func applyingAccessGroup(_ query: [String: Any]) -> [String: Any] {
+        guard let accessGroup else { return query }
+        var query = query
+        query[kSecAttrAccessGroup as String] = accessGroup
+        return query
+    }
+
     func store(_ value: String, forKey key: String) throws {
         guard let data = value.data(using: .utf8) else { return }
 
@@ -37,23 +44,21 @@ final class KeychainSecureStore: SecureStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
-            kSecAttrAccessGroup as String: accessGroup,
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
             kSecUseDataProtectionKeychain as String: true,
         ]
-        SecItemDelete(deleteQuery as CFDictionary)
+        SecItemDelete(applyingAccessGroup(deleteQuery) as CFDictionary)
 
         let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
-            kSecAttrAccessGroup as String: accessGroup,
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             kSecAttrSynchronizable as String: true,
             kSecUseDataProtectionKeychain as String: true,
         ]
-        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        let status = SecItemAdd(applyingAccessGroup(addQuery) as CFDictionary, nil)
         if status != errSecSuccess {
             throw KeychainError.storeFailed(status)
         }
@@ -64,7 +69,6 @@ final class KeychainSecureStore: SecureStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
-            kSecAttrAccessGroup as String: accessGroup,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
@@ -72,7 +76,7 @@ final class KeychainSecureStore: SecureStore {
         ]
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = SecItemCopyMatching(applyingAccessGroup(query) as CFDictionary, &result)
 
         if status == errSecItemNotFound { return nil }
         if status != errSecSuccess {
@@ -88,11 +92,10 @@ final class KeychainSecureStore: SecureStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
-            kSecAttrAccessGroup as String: accessGroup,
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
             kSecUseDataProtectionKeychain as String: true,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(applyingAccessGroup(query) as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
             throw KeychainError.deleteFailed(status)
         }
@@ -105,14 +108,13 @@ final class KeychainSecureStore: SecureStore {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
-            kSecAttrAccessGroup as String: accessGroup,
             kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
             kSecUseDataProtectionKeychain as String: true,
         ]
         var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+        guard SecItemCopyMatching(applyingAccessGroup(query) as CFDictionary, &result) == errSecSuccess,
               let items = result as? [[String: Any]] else { return }
 
         for item in items {

--- a/TableProMobile/TableProMobile/Platform/TestRuntime.swift
+++ b/TableProMobile/TableProMobile/Platform/TestRuntime.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum TestRuntime {
+    static var isActive: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        if environment["XCTestConfigurationFilePath"] != nil { return true }
+        if environment["XCTestBundlePath"] != nil { return true }
+        return NSClassFromString("XCTestCase") != nil
+    }
+}

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -65,9 +65,9 @@ struct TableProMobileApp: App {
             }
         }
         .onChange(of: scenePhase) { _, phase in
-            // Skip lifecycle side-effects under XCTest so unit tests do not
+            // Skip lifecycle side-effects under tests so unit tests do not
             // boot CloudKit sync, analytics, or biometric checks.
-            guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
+            guard !TestRuntime.isActive else { return }
             lockState.handleScenePhase(phase)
             switch phase {
             case .active:


### PR DESCRIPTION
## Problem

The **iOS Tests** CI job has failed on every commit since it was added (back to mid-May), with:

> TableProMobile encountered an error (Early unexpected exit, operation never finished bootstrapping. Test crashed with signal trap before establishing connection.)

The result bundle shows `passedTests: 0` — the host app crashes at launch before a single test runs. Not specific to any recent PR.

## Root cause

`KeychainSecureStore.resolveAccessGroup()` called `preconditionFailure(...)` when `AppIdentifierPrefix` is absent or still the unsubstituted literal `$(AppIdentifierPrefix)`. That is exactly the case in the CI build, which runs with `CODE_SIGNING_ALLOWED=NO` (no signing means no `AppIdentifierPrefix`). `KeychainSecureStore()` is constructed in `AppState.init`, which runs at app launch, so the precondition trips (SIGTRAP) before tests connect. Signed device/TestFlight builds always have the prefix, so they never hit it.

## Fix

- The keychain access group is only needed to **share** items with the widget extension; an app works fine on its own default keychain without one. `resolveAccessGroup()` now returns `String?` and logs a warning instead of crashing when the prefix is unavailable. Queries include `kSecAttrAccessGroup` only when an access group is present. Signed builds are unchanged (they still get the shared group).
- Hardened the documented "skip launch side-effects under tests" guard: it keyed off `XCTestConfigurationFilePath`, which is not set under Swift Testing (the suite uses `@Suite`/`@Test`). New `TestRuntime.isActive` also checks `XCTestBundlePath` and `NSClassFromString("XCTestCase")`, so analytics, CloudKit sync, widget, and Spotlight side-effects are reliably skipped during tests as the author intended. Centralizes a check that was duplicated in `AppState` and `TableProMobileApp`.

## Notes

- No user-facing behavior change for signed builds, so no CHANGELOG entry.
- This unblocks the iOS Tests job for the first time; the run on this PR should now actually execute the suite.