### PR TITLE
fix(hig): rebuild the key view loop so Tab crosses window panes (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tab moves keyboard focus between the window panes (sidebar, results, inspector) by rebuilding the key view loop when the window appears. (#1490)
 - Escape now dismisses search-based sheets and popovers (database switcher, quick switcher, column and connection pickers). Pressing Escape clears the search text first; a second Escape closes the sheet. (#1490)
 - Running `EXPLAIN` or `EXPLAIN ANALYZE` typed in the editor now opens the plan viewer instead of squashing the plan into one truncated grid cell. (#1480)
 - Filtering the data grid keeps you on the keyboard. Applying or clearing a filter returns focus to the grid so you can keep moving through cells, Return applies the filter, and Escape closes the filter panel and returns to the grid. (#1490)

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -215,6 +215,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
         installObservers()
         recomputeWindowMinSize()
+        window.recalculateKeyViewLoop()
     }
 
     override func viewDidDisappear() {


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). The cross-pane Tab item.

`MainSplitViewController` never called `recalculateKeyViewLoop()`, so the AppKit key view loop had no defined traversal across the three `NSSplitViewItem` panes (sidebar, detail, inspector). This calls `window.recalculateKeyViewLoop()` at the end of `viewWillAppear`, the documented mechanism for letting AppKit rebuild the geometric Tab order (leading sidebar to trailing detail to inspector). Both the sidebar `List` and the data-grid `NSTableView` are key-view-loop participants, so Tab should now move focus between panes.

This is the one item the HIG research flagged as not explicitly documented for an `NSViewRepresentable`/`NSHostingController` boundary, so **it needs a real build to confirm Tab actually crosses from the SwiftUI sidebar into the representable grid**. The call is harmless if a given pane does not participate (it just orders the views that do), and there is no custom focus handling.

Lint clean, style gate clean.