### PR TITLE
fix(plugin-etcd): verify TLS client-identity type before use to avoid a crash on malformed PKCS12

### DIFF
--- a/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
@@ -1066,7 +1066,8 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             guard status == errSecSuccess,
                   let itemArray = items as? [[String: Any]],
                   let firstItem = itemArray.first,
-                  let identityRef = firstItem[kSecImportItemIdentity as String] else {
+                  let identityRef = firstItem[kSecImportItemIdentity as String],
+                  CFGetTypeID(identityRef as CFTypeRef) == SecIdentityGetTypeID() else {
                 completionHandler(.cancelAuthenticationChallenge, nil)
                 return
             }


### PR DESCRIPTION
## Summary

Phase 9 (R-009): the etcd client-certificate auth path force-cast the PKCS12 identity item (`identityRef as! SecIdentity`). A PKCS12 blob whose first item is not an identity (e.g. a bare certificate) would crash the host process during the TLS auth challenge.

The cast now runs only after a runtime type check folded into the existing `guard`:

```swift
guard ...,
      let identityRef = firstItem[kSecImportItemIdentity as String],
      CFGetTypeID(identityRef as CFTypeRef) == SecIdentityGetTypeID() else {
    completionHandler(.cancelAuthenticationChallenge, nil)
    return
}
```

On a type mismatch the auth challenge is cancelled gracefully (same as the adjacent failure path) instead of crashing. The remaining `as!` is provably safe (type verified) and keeps a justified `// swiftlint:disable:next force_cast`.

## Risk Addressed

- R-009: plugin TLS/identity path could crash on malformed/unexpected key material.

## Verification

- [x] `xcodebuild -scheme EtcdDriverPlugin build` succeeds.

## Notes

- ABI bump required: no (plugin internals only).
- etcd is a **registry-only** plugin, so this fix reaches users via a plugin re-release, not the app build.
- Pre-existing `swiftlint --strict` warning in this file (`closure_parameter_position` on an untouched line) is out of scope.