### PR TITLE
fix(plugins): sync TableProCore PluginKit SSLHandshakeError with the framework

### DIFF
--- a/Packages/TableProCore/Sources/TableProPluginKit/SSLHandshakeError.swift
+++ b/Packages/TableProCore/Sources/TableProPluginKit/SSLHandshakeError.swift
@@ -8,6 +8,9 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
     case clientCertRequired(serverMessage: String)
     case cipherMismatch(serverMessage: String)
     case unknown(serverMessage: String)
+    case clientKeyPassphraseRequired(serverMessage: String)
+    case clientKeyPassphraseIncorrect(serverMessage: String)
+    case clientKeyInvalid(serverMessage: String)
 
     public var serverMessage: String {
         switch self {
@@ -16,6 +19,9 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
              .untrustedCertificate(let msg),
              .hostnameMismatch(let msg),
              .clientCertRequired(let msg),
+             .clientKeyPassphraseRequired(let msg),
+             .clientKeyPassphraseIncorrect(let msg),
+             .clientKeyInvalid(let msg),
              .cipherMismatch(let msg),
              .unknown(let msg):
             return msg
@@ -34,6 +40,12 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "The server's TLS certificate does not match the hostname being connected to.")
         case .clientCertRequired:
             return String(localized: "The server requires a client certificate for TLS mutual authentication.")
+        case .clientKeyPassphraseRequired:
+            return String(localized: "The client private key is encrypted and needs a passphrase.")
+        case .clientKeyPassphraseIncorrect:
+            return String(localized: "The passphrase for the client private key is incorrect.")
+        case .clientKeyInvalid:
+            return String(localized: "The client private key could not be read. It may be malformed or in an unsupported format.")
         case .cipherMismatch:
             return String(localized: "The server and TablePro could not agree on a TLS cipher or protocol version.")
         case .unknown:
@@ -86,6 +98,12 @@ public enum SSLHandshakeError: Error, LocalizedError, Sendable {
             return String(localized: "Switch SSL Mode to Verify CA (validates the CA chain but skips hostname check), or update the host field to match the certificate.")
         case .clientCertRequired:
             return String(localized: "Provide the client certificate and key paths in the SSL tab.")
+        case .clientKeyPassphraseRequired:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and enter the Key Passphrase.")
+        case .clientKeyPassphraseIncorrect:
+            return String(localized: "Open the connection editor, switch to the SSL tab, and correct the Key Passphrase.")
+        case .clientKeyInvalid:
+            return String(localized: "Check that the Client Key path points to a valid PEM private key.")
         case .cipherMismatch:
             return String(localized: "Update the server's TLS configuration or use a newer database server version that supports modern ciphers.")
         case .unknown:


### PR DESCRIPTION
## Problem

The "Shared contract drift" CI gate (`scripts/audit-refactor-health.sh --check`) fails on every PR cut from current `main`:

```
❌ new PluginKit divergence not in baseline: SSLHandshakeError.swift
```

`SSLHandshakeError` exists in two PluginKit trees that are kept byte-identical until consolidation:
- `Plugins/TableProPluginKit/SSLHandshakeError.swift` (framework, canonical)
- `Packages/TableProCore/Sources/TableProPluginKit/SSLHandshakeError.swift` (package copy)

#1520 added three client-key cases to the framework copy (`clientKeyPassphraseRequired`, `clientKeyPassphraseIncorrect`, `clientKeyInvalid`) but didn't mirror them into the package copy, so the two drifted. The baseline doesn't list the file, and its header says not to baseline fresh divergence, so the right fix is to re-sync.

## Fix

Add the three missing cases to the package copy so it matches the framework contract byte for byte. No behavior change on the desktop app (it builds against the framework copy, which already had them); this restores the package/TableProCore copy that the gate compares.

Verified locally:

```
$ scripts/audit-refactor-health.sh --check
  ✅ no new shared-contract drift beyond .github/duplicate-contract-baseline.txt
✅ drift gates passed
```

This unblocks the drift gate for all open PRs, not just one.
