### PR TITLE
fix(editor): favorite keyword autocomplete, Cmd+D shortcut, and selectable Details fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Save as Favorite uses Cmd+D again. The Cmd+Control+D set in 0.47.0 is reserved by macOS for Look Up, so it never fired.
+- Editor toolbar buttons show their keyboard shortcut in the tooltip, and it updates if you rebind the shortcut.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Save the current query as a favorite from a star button in the SQL editor toolbar.
+- Field names and types in the row Details panel can now be selected and copied.
+
+### Changed
+
+- Save as Favorite uses Cmd+D again. The Cmd+Control+D set in 0.47.0 is reserved by macOS for Look Up, so it never fired.
+
+### Fixed
+
+- Favorite keyword suggestions now show in the editor autocomplete when you type the keyword. They were being dropped before reaching the popup.
+
 ## [0.47.0] - 2026-06-01
 
 ### Added

--- a/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
@@ -111,14 +111,6 @@ final class SQLCompletionProvider {
     ) async -> [SQLCompletionItem] {
         var items: [SQLCompletionItem] = []
 
-        // Check for favorite keyword matches first (highest priority)
-        if !favoriteKeywords.isEmpty && !context.prefix.isEmpty {
-            let lowerPrefix = context.prefix.lowercased()
-            for (keyword, value) in favoriteKeywords where keyword.lowercased().hasPrefix(lowerPrefix) {
-                items.append(.favorite(keyword: keyword, name: value.name, query: value.query))
-            }
-        }
-
         // If we have a dot prefix, we're looking for columns of a specific table
         if let dotPrefix = context.dotPrefix {
             // Resolve the table name from alias or direct reference
@@ -456,7 +448,18 @@ final class SQLCompletionProvider {
             items += await schemaProvider.tableCompletionItems()
         }
 
+        items += favoriteCompletions(matching: context.prefix)
+
         return items
+    }
+
+    private func favoriteCompletions(matching prefix: String) -> [SQLCompletionItem] {
+        guard !prefix.isEmpty, !favoriteKeywords.isEmpty else { return [] }
+        let lowerPrefix = prefix.lowercased()
+        return favoriteKeywords
+            .filter { $0.key.lowercased().hasPrefix(lowerPrefix) }
+            .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+            .map { SQLCompletionItem.favorite(keyword: $0.key, name: $0.value.name, query: $0.value.query) }
     }
 
     /// SQL data type keywords (database-aware), with a slight priority boost

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -401,6 +401,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
         KeyCombo(key: "q", command: true, control: true), // Lock Screen
         KeyCombo(key: "f", command: true, control: true), // Full Screen
         KeyCombo(key: "d", command: true, option: true), // Toggle Dock
+        KeyCombo(key: "d", command: true, control: true), // Look Up / Define
     ]
 
     /// Check if this combo is reserved by the system
