### PR TITLE
fix(editor): stop the query editor stealing focus on tab open; add VoiceOver labels (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Opening a query tab no longer pulls keyboard focus away from the sidebar or another control; the editor takes focus only when nothing else holds it. VoiceOver now labels the SQL editor and the Clear and Format buttons. (#1490)
 - Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -100,6 +100,7 @@ struct QueryEditorView: View {
             }
             .buttonStyle(.borderless)
             .help(String(localized: "Clear Query"))
+            .accessibilityLabel(String(localized: "Clear Query"))
 
             // Format button
             Button(action: formatQuery) {
@@ -108,6 +109,7 @@ struct QueryEditorView: View {
             }
             .buttonStyle(.borderless)
             .help(String(localized: "Format Query (⇧⌘L)"))
+            .accessibilityLabel(String(localized: "Format Query"))
             .optionalKeyboardShortcut(AppSettingsManager.shared.keyboard.keyboardShortcut(for: .formatQuery))
 
             Divider()

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -110,7 +110,8 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
                 // Auto-focus: make the editor first responder, then ensure a
                 // cursor exists. Order matters — setCursorPositions calls
                 // updateSelectionViews which guards on isFirstResponder.
-                if !self.isDestroyed, let window = textView.window {
+                if !self.isDestroyed, let window = textView.window,
+                   window.firstResponder == nil || window.firstResponder === window {
                     window.makeFirstResponder(textView)
                 }
                 if controller.cursorPositions.isEmpty {

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -63,6 +63,7 @@ struct SQLEditorView: View {
                 coordinators: [coordinator],
                 completionDelegate: completionAdapter
             )
+            .accessibilityLabel(String(localized: "SQL query editor"))
             .onChange(of: editorState.cursorPositions) { _, newValue in
                 guard let positions = newValue else { return }
                 // Skip cursor propagation when the editor doesn't have focus


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Query editor surface.

## Focus
- The editor's deferred auto-focus on tab open now only fires when the window has no other first responder (`firstResponder == nil` or the window itself), so opening a query tab while the sidebar or another control is focused no longer yanks focus into the editor. Builds on the `isDestroyed` guard from #1497.

## VoiceOver
- The `SourceEditor` gets `.accessibilityLabel("SQL query editor")`.
- The icon-only Clear and Format toolbar buttons get accessibility labels (Execute and Explain already carry text labels).

Native APIs only. Several other gaps from the audit are already merged (filter-apply focus return in #1492) or are larger follow-ups (Tab-to-exit the editor via the key view loop, the first-responder polling refactor, the split key-view-loop wiring).

Lint clean, style gate clean. Focus/VoiceOver verified manually.