### PR TITLE
fix(toolbar): persist customizations across window opens (#1455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Toolbar customizations now persist after closing and reopening a session window. (#1455)
 - Pasting copied rows no longer misplaces values when a cell contains a comma (such as a user agent string); each value stays in its own column, and a real NULL is kept distinct from the literal text "NULL".
 - BigQuery: switching to another table now loads its data right away, instead of leaving the grid empty until you close and reopen the tab.
 - Custom and OpenAI-compatible AI providers now work when the base URL already ends in `/v1`, instead of building a doubled `/v1/v1/` path that failed. (#1400)

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -13,6 +13,8 @@ import TableProPluginKit
 internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
+    internal static let toolbarIdentifier = NSToolbar.Identifier("com.TablePro.main.toolbar")
+
     weak var coordinator: MainContentCoordinator?
 
     internal let managedToolbar: NSToolbar
@@ -26,14 +28,12 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     internal init(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
-        // Unique identifier per toolbar instance prevents tab-group merging that would collapse
-        // all tabs into one toolbar and leave subsequent windows blank.
-        self.managedToolbar = NSToolbar(identifier: "com.TablePro.main.toolbar.\(UUID().uuidString)")
+        self.managedToolbar = NSToolbar(identifier: Self.toolbarIdentifier)
         super.init()
         self.managedToolbar.delegate = self
         self.managedToolbar.displayMode = .iconOnly
         self.managedToolbar.allowsUserCustomization = true
-        self.managedToolbar.autosavesConfiguration = false
+        self.managedToolbar.autosavesConfiguration = true
     }
 
     func invalidate() {

--- a/TableProTests/Services/MainWindowToolbarValidationTests.swift
+++ b/TableProTests/Services/MainWindowToolbarValidationTests.swift
@@ -143,16 +143,16 @@ struct MainWindowToolbarValidationTests {
         #expect(MainWindowToolbar.isEnabled(itemIdentifier: unknown, context: context) == true)
     }
 
-    @Test("Toolbar identifier is stable across instances so AppKit autosave can persist customisations")
+    @Test("Toolbar identifier is stable across instances so AppKit autosave can persist customizations")
     func toolbarIdentifierIsStable() {
         #expect(MainWindowToolbar.toolbarIdentifier.rawValue == "com.TablePro.main.toolbar")
-        #expect(MainWindowToolbar.toolbarIdentifier.rawValue.contains("-") == false)
     }
 
-    @Test("Toolbar is configured for user customisation and autosave")
+    @Test("Toolbar is configured for user customization and autosave")
     func toolbarConfigurationEnablesAutosave() {
-        let owner = makeToolbarOwner()
-        defer { owner.coordinator?.teardown() }
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+        let owner = MainWindowToolbar(coordinator: coordinator)
         #expect(owner.managedToolbar.identifier == MainWindowToolbar.toolbarIdentifier)
         #expect(owner.managedToolbar.allowsUserCustomization == true)
         #expect(owner.managedToolbar.autosavesConfiguration == true)
@@ -160,21 +160,21 @@ struct MainWindowToolbarValidationTests {
 
     @Test("Allowed item identifiers are a superset of defaults so restored items survive autosave")
     func allowedItemIdentifiersAreSupersetOfDefaults() {
-        let owner = makeToolbarOwner()
-        defer { owner.coordinator?.teardown() }
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+        let owner = MainWindowToolbar(coordinator: coordinator)
         let toolbar = owner.managedToolbar
         let defaults = Set(owner.toolbarDefaultItemIdentifiers(toolbar))
         let allowed = Set(owner.toolbarAllowedItemIdentifiers(toolbar))
         #expect(defaults.isSubset(of: allowed))
     }
 
-    private func makeToolbarOwner() -> MainWindowToolbar {
-        let coordinator = MainContentCoordinator(
+    private func makeCoordinator() -> MainContentCoordinator {
+        MainContentCoordinator(
             connection: TestFixtures.makeConnection(database: "db_a"),
             tabManager: QueryTabManager(),
             changeManager: DataChangeManager(),
             toolbarState: ConnectionToolbarState()
         )
-        return MainWindowToolbar(coordinator: coordinator)
     }
 }

--- a/TableProTests/Services/MainWindowToolbarValidationTests.swift
+++ b/TableProTests/Services/MainWindowToolbarValidationTests.swift
@@ -142,4 +142,39 @@ struct MainWindowToolbarValidationTests {
         let unknown = NSToolbarItem.Identifier("com.test.unknown")
         #expect(MainWindowToolbar.isEnabled(itemIdentifier: unknown, context: context) == true)
     }
+
+    @Test("Toolbar identifier is stable across instances so AppKit autosave can persist customisations")
+    func toolbarIdentifierIsStable() {
+        #expect(MainWindowToolbar.toolbarIdentifier.rawValue == "com.TablePro.main.toolbar")
+        #expect(MainWindowToolbar.toolbarIdentifier.rawValue.contains("-") == false)
+    }
+
+    @Test("Toolbar is configured for user customisation and autosave")
+    func toolbarConfigurationEnablesAutosave() {
+        let owner = makeToolbarOwner()
+        defer { owner.coordinator?.teardown() }
+        #expect(owner.managedToolbar.identifier == MainWindowToolbar.toolbarIdentifier)
+        #expect(owner.managedToolbar.allowsUserCustomization == true)
+        #expect(owner.managedToolbar.autosavesConfiguration == true)
+    }
+
+    @Test("Allowed item identifiers are a superset of defaults so restored items survive autosave")
+    func allowedItemIdentifiersAreSupersetOfDefaults() {
+        let owner = makeToolbarOwner()
+        defer { owner.coordinator?.teardown() }
+        let toolbar = owner.managedToolbar
+        let defaults = Set(owner.toolbarDefaultItemIdentifiers(toolbar))
+        let allowed = Set(owner.toolbarAllowedItemIdentifiers(toolbar))
+        #expect(defaults.isSubset(of: allowed))
+    }
+
+    private func makeToolbarOwner() -> MainWindowToolbar {
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(database: "db_a"),
+            tabManager: QueryTabManager(),
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return MainWindowToolbar(coordinator: coordinator)
+    }
 }


### PR DESCRIPTION
## Summary

- Closes #1455 — toolbar customizations (drag/drop items in **Customize Toolbar...**) were lost on every session window reopen.
- Two compounding issues in `MainWindowToolbar.swift`: the toolbar identifier embedded a fresh `UUID` per instance (so AppKit's autosave key was never the same twice), and `autosavesConfiguration` was explicitly set to `false`.
- Use a single stable identifier `com.TablePro.main.toolbar` shared by every session window, and set `autosavesConfiguration = true`. AppKit handles read/write to `UserDefaults` under `NSToolbar Configuration <identifier>` automatically. This matches the documented pattern in Mail/Safari/Finder/Xcode.
- The comment claiming the UUID prevented tab-group merging was incorrect: tab grouping is driven by `NSWindow.tabbingIdentifier` (already set per-connection at `TabWindowController.swift:60`), not by the toolbar identifier. The per-instance `hostingControllers` retention on each `MainWindowToolbar` continues to prevent the NSHostingController orphan-view problem.

## Test plan

- [ ] Open a session window, right-click the toolbar → **Customize Toolbar...**, drag the "Export & Import" group in, click **Done**.
- [ ] Close the window, reopen it — the group should still be there.
- [ ] Open two windows for the same connection (so they tab together), customize one, switch tabs, close one. Confirm the remaining tab's toolbar still renders every item.
- [ ] Quit and relaunch — the customized layout should still be there.
- [ ] Use the customize sheet's **Default Set** button — the layout should reset to `toolbarDefaultItemIdentifiers`.
- [ ] `xcodebuild test -only-testing:TableProTests/MainWindowToolbarValidationTests` passes (three new tests added covering identifier stability, autosave configuration, and the allowed-items-superset invariant).