@@ -535,7 +536,7 @@ struct KeyboardSettings: Codable, Equatable {
         .duplicateRow: KeyCombo(key: "d", command: true, shift: true),
         .truncateTable: KeyCombo(key: "delete", option: true, isSpecialKey: true),
         .previewFKReference: KeyCombo(key: "space", isSpecialKey: true),
-        .saveAsFavorite: KeyCombo(key: "d", command: true, control: true),
+        .saveAsFavorite: KeyCombo(key: "d", command: true),
 
         // View
         .toggleTableBrowser: KeyCombo(key: "0", command: true),

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -112,6 +112,15 @@ struct QueryEditorView: View {
             .accessibilityLabel(String(localized: "Format Query"))
             .optionalKeyboardShortcut(AppSettingsManager.shared.keyboard.keyboardShortcut(for: .formatQuery))
 
+            Button(action: { onSaveAsFavorite?(queryText) }) {
+                Image(systemName: "star")
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Save as Favorite (⌘D)"))
+            .accessibilityLabel(String(localized: "Save as Favorite"))
+            .disabled(!hasQueryText)
+
             Divider()
                 .frame(height: 16)
 

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -108,7 +108,7 @@ struct QueryEditorView: View {
                     .frame(width: 24, height: 24)
             }
             .buttonStyle(.borderless)
-            .help(String(localized: "Format Query (⇧⌘L)"))
+            .help(shortcutHint(String(localized: "Format Query"), for: .formatQuery))
             .accessibilityLabel(String(localized: "Format Query"))
             .optionalKeyboardShortcut(AppSettingsManager.shared.keyboard.keyboardShortcut(for: .formatQuery))
 
@@ -117,7 +117,7 @@ struct QueryEditorView: View {
                     .frame(width: 24, height: 24)
             }
             .buttonStyle(.borderless)
-            .help(String(localized: "Save as Favorite (⌘D)"))
+            .help(shortcutHint(String(localized: "Save as Favorite"), for: .saveAsFavorite))
             .accessibilityLabel(String(localized: "Save as Favorite"))
             .disabled(!hasQueryText)
 
@@ -135,6 +135,7 @@ struct QueryEditorView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
+            .help(shortcutHint(String(localized: "Execute"), for: .executeQuery))
             .optionalKeyboardShortcut(AppSettingsManager.shared.keyboard.keyboardShortcut(for: .executeQuery))
         }
         .padding(.horizontal, 12)
@@ -143,6 +144,13 @@ struct QueryEditorView: View {
     }
 
     // MARK: - Helpers
+
+    private func shortcutHint(_ label: String, for action: ShortcutAction) -> String {
+        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: action), !combo.isCleared else {
+            return label
+        }
+        return "\(label) (\(combo.displayString))"
+    }
 
     @ViewBuilder
     private func explainButton(hasQueryText: Bool) -> some View {
@@ -167,6 +175,7 @@ struct QueryEditorView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .help(shortcutHint(String(localized: "Explain"), for: .explainQuery))
             .disabled(!hasQueryText)
         } else {
             Menu {
@@ -187,6 +196,7 @@ struct QueryEditorView: View {
             }
             .menuStyle(.borderlessButton)
             .fixedSize()
+            .help(shortcutHint(String(localized: "Explain"), for: .explainQuery))
             .disabled(!hasQueryText)
         }
     }

--- a/TablePro/Views/RightSidebar/EditableFieldView.swift
+++ b/TablePro/Views/RightSidebar/EditableFieldView.swift
@@ -119,6 +119,7 @@ internal struct FieldDetailView: View {
 
             TypeBadge(context.columnType.badgeLabel)
         }
+        .textSelection(.enabled)
     }
 
     private func editorMinHeight(for kind: FieldEditorKind) -> CGFloat? {

--- a/TableProTests/Core/Autocomplete/SQLCompletionProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLCompletionProviderTests.swift
@@ -1049,4 +1049,44 @@ struct SQLCompletionProviderTests {
         let hasStar = items.contains { $0.label == "*" }
         #expect(hasStar, "COUNT( should suggest *")
     }
+
+    // MARK: - Favorite keyword expansion
+
+    @Test("Favorite keyword expands at statement start")
+    func testFavoriteKeywordExpandsAtStatementStart() async {
+        provider.updateFavoriteKeywords(["report": (name: "Daily Report", query: "SELECT * FROM reports")])
+        let text = "rep"
+        let (items, _) = await provider.getCompletions(text: text, cursorPosition: text.count)
+        let favorite = items.first { $0.kind == .favorite }
+        #expect(favorite?.label == "report", "Typing the keyword prefix should surface the favorite")
+        #expect(favorite?.insertText == "SELECT * FROM reports", "Selecting it inserts the full query")
+        #expect(favorite?.detail == "Daily Report", "The favorite name is shown as detail")
+    }
+
+    @Test("Favorite keyword survives clause branches that rebuild candidates")
+    func testFavoriteKeywordSurvivesClauseRebuild() async {
+        provider.updateFavoriteKeywords(["usr": (name: "Users", query: "SELECT * FROM users")])
+        let text = "usr"
+        let (items, _) = await provider.getCompletions(text: text, cursorPosition: text.count)
+        let hasFavorite = items.contains { $0.kind == .favorite && $0.label == "usr" }
+        #expect(hasFavorite, "Favorite must not be discarded by the candidate switch")
+    }
+
+    @Test("Favorite keyword not offered after a dot prefix")
+    func testFavoriteKeywordNotOfferedAfterDot() async {
+        provider.updateFavoriteKeywords(["col": (name: "Columns", query: "SELECT 1")])
+        let text = "users.col"
+        let (items, _) = await provider.getCompletions(text: text, cursorPosition: text.count)
+        let hasFavorite = items.contains { $0.kind == .favorite }
+        #expect(!hasFavorite, "Column completion after a dot must not expand favorites")
+    }
+
+    @Test("Non-matching prefix does not surface favorites")
+    func testFavoriteKeywordRequiresPrefixMatch() async {
+        provider.updateFavoriteKeywords(["report": (name: "Daily Report", query: "SELECT 1")])
+        let text = "SEL"
+        let (items, _) = await provider.getCompletions(text: text, cursorPosition: text.count)
+        let hasFavorite = items.contains { $0.kind == .favorite }
+        #expect(!hasFavorite, "Favorites appear only when the typed token matches their keyword")
+    }
 }

