### PR TITLE
fix(launch): open files passed at cold launch instead of the welcome screen (#1443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS: running a query that returns a very large result no longer crashes the app. The query editor keeps the first rows it loads, stops before memory runs low, and tells you to add LIMIT to fetch more.
 - iOS: Safe Mode "Confirm Writes" now prompts before saving a row edit or inserting a row, matching the query editor. Previously grid edits and inserts saved with no confirmation.
 - Redshift: schema switching now works, along with the contains, starts with, and ends with filters and table search. All previously failed with a SQL syntax error. (#1439)
+- Double-clicking a CSV or TSV file when TablePro is closed now opens the file directly, instead of showing the welcome screen. (#1443)
 
 ## [0.45.0] - 2026-05-26
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         _ = InspectorDocumentController()
+        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
         PluginManager.shared.loadPlugins()
     }
 

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         _ = InspectorDocumentController()
+        PluginManager.shared.loadPlugins()
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -62,7 +63,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await CloudflareTunnelManager.shared.sweepStalePidsIfNeeded() }
 
         MemoryPressureAdvisor.startMonitoring()
-        PluginManager.shared.loadPlugins()
         UNUserNotificationCenter.current().delegate = self
         PluginNotificationService.shared.setUp()
         ChatToolBootstrap.register()

--- a/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
@@ -93,6 +93,7 @@ internal final class AppLaunchCoordinator {
                 for intent in intents {
                     await LaunchIntentRouter.shared.route(intent)
                 }
+                WindowOpener.shared.orderOutWelcome()
             }
         }
     }
@@ -107,6 +108,9 @@ internal final class AppLaunchCoordinator {
             guard let self else { return }
             for intent in intents {
                 await LaunchIntentRouter.shared.route(intent)
+            }
+            if !intents.isEmpty {
+                WindowOpener.shared.orderOutWelcome()
             }
             self.runStartupBehaviorIfNeeded(skipping: intents)
             self.phase = .ready

--- a/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
@@ -93,7 +93,7 @@ internal final class AppLaunchCoordinator {
                 for intent in intents {
                     await LaunchIntentRouter.shared.route(intent)
                 }
-                WindowOpener.shared.orderOutWelcome()
+                self.dismissWelcomeIfMainWindowVisible()
             }
         }
     }
@@ -109,13 +109,16 @@ internal final class AppLaunchCoordinator {
             for intent in intents {
                 await LaunchIntentRouter.shared.route(intent)
             }
-            if !intents.isEmpty {
-                WindowOpener.shared.orderOutWelcome()
-            }
+            self.dismissWelcomeIfMainWindowVisible()
             self.runStartupBehaviorIfNeeded(skipping: intents)
             self.phase = .ready
             self.finalizeWindowsIfNoVisibleMain(intents: intents)
         }
