### PR TITLE
feat(sidebar): keyboard control of the sidebar filter and tabs (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Keyboard control of the sidebar: focus the filter field (Cmd+Option+F), and switch between the Tables and Favorites sidebars (Ctrl+1 and Ctrl+2). From the filter field, Tab or the Down arrow moves into the list. All three are rebindable in Settings, Keyboard. (#1490)
 - Mark a table as a favorite by clicking the star button at the end of its sidebar row. Favorites are scoped to the connection, database, and schema, pinned to the top of their section, appear in a dedicated Tables group in the Favorites tab, and sync through iCloud when the Table Favorites toggle is on.
 - A plus button in the bottom bar of the Tables sidebar opens a menu to create a new table or view, without right-clicking. It's disabled while safe mode blocks writes.
 - The sidebar can show every database on the server as an expandable tree. Switch a connection between the flat list and the tree from the View menu (Sidebar Layout); right-click a database or schema to set it active. Set the default layout for new connections in Settings, General. Applies to MySQL, MariaDB, PostgreSQL, MSSQL, ClickHouse, Redshift; SQLite, Redis, MongoDB, BigQuery keep their existing sidebar. (#139)

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -495,6 +495,13 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         sidebarSplitItem?.isCollapsed ?? true
     }
 
+    func focusSidebarSearch() {
+        if sidebarSplitItem?.isCollapsed == true {
+            sidebarSplitItem?.animator().isCollapsed = false
+        }
+        sidebarContainer.focusSearchField()
+    }
+
     func setSidebarTab(_ tab: SidebarTab) {
         guard let connectionId = currentSession?.connection.id else { return }
         let sidebarState = SharedSidebarState.forConnection(connectionId)

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -38,12 +38,14 @@ internal final class SidebarContainerViewController: NSViewController {
         searchField.sendsSearchStringImmediately = true
         searchField.delegate = self
         searchField.setAccessibilityIdentifier("sidebar-filter")
+        searchField.setAccessibilityLabel(String(localized: "Filter"))
         view.addSubview(searchField)
 
         addChild(hostingController)
         let hostingView = hostingController.view
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hostingView)
+        searchField.nextKeyView = hostingView
 
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 5),
@@ -55,6 +57,11 @@ internal final class SidebarContainerViewController: NSViewController {
             hostingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    func focusSearchField() {
+        guard !searchField.isHidden else { return }
+        view.window?.makeFirstResponder(searchField)
     }
 
     func updateSidebarState(_ state: SharedSidebarState?, windowState: WindowSidebarState?) {
@@ -113,6 +120,7 @@ internal final class SidebarContainerViewController: NSViewController {
             searchField.stringValue = activeText
         }
         searchField.placeholderString = placeholder
+        searchField.setAccessibilityLabel(placeholder)
     }
 }
 
@@ -124,6 +132,12 @@ extension SidebarContainerViewController: NSSearchFieldDelegate {
 
     func searchFieldDidEndSearching(_ sender: NSSearchField) {
         writeSearchText("")
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        guard commandSelector == #selector(NSResponder.moveDown(_:)) else { return false }
+        view.window?.makeFirstResponder(hostingController.view)
+        return true
     }
 
     private func writeSearchText(_ text: String) {

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -88,6 +88,9 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case previousResultTab
     case nextResultTab
     case closeResultTab
+    case focusSidebarSearch
+    case showSidebarTables
+    case showSidebarFavorites
 
     // Tabs
     case showPreviousTab
@@ -112,7 +115,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .duplicateRow, .truncateTable, .previewFKReference:
             return .edit
         case .toggleTableBrowser, .toggleInspector, .toggleFilters, .toggleHistory,
-             .toggleResults, .previousResultTab, .nextResultTab, .closeResultTab:
+             .toggleResults, .previousResultTab, .nextResultTab, .closeResultTab,
+             .focusSidebarSearch, .showSidebarTables, .showSidebarFavorites:
             return .view
         case .showPreviousTab, .showNextTab:
             return .tabs
@@ -178,6 +182,9 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .previousResultTab: return String(localized: "Previous Result")
         case .nextResultTab: return String(localized: "Next Result")
         case .closeResultTab: return String(localized: "Close Result Tab")
+        case .focusSidebarSearch: return String(localized: "Focus Sidebar Filter")
+        case .showSidebarTables: return String(localized: "Show Tables Sidebar")
+        case .showSidebarFavorites: return String(localized: "Show Favorites Sidebar")
         case .showPreviousTab: return String(localized: "Show Previous Tab")
         case .showNextTab: return String(localized: "Show Next Tab")
         case .aiExplainQuery: return String(localized: "Explain with AI")
@@ -538,6 +545,9 @@ struct KeyboardSettings: Codable, Equatable {
         .previousResultTab: KeyCombo(key: "[", command: true, option: true),
         .nextResultTab: KeyCombo(key: "]", command: true, option: true),
         .closeResultTab: KeyCombo(key: "w", command: true, shift: true),
+        .focusSidebarSearch: KeyCombo(key: "f", command: true, option: true),
+        .showSidebarTables: KeyCombo(key: "1", control: true),
+        .showSidebarFavorites: KeyCombo(key: "2", control: true),
 
         // Tabs
         .showPreviousTab: KeyCombo(key: "[", command: true, shift: true),

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -572,6 +572,26 @@ struct AppMenuCommands: Commands {
 
             Divider()
 
+            Button("Focus Sidebar Filter") {
+                actions?.focusSidebarSearch()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .focusSidebarSearch))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button("Show Tables Sidebar") {
+                actions?.showSidebarTab(.tables)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .showSidebarTables))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button("Show Favorites Sidebar") {
+                actions?.showSidebarTab(.favorites)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .showSidebarFavorites))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Divider()
+
             Button("Toggle Results") {
                 actions?.toggleResults()
             }

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -783,6 +783,14 @@ final class MainContentCommandActions {
         coordinator?.inspectorProxy?.toggleInspector()
     }
 
+    func focusSidebarSearch() {
+        coordinator?.splitViewController?.focusSidebarSearch()
+    }
+
+    func showSidebarTab(_ tab: SidebarTab) {
+        coordinator?.splitViewController?.setSidebarTab(tab)
+    }
+
     func toggleResults() {
         guard let coordinator,
               let (_, tabIndex) = coordinator.tabManager.selectedTabAndIndex else { return }

--- a/TablePro/Views/Sidebar/DatabaseTreeView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeView.swift
@@ -182,6 +182,8 @@ struct DatabaseTreeView: View {
             Image(systemName: db.isSystemDatabase ? "gearshape" : "cylinder")
                 .foregroundStyle(db.isSystemDatabase ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tint))
         }
+        .accessibilityLabel(String(format: String(localized: "Database: %@"), db.name))
+        .accessibilityAddTraits(.isHeader)
         .contextMenu {
             Button(String(localized: "Use as Active Database")) {
                 setActiveDatabase(db.name)
@@ -204,6 +206,8 @@ struct DatabaseTreeView: View {
             Image(systemName: "folder")
                 .foregroundStyle(.tint)
         }
+        .accessibilityLabel(String(format: String(localized: "Schema: %@"), schema))
+        .accessibilityAddTraits(.isHeader)
         .contextMenu {
             Button(String(localized: "Use as Active Schema")) {
                 setActiveSchema(database: database, schema: schema)

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -200,6 +200,9 @@ Inherits the standard `NSDocument` shortcuts.
 | Action | Shortcut |
 |--------|----------|
 | Toggle sidebar | `Cmd+0` |
+| Focus sidebar filter | `Cmd+Option+F` |
+| Show Tables sidebar | `Control+1` |
+| Show Favorites sidebar | `Control+2` |
 | Toggle full screen | `Cmd+Control+F` |
 | Zoom in | `Cmd+=` |
 | Zoom out | `Cmd+-` |


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Sidebar surface.

## What this adds (keyboard-only)

- **Focus the sidebar filter** with a shortcut (default Cmd+Option+F). Expands the sidebar if collapsed, then focuses the search field.
- **From the filter field, move into the list**: Tab (via `nextKeyView`) or the **Down arrow** (handled in the search-field delegate) hands focus to the list. Arrow keys then navigate rows and Return opens, which already worked natively.
- **Switch sidebars by keyboard**: Show Tables (Control+1) and Show Favorites (Control+2), routed through the same `setSidebarTab` the toolbar buttons use.
- All three are real `ShortcutAction`s, so they appear under the View menu and are rebindable in Settings, Keyboard.

## Accessibility

- The sidebar search field now has a VoiceOver label ("Filter" / "Filter favorites", kept in sync with the active tab) instead of only an identifier string.
- Database and schema disclosure headers in the tree get `.accessibilityLabel` ("Database: X" / "Schema: Y") and the `.isHeader` trait.

## Native approach

No custom focus engine: the focus shortcut uses `window.makeFirstResponder(searchField)`, the Tab handoff uses the AppKit key view loop (`searchField.nextKeyView = hostingView`), and the Down-arrow handoff uses the standard `control(_:textView:doCommandBy:)` search-field delegate. Tab order and arrow navigation inside the list are the native `NSOutlineView` behavior that `List(.sidebar)` already provides.

## Files

- `KeyboardShortcutModels.swift`: 3 actions (`focusSidebarSearch`, `showSidebarTables`, `showSidebarFavorites`) with display names and default keys.
- `SidebarContainerViewController.swift`: `focusSearchField()`, `nextKeyView`, Down-arrow handoff, a11y label.
- `MainSplitViewController.swift`: `focusSidebarSearch()`.
- `MainContentCommandActions.swift`: `focusSidebarSearch()`, `showSidebarTab(_:)`.
- `TableProApp.swift`: View-menu items.
- `DatabaseTreeView.swift`: header a11y labels.
- CHANGELOG + keyboard-shortcuts doc.

## Verify (build needed)

- Cmd+Option+F focuses the sidebar filter from anywhere in the window (expands the sidebar if collapsed).
- With the filter focused, Tab or Down arrow moves into the list; arrows navigate; Return opens.
- Control+1 / Control+2 switch the Tables / Favorites sidebars.
- VoiceOver announces the filter field and the database/schema headers with real labels.

The one thing to confirm on a real build is the search -> list focus handoff (Tab and Down arrow), since it crosses the AppKit search field into the SwiftUI list inside the hosting view. If it does not land, the fix is local to `SidebarContainerViewController`.

Focus/responder behavior is not unit-testable here (consistent with the codebase); verification is manual.