--- a/TableProTests/Models/KeyboardShortcutTests.swift
+++ b/TableProTests/Models/KeyboardShortcutTests.swift
@@ -30,6 +30,26 @@ struct ShortcutActionDefaultsTests {
     func cancelQueryDefault() {
         #expect(KeyboardSettings.defaultShortcuts[.cancelQuery] == KeyCombo(key: ".", command: true))
     }
+
+    @Test("Save as Favorite default is Cmd+D")
+    func saveAsFavoriteDefault() {
+        #expect(KeyboardSettings.defaultShortcuts[.saveAsFavorite] == KeyCombo(key: "d", command: true))
+    }
+}
+
+@Suite("System reserved shortcuts")
+struct SystemReservedShortcutTests {
+    @Test("Ctrl+Cmd+D is reserved by macOS for Look Up")
+    func ctrlCmdDIsReserved() {
+        #expect(KeyCombo(key: "d", command: true, control: true).isSystemReserved)
+    }
+
+    @Test("No default shortcut collides with a system-reserved combo")
+    func defaultsAvoidSystemReserved() {
+        for (action, combo) in KeyboardSettings.defaultShortcuts {
+            #expect(!combo.isSystemReserved, "\(action.rawValue) ships a system-reserved default: \(combo.displayString)")
+        }
+    }
 }
 
 @Suite("Bare-key validation")

--- a/docs/features/favorites.mdx
+++ b/docs/features/favorites.mdx
@@ -24,8 +24,9 @@ Save queries you run often. Organize them in folders, assign keyword shortcuts, 
 
 ## Creating an SQL Favorite
 
-Three ways to save a favorite:
+Ways to save a favorite:
 
+- **From the editor toolbar**: Click the star button above the editor, or press `Cmd+D`
 - **From the editor**: Right-click selected SQL > **Save as Favorite**
 - **From query history**: Right-click an entry > **Save as Favorite**
 - **From the sidebar**: Click **+ New Favorite** in the Favorites tab
@@ -48,7 +49,7 @@ Enter a name, the SQL text, and optionally a keyword and scope.
 
 ## Keyword Expansion
 
-Assign a unique keyword to a favorite (e.g., `selall`). Type the keyword in the editor and it appears as an autocomplete suggestion. Select it to insert the full SQL.
+Assign a unique keyword to a favorite (e.g., `selall`). Start typing the keyword in the SQL editor and it shows up in the autocomplete popup as a starred suggestion with the favorite's name. Press Tab or Enter to insert the full SQL.
 
 Keywords must be unique across all favorites in the same scope.
 

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -41,6 +41,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Cancel query | `Cmd+.` | Stop the currently running query |
 | Explain query | `Option+Cmd+E` | Show execution plan for query at cursor |
 | Format SQL | `Cmd+Shift+L` | Format SQL query |
+| Save as Favorite | `Cmd+D` | Save the current query as a favorite |
 
 ### Text Editing
 


### PR DESCRIPTION
Three fixes from v0.47.0 feedback. Each goes at the root cause.

## 1. Field names in the Details panel are selectable

The row Details panel rendered the column name as a plain `Text`, which has no selection. Added the native `.textSelection(.enabled)` to the field header, so both the **field name and the type badge** can be selected and copied (double-click a word, ⌘C, right-click Copy). Scoped to this panel; the shared `TypeBadge` component is untouched.

## 2. Save as Favorite shortcut works again (Cmd+D) + toolbar button

0.47.0 moved the shortcut from Cmd+D to Control-Command-D to leave Cmd+D for the "Don't Save" sheet. But Control-Command-D is the macOS system "Look Up" shortcut, so the system swallowed it and the shortcut never fired (right-click still worked).

- Default is back to **Cmd+D**, the standard bookmark/favorite idiom. It fires reliably, and it coexists with the modal "Don't Save" sheet the same way Safari does (the sheet's Cmd+D only applies while that sheet is open).
- Added **Control-Command-D to the system-reserved list** so the settings conflict checker warns anyone who picks it.
- Added a **star button to the editor toolbar** (reuses the existing save-favorite path, disabled when the query is empty), so favoriting is discoverable without the keyboard.

## 3. Favorite keyword expansion shows in autocomplete

A saved favorite's keyword was supposed to surface as an autocomplete suggestion, but never appeared. Root cause: in `SQLCompletionProvider.getCandidates`, favorites were appended at the top of the function, then discarded by the `items = ...` reassignment in most clause branches, including the `.unknown` branch that handles the start of a statement (the natural place to type a keyword).

Moved favorite injection into a `favoriteCompletions(matching:)` helper appended after the clause switch, so it survives every branch. The early-return dot-prefix path keeps favorites out of `table.column` completion. `.favorite` already ranks first, so the suggestion appears at the top of the popup with the favorite's name as its detail.

## Tests

- `SQLCompletionProviderTests`: keyword expands at statement start, survives clause rebuild, is excluded after a dot prefix, and requires a prefix match.
- `KeyboardShortcutTests`: Cmd+D is the Save as Favorite default, Control-Command-D is system-reserved, and no default shortcut collides with a reserved combo.

## Docs / changelog

- `docs/features/favorites.mdx` and `docs/features/keyboard-shortcuts.mdx` updated for the new shortcut, the toolbar button, and clearer keyword usage.
- `CHANGELOG.md` Unreleased: Added (toolbar button, selectable Details fields), Changed (Cmd+D), Fixed (keyword autocomplete).

Production files pass `swiftlint lint --strict`. The user builds in Xcode.
