### PR TITLE
fix(datagrid): put inspector field actions in a context menu for keyboard and VoiceOver (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The cell inspector's Set NULL, Set DEFAULT, copy, and SQL-function actions are now in a right-click context menu on each field, so they're reachable by keyboard, Full Keyboard Access, and VoiceOver, not only on hover. (#1490)
 - Tab moves keyboard focus between the window panes (sidebar, results, inspector) by rebuilding the key view loop when the window appears. (#1490)
 - The license activation sheet focuses the key field on open, the SQL review sheet closes with Escape even while the editor has focus, and the integration token sheet focuses its Done button. (#1490)
 - Copy with Headers now has a default keyboard shortcut (Cmd+Option+C), so it works and is discoverable from the keyboard instead of showing in the Edit menu with no key. (#1490)

--- a/TablePro/Views/RightSidebar/EditableFieldView.swift
+++ b/TablePro/Views/RightSidebar/EditableFieldView.swift
@@ -73,6 +73,22 @@ internal struct FieldDetailView: View {
         }
         .labelsHidden()
         .onHover { isHovered = $0 }
+        .contextMenu {
+            if !context.isReadOnly {
+                FieldMenuContent(
+                    value: context.value.wrappedValue,
+                    columnType: context.columnType,
+                    sqlFunctions: SQLFunctionProvider.functions(for: databaseType),
+                    isPendingNull: isPendingNull,
+                    isPendingDefault: isPendingDefault,
+                    onSetNull: onSetNull,
+                    onSetDefault: onSetDefault,
+                    onSetEmpty: onSetEmpty,
+                    onSetFunction: onSetFunction,
+                    onClear: { context.value.wrappedValue = context.originalValue ?? "" }
+                )
+            }
+        }
     }
 
     // MARK: - Header

--- a/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
@@ -5,6 +5,62 @@
 
 import SwiftUI
 
+/// The field actions (Set NULL/DEFAULT/EMPTY, copy, SQL functions). Shared by the
+/// hover menu button and the field's context menu so both stay in sync.
+internal struct FieldMenuContent: View {
+    let value: String
+    let columnType: ColumnType
+    let sqlFunctions: [SQLFunctionProvider.SQLFunction]
+    let isPendingNull: Bool
+    let isPendingDefault: Bool
+    let onSetNull: () -> Void
+    let onSetDefault: () -> Void
+    let onSetEmpty: () -> Void
+    let onSetFunction: (String) -> Void
+    let onClear: () -> Void
+
+    var body: some View {
+        Button("Set NULL") { onSetNull() }
+        Button("Set DEFAULT") { onSetDefault() }
+        Button("Set EMPTY") { onSetEmpty() }
+
+        Divider()
+
+        if columnType.isJsonType {
+            Button("Pretty Print") {
+                if let formatted = value.prettyPrintedAsJson() {
+                    ClipboardService.shared.writeText(formatted)
+                }
+            }
+        }
+
+        if BlobFormattingService.shared.requiresFormatting(columnType: columnType) {
+            Button("Copy as Hex") {
+                if let hex = BlobFormattingService.shared.format(value, for: .detail) {
+                    ClipboardService.shared.writeText(hex)
+                }
+            }
+        }
+
+        Button("Copy Value") {
+            ClipboardService.shared.writeText(value)
+        }
+
+        Divider()
+
+        Menu("SQL Functions") {
+            ForEach(sqlFunctions, id: \.expression) { function in
+                Button(function.label) { onSetFunction(function.expression) }
+            }
+        }
+
+        if isPendingNull || isPendingDefault {
+            Divider()
+            Button("Clear") { onClear() }
+        }
+    }
+}
+
 internal struct FieldMenuView: View {
     let value: String
     let columnType: ColumnType
@@ -19,44 +75,18 @@ internal struct FieldMenuView: View {
 
     var body: some View {
         Menu {
-            Button("Set NULL") { onSetNull() }
-            Button("Set DEFAULT") { onSetDefault() }
-            Button("Set EMPTY") { onSetEmpty() }
-
-            Divider()
-
-            if columnType.isJsonType {
-                Button("Pretty Print") {
-                    if let formatted = value.prettyPrintedAsJson() {
-                        ClipboardService.shared.writeText(formatted)
-                    }
-                }
-            }
-
-            if BlobFormattingService.shared.requiresFormatting(columnType: columnType) {
-                Button("Copy as Hex") {
-                    if let hex = BlobFormattingService.shared.format(value, for: .detail) {
-                        ClipboardService.shared.writeText(hex)
-                    }
-                }
-            }
-
-            Button("Copy Value") {
-                ClipboardService.shared.writeText(value)
-            }
-
-            Divider()
-
-            Menu("SQL Functions") {
-                ForEach(sqlFunctions, id: \.expression) { function in
-                    Button(function.label) { onSetFunction(function.expression) }
-                }
-            }
-
-            if isPendingNull || isPendingDefault {
-                Divider()
-                Button("Clear") { onClear() }
-            }
+            FieldMenuContent(
+                value: value,
+                columnType: columnType,
+                sqlFunctions: sqlFunctions,
+                isPendingNull: isPendingNull,
+                isPendingDefault: isPendingDefault,
+                onSetNull: onSetNull,
+                onSetDefault: onSetDefault,
+                onSetEmpty: onSetEmpty,
+                onSetFunction: onSetFunction,
+                onClear: onClear
+            )
         } label: {
             Image(systemName: "chevron.down")
                 .font(.caption)


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Inspector surface.

The Set NULL / Set DEFAULT / Set EMPTY / copy / SQL-function actions were only reachable through a button that appears on hover, so they were mouse-only. Per HIG, contextual actions belong in a **context menu**, which is reachable by right-click, the VoiceOver actions rotor, and Full Keyboard Access. This extracts the action list into a shared `FieldMenuContent` view used by both the existing hover button and a new `.contextMenu` on each editable field, so the two stay in sync and the resting visual is unchanged.

Native SwiftUI `.contextMenu`, single source of truth for the actions. Lint clean, style gate clean.