### PR TITLE
fix(coordinator): load a table tab's initial query exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a saved connection that fails now shows the detailed troubleshooting dialog with suggested fixes, the same one Test Connection shows, instead of a generic error alert. (#1425, #483)
 - Oracle connection errors no longer surface the driver's raw internal message; failures now explain the cause in plain language. (#483)
 - AWS IAM authentication with a named profile now reads `~/.aws/config` (not just `~/.aws/credentials`) and supports `credential_process`, so profiles backed by SSO, IAM Identity Center, or assume-role work through `aws configure export-credentials`. (#1291)
+- Opening a table no longer runs the initial query multiple times before the data arrives. The same query could fire up to four times on a single tab open; it now runs once.
 - iOS: a connection's Safe Mode setting now survives relaunch. iCloud sync no longer drops the value, so a connection set to Confirm Writes or Read-Only no longer reverts to Off after reopening the app.
 - iOS: running a query that returns a very large result no longer crashes the app. The query editor keeps the first rows it loads, stops before memory runs low, and tells you to add LIMIT to fetch more.
 - iOS: Safe Mode "Confirm Writes" now prompts before saving a row edit or inserting a row, matching the query editor. Previously grid edits and inserts saved with no confirmation.

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -105,37 +105,12 @@ extension MainContentCoordinator {
 
     // MARK: - Lazy Load
 
-    /// Execute the current tab's query if it is a table tab whose row data is
-    /// missing or evicted. Apple-pattern guards in cheap-content-first order:
-    /// trivial content checks reject before the expensive connection probe.
-    /// Idempotent — repeated calls with the same state are no-ops.
     func lazyLoadCurrentTabIfNeeded() {
         guard let tab = tabManager.selectedTab else { return }
-        guard tab.tabType == .table else { return }
-        guard tab.execution.errorMessage == nil else { return }
-        guard !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard canAutoLoadTableTab(tab) else { return }
+        guard tableLoadTasks[tab.id] == nil else { return }
 
-        let rows = tabSessionRegistry.tableRows(for: tab.id)
-        let isEvicted = tabSessionRegistry.isEvicted(tab.id)
-        let hasFreshRows = !rows.rows.isEmpty && !isEvicted
-        let hasExecuted = tab.execution.lastExecutedAt != nil && !isEvicted
-        guard !hasFreshRows, !hasExecuted else { return }
-
-        let hasPendingEdits =
-            changeManager.hasChanges
-            || tab.pendingChanges.hasChanges
-        guard !hasPendingEdits else { return }
-
-        // A previous load that was cancelled mid-flight (e.g. user rapidly
-        // switched away) leaves `isExecuting = true` with no rows and no
-        // `lastExecutedAt`. Clear the stale flag inline so the executor's
-        // own `!tab.execution.isExecuting` guard inside
-        // `executeTableTabQueryDirectly` doesn't suppress this re-fire.
-        if tab.execution.isExecuting && rows.rows.isEmpty && tab.execution.lastExecutedAt == nil {
-            tabManager.mutate(tabId: tab.id) { $0.execution.isExecuting = false }
-        } else if tab.execution.isExecuting {
-            return
-        }
+        clearAbandonedExecutingFlagIfNeeded(for: tab)
 
         guard let session = DatabaseManager.shared.session(for: connectionId),
               session.isConnected else {
@@ -143,9 +118,37 @@ extension MainContentCoordinator {
             return
         }
 
+        let tabId = tab.id
         Self.lifecycleLogger.debug(
-            "[switch] coordinator.lazyLoadCurrentTabIfNeeded executing tabId=\(tab.id, privacy: .public) evicted=\(isEvicted)"
+            "[switch] coordinator.lazyLoadCurrentTabIfNeeded executing tabId=\(tabId, privacy: .public)"
         )
-        executeTableTabQueryDirectly()
+        tableLoadTasks[tabId] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.tableLoadTasks[tabId] = nil }
+            self.executeTableTabQueryDirectly()
+            if let task = self.currentQueryTask {
+                await task.value
+            }
+        }
+    }
+
+    private func canAutoLoadTableTab(_ tab: QueryTab) -> Bool {
+        guard tab.tabType == .table else { return false }
+        guard tab.execution.errorMessage == nil else { return false }
+        guard !tab.content.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+
+        let rows = tabSessionRegistry.tableRows(for: tab.id)
+        let isEvicted = tabSessionRegistry.isEvicted(tab.id)
+        let hasFreshRows = !rows.rows.isEmpty && !isEvicted
+        let hasExecuted = tab.execution.lastExecutedAt != nil && !isEvicted
+        guard !hasFreshRows, !hasExecuted else { return false }
+
+        let hasPendingEdits = changeManager.hasChanges || tab.pendingChanges.hasChanges
+        return !hasPendingEdits
+    }
+
+    private func clearAbandonedExecutingFlagIfNeeded(for tab: QueryTab) {
+        guard tab.execution.isExecuting, currentQueryTask == nil else { return }
+        tabManager.mutate(tabId: tab.id) { $0.execution.isExecuting = false }
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -67,7 +67,7 @@ extension MainContentView {
                     {
                         await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName)
                     } else {
-                        coordinator.executeTableTabQueryDirectly()
+                        coordinator.lazyLoadCurrentTabIfNeeded()
                     }
                 } else {
                     coordinator.needsLazyLoad = true
@@ -157,7 +157,7 @@ extension MainContentView {
                     {
                         Task { await coordinator.switchDatabase(to: firstTab.tableContext.databaseName) }
                     } else {
-                        coordinator.executeTableTabQueryDirectly()
+                        coordinator.lazyLoadCurrentTabIfNeeded()
                     }
                 } else {
                     coordinator.needsLazyLoad = true

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -175,6 +175,7 @@ final class MainContentCoordinator {
 
     @ObservationIgnored internal var queryGeneration: Int = 0
     @ObservationIgnored internal var currentQueryTask: Task<Void, Never>?
+    @ObservationIgnored internal var tableLoadTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored internal var redisDatabaseSwitchTask: Task<Void, Never>?
     @ObservationIgnored private var changeManagerUpdateTask: Task<Void, Never>?
     @ObservationIgnored private var activeSortTasks: [UUID: Task<Void, Never>] = [:]
@@ -612,6 +613,8 @@ final class MainContentCoordinator {
         fileWatcher = nil
         currentQueryTask?.cancel()
         currentQueryTask = nil
+        for task in tableLoadTasks.values { task.cancel() }
+        tableLoadTasks.removeAll()
         changeManagerUpdateTask?.cancel()
         changeManagerUpdateTask = nil
         redisDatabaseSwitchTask?.cancel()

--- a/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
@@ -137,20 +137,18 @@ struct MainContentCoordinatorLazyLoadTests {
         #expect(coordinator.needsLazyLoad == false)
     }
 
-    @Test("Returns early when tab is already executing")
-    func skipsWhenAlreadyExecuting() {
+    @Test("Returns early when a load Task is already registered for this tab")
+    func skipsWhenLoadTaskRegistered() {
         let (coordinator, tabManager) = makeCoordinator()
         let tabId = addTableTab(to: tabManager)
-        seedRows(coordinator, for: tabId, rowCount: 1)
-        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
-            Issue.record("expected tab to exist")
-            return
-        }
-        tabManager.tabs[idx].execution.lastExecutedAt = Date()
-        tabManager.tabs[idx].execution.isExecuting = true
-        coordinator.tabSessionRegistry.evict(for: tabId)
+        let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
+        defer { inFlight.cancel() }
+        coordinator.tableLoadTasks[tabId] = inFlight
 
         coordinator.lazyLoadCurrentTabIfNeeded()
+
+        #expect(coordinator.tableLoadTasks.count == 1)
+        #expect(coordinator.tableLoadTasks[tabId] != nil)
         #expect(coordinator.needsLazyLoad == false)
     }
 
@@ -185,6 +183,23 @@ struct MainContentCoordinatorLazyLoadTests {
         }
         #expect(coordinator.tabSessionRegistry.tableRows(for: tabId).rows.count == 4)
         #expect(coordinator.needsLazyLoad == false)
+    }
+
+    @Test("Clears an abandoned executing flag when no in-flight task remains")
+    func recoversAbandonedExecutingFlag() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].execution.isExecuting = true
+        coordinator.currentQueryTask = nil
+
+        coordinator.lazyLoadCurrentTabIfNeeded()
+
+        #expect(tabManager.tabs[idx].execution.isExecuting == false)
+        #expect(coordinator.needsLazyLoad == true)
     }
 
     // MARK: - loadEpoch bump triggers reload after eviction


### PR DESCRIPTION
## Symptom

Opening a table runs the same initial query up to four times. Logs from a Chinook sample SQLite open show four `[executeUserQuery] SELECT * FROM `Track` LIMIT 1000 OFFSET 0` lines, of which three return `rows=0` (interrupted) and one returns `rows=1000`. The grid ends up correct because `queryGeneration` discards the stale results, but four SQLite queries actually ran, three were cancelled mid-flight via `sqlite3_interrupt`, and on slower remote databases the redundant attempts add real latency and flicker.

## Root cause

The initial auto-load was not idempotent, for two reasons:

1. **Bypass path.** `initializeAndRestoreTabs` (`MainContentView+Setup.swift:70` and `:160`) called `coordinator.executeTableTabQueryDirectly()` directly, skipping the freshness guards in `lazyLoadCurrentTabIfNeeded`.
2. **In-flight blind spot.** The stale-flag heuristic in `lazyLoadCurrentTabIfNeeded` could not tell "abandoned mid-flight" from "still running." Any second trigger cleared the flag and re-fired, cancelling the running query.

Apple's docs give no exactly-once guarantee for `onAppear`/`.task` (only "before the first frame"). The correct fix is to make the load idempotent in the coordinator, not to chase lifecycle re-fires.

## Approach

Apple's WWDC21 "Protect mutable state with Swift actors" pattern: store the in-flight `Task` and have concurrent callers coalesce onto it instead of starting a new one. TablePro already uses this pattern in `SQLSchemaProvider.loadTask`. This PR extends it to table-tab loads.

## Changes

- **`MainContentCoordinator`**: new `tableLoadTasks: [UUID: Task<Void, Never>]`, keyed by tab id. `teardown()` cancels and clears the map.
- **`MainContentCoordinator+WindowLifecycle.lazyLoadCurrentTabIfNeeded`**: rewritten as the single funnel. Pure freshness gate (`canAutoLoadTableTab` helper) → map-based coalescing (`tableLoadTasks[tab.id] == nil` else return) → abandoned-flag recovery (`clearAbandonedExecutingFlagIfNeeded` helper, uses `currentQueryTask == nil` as the discriminator) → connection check → spawn wrapping Task. The wrapping Task awaits `currentQueryTask` so the map entry lives until the query observably completes; `defer` clears it.
- **`MainContentView+Setup.swift`**: the two `initializeAndRestoreTabs` auto-load call sites now go through `lazyLoadCurrentTabIfNeeded()`. Combined with the existing `.task(id:)` and `connectionStatusChanged` paths, all four view trigger paths now funnel through one coordinator method.
- **Comments removed**: the old method had a multi-line comment explaining the stale-flag heuristic. Self-documenting helper names (`canAutoLoadTableTab`, `clearAbandonedExecutingFlagIfNeeded`) replace it, matching the project's no-comments rule.

The three other callers of `executeTableTabQueryDirectly` (`runQuery:748`, Redis post-switch `Navigation:479`, and the new wrapping Task inside lazyLoad) are intentional re-runs and stay direct.

## Why a refactor, not a patch

The earlier targeted patch in this branch (`currentQueryTask` as the in-flight signal) closed the symptom but kept the auto-load orchestration spread across the view layer (`initializeAndRestoreTabs`'s direct executor calls, the lazyLoad heuristic, the abandoned-flag clear). The full refactor moves auto-load ownership onto the coordinator with the WWDC21 coalescing pattern, eliminates the heuristic in favour of an unambiguous signal (presence in the per-tab map), and makes the call shape uniform across all four lifecycle trigger paths.

## Tests

- `skipsWhenLoadTaskRegistered` (replaces `skipsWhenAlreadyExecuting`): seeds `tableLoadTasks[tabId]` with a sleeping Task, calls lazyLoad, asserts no new entry and `needsLazyLoad == false` (returned early before the connection check). Directly exercises the map-based coalescing.
- `recoversAbandonedExecutingFlag`: `isExecuting=true`, `currentQueryTask=nil`, empty map. lazyLoad clears the flag and falls through to the disconnected deferral. Proves abandoned-load recovery still works.
- All existing tests (cheap-content guards, freshness, idempotency, eviction, windowDidBecomeKey regression) untouched.

## Checks

- `swiftlint lint --strict` on changed files: clean.
- Writing-style grep on added lines: clean.
- Verified `execution.errorMessage` and `lastExecutedAt` are NOT persisted by `QueryTab.toPersistedTab()`, so the extra guards `lazyLoad` adds for restored tabs are no-ops in practice (no regression for tabs that previously errored).