### PR TITLE
fix(sync): propagate connection group membership changes to other devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Moving a connection into or out of a group now syncs across devices, instead of leaving it ungrouped on your other Macs.
+
 ## [0.46.0] - 2026-05-28
 
 ### Added

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -189,9 +189,10 @@ final class ConnectionStorage {
         guard didMutate, saveConnections(connections) else {
             return false
         }
-        for connection in updatesById.values where !connection.localOnly && !connection.isSample {
-            syncTracker.markDirty(.connection, id: connection.id.uuidString)
-        }
+        let dirtyIds = updatesById.values
+            .filter { !$0.localOnly && !$0.isSample }
+            .map { $0.id.uuidString }
+        syncTracker.markDirty(.connection, ids: dirtyIds)
         return true
     }
 

--- a/TablePro/Core/Storage/GroupStorage.swift
+++ b/TablePro/Core/Storage/GroupStorage.swift
@@ -104,15 +104,15 @@ final class GroupStorage {
 
         let storage = connectionStorageProvider()
         var connections = storage.loadConnections()
-        var changed = false
+        var changed: [DatabaseConnection] = []
         for i in connections.indices {
             if let gid = connections[i].groupId, allIdsToDelete.contains(gid) {
                 connections[i].groupId = nil
-                changed = true
+                changed.append(connections[i])
             }
         }
-        if changed {
-            if !storage.saveConnections(connections) {
+        if !changed.isEmpty {
+            if !storage.updateConnections(changed) {
                 Self.logger.error("Failed to clear groupId references after group deletion")
             }
         }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -553,25 +553,22 @@ final class WelcomeViewModel {
 
         let updatedValidGroupIds = Set(groups.map(\.id))
         var order = 0
-        var dirtyIds: [String] = []
+        var updated: [DatabaseConnection] = []
         for i in connections.indices {
             let isUngrouped = connections[i].groupId.map { !updatedValidGroupIds.contains($0) } ?? true
             if isUngrouped {
                 if connections[i].sortOrder != order {
                     connections[i].sortOrder = order
-                    dirtyIds.append(connections[i].id.uuidString)
+                    updated.append(connections[i])
                 }
                 order += 1
             }
         }
 
-        guard storage.saveConnections(connections) else {
+        guard storage.updateConnections(updated) else {
             connections = storage.loadConnections()
             rebuildTree()
             return
-        }
-        if !dirtyIds.isEmpty {
-            services.syncTracker.markDirty(.connection, ids: dirtyIds)
         }
         rebuildTree()
     }
@@ -595,22 +592,19 @@ final class WelcomeViewModel {
         connections.move(fromOffsets: globalSource, toOffset: globalDestination)
 
         var order = 0
-        var dirtyIds: [String] = []
+        var updated: [DatabaseConnection] = []
         for i in connections.indices where connections[i].groupId == group.id {
             if connections[i].sortOrder != order {
                 connections[i].sortOrder = order
-                dirtyIds.append(connections[i].id.uuidString)
+                updated.append(connections[i])
             }
             order += 1
         }
 
-        guard storage.saveConnections(connections) else {
+        guard storage.updateConnections(updated) else {
             connections = storage.loadConnections()
             rebuildTree()
             return
-        }
-        if !dirtyIds.isEmpty {
-            services.syncTracker.markDirty(.connection, ids: dirtyIds)
         }
         rebuildTree()
     }

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -415,10 +415,12 @@ final class WelcomeViewModel {
 
     func moveConnections(_ targets: [DatabaseConnection], toGroup groupId: UUID) {
         let ids = Set(targets.map(\.id))
+        var updated: [DatabaseConnection] = []
         for i in connections.indices where ids.contains(connections[i].id) {
             connections[i].groupId = groupId
+            updated.append(connections[i])
         }
-        guard storage.saveConnections(connections) else {
+        guard storage.updateConnections(updated) else {
             connections = storage.loadConnections()
             rebuildTree()
             return
@@ -428,10 +430,12 @@ final class WelcomeViewModel {
 
     func removeFromGroup(_ targets: [DatabaseConnection]) {
         let ids = Set(targets.map(\.id))
+        var updated: [DatabaseConnection] = []
         for i in connections.indices where ids.contains(connections[i].id) {
             connections[i].groupId = nil
+            updated.append(connections[i])
         }
-        guard storage.saveConnections(connections) else {
+        guard storage.updateConnections(updated) else {
             connections = storage.loadConnections()
             rebuildTree()
             return

--- a/TableProTests/Core/Storage/GroupStorageTests.swift
+++ b/TableProTests/Core/Storage/GroupStorageTests.swift
@@ -14,6 +14,9 @@ final class GroupStorageTests: XCTestCase {
     private var syncDefaults: UserDefaults!
     private var syncSuiteName: String!
     private var storage: GroupStorage!
+    private var tracker: SyncChangeTracker!
+    private var connectionStorage: ConnectionStorage!
+    private var connectionFileURL: URL!
 
     override func setUp() {
         super.setUp()
@@ -23,18 +26,38 @@ final class GroupStorageTests: XCTestCase {
         syncSuiteName = "com.TablePro.tests.Sync.\(unique)"
         syncDefaults = UserDefaults(suiteName: syncSuiteName)!
         let metadata = SyncMetadataStorage(userDefaults: syncDefaults)
-        let tracker = SyncChangeTracker(metadataStorage: metadata)
-        storage = GroupStorage(userDefaults: defaults, syncTracker: tracker)
+        tracker = SyncChangeTracker(metadataStorage: metadata)
+        connectionFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-tests")
+            .appendingPathComponent("group-connections_\(unique).json")
+        try? FileManager.default.createDirectory(
+            at: connectionFileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        connectionStorage = ConnectionStorage(
+            fileURL: connectionFileURL,
+            userDefaults: defaults,
+            syncTracker: tracker
+        )
+        storage = GroupStorage(
+            userDefaults: defaults,
+            syncTracker: tracker,
+            connectionStorage: connectionStorage
+        )
     }
 
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         syncDefaults.removePersistentDomain(forName: syncSuiteName)
+        try? FileManager.default.removeItem(at: connectionFileURL)
         defaults = nil
         suiteName = nil
         syncDefaults = nil
         syncSuiteName = nil
         storage = nil
+        tracker = nil
+        connectionStorage = nil
+        connectionFileURL = nil
         super.tearDown()
     }
 
@@ -127,6 +150,22 @@ final class GroupStorageTests: XCTestCase {
         let loaded = storage.loadGroups()
         XCTAssertEqual(loaded.count, 1)
         XCTAssertEqual(loaded[0].name, "Prod")
+    }
+
+    func testDeleteGroupClearsMembershipAndMarksConnectionDirtyForSync() {
+        let group = ConnectionGroup(name: "Dev", color: .green)
+        storage.saveGroups([group])
+
+        let connection = DatabaseConnection(name: "Grouped", groupId: group.id)
+        connectionStorage.addConnection(connection)
+        tracker.clearAllDirty(.connection)
+
+        storage.deleteGroup(group)
+
+        let reloaded = connectionStorage.loadConnections()
+        XCTAssertEqual(reloaded.count, 1)
+        XCTAssertNil(reloaded[0].groupId)
+        XCTAssertTrue(tracker.dirtyRecords(for: .connection).contains(connection.id.uuidString))
     }
 
     // MARK: - Lookup


### PR DESCRIPTION
## Problem

On one Mac, connections are organized into groups and iCloud sync is on. On a second Mac with sync enabled, the groups and connections both arrive, but the connections show up flat (ungrouped) and the groups report a count of 0. The group membership is lost across devices.

## Root cause

Group membership lives in `connection.groupId`. Three paths that change it persisted via the low-level `ConnectionStorage.saveConnections(_:)`, which writes the file but does not mark connections dirty for sync (unlike `addConnection` / `updateConnection` / `updateConnections` and the form-save and reorder paths):

- `WelcomeViewModel.moveConnections(_:toGroup:)`
- `WelcomeViewModel.removeFromGroup(_:)`
- `GroupStorage.deleteGroup(_:)`

So a `groupId` change saved locally but never re-pushed. The connection record in iCloud kept its last-pushed `groupId` (usually nil). Groups themselves synced fine (`GroupStorage.saveGroups` marks groups dirty), so the second device pulled correct groups but stale connections, leaving them ungrouped with empty group counts.

This reproduces when grouping happens while sync is already on. When grouping happens before enabling sync, `enableSync()` marks all data dirty and pushes everything correctly, which is why it sometimes works.

## Fix

Route the three membership mutations through the existing `updateConnections(_:)` API, which persists once and marks each changed connection dirty (and skips `localOnly` / sample connections). This keeps `saveConnections` as a pure write primitive, which the sync-apply path and load-time migration rely on.

## Tests

- New `testDeleteGroupClearsMembershipAndMarksConnectionDirtyForSync` in `GroupStorageTests` asserts that deleting a group clears `groupId` on its connections and marks them dirty for sync.
- The `WelcomeViewModel` paths are covered transitively: `updateConnections`' dirty-marking is already tested in `ConnectionStoragePersistenceTests`.

## Recovering already-affected devices

On the device that owns the correct grouping, toggle iCloud sync off then on. `enableSync()` re-marks all local data dirty and re-pushes every connection with its current `groupId`, which the other device then pulls.