### PR TITLE
fix(hig): give Copy with Headers a default keyboard shortcut (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Copy with Headers now has a default keyboard shortcut (Cmd+Option+C), so it works and is discoverable from the keyboard instead of showing in the Edit menu with no key. (#1490)
 - Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -525,6 +525,7 @@ struct KeyboardSettings: Codable, Equatable {
         .cut: KeyCombo(key: "x", command: true),
         .copy: KeyCombo(key: "c", command: true),
         .copyRowsExplicit: KeyCombo(key: "c", command: true, shift: true),
+        .copyWithHeaders: KeyCombo(key: "c", command: true, option: true),
         .copyAsJson: KeyCombo(key: "j", command: true, option: true),
         .paste: KeyCombo(key: "v", command: true),
         .delete: KeyCombo(key: "delete", command: true, isSpecialKey: true),

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -153,7 +153,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Copy (cell value if a cell is focused on a single row, otherwise row(s) TSV) | `Cmd+C` |
 | Copy Rows as TSV | `Cmd+Shift+C` |
 | Copy as JSON | `Cmd+Option+J` |
-| Copy with Headers | Available from Edit menu and context menu |
+| Copy with Headers | `Cmd+Option+C` |
 
 ## CSV Inspector
 


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Menus & shortcuts surface.

`ShortcutAction.copyWithHeaders` exists and the Edit-menu item binds `shortcut(for: .copyWithHeaders)`, but `defaultShortcuts` had no entry, so the menu item showed with no key and the action was keyboard-unreachable by default. This adds `Cmd+Option+C` (verified free; the other `c` combos are Cmd+C, Cmd+Shift+C, Cmd+Ctrl+C). Rebindable in Settings, Keyboard. Docs updated.

The filter focus-return menu gaps from the audit are already merged (#1492). Deferred because they are UX-policy decisions rather than clear fixes:
- 'Find...' is disabled (not hidden/retitled) on table tabs where Cmd+F routes to Toggle Filters.
- Cmd+D is 'Save as Favorite', which collides with the NSAlert 'Don't Save' accelerator.
- New Table / ER Diagram / Server Dashboard and pagination have no menu-bar shortcuts (need new actions + key choices).

Lint clean, style gate clean.