### PR TITLE
fix(plugin-cassandra): apply client certificate and key passphrase to SSL connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a table (Return or double-click in the sidebar) moves keyboard focus into the data grid so you can navigate cells with the arrow keys. Arrowing the sidebar still previews tables without taking focus. (#1490)
 - Moving a connection into or out of a group now syncs across devices, instead of leaving it ungrouped on your other Macs.
 - Opening a table on a connection with many tables no longer stalls for several seconds while autocomplete and table metadata load. Background schema introspection now runs on separate connections instead of waiting behind, or blocking, the query that fills the grid. (#1483)
+- Cassandra SSL connections that use a client certificate now have a Key Passphrase field for an encrypted private key, and report a clear "key is encrypted" or "passphrase is incorrect" message instead of a generic handshake failure. The passphrase is stored in the Keychain. (#1487)
 
 ## [0.46.0] - 2026-05-28
 

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -137,7 +137,10 @@ private actor CassandraConnectionActor {
         password: String?,
         keyspace: String?,
         sslMode: SSLMode,
-        sslCaCertPath: String?
+        sslCaCertPath: String?,
+        sslClientCertPath: String?,
+        sslClientKeyPath: String?,
+        sslClientKeyPassphrase: String?
     ) throws {
         cluster = cass_cluster_new()
         guard let cluster else {
@@ -180,6 +183,21 @@ private actor CassandraConnectionActor {
                     cass_cluster_free(cluster)
                     self.cluster = nil
                     throw SSLHandshakeError.untrustedCertificate(serverMessage: "CA certificate at \(caCertPath) is not a valid PEM")
+                }
+            }
+
+            let trimmedClientCertPath = sslClientCertPath?.trimmingCharacters(in: .whitespaces) ?? ""
+            let trimmedClientKeyPath = sslClientKeyPath?.trimmingCharacters(in: .whitespaces) ?? ""
+            if !trimmedClientCertPath.isEmpty || !trimmedClientKeyPath.isEmpty {
+                try applyClientCertificate(
+                    to: ssl,
+                    certPath: trimmedClientCertPath,
+                    keyPath: trimmedClientKeyPath,
+                    keyPassphrase: sslClientKeyPassphrase
+                ) {
+                    cass_ssl_free(ssl)
+                    cass_cluster_free(cluster)
+                    self.cluster = nil
                 }
             }
 
@@ -233,6 +251,49 @@ private actor CassandraConnectionActor {
         session = newSession
 
         Self.logger.info("Connected to Cassandra at \(host):\(port)")
+    }
+
+    private func applyClientCertificate(
+        to ssl: OpaquePointer,
+        certPath: String,
+        keyPath: String,
+        keyPassphrase: String?,
+        cleanup: () -> Void
+    ) throws {
+        guard !certPath.isEmpty else {
+            cleanup()
+            throw SSLHandshakeError.clientCertRequired(serverMessage: "A client certificate is required when a client key is set")
+        }
+        guard !keyPath.isEmpty else {
+            cleanup()
+            throw SSLHandshakeError.clientCertRequired(serverMessage: "A client key is required when a client certificate is set")
+        }
+
+        guard let certData = FileManager.default.contents(atPath: certPath),
+              let certString = String(data: certData, encoding: .utf8) else {
+            cleanup()
+            throw SSLHandshakeError.clientCertRequired(serverMessage: "Could not read client certificate at \(certPath)")
+        }
+        let certResult = cass_ssl_set_cert(ssl, certString)
+        if certResult != CASS_OK {
+            cleanup()
+            throw SSLHandshakeError.clientCertRequired(serverMessage: "Client certificate at \(certPath) is not a valid PEM")
+        }
+
+        guard let keyData = FileManager.default.contents(atPath: keyPath),
+              let keyString = String(data: keyData, encoding: .utf8) else {
+            cleanup()
+            throw SSLHandshakeError.clientCertRequired(serverMessage: "Could not read client key at \(keyPath)")
+        }
+        let passphrase = keyPassphrase?.isEmpty == false ? keyPassphrase : nil
+        let keyResult = cass_ssl_set_private_key(ssl, keyString, passphrase)
+        if keyResult != CASS_OK {
+            cleanup()
+            if passphrase == nil {
+                throw SSLHandshakeError.clientKeyPassphraseRequired(serverMessage: "The client key at \(keyPath) is encrypted. Enter its passphrase.")
+            }
+            throw SSLHandshakeError.clientKeyPassphraseIncorrect(serverMessage: "The passphrase for the client key at \(keyPath) is incorrect.")
+        }
     }
 
     func close() {
@@ -921,6 +982,9 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
         let keyspace = config.database.isEmpty ? nil : config.database
         let legacyCaPath = config.additionalFields["sslCaCertPath"]
         let resolvedCaPath = config.ssl.caCertificatePath.isEmpty ? legacyCaPath : config.ssl.caCertificatePath
+        let clientCertPath = config.ssl.clientCertificatePath.isEmpty ? nil : config.ssl.clientCertificatePath
+        let clientKeyPath = config.ssl.clientKeyPath.isEmpty ? nil : config.ssl.clientKeyPath
+        let clientKeyPassphrase = config.additionalFields["sslClientKeyPassphrase"]
 
         try await connectionActor.connect(
             host: config.host,
@@ -929,7 +993,10 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
             password: config.password.isEmpty ? nil : config.password,
             keyspace: keyspace,
             sslMode: config.ssl.mode,
-            sslCaCertPath: resolvedCaPath
+            sslCaCertPath: resolvedCaPath,
+            sslClientCertPath: clientCertPath,
+            sslClientKeyPath: clientKeyPath,
+            sslClientKeyPassphrase: clientKeyPassphrase
         )
 
         if let keyspace {

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -283,17 +283,28 @@ private actor CassandraConnectionActor {
         guard let keyData = FileManager.default.contents(atPath: keyPath),
               let keyString = String(data: keyData, encoding: .utf8) else {
             cleanup()
-            throw SSLHandshakeError.clientCertRequired(serverMessage: "Could not read client key at \(keyPath)")
+            throw SSLHandshakeError.clientKeyInvalid(serverMessage: "Could not read client key at \(keyPath)")
         }
         let passphrase = keyPassphrase?.isEmpty == false ? keyPassphrase : nil
         let keyResult = cass_ssl_set_private_key(ssl, keyString, passphrase)
         if keyResult != CASS_OK {
             cleanup()
-            if passphrase == nil {
-                throw SSLHandshakeError.clientKeyPassphraseRequired(serverMessage: "The client key at \(keyPath) is encrypted. Enter its passphrase.")
-            }
-            throw SSLHandshakeError.clientKeyPassphraseIncorrect(serverMessage: "The passphrase for the client key at \(keyPath) is incorrect.")
+            throw Self.privateKeyLoadError(keyPEM: keyString, hasPassphrase: passphrase != nil, keyPath: keyPath)
         }
+    }
+
+    static func isEncryptedPrivateKey(_ pem: String) -> Bool {
+        pem.contains("ENCRYPTED PRIVATE KEY") || (pem.contains("Proc-Type:") && pem.contains("ENCRYPTED"))
+    }
+
+    static func privateKeyLoadError(keyPEM: String, hasPassphrase: Bool, keyPath: String) -> SSLHandshakeError {
+        guard isEncryptedPrivateKey(keyPEM) else {
+            return .clientKeyInvalid(serverMessage: "The client key at \(keyPath) is not a valid private key")
+        }
+        if hasPassphrase {
+            return .clientKeyPassphraseIncorrect(serverMessage: "The passphrase for the client key at \(keyPath) is incorrect")
+        }
+        return .clientKeyPassphraseRequired(serverMessage: "The client key at \(keyPath) is encrypted. Enter its passphrase.")
     }
 
     func close() {

--- a/Plugins/TableProPluginKit/SSLHandshakeError.swift
+++ b/Plugins/TableProPluginKit/SSLHandshakeError.swift
@@ -10,6 +10,7 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
     case unknown(serverMessage: String)
     case clientKeyPassphraseRequired(serverMessage: String)
     case clientKeyPassphraseIncorrect(serverMessage: String)
+    case clientKeyInvalid(serverMessage: String)
 
     public var serverMessage: String {
         switch self {
@@ -20,6 +21,7 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
              .clientCertRequired(let msg),
              .clientKeyPassphraseRequired(let msg),
              .clientKeyPassphraseIncorrect(let msg),
+             .clientKeyInvalid(let msg),
              .cipherMismatch(let msg),
              .unknown(let msg):
             return msg
@@ -42,6 +44,8 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "The client private key is encrypted and needs a passphrase.")
         case .clientKeyPassphraseIncorrect:
             return String(localized: "The passphrase for the client private key is incorrect.")
+        case .clientKeyInvalid:
+            return String(localized: "The client private key could not be read. It may be malformed or in an unsupported format.")
         case .cipherMismatch:
             return String(localized: "The server and TablePro could not agree on a TLS cipher or protocol version.")
         case .unknown:
@@ -98,6 +102,8 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "Open the connection editor, switch to the SSL tab, and enter the Key Passphrase.")
         case .clientKeyPassphraseIncorrect:
             return String(localized: "Open the connection editor, switch to the SSL tab, and correct the Key Passphrase.")
+        case .clientKeyInvalid:
+            return String(localized: "Check that the Client Key path points to a valid PEM private key.")
         case .cipherMismatch:
             return String(localized: "Update the server's TLS configuration or use a newer database server version that supports modern ciphers.")
         case .unknown:

--- a/Plugins/TableProPluginKit/SSLHandshakeError.swift
+++ b/Plugins/TableProPluginKit/SSLHandshakeError.swift
@@ -8,6 +8,8 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
     case clientCertRequired(serverMessage: String)
     case cipherMismatch(serverMessage: String)
     case unknown(serverMessage: String)
+    case clientKeyPassphraseRequired(serverMessage: String)
+    case clientKeyPassphraseIncorrect(serverMessage: String)
 
     public var serverMessage: String {
         switch self {
@@ -16,6 +18,8 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
              .untrustedCertificate(let msg),
              .hostnameMismatch(let msg),
              .clientCertRequired(let msg),
+             .clientKeyPassphraseRequired(let msg),
+             .clientKeyPassphraseIncorrect(let msg),
              .cipherMismatch(let msg),
              .unknown(let msg):
             return msg
@@ -34,6 +38,10 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "The server's TLS certificate does not match the hostname being connected to.")
         case .clientCertRequired:
             return String(localized: "The server requires a client certificate for TLS mutual authentication.")
+        case .clientKeyPassphraseRequired:
+            return String(localized: "The client private key is encrypted and needs a passphrase.")
+        case .clientKeyPassphraseIncorrect:
+            return String(localized: "The passphrase for the client private key is incorrect.")
         case .cipherMismatch:
             return String(localized: "The server and TablePro could not agree on a TLS cipher or protocol version.")
         case .unknown:
@@ -86,6 +94,10 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "Switch SSL Mode to Verify CA (validates the CA chain but skips hostname check), or update the host field to match the certificate.")
         case .clientCertRequired:
             return String(localized: "Provide the client certificate and key paths in the SSL tab.")
+        case .clientKeyPassphraseRequired:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and enter the Key Passphrase.")
+        case .clientKeyPassphraseIncorrect:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and correct the Key Passphrase.")
         case .cipherMismatch:
             return String(localized: "Update the server's TLS configuration or use a newer database server version that supports modern ciphers.")
         case .unknown:

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -432,6 +432,10 @@ enum DatabaseDriverFactory {
         }
         var ssl = connection.sslConfig
         var additionalFields = buildAdditionalFields(for: connection, plugin: plugin)
+        if let sslClientKeyPassphrase = ConnectionStorage.shared.loadSSLClientKeyPassphrase(for: connection.id),
+           !sslClientKeyPassphrase.isEmpty {
+            additionalFields["sslClientKeyPassphrase"] = sslClientKeyPassphrase
+        }
         if connection.usesAWSIAM {
             if ssl.mode == .disabled || ssl.mode == .preferred {
                 ssl.mode = .required

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -882,7 +882,8 @@ extension PluginMetadataRegistry {
                     supportsAddIndex: false,
                     supportsDropIndex: false,
                     supportsModifyPrimaryKey: false,
-                    supportsOpportunisticTLS: false
+                    supportsOpportunisticTLS: false,
+                    supportsClientKeyPassphrase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",
@@ -944,7 +945,8 @@ extension PluginMetadataRegistry {
                     supportsAddIndex: false,
                     supportsDropIndex: false,
                     supportsModifyPrimaryKey: false,
-                    supportsOpportunisticTLS: false
+                    supportsOpportunisticTLS: false,
+                    supportsClientKeyPassphrase: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -57,6 +57,7 @@ struct PluginMetadataSnapshot: Sendable {
         var defaultSSLMode: SSLMode = .disabled
         var supportsOpportunisticTLS: Bool = true
         var supportsCloudflareTunnel: Bool = true
+        var supportsClientKeyPassphrase: Bool = false
 
         static let defaults = CapabilityFlags(
             supportsSchemaSwitching: false,
@@ -938,7 +939,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 supportsModifyPrimaryKey: driverType.supportsModifyPrimaryKey,
                 defaultSSLMode: existingSnapshot?.capabilities.defaultSSLMode ?? .disabled,
                 supportsOpportunisticTLS: existingSnapshot?.capabilities.supportsOpportunisticTLS ?? true,
-                supportsCloudflareTunnel: driverType.supportsSSH
+                supportsCloudflareTunnel: driverType.supportsSSH,
+                supportsClientKeyPassphrase: existingSnapshot?.capabilities.supportsClientKeyPassphrase ?? false
             ),
             schema: PluginMetadataSnapshot.SchemaInfo(
                 defaultSchemaName: driverType.defaultSchemaName,

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -266,6 +266,7 @@ enum ConnectionExportService {
             let password = ConnectionStorage.shared.loadPassword(for: connection.id)
             let sshPassword = ConnectionStorage.shared.loadSSHPassword(for: connection.id)
             let keyPassphrase = ConnectionStorage.shared.loadKeyPassphrase(for: connection.id)
+            let sslClientKeyPassphrase = ConnectionStorage.shared.loadSSLClientKeyPassphrase(for: connection.id)
             let totpSecret = ConnectionStorage.shared.loadTOTPSecret(for: connection.id)
 
             // Collect plugin-specific secure fields
@@ -291,13 +292,15 @@ enum ConnectionExportService {
             }
 
             let hasAnyCredential = password != nil || sshPassword != nil
-                || keyPassphrase != nil || totpSecret != nil || pluginSecureFields != nil
+                || keyPassphrase != nil || sslClientKeyPassphrase != nil
+                || totpSecret != nil || pluginSecureFields != nil
 
             if hasAnyCredential {
                 credentialsMap[String(index)] = ExportableCredentials(
                     password: password,
                     sshPassword: sshPassword,
                     keyPassphrase: keyPassphrase,
+                    sslClientKeyPassphrase: sslClientKeyPassphrase,
                     totpSecret: totpSecret,
                     pluginSecureFields: pluginSecureFields
                 )
@@ -375,6 +378,9 @@ enum ConnectionExportService {
             }
             if let keyPassphrase = creds.keyPassphrase {
                 ConnectionStorage.shared.saveKeyPassphrase(keyPassphrase, for: connectionId)
+            }
+            if let sslClientKeyPassphrase = creds.sslClientKeyPassphrase {
+                ConnectionStorage.shared.saveSSLClientKeyPassphrase(sslClientKeyPassphrase, for: connectionId)
             }
             if let totpSecret = creds.totpSecret {
                 ConnectionStorage.shared.saveTOTPSecret(totpSecret, for: connectionId)

--- a/TablePro/Core/Services/Export/ForeignApp/BeekeeperStudioImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/BeekeeperStudioImporter.swift
@@ -247,6 +247,7 @@ struct BeekeeperStudioImporter: ForeignAppImporter {
             password: decrypt(row.password, key: key),
             sshPassword: decrypt(row.sshPassword, key: key),
             keyPassphrase: decrypt(row.sshKeyfilePassword, key: key),
+            sslClientKeyPassphrase: nil,
             totpSecret: nil,
             pluginSecureFields: nil
         )

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -371,6 +371,7 @@ struct DBeaverImporter: ForeignAppImporter {
             password: password,
             sshPassword: sshPassword,
             keyPassphrase: nil,
+            sslClientKeyPassphrase: nil,
             totpSecret: nil,
             pluginSecureFields: nil
         )

--- a/TablePro/Core/Services/Export/ForeignApp/DataGripImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DataGripImporter.swift
@@ -156,6 +156,7 @@ struct DataGripImporter: ForeignAppImporter {
                 password: password,
                 sshPassword: sshPassword,
                 keyPassphrase: keyPassphrase,
+                sslClientKeyPassphrase: nil,
                 totpSecret: nil,
                 pluginSecureFields: nil
             ),

--- a/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/SequelAceImporter.swift
@@ -286,6 +286,7 @@ struct SequelAceImporter: ForeignAppImporter {
             password: dbPassword,
             sshPassword: sshPassword,
             keyPassphrase: nil,
+            sslClientKeyPassphrase: nil,
             totpSecret: nil,
             pluginSecureFields: nil
         )

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -261,6 +261,7 @@ struct TablePlusImporter: ForeignAppImporter {
             password: dbPassword,
             sshPassword: sshPassword,
             keyPassphrase: keyPassphrase,
+            sslClientKeyPassphrase: nil,
             totpSecret: nil,
             pluginSecureFields: nil
         )

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -210,6 +210,7 @@ final class ConnectionStorage {
         deletePassword(for: connection.id)
         deleteSSHPassword(for: connection.id)
         deleteKeyPassphrase(for: connection.id)
+        deleteSSLClientKeyPassphrase(for: connection.id)
         deleteTOTPSecret(for: connection.id)
         deleteCloudflareTokenId(for: connection.id)
         deleteCloudflareTokenSecret(for: connection.id)
@@ -240,6 +241,7 @@ final class ConnectionStorage {
             deletePassword(for: conn.id)
             deleteSSHPassword(for: conn.id)
             deleteKeyPassphrase(for: conn.id)
+            deleteSSLClientKeyPassphrase(for: conn.id)
             deleteTOTPSecret(for: conn.id)
             deleteCloudflareTokenId(for: conn.id)
             deleteCloudflareTokenSecret(for: conn.id)
@@ -306,6 +308,9 @@ final class ConnectionStorage {
         if let keyPassphrase = loadKeyPassphrase(for: connection.id) {
             saveKeyPassphrase(keyPassphrase, for: newId)
         }
+        if let sslKeyPassphrase = loadSSLClientKeyPassphrase(for: connection.id) {
+            saveSSLClientKeyPassphrase(sslKeyPassphrase, for: newId)
+        }
         if let totpSecret = loadTOTPSecret(for: connection.id) {
             saveTOTPSecret(totpSecret, for: newId)
         }
@@ -368,6 +373,23 @@ final class ConnectionStorage {
 
     func deleteKeyPassphrase(for connectionId: UUID) {
         let key = "com.TablePro.keypassphrase.\(connectionId.uuidString)"
+        keychain.delete(forKey: key)
+    }
+
+    // MARK: - SSL Client Key Passphrase Storage
+
+    func saveSSLClientKeyPassphrase(_ passphrase: String, for connectionId: UUID) {
+        let key = "com.TablePro.sslkeypassphrase.\(connectionId.uuidString)"
+        keychain.writeString(passphrase, forKey: key)
+    }
+
+    func loadSSLClientKeyPassphrase(for connectionId: UUID) -> String? {
+        let key = "com.TablePro.sslkeypassphrase.\(connectionId.uuidString)"
+        return resolveString(.init(label: "SSL client key passphrase", connectionId: connectionId), forKey: key)
+    }
+
+    func deleteSSLClientKeyPassphrase(for connectionId: UUID) {
+        let key = "com.TablePro.sslkeypassphrase.\(connectionId.uuidString)"
         keychain.delete(forKey: key)
     }
 

--- a/TablePro/Models/Connection/ConnectionExport.swift
+++ b/TablePro/Models/Connection/ConnectionExport.swift
@@ -136,6 +136,7 @@ struct ExportableCredentials: Codable {
     let password: String?
     let sshPassword: String?
     let keyPassphrase: String?
+    let sslClientKeyPassphrase: String?
     let totpSecret: String?
     let pluginSecureFields: [String: String]?
 }

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -113,6 +113,10 @@ extension DatabaseType {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.supportsOpportunisticTLS ?? true
     }
 
+    var supportsClientKeyPassphrase: Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.supportsClientKeyPassphrase ?? false
+    }
+
     var sslPaneTooltip: String {
         switch rawValue {
         case "PostgreSQL", "Redshift", "CockroachDB":

--- a/TablePro/Views/Connection/ConnectionSSLView.swift
+++ b/TablePro/Views/Connection/ConnectionSSLView.swift
@@ -15,6 +15,7 @@ struct ConnectionSSLView: View {
     @Binding var sslCaCertPath: String
     @Binding var sslClientCertPath: String
     @Binding var sslClientKeyPath: String
+    @Binding var sslClientKeyPassphrase: String
 
     private var supportsPerConnectionCertPaths: Bool { databaseType != .mssql }
 
@@ -101,6 +102,14 @@ struct ConnectionSSLView: View {
                                     browseForCertificate(binding: $sslClientKeyPath)
                                 }
                                 .controlSize(.small)
+                            }
+                        }
+                        if databaseType.supportsClientKeyPassphrase,
+                           !sslClientKeyPath.trimmingCharacters(in: .whitespaces).isEmpty {
+                            LabeledContent(String(localized: "Key Passphrase")) {
+                                SecureField(
+                                    "", text: $sslClientKeyPassphrase,
+                                    prompt: Text(String(localized: "Required only for an encrypted key")))
                             }
                         }
                     } header: {

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -318,6 +318,12 @@ final class ConnectionFormCoordinator {
             storage.deleteTOTPSecret(for: connectionToSave.id)
         }
 
+        if !ssl.clientKeyPassphrase.isEmpty && !ssl.clientKeyPath.trimmingCharacters(in: .whitespaces).isEmpty {
+            storage.saveSSLClientKeyPassphrase(ssl.clientKeyPassphrase, for: connectionToSave.id)
+        } else {
+            storage.deleteSSLClientKeyPassphrase(for: connectionToSave.id)
+        }
+
         cloudflareTunnel.save(to: connectionToSave.id, storage: storage)
 
         var savedConnections = storage.loadConnections()
@@ -471,42 +477,24 @@ final class ConnectionFormCoordinator {
         let displayName = network.name.isEmpty ? network.host : network.name
         let sshState = ssh.state
         let cloudflareState = cloudflareTunnel.state
+        let sslClientKeyPassphrase = ssl.clientKeyPassphrase
+        let sslClientKeyPath = ssl.clientKeyPath
         let additionalFieldValues = finalAdditionalFields
+
+        persistTestSecrets(
+            for: testConn.id,
+            password: password,
+            promptForPassword: promptForPassword,
+            sshState: sshState,
+            sslClientKeyPassphrase: sslClientKeyPassphrase,
+            sslClientKeyPath: sslClientKeyPath,
+            cloudflareState: cloudflareState,
+            connectionType: connectionType,
+            additionalFieldValues: additionalFieldValues
+        )
 
         testTask = Task { [weak self] in
             do {
-                if !password.isEmpty && !promptForPassword {
-                    services.connectionStorage.savePassword(password, for: testConn.id)
-                }
-                if sshState.enabled && sshState.profileId == nil {
-                    if (sshState.authMethod == .password || sshState.authMethod == .keyboardInteractive)
-                        && !sshState.password.isEmpty
-                    {
-                        services.connectionStorage.saveSSHPassword(sshState.password, for: testConn.id)
-                    }
-                    if sshState.authMethod == .privateKey && !sshState.keyPassphrase.isEmpty {
-                        services.connectionStorage.saveKeyPassphrase(sshState.keyPassphrase, for: testConn.id)
-                    }
-                    if sshState.totpMode == .autoGenerate && !sshState.totpSecret.isEmpty {
-                        services.connectionStorage.saveTOTPSecret(sshState.totpSecret, for: testConn.id)
-                    }
-                }
-
-                if cloudflareState.enabled && cloudflareState.authMethod == .serviceToken {
-                    services.connectionStorage.saveCloudflareTokenId(cloudflareState.serviceTokenId, for: testConn.id)
-                    services.connectionStorage.saveCloudflareTokenSecret(cloudflareState.serviceTokenSecret, for: testConn.id)
-                }
-
-                for field in services.pluginManager.additionalConnectionFields(for: connectionType)
-                    where field.isSecure
-                {
-                    if let value = additionalFieldValues[field.id], !value.isEmpty {
-                        services.connectionStorage.savePluginSecureField(
-                            value, fieldId: field.id, for: testConn.id
-                        )
-                    }
-                }
-
                 let sshPasswordForTest = sshState.profileId == nil ? sshState.password : nil
                 let isApiOnly = services.pluginManager.connectionMode(for: connectionType) == .apiOnly
                 let testPwOverride: String? = promptForPassword
@@ -571,10 +559,59 @@ final class ConnectionFormCoordinator {
         }
     }
 
+    private func persistTestSecrets(
+        for testId: UUID,
+        password: String,
+        promptForPassword: Bool,
+        sshState: SSHTunnelFormState,
+        sslClientKeyPassphrase: String,
+        sslClientKeyPath: String,
+        cloudflareState: CloudflareTunnelFormState,
+        connectionType: DatabaseType,
+        additionalFieldValues: [String: String]
+    ) {
+        if !password.isEmpty && !promptForPassword {
+            services.connectionStorage.savePassword(password, for: testId)
+        }
+        if sshState.enabled && sshState.profileId == nil {
+            if (sshState.authMethod == .password || sshState.authMethod == .keyboardInteractive)
+                && !sshState.password.isEmpty
+            {
+                services.connectionStorage.saveSSHPassword(sshState.password, for: testId)
+            }
+            if sshState.authMethod == .privateKey && !sshState.keyPassphrase.isEmpty {
+                services.connectionStorage.saveKeyPassphrase(sshState.keyPassphrase, for: testId)
+            }
+            if sshState.totpMode == .autoGenerate && !sshState.totpSecret.isEmpty {
+                services.connectionStorage.saveTOTPSecret(sshState.totpSecret, for: testId)
+            }
+        }
+
+        if !sslClientKeyPassphrase.isEmpty
+            && !sslClientKeyPath.trimmingCharacters(in: .whitespaces).isEmpty
+        {
+            services.connectionStorage.saveSSLClientKeyPassphrase(sslClientKeyPassphrase, for: testId)
+        }
+
+        if cloudflareState.enabled && cloudflareState.authMethod == .serviceToken {
+            services.connectionStorage.saveCloudflareTokenId(cloudflareState.serviceTokenId, for: testId)
+            services.connectionStorage.saveCloudflareTokenSecret(cloudflareState.serviceTokenSecret, for: testId)
+        }
+
+        for field in services.pluginManager.additionalConnectionFields(for: connectionType)
+            where field.isSecure
+        {
+            if let value = additionalFieldValues[field.id], !value.isEmpty {
+                services.connectionStorage.savePluginSecureField(value, fieldId: field.id, for: testId)
+            }
+        }
+    }
+
     func cleanupTestSecrets(for testId: UUID) {
         services.connectionStorage.deletePassword(for: testId)
         services.connectionStorage.deleteSSHPassword(for: testId)
         services.connectionStorage.deleteKeyPassphrase(for: testId)
+        services.connectionStorage.deleteSSLClientKeyPassphrase(for: testId)
         services.connectionStorage.deleteTOTPSecret(for: testId)
         services.connectionStorage.deleteCloudflareTokenId(for: testId)
         services.connectionStorage.deleteCloudflareTokenSecret(for: testId)

--- a/TablePro/Views/ConnectionForm/Panes/SSLPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/SSLPaneView.swift
@@ -14,7 +14,8 @@ struct SSLPaneView: View {
             sslMode: $coordinator.ssl.mode,
             sslCaCertPath: $coordinator.ssl.caCertPath,
             sslClientCertPath: $coordinator.ssl.clientCertPath,
-            sslClientKeyPath: $coordinator.ssl.clientKeyPath
+            sslClientKeyPath: $coordinator.ssl.clientKeyPath,
+            sslClientKeyPassphrase: $coordinator.ssl.clientKeyPassphrase
         )
     }
 }

--- a/TablePro/Views/ConnectionForm/ViewModels/SSLPaneViewModel.swift
+++ b/TablePro/Views/ConnectionForm/ViewModels/SSLPaneViewModel.swift
@@ -13,6 +13,7 @@ final class SSLPaneViewModel {
     var caCertPath: String = ""
     var clientCertPath: String = ""
     var clientKeyPath: String = ""
+    var clientKeyPassphrase: String = ""
 
     var coordinator: WeakCoordinatorRef?
 
@@ -36,6 +37,7 @@ final class SSLPaneViewModel {
         caCertPath = connection.sslConfig.caCertificatePath
         clientCertPath = connection.sslConfig.clientCertificatePath
         clientKeyPath = connection.sslConfig.clientKeyPath
+        clientKeyPassphrase = ConnectionStorage.shared.loadSSLClientKeyPassphrase(for: connection.id) ?? ""
     }
 
     func resetForType(_ type: DatabaseType) {
@@ -43,6 +45,7 @@ final class SSLPaneViewModel {
         caCertPath = ""
         clientCertPath = ""
         clientKeyPath = ""
+        clientKeyPassphrase = ""
     }
 
     func buildConfig() -> SSLConfiguration {

--- a/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
+++ b/TableProTests/PluginTestSources/PluginSSLClassifiers.swift
@@ -157,3 +157,19 @@ enum ClickHouseClassifier {
         return nil
     }
 }
+
+enum CassandraClassifier {
+    static func isEncryptedPrivateKey(_ pem: String) -> Bool {
+        pem.contains("ENCRYPTED PRIVATE KEY") || (pem.contains("Proc-Type:") && pem.contains("ENCRYPTED"))
+    }
+
+    static func privateKeyLoadError(keyPEM: String, hasPassphrase: Bool, keyPath: String) -> SSLHandshakeError {
+        guard isEncryptedPrivateKey(keyPEM) else {
+            return .clientKeyInvalid(serverMessage: "The client key at \(keyPath) is not a valid private key")
+        }
+        if hasPassphrase {
+            return .clientKeyPassphraseIncorrect(serverMessage: "The passphrase for the client key at \(keyPath) is incorrect")
+        }
+        return .clientKeyPassphraseRequired(serverMessage: "The client key at \(keyPath) is encrypted. Enter its passphrase.")
+    }
+}

--- a/TableProTests/Plugins/PluginSSLClassifierTests.swift
+++ b/TableProTests/Plugins/PluginSSLClassifierTests.swift
@@ -209,3 +209,60 @@ struct ClickHouseClassifierTests {
         #expect(ClickHouseClassifier.classifySSLError(error) == nil)
     }
 }
+
+@Suite("Cassandra Client Key Classifier")
+struct CassandraClassifierTests {
+    private let encryptedPkcs8 = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIF...\n-----END ENCRYPTED PRIVATE KEY-----"
+    private let encryptedPkcs1 = """
+    -----BEGIN RSA PRIVATE KEY-----
+    Proc-Type: 4,ENCRYPTED
+    DEK-Info: AES-256-CBC,1234
+
+    MIIE...
+    -----END RSA PRIVATE KEY-----
+    """
+    private let unencryptedPkcs8 = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----"
+
+    @Test("Detects PKCS#8 and PKCS#1 encrypted keys, not unencrypted ones")
+    func testEncryptionDetection() {
+        #expect(CassandraClassifier.isEncryptedPrivateKey(encryptedPkcs8))
+        #expect(CassandraClassifier.isEncryptedPrivateKey(encryptedPkcs1))
+        #expect(!CassandraClassifier.isEncryptedPrivateKey(unencryptedPkcs8))
+    }
+
+    @Test("Encrypted key with no passphrase → clientKeyPassphraseRequired")
+    func testEncryptedNoPassphrase() {
+        let error = CassandraClassifier.privateKeyLoadError(
+            keyPEM: encryptedPkcs8, hasPassphrase: false, keyPath: "/k.pem")
+        guard case .clientKeyPassphraseRequired = error else {
+            Issue.record("Expected clientKeyPassphraseRequired")
+            return
+        }
+    }
+
+    @Test("Encrypted key with wrong passphrase → clientKeyPassphraseIncorrect")
+    func testEncryptedWrongPassphrase() {
+        let error = CassandraClassifier.privateKeyLoadError(
+            keyPEM: encryptedPkcs1, hasPassphrase: true, keyPath: "/k.pem")
+        guard case .clientKeyPassphraseIncorrect = error else {
+            Issue.record("Expected clientKeyPassphraseIncorrect")
+            return
+        }
+    }
+
+    @Test("Unencrypted but unreadable key → clientKeyInvalid, never a passphrase error")
+    func testUnencryptedInvalid() {
+        let withoutPassphrase = CassandraClassifier.privateKeyLoadError(
+            keyPEM: unencryptedPkcs8, hasPassphrase: false, keyPath: "/k.pem")
+        let withPassphrase = CassandraClassifier.privateKeyLoadError(
+            keyPEM: unencryptedPkcs8, hasPassphrase: true, keyPath: "/k.pem")
+        guard case .clientKeyInvalid = withoutPassphrase else {
+            Issue.record("Expected clientKeyInvalid without passphrase")
+            return
+        }
+        guard case .clientKeyInvalid = withPassphrase else {
+            Issue.record("Expected clientKeyInvalid with passphrase")
+            return
+        }
+    }
+}

--- a/TableProTests/Plugins/SSLConfigurationTests.swift
+++ b/TableProTests/Plugins/SSLConfigurationTests.swift
@@ -59,6 +59,20 @@ struct SSLConfigurationTests {
         #expect(decoded == original)
     }
 
+    @Test("encoded JSON never carries a client key passphrase")
+    func encodedJsonExcludesPassphrase() throws {
+        let ssl = SSLConfiguration(
+            mode: .verifyIdentity,
+            caCertificatePath: "/etc/ssl/ca.pem",
+            clientCertificatePath: "/etc/ssl/client.crt",
+            clientKeyPath: "/etc/ssl/client.key"
+        )
+        let data = try JSONEncoder().encode(ssl)
+        let json = String(bytes: data, encoding: .utf8) ?? ""
+        #expect(!json.lowercased().contains("passphrase"))
+        #expect(!json.lowercased().contains("password"))
+    }
+
     @Test("raw values match the strings used in the connection form picker")
     func rawValueStability() {
         #expect(SSLMode.disabled.rawValue == "Disabled")

--- a/TableProTests/Plugins/SSLHandshakeErrorTests.swift
+++ b/TableProTests/Plugins/SSLHandshakeErrorTests.swift
@@ -54,6 +54,13 @@ struct SSLHandshakeErrorTests {
         #expect(error.recoverySuggestion?.contains("Key Passphrase") == true)
     }
 
+    @Test("clientKeyInvalid describes a malformed key and points at the path")
+    func testClientKeyInvalid() {
+        let error = SSLHandshakeError.clientKeyInvalid(serverMessage: "not a PEM")
+        #expect(error.errorDescription?.contains("malformed") == true)
+        #expect(error.recoverySuggestion?.contains("Client Key") == true)
+    }
+
     @Test("cipherMismatch suggests server update")
     func testCipherMismatch() {
         let error = SSLHandshakeError.cipherMismatch(serverMessage: "no shared cipher")
@@ -93,8 +100,9 @@ struct SSLHandshakeErrorTests {
             .clientCertRequired(serverMessage: "msg-5"),
             .clientKeyPassphraseRequired(serverMessage: "msg-6"),
             .clientKeyPassphraseIncorrect(serverMessage: "msg-7"),
-            .cipherMismatch(serverMessage: "msg-8"),
-            .unknown(serverMessage: "msg-9")
+            .clientKeyInvalid(serverMessage: "msg-8"),
+            .cipherMismatch(serverMessage: "msg-9"),
+            .unknown(serverMessage: "msg-10")
         ]
         for error in cases {
             #expect(!error.serverMessage.isEmpty)

--- a/TableProTests/Plugins/SSLHandshakeErrorTests.swift
+++ b/TableProTests/Plugins/SSLHandshakeErrorTests.swift
@@ -40,6 +40,20 @@ struct SSLHandshakeErrorTests {
         #expect(error.recoverySuggestion?.contains("client certificate") == true)
     }
 
+    @Test("clientKeyPassphraseRequired explains the key is encrypted")
+    func testClientKeyPassphraseRequired() {
+        let error = SSLHandshakeError.clientKeyPassphraseRequired(serverMessage: "bad decrypt")
+        #expect(error.errorDescription?.contains("encrypted") == true)
+        #expect(error.recoverySuggestion?.contains("Key Passphrase") == true)
+    }
+
+    @Test("clientKeyPassphraseIncorrect points at the wrong passphrase")
+    func testClientKeyPassphraseIncorrect() {
+        let error = SSLHandshakeError.clientKeyPassphraseIncorrect(serverMessage: "bad decrypt")
+        #expect(error.errorDescription?.contains("incorrect") == true)
+        #expect(error.recoverySuggestion?.contains("Key Passphrase") == true)
+    }
+
     @Test("cipherMismatch suggests server update")
     func testCipherMismatch() {
         let error = SSLHandshakeError.cipherMismatch(serverMessage: "no shared cipher")
@@ -77,8 +91,10 @@ struct SSLHandshakeErrorTests {
             .untrustedCertificate(serverMessage: "msg-3"),
             .hostnameMismatch(serverMessage: "msg-4"),
             .clientCertRequired(serverMessage: "msg-5"),
-            .cipherMismatch(serverMessage: "msg-6"),
-            .unknown(serverMessage: "msg-7")
+            .clientKeyPassphraseRequired(serverMessage: "msg-6"),
+            .clientKeyPassphraseIncorrect(serverMessage: "msg-7"),
+            .cipherMismatch(serverMessage: "msg-8"),
+            .unknown(serverMessage: "msg-9")
         ]
         for error in cases {
             #expect(!error.serverMessage.isEmpty)

--- a/docs/databases/cassandra.mdx
+++ b/docs/databases/cassandra.mdx
@@ -36,7 +36,7 @@ See [Connection URL Reference](/databases/connection-urls#cassandra--scylladb) f
 **DataStax Astra DB**: Port 29042, use Client ID/Secret, needs Secure Connect Bundle (SSL/TLS)
 **Remote**: Use [SSH tunneling](/databases/ssh-tunneling) for production
 
-**SSL/TLS**: The Cassandra driver has no TLS fallback. **Preferred** behaves the same as **Required** (the SSL pane shows a warning). Use **Required** for AstraDB, **Verify CA** with a CA certificate path for private PKI. See [SSL/TLS](/features/ssl) for details.
+**SSL/TLS**: The Cassandra driver has no TLS fallback. **Preferred** behaves the same as **Required** (the SSL pane shows a warning). Use **Required** for AstraDB, **Verify CA** with a CA certificate path for private PKI. For mutual TLS, set the client certificate and key paths; if the key is encrypted, enter its passphrase in the **Key Passphrase** field (stored in the Keychain). See [SSL/TLS](/features/ssl) for details.
 
 ## Features
 

--- a/docs/features/ssl.mdx
+++ b/docs/features/ssl.mdx
@@ -69,6 +69,10 @@ The certificate's CN/SAN doesn't include the host you're connecting to. Switch f
 
 Server requires mutual TLS. Fill in the **Client Certificate** and **Client Key** paths in the SSL tab.
 
+### "client private key is encrypted" / "passphrase is incorrect"
+
+The client key is password-protected. Enter the **Key Passphrase** in the SSL tab. The field appears once a client key path is set, and the passphrase is stored in the Keychain. Currently supported by the Cassandra driver.
+
 ## Preferred fallback behavior
 
 Preferred mode tries TLS first. What happens if the server doesn't support TLS depends on the driver:


### PR DESCRIPTION
Fixes #1487.

## Problem

The Cassandra SSL pane let you set a client certificate and key path, but the driver never applied them to the SSL context, and there was no field for an encrypted key's passphrase. An encrypted private key failed inside the handshake with a generic error that gave no hint about the passphrase.

## Fix

**Driver (the actual cause)**
- `CassandraConnectionActor` now applies the client cert and key to the SSL context with `cass_ssl_set_cert` and `cass_ssl_set_private_key(ssl, key, password)` before `cass_cluster_set_ssl`.
- Wrong or missing passphrase fails immediately at key load with a clear message: `clientKeyPassphraseRequired` (encrypted key, no passphrase) or `clientKeyPassphraseIncorrect` (wrong passphrase). These two `SSLHandshakeError` cases are appended at the end of the enum so existing discriminators don't shift for plugins built against the older PluginKit.

**UI**
- The SSL pane shows a **Key Passphrase** `SecureField`, but only when a client key path is set and the engine advertises the new `supportsClientKeyPassphrase` capability (true for Cassandra/ScyllaDB, false elsewhere), so it never appears as a dead control for engines that ignore it.

**Secret handling**
- The passphrase is stored in the Keychain (`com.TablePro.sslkeypassphrase.<id>`), wired into delete and duplicate, and never written to the Codable/iCloud-synced `SSLConfiguration`. It reaches the driver through `additionalFields["sslClientKeyPassphrase"]`.
- Saved, applied, and cleaned up on the connection form's Test action, and round-tripped through encrypted export/import.

## Tests
- `SSLHandshakeErrorTests`: the two new error cases.
- `SSLConfigurationTests`: the encoded JSON carries no passphrase or password.

## PluginKit / registry
- No `currentPluginKitVersion` bump: no protocol or signature change, and the new enum cases are appended for layout compatibility.
- Cassandra is registry-only, so after merge it needs a `plugin-cassandra-v*` rebuild and release for the cert/key application and new error cases to reach registry users.