### PR TITLE
fix(plugin-redis): throw on unexpected operation instead of crashing the host

### DIFF
--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -789,7 +789,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeKeyOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeKeyOperation")
         }
     }
 
@@ -844,7 +844,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeHashOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeHashOperation")
         }
     }
 
@@ -896,7 +896,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeListOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeListOperation")
         }
     }
 
@@ -948,7 +948,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeSetOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeSetOperation")
         }
     }
 
@@ -1019,7 +1019,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeSortedSetOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeSortedSetOperation")
         }
     }
 
@@ -1049,7 +1049,7 @@ private extension RedisPluginDriver {
             )
 
         default:
-            fatalError("Unexpected operation in executeStreamOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeStreamOperation")
         }
     }
 
@@ -1130,7 +1130,7 @@ private extension RedisPluginDriver {
             return buildStatusResult("OK", startTime: startTime)
 
         default:
-            fatalError("Unexpected operation in executeServerOperation")
+            throw RedisPluginError(code: 0, message: "Unexpected operation in executeServerOperation")
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 9 (R-009): remove a user-triggerable host crash from the Redis driver. The 7 `default: fatalError("Unexpected operation in execute…Operation")` branches in `RedisPluginDriver` now `throw RedisPluginError(code: 0, message: …)`. The dispatch methods are already `async throws`, so an unexpected operation surfaces as a normal query error instead of crashing the whole app via `fatalError`.

## Risk Addressed

- R-009: plugin runtime path guarded by `fatalError` could take down the host process.

## Verification

- [x] `xcodebuild -scheme RedisDriver build` succeeds.
- Line-neutral change (one `fatalError` line → one `throw` line each); no behavior change on the happy path.

## Notes

- ABI bump required: no (plugin internals only, no protocol change). Bundled plugin, ships with the next app build.
- Docs updated: no.
- No CHANGELOG entry: these are unreachable defensive `default:` branches, so there is no observable behavior change.
- Pre-existing `swiftlint --strict` warnings in this file (`file_length` 1426, plus an `implicit_return`/`vertical_whitespace` on untouched lines) are out of scope; this change doesn't add or remove lines.