### PR TITLE
feat(connections): add desktop DatabaseType constants to TableProModels (Phase 1 prep)

### DIFF
--- a/Packages/TableProCore/Sources/TableProModels/DatabaseType.swift
+++ b/Packages/TableProCore/Sources/TableProModels/DatabaseType.swift
@@ -26,6 +26,9 @@ public struct DatabaseType: Hashable, Codable, Sendable, RawRepresentable {
     public static let dynamodb = DatabaseType(rawValue: "DynamoDB")
     public static let bigquery = DatabaseType(rawValue: "BigQuery")
     public static let libsql = DatabaseType(rawValue: "libSQL")
+    public static let cockroachdb = DatabaseType(rawValue: "CockroachDB")
+    public static let scylladb = DatabaseType(rawValue: "ScyllaDB")
+    public static let turso = DatabaseType(rawValue: "Turso")
 
     public static let allKnownTypes: [DatabaseType] = [
         .mysql, .mariadb, .postgresql, .sqlite, .redis, .mongodb,

--- a/Packages/TableProCore/Tests/TableProModelsTests/DatabaseTypeTests.swift
+++ b/Packages/TableProCore/Tests/TableProModelsTests/DatabaseTypeTests.swift
@@ -64,4 +64,30 @@ struct DatabaseTypeTests {
         set.insert(DatabaseType(rawValue: "MySQL"))
         #expect(set.count == 2)
     }
+
+    @Test("Desktop-recognized constants have correct raw values")
+    func desktopConstants() {
+        #expect(DatabaseType.cockroachdb.rawValue == "CockroachDB")
+        #expect(DatabaseType.scylladb.rawValue == "ScyllaDB")
+        #expect(DatabaseType.turso.rawValue == "Turso")
+    }
+
+    @Test("Desktop-recognized constants stay out of the built-in allKnownTypes list")
+    func desktopConstantsNotInAllKnownTypes() {
+        #expect(!DatabaseType.allKnownTypes.contains(.cockroachdb))
+        #expect(!DatabaseType.allKnownTypes.contains(.scylladb))
+        #expect(!DatabaseType.allKnownTypes.contains(.turso))
+    }
+
+    @Test("Decodes a persisted connection type string")
+    func decodesPersistedTypeString() throws {
+        let decoded = try JSONDecoder().decode(DatabaseType.self, from: Data("\"MySQL\"".utf8))
+        #expect(decoded == .mysql)
+    }
+
+    @Test("Decodes an unknown persisted type string without loss")
+    func decodesUnknownPersistedTypeString() throws {
+        let decoded = try JSONDecoder().decode(DatabaseType.self, from: Data("\"FutureDB\"".utf8))
+        #expect(decoded.rawValue == "FutureDB")
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 (R-002) step 8.1: bring the authoritative `TableProModels.DatabaseType` to constant parity with the desktop app's duplicate, so the desktop type can be removed in a later PR without breaking call sites. Package-only and additive.

- Adds the 3 constants the desktop type has but the package lacked: `.cockroachdb` ("CockroachDB"), `.scylladb` ("ScyllaDB"), `.turso` ("Turso").
- Leaves the built-in `allKnownTypes` list at 17 (mobile's type picker is unchanged); the new constants are intentionally outside it.
- Does not touch `allKnownTypes` (static), `pluginTypeId`/`iconName` (hardcoded). Mobile and the TableProCore library modules depend on those as-is.

## Risk Addressed

- R-002: duplicate `DatabaseType` definitions (groundwork; full consolidation is the follow-up).

## Seam note for the follow-up (8.2)

The desktop type's `allKnownTypes`, `pluginTypeId`, and `iconName` are registry-driven; the package's are static/hardcoded. Swift extensions can't override static/instance members, so when the desktop adopts this type it must install the registry-driven behavior via a resolver hook (or distinct names), not as overrides. The desktop `.bigQuery` vs package `.bigquery` constant-name mismatch is reconciled there too.

## Verification

- [x] `swift test --package-path Packages/TableProCore` (61 tests pass; new `DatabaseType` cases included)
- [x] `scripts/audit-refactor-health.sh --check` (contract-drift gate clean)
- Codable form unchanged (string rawValue), so persisted connection JSON is unaffected.

## Notes

- ABI bump required: no.
- Docs updated: no.
- macOS app untouched (it does not import TableProModels yet).