### PR TITLE
feat(coordinator): add result pagination to the Query menu for keyboard access (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Previous Page, Next Page, First Page, and Last Page are now in the Query menu, so the result pager is discoverable and keyboard-reachable from the menu bar (Previous and Next keep their Cmd+[ and Cmd+] shortcuts). (#1490)
 - Keyboard control of the sidebar: focus the filter field (Cmd+Option+F), and switch between the Tables and Favorites sidebars (Ctrl+1 and Ctrl+2). From the filter field, Tab or the Down arrow moves into the list. All three are rebindable in Settings, Keyboard. (#1490)
 - Mark a table as a favorite by clicking the star button at the end of its sidebar row. Favorites are scoped to the connection, database, and schema, pinned to the top of their section, appear in a dedicated Tables group in the Favorites tab, and sync through iCloud when the Table Favorites toggle is on.
 - A plus button in the bottom bar of the Tables sidebar opens a menu to create a new table or view, without right-clicking. It's disabled while safe mode blocks writes.

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -427,6 +427,32 @@ struct AppMenuCommands: Commands {
 
             Divider()
 
+            Button(String(localized: "Previous Page")) {
+                actions?.goToPreviousPage()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .previousPage))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button(String(localized: "Next Page")) {
+                actions?.goToNextPage()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .nextPage))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button(String(localized: "First Page")) {
+                actions?.goToFirstPage()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .firstPage))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button(String(localized: "Last Page")) {
+                actions?.goToLastPage()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .lastPage))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Divider()
+
             Button(String(localized: "Save as Favorite")) {
                 actions?.saveAsFavorite()
             }

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -783,6 +783,22 @@ final class MainContentCommandActions {
         coordinator?.inspectorProxy?.toggleInspector()
     }
 
+    func goToPreviousPage() {
+        coordinator?.goToPreviousPage()
+    }
+
+    func goToNextPage() {
+        coordinator?.goToNextPage()
+    }
+
+    func goToFirstPage() {
+        coordinator?.goToFirstPage()
+    }
+
+    func goToLastPage() {
+        coordinator?.goToLastPage()
+    }
+
     func focusSidebarSearch() {
         coordinator?.splitViewController?.focusSidebarSearch()
     }


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Menus & shortcuts surface.

The pagination shortcuts (Cmd+[ / Cmd+]) were bound only on the results-bar toolbar buttons, so they were not discoverable from the menu bar and First/Last Page had no menu home at all. This adds Previous / Next / First / Last Page to the Query menu, wired to the existing `MainContentCoordinator` paging methods through four thin `MainContentCommandActions` wrappers, with the existing `.optionalKeyboardShortcut` bindings. No new shortcut keys invented; First/Last stay unbound by default and are rebindable in Settings, Keyboard.

Makes the pager keyboard-discoverable and reachable from the menu bar. Lint clean, style gate clean.