### PR TITLE
fix(hig): move Save as Favorite off Cmd+D to free the system Don't Save accelerator (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Save as Favorite moved from Cmd+D to Cmd+Control+D, so Cmd+D stays free for the system "Don't Save" action in save-changes dialogs. Rebindable in Settings, Keyboard. (#1490)
 - The Tables sidebar bottom bar uses native macOS styling. The schema switcher is a borderless pull-down menu on the sidebar's own background instead of a wide gray bordered control, matching the Favorites footer, and switching schemas now goes through the same path as the toolbar so filters and the active tab stay in sync.
 - The Maintenance submenu in the sidebar context menu is hidden when no maintenance operations are available or the target is read-only, instead of showing an empty disabled menu.
 - The window minimum width now adjusts to the visible panes, so opening the inspector on a small window no longer pushes content off-screen.

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -535,7 +535,7 @@ struct KeyboardSettings: Codable, Equatable {
         .duplicateRow: KeyCombo(key: "d", command: true, shift: true),
         .truncateTable: KeyCombo(key: "delete", option: true, isSpecialKey: true),
         .previewFKReference: KeyCombo(key: "space", isSpecialKey: true),
-        .saveAsFavorite: KeyCombo(key: "d", command: true),
+        .saveAsFavorite: KeyCombo(key: "d", command: true, control: true),
 
         // View
         .toggleTableBrowser: KeyCombo(key: "0", command: true),


### PR DESCRIPTION
Part of #1490 (keyboard, focus, accessibility). Menus & shortcuts.

macOS reserves Cmd+D for the 'Don't Save' button in save-changes dialogs (NSAlert maps it automatically). Save as Favorite was bound to Cmd+D, which shadows that system accelerator in the exact moment a user tries to dismiss a save dialog. This moves the default to **Cmd+Control+D** (Cmd+Option+D is the system Toggle Dock and Cmd+Shift+D is Duplicate Row, both taken). Rebindable in Settings, Keyboard.

Lint clean, style gate clean.