### PR TITLE
fix(tabs): announce the active tab to VoiceOver on tab switch (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- VoiceOver announces the active tab title when you switch between window tabs. (#1490)
 - Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -30,6 +30,7 @@ extension MainContentCoordinator {
         evictionTask = nil
 
         syncSidebarToSelectedTab()
+        announceActiveTabToVoiceOver()
 
         Self.lifecycleLogger.debug(
             "[switch] coordinator.handleWindowDidBecomeKey done connId=\(self.connectionId, privacy: .public) totalMs=\(Int(Date().timeIntervalSince(t0) * 1_000))"
@@ -79,6 +80,20 @@ extension MainContentCoordinator {
 
         Self.lifecycleLogger.info(
             "[close] coordinator.handleWindowWillClose done connId=\(self.connectionId, privacy: .public) elapsedMs=\(Int(Date().timeIntervalSince(t0) * 1_000))"
+        )
+    }
+
+    /// Announce the active tab title to VoiceOver when the window becomes key,
+    /// so assistive-technology users get the same context the window title gives.
+    private func announceActiveTabToVoiceOver() {
+        guard let title = tabManager.selectedTab?.title, !title.isEmpty else { return }
+        NSAccessibility.post(
+            element: NSApp as Any,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: title,
+                .priority: NSAccessibilityPriorityLevel.medium.rawValue,
+            ]
         )
     }
 


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Tabs & windows surface.

Most of this surface's critical gaps (filter Apply focus return, Apply `.defaultAction`, filter button labels) already landed in #1492. The remaining clean win is the VoiceOver gap:

- On `windowDidBecomeKey` (a native window-tab switch), post an `.announcementRequested` accessibility notification with the active tab's title, so VoiceOver users get the same context the window title gives sighted users. Posted unconditionally (the system delivers it only to running assistive tech).

Native `NSAccessibility.post`, no behavior change for non-VoiceOver users.

Deferred (uncertain / larger): explicit first-responder restore on tab switch (AppKit's `NSWindow` already restores its first responder), and `recalculateKeyViewLoop` wiring, which belongs with the Tab-between-panes work.

Lint clean, style gate clean.