### PR TITLE
fix(hig): dismiss search sheets and popovers with Escape (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)
 - Opening a table (Return or double-click in the sidebar) moves keyboard focus into the data grid so you can navigate cells with the arrow keys. Arrowing the sidebar still previews tables without taking focus. (#1490)

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -70,6 +70,7 @@ struct DatabaseSwitcherSheet: View {
             }
         }
         .frame(width: 480, height: 460)
+        .onExitCommand { dismiss() }
         .task { await viewModel.fetchDatabases() }
     }
 

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -94,11 +94,11 @@ struct NativeSearchField: NSViewRepresentable {
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-                guard let field = control as? NSSearchField else { return false }
-                if !field.stringValue.isEmpty {
-                    field.stringValue = ""
-                    text.wrappedValue = ""
+                guard let field = control as? NSSearchField, !field.stringValue.isEmpty else {
+                    return false
                 }
+                field.stringValue = ""
+                text.wrappedValue = ""
                 return true
             }
             if commandSelector == #selector(NSResponder.moveUp(_:)), let onMoveUp {


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility).

## Problem

`NativeSearchField` (the shared `NSSearchField` wrapper) always returned `true` for `cancelOperation`, even when the field was empty, so Escape was swallowed and never reached the enclosing sheet or popover. Pressing Escape in the database switcher or quick switcher did nothing; you had to Tab to Cancel or click. The same swallow blocked Escape from closing the search popovers (column visibility, connection switcher, type picker). `DatabaseSwitcherSheet` also had no container Escape handler.

## Fix (standard NSSearchField behavior)

- `NativeSearchField.cancelOperation`: when the field has text, clear it and consume the key (return `true`); **when the field is empty, return `false`** so Escape propagates up the responder chain to the enclosing sheet or popover. This is the documented search-field convention: first Escape clears, second Escape dismisses.
- `DatabaseSwitcherSheet`: add `.onExitCommand { dismiss() }`. (`QuickSwitcherSheet` already had one, so it starts working once the search field stops swallowing Escape.)

No custom focus machinery; this restores the native responder-chain behavior the search field was short-circuiting.

## Scope note

`NativeSearchField` is shared across ~17 call sites. This change also lets Escape-when-empty close the four search popovers (column visibility, database/connection switcher, type picker) and propagate normally in settings and inline panels. That is an improvement and matches native behavior; a propagated Escape with no handler is a no-op, so nothing should regress.

## Verify

- Database switcher / quick switcher: type, press Escape -> text clears; press Escape again (empty) -> sheet dismisses.
- Column visibility / connection switcher / type picker popovers: Escape when empty closes the popover.
- A search field inside settings/inline panels: Escape when empty does nothing harmful.

## Out of scope (separate #1490 follow-ups)

Initial-focus gaps (`MCPTokenRevealSheet`, `LicenseActivationSheet`), `SQLReviewSheet` Escape-from-editor (needs verifying whether the editor releases Escape), accessibility hints on dialog toggles, and the `AlertHelper.runModal()` fallback.

Focus/responder behavior is not unit-testable here (consistent with the codebase); verification is manual.