+    }
+
+    private func dismissWelcomeIfMainWindowVisible() {
+        guard NSApp.windows.contains(where: { Self.isMainWindow($0) && $0.isVisible }) else { return }
+        WindowOpener.shared.orderOutWelcome()
     }
 
     private func runStartupBehaviorIfNeeded(skipping intents: [LaunchIntent]) {

--- a/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
@@ -28,7 +28,7 @@ internal final class LaunchIntentRouter {
 
             case .openInspectorFile(let url):
                 Self.logger.debug("LaunchIntentRouter.route(.openInspectorFile(\(url.lastPathComponent, privacy: .public)))")
-                openInspectorDocument(at: url)
+                try await openInspectorDocument(at: url)
 
             case .importConnection(let exportable):
                 WelcomeRouter.shared.routeImport(exportable)
@@ -57,21 +57,19 @@ internal final class LaunchIntentRouter {
         }
     }
 
-    private func openInspectorDocument(at url: URL) {
+    private func openInspectorDocument(at url: URL) async throws {
         Self.logger.debug("LaunchIntentRouter.openInspectorDocument - calling NSDocumentController.shared (\(String(describing: Swift.type(of: NSDocumentController.shared)), privacy: .public)).openDocument for \(url.lastPathComponent, privacy: .public)")
-        NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { document, alreadyOpen, error in
-            Self.logger.debug("LaunchIntentRouter.openInspectorDocument completion - document=\(document == nil ? "nil" : "present", privacy: .public) alreadyOpen=\(alreadyOpen, privacy: .public) error=\(error?.localizedDescription ?? "nil", privacy: .public)")
-            if let error {
-                Self.logger.error("Failed to open inspector document at \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                AlertHelper.showErrorSheet(
-                    title: String(localized: "Could Not Open File"),
-                    message: error.localizedDescription,
-                    window: NSApp.keyWindow
-                )
-                return
-            }
-            if document == nil {
-                Self.logger.warning("NSDocumentController returned no document for \(url.lastPathComponent, privacy: .public)")
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { document, alreadyOpen, error in
+                Self.logger.debug("LaunchIntentRouter.openInspectorDocument completion - document=\(document == nil ? "nil" : "present", privacy: .public) alreadyOpen=\(alreadyOpen, privacy: .public) error=\(error?.localizedDescription ?? "nil", privacy: .public)")
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                if document == nil {
+                    Self.logger.warning("NSDocumentController returned no document for \(url.lastPathComponent, privacy: .public)")
+                }
+                continuation.resume()
             }
         }
     }

--- a/TableProTests/Core/Services/Infrastructure/URLClassifierTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/URLClassifierTests.swift
@@ -1,0 +1,52 @@
+//
+//  URLClassifierTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("URLClassifier file extension routing", .serialized)
+@MainActor
+struct URLClassifierTests {
+    private func withInspectorState<T>(
+        lazy: [String: URL],
+        active: [String: any DocumentInspectorPlugin] = [:],
+        body: () throws -> T
+    ) rethrows -> T {
+        let originalLazy = PluginManager.shared.lazyInspectorFileExtensions
+        let originalActive = PluginManager.shared.inspectorPlugins
+        defer {
+            PluginManager.shared.lazyInspectorFileExtensions = originalLazy
+            PluginManager.shared.inspectorPlugins = originalActive
+        }
+        PluginManager.shared.lazyInspectorFileExtensions = lazy
+        PluginManager.shared.inspectorPlugins = active
+        return try body()
+    }
+
+    @Test("CSV routes to openInspectorFile when the extension is registered")
+    func routesCSVWhenExtensionRegistered() {
+        let csvURL = URL(fileURLWithPath: "/tmp/sample.csv")
+        let stubPluginURL = URL(fileURLWithPath: "/tmp/stub.tableplugin")
+        let intent = withInspectorState(lazy: ["csv": stubPluginURL]) {
+            URLClassifier.classify(csvURL)
+        }
+        guard case .some(.success(.openInspectorFile(let routed))) = intent else {
+            Issue.record("Expected .openInspectorFile, got \(String(describing: intent))")
+            return
+        }
+        #expect(routed == csvURL)
+    }
+
+    @Test("CSV returns nil when no inspector plugin registers the extension")
+    func returnsNilWhenExtensionMissing() {
+        let csvURL = URL(fileURLWithPath: "/tmp/sample.csv")
+        let intent = withInspectorState(lazy: [:]) {
+            URLClassifier.classify(csvURL)
+        }
+        #expect(intent == nil)
+    }
+}


### PR DESCRIPTION
Fixes #1443.

## Problem

When TablePro is closed and the user double-clicks a `.csv` file in Finder (with TablePro as the default app for CSV), TablePro launches and shows its welcome screen. The CSV that triggered the launch is never opened.

## Root cause

On cold launch, macOS calls `application(_:open:)` between `applicationWillFinishLaunching` and `applicationDidFinishLaunching`. `URLClassifier.classifyFile` queries `PluginManager.allInspectorFileExtensions`, but `PluginManager.shared.loadPlugins()` ran inside `applicationDidFinishLaunching` (42ms too late, verified by the existing OSLog instrumentation). At the moment the open event arrived, `lazyInspectorFileExtensions` was empty, the classifier returned `nil`, the URL was silently dropped with an `Unrecognized URL` warning, and `deliver([])` early-returned. The 150ms intent-collection timer in `AppLaunchCoordinator` then fired with no intents, `finalizeWindowsIfNoVisibleMain` showed the welcome window, and the CSV never opened.

Captured cold-launch log:

```
09:41:54.076  AppDelegate.application(_:open:) urls=customers-100.csv
09:41:54.076  Unrecognized URL: file:///.../customers-100.csv
09:41:54.077  ThemeEngine activated                              (didFinishLaunching starts)
09:41:54.118  Discovered 13 plugin(s)                            (loadPlugins, 42ms too late)
```

Same class of issue would have applied to any inspector file type the plugin system registers (TSV, future inspectors), not just CSV.

## Fix

- `AppDelegate` — `PluginManager.shared.loadPlugins()` moves from `applicationDidFinishLaunching` to `applicationWillFinishLaunching`, right after the existing `InspectorDocumentController()`. `InspectorDocumentController.typeForContents(of:)` already reads `allInspectorFileExtensions`, so putting plugin load next to it matches the existing precedent for "must be ready before any file-open event." The synchronous lazy-manifest registration inside `loadPlugins` populates `lazyInspectorFileExtensions` before returning; the async eager-loading `Task` continues in the background, unchanged.
- `AppLaunchCoordinator` — `WindowOpener.shared.orderOutWelcome()` is now called after intents are routed in both code paths: `deliver`'s warm-launch branch and `transitionToRouting`'s cold-launch branch. The pre-existing `orderOut` loop in `deliver`'s accepting-phase branch only ran during `application(_:open:)`, when SwiftUI had not yet auto-shown the welcome `Window` scene, so `NSApp.windows` was empty and the loop was a no-op. The post-routing dismissal is deterministic and runs after SwiftUI has had a chance to show the welcome window.

## Verification

Cold-launch reproduction with logging on the patched build: `application(_:open:)` receives the URL, classifier returns `.openInspectorFile`, the intent is captured in `pendingIntents`, `transitionToRouting` routes it through `NSDocumentController.openDocument`, the CSV inspector window opens, and the welcome window is dismissed.

One caveat: the welcome window may briefly flash (≤150ms, the intent-collection window) before being dismissed, because SwiftUI auto-shows the first `Window` scene during `didFinishLaunching` and macOS 14 has no API to suppress that (`defaultLaunchBehavior(.suppressed)` is macOS 15+). Eliminating the flash entirely would require replacing the SwiftUI welcome `Window` scene with an AppKit `NSWindowController` managed by `WindowOpener`. Out of scope for this fix.

## Tests

Not added. The bug is a singleton-lifecycle ordering race across `AppDelegate`, `AppLaunchCoordinator`, `WindowOpener`, `LaunchIntentRouter`, and `PluginManager`. A meaningful regression test would need invasive dependency injection across all of them. The existing OSLog instrumentation (`AppDelegate.application(_:open:)`, `AppLaunchCoordinator.handleOpenURLs`, `LaunchIntentRouter.openInspectorDocument`) makes the cold-launch reproduction the practical verification path.
