### PR TITLE
refactor: route ClickHouse partition SQL through the driver's dialect-aware quoting

### DIFF
--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -112,8 +112,7 @@ struct ClickHousePartsView: View {
     private func optimizeTable() {
         Task {
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
-            let sql = "OPTIMIZE TABLE `\(escapedTable)` FINAL"
+            let sql = "OPTIMIZE TABLE \(driver.quoteIdentifier(tableName)) FINAL"
             do {
                 _ = try await driver.execute(query: sql)
                 await loadParts()
@@ -138,8 +137,7 @@ struct ClickHousePartsView: View {
             guard confirmed else { return }
 
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
-            let sql = "ALTER TABLE `\(escapedTable)` DROP PARTITION '\(partitionValue.replacingOccurrences(of: "'", with: "''"))'"
+            let sql = "ALTER TABLE \(driver.quoteIdentifier(tableName)) DROP PARTITION '\(driver.escapeStringLiteral(partitionValue))'"
             do {
                 _ = try await driver.execute(query: sql)
                 selection.removeAll()
@@ -165,8 +163,7 @@ struct ClickHousePartsView: View {
             guard confirmed else { return }
 
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let escapedTable = tableName.replacingOccurrences(of: "`", with: "``")
-            let sql = "ALTER TABLE `\(escapedTable)` DETACH PARTITION '\(partitionValue.replacingOccurrences(of: "'", with: "''"))'"
+            let sql = "ALTER TABLE \(driver.quoteIdentifier(tableName)) DETACH PARTITION '\(driver.escapeStringLiteral(partitionValue))'"
             do {
                 _ = try await driver.execute(query: sql)
                 selection.removeAll()
@@ -197,12 +194,11 @@ struct ClickHousePartsView: View {
         }
 
         do {
-            let escapedTable = tableName.replacingOccurrences(of: "'", with: "''")
             let sql = """
                 SELECT partition, name, rows, bytes_on_disk,
                        toString(modification_time) AS mod_time, active
                 FROM system.parts
-                WHERE database = currentDatabase() AND table = '\(escapedTable)'
+                WHERE database = currentDatabase() AND table = '\(driver.escapeStringLiteral(tableName))'
                 ORDER BY partition, name
                 """
             let result = try await driver.execute(query: sql)


### PR DESCRIPTION
## Summary

Phase 4 (R-007): `ClickHousePartsView` built four SQL statements with hand-rolled escaping — backtick-doubling for the table identifier and single-quote-doubling for user-supplied partition values. This routes all four through the driver's dialect-aware `quoteIdentifier(_:)` / `escapeStringLiteral(_:)` instead:

- OPTIMIZE TABLE
- ALTER TABLE ... DROP PARTITION
- ALTER TABLE ... DETACH PARTITION
- the `system.parts` lookup (table name used as a string literal)

## Risk Addressed

- R-007: scattered, hand-rolled SQL escaping (injection surface). Partition values are user input.

## Correctness

`PluginDriverAdapter` forwards `quoteIdentifier`/`escapeStringLiteral` to the ClickHouse plugin, which overrides `quoteIdentifier` to use backticks (identical to the previous output) and provides ClickHouse-specific `escapeStringLiteral` (more robust than the manual `''`). So identifiers are behavior-preserving and the user-value escaping is strictly safer.

## Verification

- [x] `xcodebuild -scheme TablePro build` succeeds.
- [x] `swiftlint --strict` clean.

## Notes

- No test: the change delegates to the driver's `quoteIdentifier`/`escapeStringLiteral` (the tested units); the view's inline SQL lives in private SwiftUI methods.
- No CHANGELOG: output is equivalent/more-correct ClickHouse SQL, no observable user change.
- ABI bump: no. Docs: no.