### PR TITLE
fix(datagrid): label cell-inspector field editors for VoiceOver (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- VoiceOver now reads the column name and current value for each field editor in the cell inspector. (#1490)
 - Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)

--- a/TablePro/Views/RightSidebar/EditableFieldView.swift
+++ b/TablePro/Views/RightSidebar/EditableFieldView.swift
@@ -120,8 +120,14 @@ internal struct FieldDetailView: View {
 
     // MARK: - Editor Dispatch
 
-    @ViewBuilder
     private func resolvedEditor(for kind: FieldEditorKind) -> some View {
+        editorContent(for: kind)
+            .accessibilityLabel(context.columnName)
+            .accessibilityValue(context.value.wrappedValue)
+    }
+
+    @ViewBuilder
+    private func editorContent(for kind: FieldEditorKind) -> some View {
         switch kind {
         case .json:
             JsonEditorView(context: context, onExpand: onExpand, onPopOut: onPopOut)


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Inspector / cell-editor surface.

The cell-inspector field editors (single-line, multi-line, blob/hex, JSON, boolean/enum/set pickers) had no accessibility label on the editor control, so VoiceOver announced a bare text field with no context. This adds the column name and current value at the shared editor dispatch (`EditableFieldView.resolvedEditor`), so every editor inherits `.accessibilityLabel(columnName)` and `.accessibilityValue(value)`. Zero visual change.

Several gaps from the audit are already merged (filter Apply focus return and `.defaultAction` in #1492). Deferred because they are UX/visual decisions or larger refactors:
- The Set NULL / Set DEFAULT / SQL-functions menu is hover-gated (mouse-only); making it keyboard-reachable means showing it always or on focus, a visible UX change worth deciding deliberately.
- Lifting the per-editor `@FocusState` to the parent for Tab order + commit/cancel shortcuts.
- The `CellOverlayEditor` focus-ring treatment.

Lint clean, style gate clean.