### PR TITLE
fix(datagrid): announce grid selection to all assistive tech; label dialog controls (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- VoiceOver reliability: grid selection changes are announced to all assistive technologies (not only when VoiceOver was already on), the drop and truncate dialog toggles describe their effect, and the favorite query editor is labeled. (#1490)
 - Tab moves keyboard focus between the window panes (sidebar, results, inspector) by rebuilding the key view loop when the window appears. (#1490)
 - The license activation sheet focuses the key field on open, the SQL review sheet closes with Escape even while the editor has focus, and the integration token sheet focuses its Done button. (#1490)
 - Copy with Headers now has a default keyboard shortcut (Cmd+Option+C), so it works and is discoverable from the keyboard instead of showing in the Edit menu with no key. (#1490)

--- a/TablePro/Views/Results/Selection/GridSelectionController.swift
+++ b/TablePro/Views/Results/Selection/GridSelectionController.swift
@@ -39,7 +39,7 @@ final class GridSelectionController {
     }
 
     private func postAccessibilityAnnouncement(for newSelection: GridSelection) {
-        guard NSWorkspace.shared.isVoiceOverEnabled, let tableView else { return }
+        guard let tableView else { return }
         let announcement: String
         if newSelection.isEmpty {
             announcement = String(localized: "Cell selection cleared")

--- a/TablePro/Views/Sidebar/FavoriteEditDialog.swift
+++ b/TablePro/Views/Sidebar/FavoriteEditDialog.swift
@@ -81,6 +81,7 @@ internal struct FavoriteEditDialog: View {
                 LabeledContent("Query") {
                     TextEditor(text: $query)
                         .font(.system(.body, design: .monospaced))
+                        .accessibilityLabel(String(localized: "Query"))
                         .frame(height: 160)
                         .scrollContentBackground(.hidden)
                         .padding(4)

--- a/TablePro/Views/Sidebar/TableOperationDialog.swift
+++ b/TablePro/Views/Sidebar/TableOperationDialog.swift
@@ -112,6 +112,7 @@ struct TableOperationDialog: View {
                     }
                     .toggleStyle(.checkbox)
                     .disabled(ignoreFKDisabled)
+                    .accessibilityHint(String(localized: "Skips foreign key constraint checks for this operation"))
 
                     if let description = ignoreFKDescription {
                         Text(description)
@@ -130,6 +131,7 @@ struct TableOperationDialog: View {
                     }
                     .toggleStyle(.checkbox)
                     .disabled(cascadeDisabled)
+                    .accessibilityHint(cascadeDescription)
 
                     Text(cascadeDescription)
                         .font(.subheadline)


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). VoiceOver polish.

- **Grid selection announcement**: dropped the `NSWorkspace.shared.isVoiceOverEnabled` guard in `GridSelectionController.postAccessibilityAnnouncement`. `NSAccessibility.post` is only delivered to running assistive technologies anyway, so the guard added nothing and excluded non-VoiceOver AT (Switch Control, etc.) and the case where VoiceOver is enabled mid-session.
- **TableOperationDialog**: `.accessibilityHint` on the 'Ignore foreign key checks' and 'Cascade' toggles describing the consequence.
- **FavoriteEditDialog**: `.accessibilityLabel("Query")` on the query `TextEditor` (it had no adjacent field label for VoiceOver).

Additive, no behavior change for sighted users. Lint clean, style gate clean.