### PR TITLE
fix(datagrid): keep keyboard focus across the grid filter flow (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)
 - Moving a connection into or out of a group now syncs across devices, instead of leaving it ungrouped on your other Macs.
 - Opening a table on a connection with many tables no longer stalls for several seconds while autocomplete and table metadata load. Background schema introspection now runs on separate connections instead of waiting behind, or blocking, the query that fills the grid. (#1483)
 

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -40,6 +40,10 @@ struct FilterPanelView: View {
             }
         }
         .background(Color(nsColor: .windowBackgroundColor))
+        .focusSection()
+        .onExitCommand {
+            closePanelAndFocusGrid()
+        }
         .onAppear {
             if filterState.filters.isEmpty && !columns.isEmpty {
                 coordinator.addFilter(columns: columns, primaryKeyColumn: primaryKeyColumn)
@@ -85,6 +89,7 @@ struct FilterPanelView: View {
             Button("Unset") {
                 coordinator.clearFilterState()
                 onUnset()
+                coordinator.focusActiveGrid()
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -96,6 +101,7 @@ struct FilterPanelView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
+            .keyboardShortcut(.defaultAction)
             .disabled(validFilterCount == 0)
             .help(String(localized: "Apply filters"))
         }
@@ -202,9 +208,11 @@ struct FilterPanelView: View {
                         coordinator.removeFilterAndReload(filter)
                         if filterState.filters.isEmpty {
                             coordinator.closeFilterPanel()
+                            coordinator.focusActiveGrid()
                         }
                     },
                     onSubmit: { applyAllValidFilters() },
+                    onCancel: { closePanelAndFocusGrid() },
                     focusedFilterId: $focusedFilterId
                 )
             }
@@ -237,6 +245,12 @@ struct FilterPanelView: View {
     private func applyAllValidFilters() {
         coordinator.applyAllFilters()
         onApply(coordinator.selectedTabFilterState.appliedFilters)
+        coordinator.focusActiveGrid()
+    }
+
+    private func closePanelAndFocusGrid() {
+        coordinator.closeFilterPanel()
+        coordinator.focusActiveGrid()
     }
 
     private var isSQLDialect: Bool {

--- a/TablePro/Views/Filter/FilterRowView.swift
+++ b/TablePro/Views/Filter/FilterRowView.swift
@@ -15,6 +15,7 @@ struct FilterRowView: View {
     let onDuplicate: () -> Void
     let onRemove: () -> Void
     let onSubmit: () -> Void
+    let onCancel: () -> Void
     @Binding var focusedFilterId: UUID?
 
     private var pickerEligibleOperators: Set<FilterOperator> {
@@ -65,6 +66,7 @@ struct FilterRowView: View {
         .fixedSize()
         .labelsHidden()
         .accessibilityLabel(String(localized: "Filter column"))
+        .accessibilityValue(filter.isRawSQL ? String(localized: "Raw SQL") : filter.columnName)
         .help(String(localized: "Select filter column"))
     }
 
@@ -79,6 +81,7 @@ struct FilterRowView: View {
         .fixedSize()
         .labelsHidden()
         .accessibilityLabel(String(localized: "Filter operator"))
+        .accessibilityValue(filter.filterOperator.displayName)
         .help(String(localized: "Select filter operator"))
     }
 
@@ -95,7 +98,8 @@ struct FilterRowView: View {
                 placeholder: "e.g. id = 1",
                 completionSource: rawSQLCompletionSource,
                 allowsMultiLine: true,
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                onCancel: onCancel
             )
             .accessibilityLabel(String(localized: "WHERE clause"))
         } else if filter.filterOperator.requiresValue {
@@ -109,7 +113,8 @@ struct FilterRowView: View {
                     identity: filter.id,
                     placeholder: String(localized: "Value"),
                     completionSource: .staticValues(completions),
-                    onSubmit: onSubmit
+                    onSubmit: onSubmit,
+                    onCancel: onCancel
                 )
                 .frame(minWidth: 80)
                 .accessibilityLabel(String(localized: "Filter value"))

--- a/TablePro/Views/Filter/FilterValueTextField.swift
+++ b/TablePro/Views/Filter/FilterValueTextField.swift
@@ -20,6 +20,7 @@ struct FilterValueTextField: NSViewRepresentable {
     var completionSource: FilterCompletionSource = .staticValues([])
     var allowsMultiLine: Bool = false
     var onSubmit: () -> Void = {}
+    var onCancel: () -> Void = {}
 
     static func suggestions(for input: String, in completions: [String]) -> [String] {
         guard !input.isEmpty else { return [] }
@@ -75,12 +76,14 @@ struct FilterValueTextField: NSViewRepresentable {
             textField.lineBreakMode = .byTruncatingTail
         }
 
+        textField.owner = context.coordinator
         context.coordinator.textField = textField
         context.coordinator.text = $text
         context.coordinator.focusedId = $focusedId
         context.coordinator.identity = identity
         context.coordinator.completionSource = completionSource
         context.coordinator.onSubmit = onSubmit
+        context.coordinator.onCancel = onCancel
 
         return textField
     }
@@ -91,6 +94,7 @@ struct FilterValueTextField: NSViewRepresentable {
         context.coordinator.identity = identity
         context.coordinator.completionSource = completionSource
         context.coordinator.onSubmit = onSubmit
+        context.coordinator.onCancel = onCancel
         context.coordinator.textField = textField
 
         textField.placeholderString = placeholder
@@ -101,18 +105,7 @@ struct FilterValueTextField: NSViewRepresentable {
             textField.stringValue = text
         }
 
-        if focusedId == identity {
-            let binding = $focusedId
-            let pendingId = identity
-            DispatchQueue.main.async {
-                guard let window = textField.window,
-                      binding.wrappedValue == pendingId else { return }
-                if window.firstResponder !== textField.currentEditor() {
-                    window.makeFirstResponder(textField)
-                }
-                binding.wrappedValue = nil
-            }
-        }
+        context.coordinator.focusIfRequested()
     }
 
     func makeCoordinator() -> Coordinator {
@@ -121,7 +114,8 @@ struct FilterValueTextField: NSViewRepresentable {
             focusedId: $focusedId,
             identity: identity,
             completionSource: completionSource,
-            onSubmit: onSubmit
+            onSubmit: onSubmit,
+            onCancel: onCancel
         )
     }
 
@@ -132,6 +126,7 @@ struct FilterValueTextField: NSViewRepresentable {
         var identity: UUID
         var completionSource: FilterCompletionSource
         var onSubmit: () -> Void
+        var onCancel: () -> Void
         weak var textField: NSTextField?
 
         private let suggestionState = SuggestionState()
@@ -151,13 +146,36 @@ struct FilterValueTextField: NSViewRepresentable {
             focusedId: Binding<UUID?>,
             identity: UUID,
             completionSource: FilterCompletionSource,
-            onSubmit: @escaping () -> Void
+            onSubmit: @escaping () -> Void,
+            onCancel: @escaping () -> Void
         ) {
             self.text = text
             self.focusedId = focusedId
             self.identity = identity
             self.completionSource = completionSource
             self.onSubmit = onSubmit
+            self.onCancel = onCancel
+        }
+
+        func focusIfRequested() {
+            guard focusedId.wrappedValue == identity,
+                  let textField,
+                  let window = textField.window else { return }
+            if window.firstResponder !== textField.currentEditor() {
+                window.makeFirstResponder(textField)
+            }
+        }
+
+        func handleBecameFirstResponder() {
+            if focusedId.wrappedValue != identity {
+                focusedId.wrappedValue = identity
+            }
+        }
+
+        func handleResignedFirstResponder() {
+            if focusedId.wrappedValue == identity {
+                focusedId.wrappedValue = nil
+            }
         }
 
         deinit {
@@ -195,7 +213,11 @@ struct FilterValueTextField: NSViewRepresentable {
                 return true
             }
             if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-                dismissSuggestions()
+                if suggestionPopover != nil {
+                    dismissSuggestions()
+                    return true
+                }
+                onCancel()
                 return true
             }
             return false
@@ -391,6 +413,13 @@ struct FilterValueTextField: NSViewRepresentable {
     }
 
     private final class SubstitutionDisabledTextField: NSTextField {
+        weak var owner: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            owner?.focusIfRequested()
+        }
+
         override func becomeFirstResponder() -> Bool {
             let result = super.becomeFirstResponder()
             if result, let editor = currentEditor() as? NSTextView {
@@ -398,6 +427,17 @@ struct FilterValueTextField: NSViewRepresentable {
                 editor.isAutomaticDashSubstitutionEnabled = false
                 editor.isAutomaticTextReplacementEnabled = false
                 editor.isAutomaticSpellingCorrectionEnabled = false
+            }
+            if result {
+                owner?.handleBecameFirstResponder()
+            }
+            return result
+        }
+
+        override func resignFirstResponder() -> Bool {
+            let result = super.resignFirstResponder()
+            if result {
+                owner?.handleResignedFirstResponder()
             }
             return result
         }
@@ -438,6 +478,11 @@ struct FilterValueTextField: NSViewRepresentable {
                                 .contentShape(Rectangle())
                                 .onTapGesture { onSelect(item) }
                                 .id(index)
+                                .accessibilityElement(children: .ignore)
+                                .accessibilityLabel(item.label)
+                                .accessibilityAddTraits(
+                                    state.selectedIndex == index ? [.isButton, .isSelected] : .isButton
+                                )
                         }
                     }
                     .padding(4)

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -70,6 +70,15 @@ struct MainStatusBarView: View {
     private var isStructureMode: Bool { viewMode == .structure }
     private var showsDataChrome: Bool { !isStructureMode }
 
+    private var filterToggleHelp: String {
+        let label = String(localized: "Toggle Filters")
+        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: .toggleFilters),
+              !combo.isCleared else {
+            return label
+        }
+        return "\(label) (\(combo.displayString))"
+    }
+
     var body: some View {
         HStack {
             if snapshot.tabId != nil {
@@ -191,7 +200,7 @@ struct MainStatusBarView: View {
                         }
                         .toggleStyle(.button)
                         .controlSize(.small)
-                        .help(String(localized: "Toggle Filters (⇧⌘F)"))
+                        .help(filterToggleHelp)
                     }
 
                     if snapshot.tabType == .table, snapshot.hasTableName, showsPaginationControls {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+GridFocus.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+GridFocus.swift
@@ -1,0 +1,12 @@
+//
+//  MainContentCoordinator+GridFocus.swift
+//  TablePro
+//
+
+import Foundation
+
+extension MainContentCoordinator {
+    func focusActiveGrid() {
+        dataTabDelegate?.tableViewCoordinator?.focusGrid()
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+GridFocus.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+GridFocus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension MainContentCoordinator {
+internal extension MainContentCoordinator {
     func focusActiveGrid() {
         dataTabDelegate?.tableViewCoordinator?.focusGrid()
     }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -604,6 +604,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
     }
 
+    func focusGrid() {
+        guard let tableView, let window = tableView.window else { return }
+        window.makeFirstResponder(tableView)
+    }
+
     func beginEditing(displayRow: Int, column: Int) {
         guard let tableView,
               let displayCol = DataGridView.tableColumnIndex(for: column, in: tableView, schema: identitySchema)

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -604,7 +604,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
     }
 
-    func focusGrid() {
+    internal func focusGrid() {
         guard let tableView, let window = tableView.window else { return }
         window.makeFirstResponder(tableView)
     }


### PR DESCRIPTION
Part of #1490 (keyboard, focus, and accessibility).

Makes the reported grid -> filter -> grid flow work without the mouse, the native way. From the audit, the breaks were all at the SwiftUI filter panel / AppKit grid boundary.

## What changed

- **Focus returns to the grid.** New `TableViewCoordinator.focusGrid()` and `MainContentCoordinator.focusActiveGrid()` route through the existing `dataGridAttach(tableViewCoordinator:)` registration (no new references). Called after Apply, Unset, removing the last filter row, and Escape.
- **Return applies.** The Apply button is now `.keyboardShortcut(.defaultAction)`, and the panel is a `.focusSection()` so the default action and Tab grouping scope to the panel.
- **Escape works.** In `FilterValueTextField`, `cancelOperation` now consumes the event only when the suggestion popover is open; otherwise it calls `onCancel`, which closes the panel and returns focus to the grid. `.onExitCommand` covers the case where focus is on a SwiftUI control in the panel.
- **Removed the focus hack.** Focus into the filter value field no longer uses `DispatchQueue.main.async { makeFirstResponder }` plus a UUID nil-poke. It is now a proper AppKit first-responder bridge: synchronous `makeFirstResponder` in `updateNSView`/`viewDidMoveToWindow`, with `becomeFirstResponder`/`resignFirstResponder` writing the binding back so it always reflects the real first responder.
- **Accessibility + tooltip.** `accessibilityValue` on the column and operator pickers, label + button/selected traits on suggestion-dropdown rows, and the status-bar Filters tooltip now reads the live shortcut instead of a hardcoded "⇧⌘F".

## Design notes

- I evaluated SwiftUI `@FocusState` for the value field (the audit suggested it) and chose a plain `Binding<UUID?>` bridge instead. `@FocusState` bound to a value with no SwiftUI `.focused()` target (an `NSViewRepresentable` text field is not one) gets reset to nil by SwiftUI's focus engine, which makes focus-into-field flaky. The manual first-responder bridge is the correct, reliable pattern for an AppKit `NSTextField`, and it still removes the async/nil-poke hacks.
- No custom focus engine, no suppressed focus rings, documented APIs only (`.defaultAction`, `.cancelAction`/`onExitCommand`, `.focusSection`, NSResponder first responder).

## Deferred (follow-up, on purpose)

- **Initial grid focus when a table opens** (step 1 of the flow). This is coupled to `SQLEditorCoordinator` re-focusing the editor ~50ms after a tab appears; a guarded grid auto-focus would either be a no-op or lose a focus race, which would be a timing hack. It should land with the SQL-editor focus guard (tracked in the audit's focus-infrastructure notes).
- Full AppKit key-view-loop wiring so Tab cycles value -> picker -> Apply without Full Keyboard Access. `.focusSection()` keeps focus from leaking out; deeper Tab ordering is a separate pass.

Out of scope here (separate surfaces in #1490): toolbar `.focusable(false)`, overlay-editor focus ring, menu-picker Tab reachability without Full Keyboard Access.

## Verify

Build the branch, then keyboard-only with a table open and focus in the grid:
1. Open filters, type a value, Return -> filter applies and focus is back on a grid cell.
2. Open filters, Escape -> panel closes, focus back on the grid.
3. Apply, then arrow keys move cells immediately (no click).
4. With Full Keyboard Access on, the Apply button and pickers are reachable and the focus ring shows.

Focus/responder behavior is not unit-testable here (consistent with the codebase); verification is manual.
