### PR TITLE
test(connections): cover the delete persist-before-notify sync invariant

### DIFF
--- a/TableProTests/Core/Storage/ConnectionStorageSyncDeleteTests.swift
+++ b/TableProTests/Core/Storage/ConnectionStorageSyncDeleteTests.swift
@@ -1,0 +1,58 @@
+//
+//  ConnectionStorageSyncDeleteTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("ConnectionStorage sync delete ordering")
+@MainActor
+struct ConnectionStorageSyncDeleteTests {
+    private let storage: ConnectionStorage
+    private let metadata: SyncMetadataStorage
+    private let storageDirectory: URL
+
+    init() {
+        let unique = UUID().uuidString
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tablepro-tests")
+            .appendingPathComponent("connections_\(unique).json")
+        storageDirectory = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: storageDirectory, withIntermediateDirectories: true)
+
+        let defaults = UserDefaults(suiteName: "com.TablePro.tests.ConnectionStorage.\(unique)")!
+        let syncDefaults = UserDefaults(suiteName: "com.TablePro.tests.Sync.\(unique)")!
+        metadata = SyncMetadataStorage(userDefaults: syncDefaults)
+        storage = ConnectionStorage(
+            fileURL: fileURL,
+            userDefaults: defaults,
+            syncTracker: SyncChangeTracker(metadataStorage: metadata)
+        )
+    }
+
+    @Test("Deleting a connection records a sync tombstone after it is persisted")
+    func deleteRecordsTombstoneAfterPersisting() {
+        let connection = TestFixtures.makeConnection()
+        storage.addConnection(connection)
+        #expect(metadata.tombstones(for: .connection).isEmpty)
+
+        storage.deleteConnection(connection)
+
+        #expect(metadata.tombstones(for: .connection).contains { $0.id == connection.id.uuidString })
+    }
+
+    @Test("A delete that fails to persist records no tombstone (persist before notify)")
+    func failedPersistenceRecordsNoTombstone() {
+        let connection = TestFixtures.makeConnection()
+        storage.addConnection(connection)
+        try? FileManager.default.removeItem(at: storageDirectory)
+
+        storage.deleteConnection(connection)
+
+        #expect(metadata.tombstones(for: .connection).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 8 / R-008: make the documented sync invariant executable. CLAUDE.md records that `SyncChangeTracker.markDeleted()` must run **after** `saveConnections()` — persist before notify, or a sync can re-upload a just-deleted record. `ConnectionStorage.deleteConnection` implements this (persist behind a `guard`, then `markDeleted` for non-local/non-sample connections), but it had no test.

Adds two regression tests against a real `ConnectionStorage` wired to a test-backed `SyncChangeTracker`/`SyncMetadataStorage` and a temp file:
- Deleting a connection records a sync tombstone after it is persisted.
- A delete that fails to persist (storage directory removed to force the `saveConnections` write to fail) records **no** tombstone — pinning the persist-before-notify guard.

## Risk Addressed

- R-008: sync invariants were documented but not enforced by tests; a regression in the delete ordering could silently re-upload deleted records across devices.

## Verification

- [x] `xcodebuild test -only-testing:TableProTests/ConnectionStorageSyncDeleteTests` — both tests pass.
- [x] Test target builds.

## Notes

- Test-only change; no production code touched. No CHANGELOG / ABI / docs.
- `UserDefaults(suiteName:)!` matches the existing storage-test convention (force_unwrapping is warning-level).
- Scope note: the broader R-008 sync *consolidation* (shared record/conflict types in TableProSync, desktop adopting them) is blocked behind the same PluginKit single-module work as the desktop `DatabaseType` adoption, and is tracked separately.