### PR TITLE
feat(ios): DuckDB support for files and in-memory databases

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -57,9 +57,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: Libs
-          # Include the FreeTDS stub header in the cache key so iOS xcframework refreshes
-          # whenever the C bridge surface (e.g. new symbol declarations) changes.
-          key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h') }}
+          # Include C bridge stub headers in the cache key so the iOS xcframework set
+          # refreshes whenever a bridge surface (e.g. a new driver's headers) changes.
+          key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h', 'TableProMobile/TableProMobile/CBridges/CDuckDB/CDuckDB.h') }}
 
       - name: Download static libraries
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- iOS: open DuckDB database files and in-memory DuckDB databases, matching the Mac app. (#1526)
+
 ## [0.47.0] - 2026-06-01
 
 ### Added

--- a/Packages/TableProCore/Sources/TableProDatabase/ConnectionManager.swift
+++ b/Packages/TableProCore/Sources/TableProDatabase/ConnectionManager.swift
@@ -20,6 +20,7 @@ public final class ConnectionManager: @unchecked Sendable {
     }
 
     public func connect(_ connection: DatabaseConnection) async throws -> ConnectionSession {
+        await disconnect(connection.id)
         let password = try secureStore.retrieve(forKey: Self.passwordKey(for: connection.id))
 
         var effectiveHost = connection.host

--- a/Packages/TableProCore/Tests/TableProDatabaseTests/ConnectionManagerTests.swift
+++ b/Packages/TableProCore/Tests/TableProDatabaseTests/ConnectionManagerTests.swift
@@ -8,13 +8,17 @@ import Foundation
 private final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var isConnected = false
     var shouldFailConnect = false
+    private(set) var disconnectCount = 0
 
     func connect() async throws {
         if shouldFailConnect { throw NSError(domain: "test", code: 1) }
         isConnected = true
     }
 
-    func disconnect() async throws { isConnected = false }
+    func disconnect() async throws {
+        isConnected = false
+        disconnectCount += 1
+    }
     func ping() async throws -> Bool { isConnected }
 
     func execute(query: String) async throws -> QueryResult {
@@ -109,6 +113,30 @@ struct ConnectionManagerTests {
 
         let session = manager.session(for: connection.id)
         #expect(session == nil)
+    }
+
+    @Test("Reconnecting for the same id tears down the previous session")
+    func reconnectDisconnectsPrevious() async throws {
+        let factory = MockDriverFactory()
+        let store = MockSecureStore()
+        let manager = ConnectionManager(driverFactory: factory, secureStore: store)
+
+        let connection = DatabaseConnection(
+            name: "Test",
+            type: DatabaseType(rawValue: "mock")
+        )
+
+        let first = MockDatabaseDriver()
+        factory.drivers["mock"] = first
+        _ = try await manager.connect(connection)
+
+        let second = MockDatabaseDriver()
+        factory.drivers["mock"] = second
+        _ = try await manager.connect(connection)
+
+        #expect(first.disconnectCount == 1)
+        #expect(second.isConnected)
+        #expect(manager.session(for: connection.id)?.driver === second)
     }
 
     @Test("Connect with unknown type throws driverNotFound")

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		5AB9F3EF2F7C1D03001F3337 /* TableProQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB9F3EE2F7C1D03001F3337 /* TableProQuery */; };
 		5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */ = {isa = PBXBuildFile; productRef = 5AD1F1B52FB4455700296783 /* TableProMSSQLCore */; };
 		5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD1F1B72FB4456900296783 /* FreeTDS.xcframework */; };
+		5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD0CCDB2F0000000000F001 /* DuckDB.xcframework */; };
 		5AD1F2002FB5500000000002 /* FreeTDSConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1F2002FB5500000000001 /* FreeTDSConnection.swift */; };
 /* End PBXBuildFile section */
 
@@ -529,6 +530,7 @@
 		5AB9F3D92F7C1C12001F3337 /* TableProMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TableProMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AC8A8F82FAFC99F005DE2A3 /* TableProMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TableProMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AD1F1B72FB4456900296783 /* FreeTDS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FreeTDS.xcframework; path = ../Libs/ios/FreeTDS.xcframework; sourceTree = "<group>"; };
+		5AD0CCDB2F0000000000F001 /* DuckDB.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DuckDB.xcframework; path = ../Libs/ios/DuckDB.xcframework; sourceTree = "<group>"; };
 		5AD1F2002FB5500000000001 /* FreeTDSConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FreeTDSConnection.swift; path = ../Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -609,6 +611,7 @@
 				5AA313442F7EA5B4008EBA97 /* OpenSSL-SSL.xcframework in Frameworks */,
 				5AB9F3ED2F7C1D03001F3337 /* TableProPluginKit in Frameworks */,
 				5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */,
+				5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */,
 				5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */,
 				5A87EEED2F7F893000D028D0 /* TableProSync in Frameworks */,
 				5AB9F3EB2F7C1D03001F3337 /* TableProModels in Frameworks */,
@@ -1634,6 +1637,7 @@
 			isa = PBXGroup;
 			children = (
 				5AD1F1B72FB4456900296783 /* FreeTDS.xcframework */,
+				5AD0CCDB2F0000000000F001 /* DuckDB.xcframework */,
 				5A87EEEB2F7F891F00D028D0 /* TableProSync */,
 				5A87EEE42F7F88F200D028D0 /* TablePro */,
 				5AA313532F7EC188008EBA97 /* LibSSH2.xcframework */,
@@ -2085,6 +2089,7 @@
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
+					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2092,7 +2097,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS $(SRCROOT)/TableProMobile/CBridges/CDuckDB";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2127,6 +2132,7 @@
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
+					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2134,7 +2140,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS $(SRCROOT)/TableProMobile/CBridges/CDuckDB";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2156,7 +2162,7 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS $(SRCROOT)/TableProMobile/CBridges/CDuckDB";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2179,7 +2185,7 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TableProMobile/CBridges/CMariaDB $(SRCROOT)/TableProMobile/CBridges/CLibPQ $(SRCROOT)/TableProMobile/CBridges/CRedis $(SRCROOT)/TableProMobile/CBridges/CLibSSH2 $(SRCROOT)/TableProMobile/CBridges/CFreeTDS $(SRCROOT)/TableProMobile/CBridges/CDuckDB";
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -2171,7 +2171,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-					HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;
@@ -2195,7 +2194,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-					HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		5AB9F3EF2F7C1D03001F3337 /* TableProQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB9F3EE2F7C1D03001F3337 /* TableProQuery */; };
 		5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */ = {isa = PBXBuildFile; productRef = 5AD1F1B52FB4455700296783 /* TableProMSSQLCore */; };
 		5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD1F1B72FB4456900296783 /* FreeTDS.xcframework */; };
-		5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD0CCDB2F0000000000F001 /* DuckDB.xcframework */; };
 		5AD1F2002FB5500000000002 /* FreeTDSConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1F2002FB5500000000001 /* FreeTDSConnection.swift */; };
 /* End PBXBuildFile section */
 
@@ -611,7 +610,6 @@
 				5AA313442F7EA5B4008EBA97 /* OpenSSL-SSL.xcframework in Frameworks */,
 				5AB9F3ED2F7C1D03001F3337 /* TableProPluginKit in Frameworks */,
 				5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */,
-				5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */,
 				5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */,
 				5A87EEED2F7F893000D028D0 /* TableProSync in Frameworks */,
 				5AB9F3EB2F7C1D03001F3337 /* TableProModels in Frameworks */,
@@ -2086,10 +2084,21 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
 					"-lc++",
+				);
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/libduckdb-device.a",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64_x86_64-simulator/libduckdb-sim.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2129,10 +2138,21 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
 					"-lc++",
+				);
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/libduckdb-device.a",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-force_load",
+					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64_x86_64-simulator/libduckdb-sim.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -2171,6 +2171,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+					HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;
@@ -2194,6 +2195,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+					HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D7HJ5TFYCU;

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		5AB9F3EF2F7C1D03001F3337 /* TableProQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB9F3EE2F7C1D03001F3337 /* TableProQuery */; };
 		5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */ = {isa = PBXBuildFile; productRef = 5AD1F1B52FB4455700296783 /* TableProMSSQLCore */; };
 		5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD1F1B72FB4456900296783 /* FreeTDS.xcframework */; };
+		5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD0CCDB2F0000000000F001 /* DuckDB.xcframework */; };
 		5AD1F2002FB5500000000002 /* FreeTDSConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1F2002FB5500000000001 /* FreeTDSConnection.swift */; };
 /* End PBXBuildFile section */
 
@@ -610,6 +611,7 @@
 				5AA313442F7EA5B4008EBA97 /* OpenSSL-SSL.xcframework in Frameworks */,
 				5AB9F3ED2F7C1D03001F3337 /* TableProPluginKit in Frameworks */,
 				5AD1F1B82FB4456900296783 /* FreeTDS.xcframework in Frameworks */,
+				5AD0CCDB2F0000000000F002 /* DuckDB.xcframework in Frameworks */,
 				5AD1F1B62FB4455700296783 /* TableProMSSQLCore in Frameworks */,
 				5A87EEED2F7F893000D028D0 /* TableProSync in Frameworks */,
 				5AB9F3EB2F7C1D03001F3337 /* TableProModels in Frameworks */,
@@ -2084,21 +2086,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
 					"-lc++",
-				);
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"-force_load",
-					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/libduckdb-device.a",
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"-force_load",
-					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64_x86_64-simulator/libduckdb-sim.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2138,21 +2129,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/Headers";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-liconv",
 					"-lc++",
-				);
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"-force_load",
-					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64/libduckdb-device.a",
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"-force_load",
-					"$(SRCROOT)/../Libs/ios/DuckDB.xcframework/ios-arm64_x86_64-simulator/libduckdb-sim.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.TablePro.TableProMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TableProMobile/TableProMobile/AppState.swift
+++ b/TableProMobile/TableProMobile/AppState.swift
@@ -189,6 +189,7 @@ final class AppState {
         try? secureStore.delete(forKey: "com.TablePro.sshpassword.\(connection.id.uuidString)")
         try? secureStore.delete(forKey: "com.TablePro.keypassphrase.\(connection.id.uuidString)")
         try? secureStore.delete(forKey: "com.TablePro.sshkeydata.\(connection.id.uuidString)")
+        FileBookmarkStore().delete(for: connection.id)
         clearPerConnectionPreferences(for: connection.id)
         persist(connections: updated)
         updateWidgetData()

--- a/TableProMobile/TableProMobile/CBridges/CDuckDB/CDuckDB.h
+++ b/TableProMobile/TableProMobile/CBridges/CDuckDB/CDuckDB.h
@@ -1,0 +1,6 @@
+#ifndef CDuckDB_h
+#define CDuckDB_h
+
+#include <duckdb.h>
+
+#endif

--- a/TableProMobile/TableProMobile/CBridges/CDuckDB/module.modulemap
+++ b/TableProMobile/TableProMobile/CBridges/CDuckDB/module.modulemap
@@ -1,0 +1,4 @@
+module CDuckDB [system] {
+    header "CDuckDB.h"
+    export *
+}

--- a/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
+++ b/TableProMobile/TableProMobile/Coordinators/ConnectionCoordinator.swift
@@ -55,7 +55,7 @@ final class ConnectionCoordinator {
 
     var supportsSchemas: Bool {
         connection.type == .postgresql || connection.type == .redshift ||
-        connection.type == .mssql
+        connection.type == .mssql || connection.type == .duckdb
     }
 
     init(connection: DatabaseConnection, appState: AppState) {

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
@@ -1,0 +1,231 @@
+import CDuckDB
+import Foundation
+import TableProModels
+
+extension DuckDBActor {
+    static func decodeCell(vector: duckdb_vector, row: idx_t, column: DuckDBStreamColumn, options: StreamOptions) -> Cell {
+        if let validity = duckdb_vector_get_validity(vector), !duckdb_validity_row_is_valid(validity, row) {
+            return .null
+        }
+        guard let data = duckdb_vector_get_data(vector) else { return .null }
+
+        if column.castToText {
+            return decodeVarchar(data, row: row, options: options)
+        }
+
+        switch column.type {
+        case DUCKDB_TYPE_VARCHAR:
+            return decodeVarchar(data, row: row, options: options)
+        case DUCKDB_TYPE_BLOB:
+            return decodeBlob(data, row: row)
+        case DUCKDB_TYPE_BOOLEAN:
+            return .text(data.load(fromByteOffset: Int(row) * MemoryLayout<Bool>.stride, as: Bool.self) ? "true" : "false")
+        case DUCKDB_TYPE_TINYINT:
+            return .text(String(element(data, row, Int8.self)))
+        case DUCKDB_TYPE_SMALLINT:
+            return .text(String(element(data, row, Int16.self)))
+        case DUCKDB_TYPE_INTEGER:
+            return .text(String(element(data, row, Int32.self)))
+        case DUCKDB_TYPE_BIGINT:
+            return .text(String(element(data, row, Int64.self)))
+        case DUCKDB_TYPE_UTINYINT:
+            return .text(String(element(data, row, UInt8.self)))
+        case DUCKDB_TYPE_USMALLINT:
+            return .text(String(element(data, row, UInt16.self)))
+        case DUCKDB_TYPE_UINTEGER:
+            return .text(String(element(data, row, UInt32.self)))
+        case DUCKDB_TYPE_UBIGINT:
+            return .text(String(element(data, row, UInt64.self)))
+        case DUCKDB_TYPE_FLOAT:
+            return .text(String(element(data, row, Float.self)))
+        case DUCKDB_TYPE_DOUBLE:
+            return .text(String(element(data, row, Double.self)))
+        case DUCKDB_TYPE_HUGEINT:
+            let value = element(data, row, duckdb_hugeint.self)
+            return .text(HugeIntFormatter.format(upper: value.upper, lower: value.lower))
+        case DUCKDB_TYPE_UHUGEINT:
+            let value = element(data, row, duckdb_uhugeint.self)
+            return .text(HugeIntFormatter.formatUnsigned(upper: value.upper, lower: value.lower))
+        case DUCKDB_TYPE_UUID:
+            let value = element(data, row, duckdb_hugeint.self)
+            return .text(formatUUID(value))
+        case DUCKDB_TYPE_DATE:
+            let value = element(data, row, duckdb_date.self)
+            return .text(formatDate(duckdb_from_date(value)))
+        case DUCKDB_TYPE_TIME:
+            let value = element(data, row, duckdb_time.self)
+            return .text(formatTime(duckdb_from_time(value)))
+        case DUCKDB_TYPE_TIMESTAMP, DUCKDB_TYPE_TIMESTAMP_S, DUCKDB_TYPE_TIMESTAMP_MS, DUCKDB_TYPE_TIMESTAMP_NS:
+            return .text(formatTimestamp(normalizedTimestamp(data, row: row, type: column.type)))
+        default:
+            return decodeVarchar(data, row: row, options: options)
+        }
+    }
+
+    private static func element<T>(_ data: UnsafeMutableRawPointer, _ row: idx_t, _ type: T.Type) -> T {
+        data.load(fromByteOffset: Int(row) * MemoryLayout<T>.stride, as: T.self)
+    }
+
+    private static func decodeVarchar(_ data: UnsafeMutableRawPointer, row: idx_t, options: StreamOptions) -> Cell {
+        let strings = data.assumingMemoryBound(to: duckdb_string_t.self)
+        var value = strings[Int(row)]
+        let length = Int(duckdb_string_t_length(value))
+        guard length > 0, let pointer = duckdb_string_t_data(&value) else { return .text("") }
+        let text = String(bytes: UnsafeRawBufferPointer(start: pointer, count: length), encoding: .utf8) ?? ""
+        if length > options.textTruncationBytes {
+            let prefix = String(text.prefix(options.textTruncationBytes))
+            return .truncatedText(prefix: prefix, totalBytes: length, ref: nil)
+        }
+        return .text(text)
+    }
+
+    private static func decodeBlob(_ data: UnsafeMutableRawPointer, row: idx_t) -> Cell {
+        let strings = data.assumingMemoryBound(to: duckdb_string_t.self)
+        var value = strings[Int(row)]
+        let length = Int(duckdb_string_t_length(value))
+        guard length > 0, let pointer = duckdb_string_t_data(&value) else { return .text("") }
+        let bytes = UnsafeRawBufferPointer(start: pointer, count: length)
+        return .text(Data(bytes).base64EncodedString())
+    }
+
+    private static func normalizedTimestamp(_ data: UnsafeMutableRawPointer, row: idx_t, type: duckdb_type) -> duckdb_timestamp {
+        let raw = element(data, row, duckdb_timestamp.self).micros
+        switch type {
+        case DUCKDB_TYPE_TIMESTAMP_S:
+            return duckdb_timestamp(micros: raw * 1_000_000)
+        case DUCKDB_TYPE_TIMESTAMP_MS:
+            return duckdb_timestamp(micros: raw * 1_000)
+        case DUCKDB_TYPE_TIMESTAMP_NS:
+            return duckdb_timestamp(micros: raw / 1_000)
+        default:
+            return duckdb_timestamp(micros: raw)
+        }
+    }
+
+    // MARK: - Formatting (matches duckdb_value_varchar output)
+
+    static func formatTimestamp(_ ts: duckdb_timestamp) -> String {
+        let parts = duckdb_from_timestamp(ts)
+        let date = parts.date
+        let time = parts.time
+        let micros = time.micros % 1_000_000
+        let year = formatYearISO(date.year)
+        if micros == 0 {
+            return String(format: "\(year)-%02d-%02d %02d:%02d:%02d", date.month, date.day, time.hour, time.min, time.sec)
+        }
+        return String(format: "\(year)-%02d-%02d %02d:%02d:%02d.%06d", date.month, date.day, time.hour, time.min, time.sec, micros)
+    }
+
+    static func formatDate(_ date: duckdb_date_struct) -> String {
+        String(format: "\(formatYearISO(date.year))-%02d-%02d", date.month, date.day)
+    }
+
+    static func formatTime(_ time: duckdb_time_struct) -> String {
+        let micros = time.micros % 1_000_000
+        if micros == 0 {
+            return String(format: "%02d:%02d:%02d", time.hour, time.min, time.sec)
+        }
+        return String(format: "%02d:%02d:%02d.%06d", time.hour, time.min, time.sec, micros)
+    }
+
+    static func formatYearISO(_ year: Int32) -> String {
+        year < 0 ? String(format: "-%04d", -Int(year)) : String(format: "%04d", year)
+    }
+
+    static func formatUUID(_ value: duckdb_hugeint) -> String {
+        let high = UInt64(bitPattern: value.upper) ^ 0x8000_0000_0000_0000
+        let low = value.lower
+        let hex = String(format: "%016llx%016llx", high, low)
+        let s = Array(hex)
+        return "\(String(s[0..<8]))-\(String(s[8..<12]))-\(String(s[12..<16]))-\(String(s[16..<20]))-\(String(s[20..<32]))"
+    }
+
+    static func streamTypeName(for type: duckdb_type) -> String {
+        switch type {
+        case DUCKDB_TYPE_BOOLEAN: return "BOOLEAN"
+        case DUCKDB_TYPE_TINYINT: return "TINYINT"
+        case DUCKDB_TYPE_SMALLINT: return "SMALLINT"
+        case DUCKDB_TYPE_INTEGER: return "INTEGER"
+        case DUCKDB_TYPE_BIGINT: return "BIGINT"
+        case DUCKDB_TYPE_UTINYINT: return "UTINYINT"
+        case DUCKDB_TYPE_USMALLINT: return "USMALLINT"
+        case DUCKDB_TYPE_UINTEGER: return "UINTEGER"
+        case DUCKDB_TYPE_UBIGINT: return "UBIGINT"
+        case DUCKDB_TYPE_FLOAT: return "FLOAT"
+        case DUCKDB_TYPE_DOUBLE: return "DOUBLE"
+        case DUCKDB_TYPE_TIMESTAMP: return "TIMESTAMP"
+        case DUCKDB_TYPE_DATE: return "DATE"
+        case DUCKDB_TYPE_TIME: return "TIME"
+        case DUCKDB_TYPE_INTERVAL: return "INTERVAL"
+        case DUCKDB_TYPE_HUGEINT: return "HUGEINT"
+        case DUCKDB_TYPE_UHUGEINT: return "UHUGEINT"
+        case DUCKDB_TYPE_VARCHAR: return "VARCHAR"
+        case DUCKDB_TYPE_BLOB: return "BLOB"
+        case DUCKDB_TYPE_DECIMAL: return "DECIMAL"
+        case DUCKDB_TYPE_TIMESTAMP_S: return "TIMESTAMP_S"
+        case DUCKDB_TYPE_TIMESTAMP_MS: return "TIMESTAMP_MS"
+        case DUCKDB_TYPE_TIMESTAMP_NS: return "TIMESTAMP_NS"
+        case DUCKDB_TYPE_ENUM: return "ENUM"
+        case DUCKDB_TYPE_LIST: return "LIST"
+        case DUCKDB_TYPE_STRUCT: return "STRUCT"
+        case DUCKDB_TYPE_MAP: return "MAP"
+        case DUCKDB_TYPE_ARRAY: return "ARRAY"
+        case DUCKDB_TYPE_UUID: return "UUID"
+        case DUCKDB_TYPE_UNION: return "UNION"
+        case DUCKDB_TYPE_BIT: return "BIT"
+        case DUCKDB_TYPE_TIMESTAMP_TZ: return "TIMESTAMPTZ"
+        case DUCKDB_TYPE_TIME_TZ: return "TIMETZ"
+        case DUCKDB_TYPE_GEOMETRY: return "GEOMETRY"
+        default: return "VARCHAR"
+        }
+    }
+}
+
+enum HugeIntFormatter {
+    static func format(upper: Int64, lower: UInt64) -> String {
+        if upper == 0 {
+            return String(lower)
+        }
+        let negative = upper < 0
+        var magHigh: UInt64
+        var magLow: UInt64
+        if negative {
+            let low = ~lower &+ 1
+            let carry: UInt64 = low == 0 ? 1 : 0
+            magHigh = ~UInt64(bitPattern: upper) &+ carry
+            magLow = low
+        } else {
+            magHigh = UInt64(bitPattern: upper)
+            magLow = lower
+        }
+        let digits = decimalString(high: magHigh, low: magLow)
+        return negative ? "-\(digits)" : digits
+    }
+
+    static func formatUnsigned(upper: UInt64, lower: UInt64) -> String {
+        if upper == 0 {
+            return String(lower)
+        }
+        return decimalString(high: upper, low: lower)
+    }
+
+    private static func decimalString(high: UInt64, low: UInt64) -> String {
+        var parts: [UInt32] = [
+            UInt32(low & 0xFFFF_FFFF),
+            UInt32((low >> 32) & 0xFFFF_FFFF),
+            UInt32(high & 0xFFFF_FFFF),
+            UInt32((high >> 32) & 0xFFFF_FFFF),
+        ]
+        var digits = ""
+        repeat {
+            var remainder: UInt64 = 0
+            for index in stride(from: parts.count - 1, through: 0, by: -1) {
+                let acc = (remainder << 32) | UInt64(parts[index])
+                parts[index] = UInt32(acc / 10)
+                remainder = acc % 10
+            }
+            digits = "\(remainder)\(digits)"
+        } while parts.contains(where: { $0 != 0 })
+        return digits.isEmpty ? "0" : digits
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
@@ -140,44 +140,26 @@ extension DuckDBActor {
         return "\(String(s[0..<8]))-\(String(s[8..<12]))-\(String(s[12..<16]))-\(String(s[16..<20]))-\(String(s[20..<32]))"
     }
 
-    static func streamTypeName(for type: duckdb_type) -> String {
+    // Single source of truth for which types decodeCell handles directly from
+    // vector data. Anything not in this allowlist is cast to VARCHAR in the
+    // query (requiresTextCast), so an unhandled or future type can never reach
+    // the native decode path and reinterpret non-string bytes as a string.
+    static func isNativelyDecodable(_ type: duckdb_type) -> Bool {
         switch type {
-        case DUCKDB_TYPE_BOOLEAN: return "BOOLEAN"
-        case DUCKDB_TYPE_TINYINT: return "TINYINT"
-        case DUCKDB_TYPE_SMALLINT: return "SMALLINT"
-        case DUCKDB_TYPE_INTEGER: return "INTEGER"
-        case DUCKDB_TYPE_BIGINT: return "BIGINT"
-        case DUCKDB_TYPE_UTINYINT: return "UTINYINT"
-        case DUCKDB_TYPE_USMALLINT: return "USMALLINT"
-        case DUCKDB_TYPE_UINTEGER: return "UINTEGER"
-        case DUCKDB_TYPE_UBIGINT: return "UBIGINT"
-        case DUCKDB_TYPE_FLOAT: return "FLOAT"
-        case DUCKDB_TYPE_DOUBLE: return "DOUBLE"
-        case DUCKDB_TYPE_TIMESTAMP: return "TIMESTAMP"
-        case DUCKDB_TYPE_DATE: return "DATE"
-        case DUCKDB_TYPE_TIME: return "TIME"
-        case DUCKDB_TYPE_INTERVAL: return "INTERVAL"
-        case DUCKDB_TYPE_HUGEINT: return "HUGEINT"
-        case DUCKDB_TYPE_UHUGEINT: return "UHUGEINT"
-        case DUCKDB_TYPE_VARCHAR: return "VARCHAR"
-        case DUCKDB_TYPE_BLOB: return "BLOB"
-        case DUCKDB_TYPE_DECIMAL: return "DECIMAL"
-        case DUCKDB_TYPE_TIMESTAMP_S: return "TIMESTAMP_S"
-        case DUCKDB_TYPE_TIMESTAMP_MS: return "TIMESTAMP_MS"
-        case DUCKDB_TYPE_TIMESTAMP_NS: return "TIMESTAMP_NS"
-        case DUCKDB_TYPE_ENUM: return "ENUM"
-        case DUCKDB_TYPE_LIST: return "LIST"
-        case DUCKDB_TYPE_STRUCT: return "STRUCT"
-        case DUCKDB_TYPE_MAP: return "MAP"
-        case DUCKDB_TYPE_ARRAY: return "ARRAY"
-        case DUCKDB_TYPE_UUID: return "UUID"
-        case DUCKDB_TYPE_UNION: return "UNION"
-        case DUCKDB_TYPE_BIT: return "BIT"
-        case DUCKDB_TYPE_TIMESTAMP_TZ: return "TIMESTAMPTZ"
-        case DUCKDB_TYPE_TIME_TZ: return "TIMETZ"
-        case DUCKDB_TYPE_GEOMETRY: return "GEOMETRY"
-        default: return "VARCHAR"
+        case DUCKDB_TYPE_VARCHAR, DUCKDB_TYPE_BLOB, DUCKDB_TYPE_BOOLEAN,
+             DUCKDB_TYPE_TINYINT, DUCKDB_TYPE_SMALLINT, DUCKDB_TYPE_INTEGER, DUCKDB_TYPE_BIGINT,
+             DUCKDB_TYPE_UTINYINT, DUCKDB_TYPE_USMALLINT, DUCKDB_TYPE_UINTEGER, DUCKDB_TYPE_UBIGINT,
+             DUCKDB_TYPE_FLOAT, DUCKDB_TYPE_DOUBLE, DUCKDB_TYPE_HUGEINT, DUCKDB_TYPE_UHUGEINT,
+             DUCKDB_TYPE_UUID, DUCKDB_TYPE_DATE, DUCKDB_TYPE_TIME,
+             DUCKDB_TYPE_TIMESTAMP, DUCKDB_TYPE_TIMESTAMP_S, DUCKDB_TYPE_TIMESTAMP_MS, DUCKDB_TYPE_TIMESTAMP_NS:
+            return true
+        default:
+            return false
         }
+    }
+
+    static func requiresTextCast(_ type: duckdb_type) -> Bool {
+        !isNativelyDecodable(type)
     }
 }
 

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Schema.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Schema.swift
@@ -1,0 +1,177 @@
+import Foundation
+import TableProDatabase
+import TableProModels
+
+extension DuckDBDriver {
+    func fetchTables(schema: String?) async throws -> [TableInfo] {
+        let schemaName = resolveSchema(schema)
+        let query = """
+            SELECT table_name, table_type
+            FROM information_schema.tables
+            WHERE table_schema = '\(escapeLiteral(schemaName))'
+            ORDER BY table_name
+            """
+        let result = try await actor.query(query)
+        return result.rows.compactMap { row in
+            guard row.count > 0, let name = row[0] else { return nil }
+            let typeString = (row.count > 1 ? row[1] : nil) ?? "BASE TABLE"
+            let kind: TableInfo.TableKind = typeString.uppercased().contains("VIEW") ? .view : .table
+            return TableInfo(name: name, type: kind)
+        }
+    }
+
+    func fetchColumns(table: String, schema: String?) async throws -> [ColumnInfo] {
+        let schemaName = resolveSchema(schema)
+        let query = """
+            SELECT column_name, data_type, is_nullable, column_default, ordinal_position
+            FROM information_schema.columns
+            WHERE table_schema = '\(escapeLiteral(schemaName))'
+              AND table_name = '\(escapeLiteral(table))'
+            ORDER BY ordinal_position
+            """
+        let result = try await actor.query(query)
+        let primaryKeys = try await fetchPrimaryKeyColumns(table: table, schema: schemaName)
+
+        return result.rows.enumerated().compactMap { index, row in
+            guard row.count >= 2, let name = row[0], let dataType = row[1] else { return nil }
+            return ColumnInfo(
+                name: name,
+                typeName: dataType,
+                isPrimaryKey: primaryKeys.contains(name),
+                isNullable: (row.count > 2 ? row[2] : nil) == "YES",
+                defaultValue: row.count > 3 ? row[3] : nil,
+                ordinalPosition: index
+            )
+        }
+    }
+
+    func fetchIndexes(table: String, schema: String?) async throws -> [IndexInfo] {
+        let schemaName = resolveSchema(schema)
+        let query = """
+            SELECT index_name, is_unique, sql
+            FROM duckdb_indexes()
+            WHERE schema_name = '\(escapeLiteral(schemaName))'
+              AND table_name = '\(escapeLiteral(table))'
+            """
+        let result = try await actor.query(query)
+        return result.rows.compactMap { row in
+            guard row.count > 0, let name = row[0] else { return nil }
+            let sql = row.count > 2 ? row[2] : nil
+            let isUnique = (row.count > 1 ? row[1] : nil) == "true"
+            let isPrimary = name.lowercased().contains("primary")
+                || (sql?.uppercased().contains("PRIMARY KEY") ?? false)
+            return IndexInfo(
+                name: name,
+                columns: Self.extractIndexColumns(from: sql),
+                isUnique: isUnique || isPrimary,
+                isPrimary: isPrimary,
+                type: "ART"
+            )
+        }
+    }
+
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [ForeignKeyInfo] {
+        let schemaName = resolveSchema(schema)
+        let query = """
+            SELECT
+                rc.constraint_name,
+                kcu.column_name,
+                kcu2.table_name AS referenced_table,
+                kcu2.column_name AS referenced_column,
+                rc.delete_rule,
+                rc.update_rule
+            FROM information_schema.referential_constraints rc
+            JOIN information_schema.key_column_usage kcu
+                ON rc.constraint_name = kcu.constraint_name
+                AND rc.constraint_schema = kcu.constraint_schema
+            JOIN information_schema.key_column_usage kcu2
+                ON rc.unique_constraint_name = kcu2.constraint_name
+                AND rc.unique_constraint_schema = kcu2.constraint_schema
+                AND kcu.ordinal_position = kcu2.ordinal_position
+            WHERE kcu.table_schema = '\(escapeLiteral(schemaName))'
+              AND kcu.table_name = '\(escapeLiteral(table))'
+            """
+        do {
+            let result = try await actor.query(query)
+            return result.rows.compactMap { row in
+                guard row.count >= 4,
+                      let name = row[0],
+                      let column = row[1],
+                      let referencedTable = row[2],
+                      let referencedColumn = row[3] else {
+                    return nil
+                }
+                return ForeignKeyInfo(
+                    name: name,
+                    column: column,
+                    referencedTable: referencedTable,
+                    referencedColumn: referencedColumn,
+                    onDelete: (row.count > 4 ? row[4] : nil) ?? "NO ACTION",
+                    onUpdate: (row.count > 5 ? row[5] : nil) ?? "NO ACTION"
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+
+    func fetchSchemas() async throws -> [String] {
+        let query = "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name"
+        let result = try await actor.query(query)
+        return result.rows.compactMap { $0.first ?? nil }
+    }
+
+    func switchDatabase(to name: String) async throws {
+        throw DuckDBDriverError.unsupported("DuckDB does not support switching databases on this platform")
+    }
+
+    func switchSchema(to name: String) async throws {
+        _ = try await actor.query("SET schema = \"\(escapeIdentifier(name))\"")
+        setCurrentSchema(name)
+    }
+
+    // MARK: - Helpers
+
+    private func fetchPrimaryKeyColumns(table: String, schema: String) async throws -> Set<String> {
+        let query = """
+            SELECT kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+              AND tc.table_schema = kcu.table_schema
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+              AND tc.table_schema = '\(escapeLiteral(schema))'
+              AND tc.table_name = '\(escapeLiteral(table))'
+            """
+        let result = try await actor.query(query)
+        return Set(result.rows.compactMap { $0.first ?? nil })
+    }
+
+    private func escapeLiteral(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "''")
+    }
+
+    private func escapeIdentifier(_ value: String) -> String {
+        value.replacingOccurrences(of: "\"", with: "\"\"")
+    }
+
+    private static let indexColumnsRegex = try? NSRegularExpression(
+        pattern: #"ON\s+(?:(?:"[^"]*"|[^\s(]+)\s*\.\s*)*(?:"[^"]*"|[^\s(]+)\s*\(([^)]+)\)"#,
+        options: .caseInsensitive
+    )
+
+    private static func extractIndexColumns(from sql: String?) -> [String] {
+        guard let sql, let regex = indexColumnsRegex else { return [] }
+        let range = NSRange(sql.startIndex..., in: sql)
+        guard let match = regex.firstMatch(in: sql, range: range),
+              match.numberOfRanges > 1,
+              let columnsRange = Range(match.range(at: 1), in: sql) else {
+            return []
+        }
+        return String(sql[columnsRange]).split(separator: ",").map {
+            $0.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "\"", with: "")
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
@@ -41,7 +41,7 @@ extension DuckDBDriver {
 
     func executeStreaming(query: String, options: StreamOptions) -> AsyncThrowingStream<StreamElement, Error> {
         let actor = self.actor
-        return AsyncThrowingStream { continuation in
+        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let task = Task {
                 do {
                     let columns: [DuckDBStreamColumn]

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
@@ -99,7 +99,9 @@ extension DuckDBActor {
         endStream()
 
         let plan = try planColumns(connection: connection, query: query)
-        let streamQuery = Self.buildStreamQuery(originalQuery: query, columns: plan)
+        let streamQuery = plan.contains(where: { $0.castToText })
+            ? Self.castedQuery(originalQuery: query, columns: plan)
+            : query
 
         var stmt: duckdb_prepared_statement?
         guard duckdb_prepare(connection, streamQuery, &stmt) != DuckDBError, let preparedStmt = stmt else {
@@ -188,7 +190,7 @@ extension DuckDBActor {
             let type = duckdb_column_type(&probe, index)
             columns.append(DuckDBStreamColumn(
                 name: name,
-                typeName: Self.streamTypeName(for: type),
+                typeName: Self.typeName(for: type),
                 type: type,
                 castToText: Self.requiresTextCast(type)
             ))
@@ -198,39 +200,5 @@ extension DuckDBActor {
 
     private static func zeroRowQuery(for query: String) -> String {
         "SELECT * FROM (\(stripTrailingSemicolon(query))) AS _tp_probe LIMIT 0"
-    }
-
-    static func buildStreamQuery(originalQuery: String, columns: [DuckDBStreamColumn]) -> String {
-        guard columns.contains(where: { $0.castToText }) else {
-            return originalQuery
-        }
-        let projection = columns.map { column -> String in
-            let quoted = quoteIdentifier(column.name)
-            guard column.castToText else { return quoted }
-            if column.type == DUCKDB_TYPE_GEOMETRY {
-                return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
-            }
-            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
-        }
-        return "SELECT \(projection.joined(separator: ", ")) FROM (\(stripTrailingSemicolon(originalQuery))) AS _tp_stream"
-    }
-
-    private static func stripTrailingSemicolon(_ query: String) -> String {
-        var trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasSuffix(";") {
-            trimmed = String(trimmed.dropLast())
-        }
-        return trimmed
-    }
-
-    private static func requiresTextCast(_ type: duckdb_type) -> Bool {
-        switch type {
-        case DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
-             DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY,
-             DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT, DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM:
-            return true
-        default:
-            return false
-        }
     }
 }

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
@@ -1,0 +1,240 @@
+import CDuckDB
+import Foundation
+import TableProDatabase
+import TableProModels
+
+struct DuckDBStreamColumn: Sendable {
+    let name: String
+    let typeName: String
+    let type: duckdb_type
+    let castToText: Bool
+}
+
+extension DuckDBDriver {
+    private static func yieldMaterialized(
+        query: String,
+        options: StreamOptions,
+        actor: DuckDBActor,
+        continuation: AsyncThrowingStream<StreamElement, Error>.Continuation
+    ) async throws {
+        let raw = try await actor.query(query)
+        let columns = raw.columnNames.enumerated().map { index, name in
+            ColumnInfo(name: name, typeName: index < raw.columnTypeNames.count ? raw.columnTypeNames[index] : "", ordinalPosition: index)
+        }
+        continuation.yield(.columns(columns))
+        var emitted = 0
+        for legacyRow in raw.rows {
+            if emitted >= options.maxRows {
+                continuation.yield(.truncated(reason: .rowCap(options.maxRows)))
+                break
+            }
+            let cells = legacyRow.enumerated().map { index, value -> Cell in
+                Cell.from(legacyValue: value, columnTypeName: index < columns.count ? columns[index].typeName : nil, options: options)
+            }
+            continuation.yield(.row(Row(cells: cells)))
+            emitted += 1
+        }
+        if raw.rowsAffected != 0 {
+            continuation.yield(.rowsAffected(raw.rowsAffected))
+        }
+    }
+
+    func executeStreaming(query: String, options: StreamOptions) -> AsyncThrowingStream<StreamElement, Error> {
+        let actor = self.actor
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let columns: [DuckDBStreamColumn]
+                    do {
+                        columns = try await actor.beginStream(query: query)
+                    } catch {
+                        try await Self.yieldMaterialized(query: query, options: options, actor: actor, continuation: continuation)
+                        continuation.finish()
+                        return
+                    }
+                    continuation.yield(.columns(columns.map {
+                        ColumnInfo(name: $0.name, typeName: $0.typeName, ordinalPosition: 0)
+                    }))
+
+                    var emitted = 0
+                    rows: while !Task.isCancelled, emitted < options.maxRows {
+                        guard let chunk = try await actor.fetchStreamChunk(options: options) else { break }
+                        for cells in chunk {
+                            if emitted >= options.maxRows {
+                                continuation.yield(.truncated(reason: .rowCap(options.maxRows)))
+                                break rows
+                            }
+                            continuation.yield(.row(Row(cells: cells)))
+                            emitted += 1
+                        }
+                    }
+
+                    if Task.isCancelled {
+                        continuation.yield(.truncated(reason: .cancelled))
+                    }
+                    await actor.endStream()
+                    continuation.finish()
+                } catch is CancellationError {
+                    await actor.endStream()
+                    continuation.yield(.truncated(reason: .cancelled))
+                    continuation.finish()
+                } catch {
+                    await actor.endStream()
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { reason in
+                task.cancel()
+                if case .cancelled = reason {
+                    Task { await actor.interrupt() }
+                }
+            }
+        }
+    }
+}
+
+extension DuckDBActor {
+    func beginStream(query: String) throws -> [DuckDBStreamColumn] {
+        guard let connection else { throw DuckDBDriverError.notConnected }
+        endStream()
+
+        let plan = try planColumns(connection: connection, query: query)
+        let streamQuery = Self.buildStreamQuery(originalQuery: query, columns: plan)
+
+        var stmt: duckdb_prepared_statement?
+        guard duckdb_prepare(connection, streamQuery, &stmt) != DuckDBError, let preparedStmt = stmt else {
+            let message = stmt.flatMap { duckdb_prepare_error($0).map { String(cString: $0) } } ?? "Failed to prepare query"
+            duckdb_destroy_prepare(&stmt)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+        defer { duckdb_destroy_prepare(&stmt) }
+
+        var pending: duckdb_pending_result?
+        guard duckdb_pending_prepared_streaming(preparedStmt, &pending) != DuckDBError, pending != nil else {
+            let message = pending.flatMap { duckdb_pending_error($0).map { String(cString: $0) } } ?? "Failed to start streaming"
+            duckdb_destroy_pending(&pending)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+        defer { duckdb_destroy_pending(&pending) }
+
+        var result = duckdb_result()
+        guard duckdb_execute_pending(pending, &result) != DuckDBError else {
+            let message = duckdb_result_error(&result).map { String(cString: $0) } ?? "Failed to execute query"
+            duckdb_destroy_result(&result)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+
+        streamResult = result
+        streamColumns = plan
+        return plan
+    }
+
+    func fetchStreamChunk(options: StreamOptions) -> [[Cell]]? {
+        guard let result = streamResult else { return nil }
+        var chunk = duckdb_stream_fetch_chunk(result)
+        guard chunk != nil else { return nil }
+        defer { duckdb_destroy_data_chunk(&chunk) }
+
+        let rowCount = duckdb_data_chunk_get_size(chunk)
+        guard rowCount > 0 else { return [] }
+
+        var rows: [[Cell]] = []
+        rows.reserveCapacity(Int(rowCount))
+        let columns = streamColumns
+
+        var vectors: [duckdb_vector?] = []
+        for index in 0..<columns.count {
+            vectors.append(duckdb_data_chunk_get_vector(chunk, idx_t(index)))
+        }
+
+        for row in 0..<rowCount {
+            var cells: [Cell] = []
+            cells.reserveCapacity(columns.count)
+            for index in 0..<columns.count {
+                guard let vector = vectors[index] else {
+                    cells.append(.null)
+                    continue
+                }
+                cells.append(Self.decodeCell(vector: vector, row: row, column: columns[index], options: options))
+            }
+            rows.append(cells)
+        }
+        return rows
+    }
+
+    func endStream() {
+        if var result = streamResult {
+            duckdb_destroy_result(&result)
+            streamResult = nil
+        }
+        streamColumns = []
+    }
+
+    // MARK: - Column Planning
+
+    private func planColumns(connection: duckdb_connection, query: String) throws -> [DuckDBStreamColumn] {
+        var probe = duckdb_result()
+        guard duckdb_query(connection, Self.zeroRowQuery(for: query), &probe) != DuckDBError else {
+            let message = duckdb_result_error(&probe).map { String(cString: $0) } ?? "Unknown DuckDB error"
+            duckdb_destroy_result(&probe)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+        defer { duckdb_destroy_result(&probe) }
+
+        let columnCount = duckdb_column_count(&probe)
+        var columns: [DuckDBStreamColumn] = []
+        for index in 0..<columnCount {
+            let name = duckdb_column_name(&probe, index).map { String(cString: $0) } ?? "column_\(index)"
+            let type = duckdb_column_type(&probe, index)
+            columns.append(DuckDBStreamColumn(
+                name: name,
+                typeName: Self.streamTypeName(for: type),
+                type: type,
+                castToText: Self.requiresTextCast(type)
+            ))
+        }
+        return columns
+    }
+
+    private static func zeroRowQuery(for query: String) -> String {
+        "SELECT * FROM (\(stripTrailingSemicolon(query))) AS _tp_probe LIMIT 0"
+    }
+
+    static func buildStreamQuery(originalQuery: String, columns: [DuckDBStreamColumn]) -> String {
+        guard columns.contains(where: { $0.castToText }) else {
+            return originalQuery
+        }
+        let projection = columns.map { column -> String in
+            let quoted = quoteIdentifier(column.name)
+            guard column.castToText else { return quoted }
+            if column.type == DUCKDB_TYPE_GEOMETRY {
+                return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
+            }
+            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
+        }
+        return "SELECT \(projection.joined(separator: ", ")) FROM (\(stripTrailingSemicolon(originalQuery))) AS _tp_stream"
+    }
+
+    private static func stripTrailingSemicolon(_ query: String) -> String {
+        var trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix(";") {
+            trimmed = String(trimmed.dropLast())
+        }
+        return trimmed
+    }
+
+    static func quoteIdentifier(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    private static func requiresTextCast(_ type: duckdb_type) -> Bool {
+        switch type {
+        case DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
+             DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY,
+             DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT, DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
@@ -58,7 +58,7 @@ extension DuckDBDriver {
 
                     var emitted = 0
                     rows: while !Task.isCancelled, emitted < options.maxRows {
-                        guard let chunk = try await actor.fetchStreamChunk(options: options) else { break }
+                        guard let chunk = await actor.fetchStreamChunk(options: options) else { break }
                         for cells in chunk {
                             if emitted >= options.maxRows {
                                 continuation.yield(.truncated(reason: .rowCap(options.maxRows)))
@@ -221,10 +221,6 @@ extension DuckDBActor {
             trimmed = String(trimmed.dropLast())
         }
         return trimmed
-    }
-
-    static func quoteIdentifier(_ identifier: String) -> String {
-        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 
     private static func requiresTextCast(_ type: duckdb_type) -> Bool {

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -1,0 +1,406 @@
+import CDuckDB
+import Foundation
+import TableProDatabase
+import TableProModels
+
+final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
+    static let inMemoryPath = ":memory:"
+
+    let actor = DuckDBActor()
+    private let dbPath: String
+    private let bookmark: Data?
+    private let stateLock = NSLock()
+    private var currentSchemaName = "main"
+    private var securedURL: URL?
+
+    var supportsSchemas: Bool { true }
+    var supportsTransactions: Bool { true }
+    var serverVersion: String? { String(cString: duckdb_library_version()) }
+
+    var currentSchema: String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return currentSchemaName
+    }
+
+    init(path: String, bookmark: Data?) {
+        self.dbPath = path
+        self.bookmark = bookmark
+    }
+
+    // MARK: - Connection
+
+    func connect() async throws {
+        let resolvedPath = try resolvePath()
+        try await actor.open(path: resolvedPath)
+    }
+
+    func disconnect() async throws {
+        await actor.close()
+        if let url = takeSecuredURL() {
+            url.stopAccessingSecurityScopedResource()
+        }
+    }
+
+    func ping() async throws -> Bool {
+        _ = try await actor.query("SELECT 1")
+        return true
+    }
+
+    private func resolvePath() throws -> String {
+        if dbPath == Self.inMemoryPath {
+            return Self.inMemoryPath
+        }
+
+        if let bookmark {
+            var isStale = false
+            let url = try URL(
+                resolvingBookmarkData: bookmark,
+                options: [],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            guard url.startAccessingSecurityScopedResource() else {
+                throw DuckDBDriverError.connectionFailed("Cannot access the DuckDB file. Open it again to grant access.")
+            }
+            setSecuredURL(url)
+            return url.path
+        }
+
+        let expanded = (dbPath as NSString).expandingTildeInPath
+        if !FileManager.default.fileExists(atPath: expanded) {
+            let directory = (expanded as NSString).deletingLastPathComponent
+            if !directory.isEmpty {
+                try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+            }
+        }
+        return expanded
+    }
+
+    // MARK: - Query Execution
+
+    func execute(query: String) async throws -> QueryResult {
+        let raw = try await actor.query(query)
+        let columns = raw.columnNames.enumerated().map { index, name in
+            ColumnInfo(
+                name: name,
+                typeName: index < raw.columnTypeNames.count ? raw.columnTypeNames[index] : "",
+                ordinalPosition: index
+            )
+        }
+        return QueryResult(
+            columns: columns,
+            rows: raw.rows,
+            rowsAffected: raw.rowsAffected,
+            executionTime: raw.executionTime,
+            isTruncated: raw.isTruncated
+        )
+    }
+
+    func cancelCurrentQuery() async throws {
+        await actor.interrupt()
+    }
+
+    // MARK: - Transactions
+
+    func beginTransaction() async throws {
+        _ = try await actor.query("BEGIN TRANSACTION")
+    }
+
+    func commitTransaction() async throws {
+        _ = try await actor.query("COMMIT")
+    }
+
+    func rollbackTransaction() async throws {
+        _ = try await actor.query("ROLLBACK")
+    }
+
+    // MARK: - State
+
+    func resolveSchema(_ schema: String?) -> String {
+        if let schema { return schema }
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return currentSchemaName
+    }
+
+    func setCurrentSchema(_ schema: String) {
+        stateLock.lock()
+        currentSchemaName = schema
+        stateLock.unlock()
+    }
+
+    private func setSecuredURL(_ url: URL) {
+        stateLock.lock()
+        securedURL = url
+        stateLock.unlock()
+    }
+
+    private func takeSecuredURL() -> URL? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        let url = securedURL
+        securedURL = nil
+        return url
+    }
+}
+
+// MARK: - DuckDB Actor (thread-safe C API access)
+
+actor DuckDBActor {
+    private static let maxRows = 100_000
+
+    private var database: duckdb_database?
+    private var connection: duckdb_connection?
+
+    func interrupt() {
+        guard let connection else { return }
+        duckdb_interrupt(connection)
+    }
+
+    func open(path: String) throws {
+        var db: duckdb_database?
+        var errorPtr: UnsafeMutablePointer<CChar>?
+        let state = duckdb_open_ext(path, &db, nil, &errorPtr)
+
+        if state == DuckDBError {
+            let detail: String
+            if let errorPtr {
+                detail = String(cString: errorPtr)
+                duckdb_free(errorPtr)
+            } else {
+                detail = "unknown error"
+            }
+            throw DuckDBDriverError.connectionFailed(detail)
+        }
+
+        guard db != nil else {
+            throw DuckDBDriverError.connectionFailed("Failed to open the DuckDB database")
+        }
+
+        var conn: duckdb_connection?
+        if duckdb_connect(db, &conn) == DuckDBError {
+            duckdb_close(&db)
+            throw DuckDBDriverError.connectionFailed("Failed to create a DuckDB connection")
+        }
+
+        database = db
+        connection = conn
+    }
+
+    func close() {
+        if connection != nil {
+            duckdb_disconnect(&connection)
+            connection = nil
+        }
+        if database != nil {
+            duckdb_close(&database)
+            database = nil
+        }
+    }
+
+    func query(_ sql: String) throws -> DuckDBRawResult {
+        guard let connection else { throw DuckDBDriverError.notConnected }
+
+        let startTime = Date()
+        var result = duckdb_result()
+
+        if duckdb_query(connection, sql, &result) == DuckDBError {
+            let message = duckdb_result_error(&result).map { String(cString: $0) } ?? "Unknown DuckDB error"
+            duckdb_destroy_result(&result)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+
+        let columnCount = duckdb_column_count(&result)
+        var names: [String] = []
+        var typeNames: [String] = []
+        var types: [duckdb_type] = []
+        for index in 0..<columnCount {
+            names.append(duckdb_column_name(&result, index).map { String(cString: $0) } ?? "column_\(index)")
+            let type = duckdb_column_type(&result, index)
+            types.append(type)
+            typeNames.append(Self.typeName(for: type))
+        }
+
+        if types.contains(where: Self.isUnrenderable) {
+            duckdb_destroy_result(&result)
+            return try queryWithCasts(connection: connection, sql: sql, names: names, typeNames: typeNames, types: types, startTime: startTime)
+        }
+
+        defer { duckdb_destroy_result(&result) }
+        return Self.extract(&result, names: names, typeNames: typeNames, startTime: startTime)
+    }
+
+    private func queryWithCasts(
+        connection: duckdb_connection,
+        sql: String,
+        names: [String],
+        typeNames: [String],
+        types: [duckdb_type],
+        startTime: Date
+    ) throws -> DuckDBRawResult {
+        let wrapped = Self.buildWrappedQuery(originalQuery: sql, columns: names, types: types)
+        var result = duckdb_result()
+        if duckdb_query(connection, wrapped, &result) == DuckDBError {
+            let message = duckdb_result_error(&result).map { String(cString: $0) } ?? "Unknown DuckDB error"
+            duckdb_destroy_result(&result)
+            throw DuckDBDriverError.queryFailed(message)
+        }
+        defer { duckdb_destroy_result(&result) }
+        return Self.extract(&result, names: names, typeNames: typeNames, startTime: startTime)
+    }
+
+    private static func extract(
+        _ result: inout duckdb_result,
+        names: [String],
+        typeNames: [String],
+        startTime: Date
+    ) -> DuckDBRawResult {
+        let columnCount = duckdb_column_count(&result)
+        let rowCount = duckdb_row_count(&result)
+        let rowsChanged = duckdb_rows_changed(&result)
+        let cappedRowCount = min(rowCount, UInt64(maxRows))
+
+        var rows: [[String?]] = []
+        rows.reserveCapacity(Int(cappedRowCount))
+
+        for row in 0..<cappedRowCount {
+            var values: [String?] = []
+            values.reserveCapacity(Int(columnCount))
+            for col in 0..<columnCount {
+                if duckdb_value_is_null(&result, col, row) {
+                    values.append(nil)
+                } else if duckdb_column_type(&result, col) == DUCKDB_TYPE_BLOB {
+                    let blob = duckdb_value_blob(&result, col, row)
+                    if let pointer = blob.data {
+                        values.append(Data(bytes: pointer, count: Int(blob.size)).base64EncodedString())
+                    } else {
+                        values.append("")
+                    }
+                    duckdb_free(blob.data)
+                } else if let valuePointer = duckdb_value_varchar(&result, col, row) {
+                    values.append(String(cString: valuePointer))
+                    duckdb_free(valuePointer)
+                } else {
+                    values.append(nil)
+                }
+            }
+            rows.append(values)
+        }
+
+        return DuckDBRawResult(
+            columnNames: names,
+            columnTypeNames: typeNames,
+            rows: rows,
+            rowsAffected: Int(rowsChanged),
+            executionTime: Date().timeIntervalSince(startTime),
+            isTruncated: rowCount > UInt64(maxRows)
+        )
+    }
+
+    // MARK: - Type Rendering
+
+    private static func isUnrenderable(_ type: duckdb_type) -> Bool {
+        switch type {
+        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func buildWrappedQuery(originalQuery: String, columns: [String], types: [duckdb_type]) -> String {
+        let castExpressions = columns.enumerated().map { index, name in
+            castExpression(for: types[index], column: name)
+        }
+        var trimmed = originalQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix(";") {
+            trimmed = String(trimmed.dropLast())
+        }
+        return "SELECT \(castExpressions.joined(separator: ", ")) FROM (\(trimmed)) AS _tp_cast"
+    }
+
+    private static func castExpression(for type: duckdb_type, column: String) -> String {
+        let quoted = quoteIdentifier(column)
+        switch type {
+        case DUCKDB_TYPE_GEOMETRY:
+            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
+        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ:
+            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
+        default:
+            return quoted
+        }
+    }
+
+    private static func quoteIdentifier(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    private static func typeName(for type: duckdb_type) -> String {
+        switch type {
+        case DUCKDB_TYPE_BOOLEAN: return "BOOLEAN"
+        case DUCKDB_TYPE_TINYINT: return "TINYINT"
+        case DUCKDB_TYPE_SMALLINT: return "SMALLINT"
+        case DUCKDB_TYPE_INTEGER: return "INTEGER"
+        case DUCKDB_TYPE_BIGINT: return "BIGINT"
+        case DUCKDB_TYPE_UTINYINT: return "UTINYINT"
+        case DUCKDB_TYPE_USMALLINT: return "USMALLINT"
+        case DUCKDB_TYPE_UINTEGER: return "UINTEGER"
+        case DUCKDB_TYPE_UBIGINT: return "UBIGINT"
+        case DUCKDB_TYPE_FLOAT: return "FLOAT"
+        case DUCKDB_TYPE_DOUBLE: return "DOUBLE"
+        case DUCKDB_TYPE_TIMESTAMP: return "TIMESTAMP"
+        case DUCKDB_TYPE_DATE: return "DATE"
+        case DUCKDB_TYPE_TIME: return "TIME"
+        case DUCKDB_TYPE_INTERVAL: return "INTERVAL"
+        case DUCKDB_TYPE_HUGEINT: return "HUGEINT"
+        case DUCKDB_TYPE_UHUGEINT: return "UHUGEINT"
+        case DUCKDB_TYPE_VARCHAR: return "VARCHAR"
+        case DUCKDB_TYPE_BLOB: return "BLOB"
+        case DUCKDB_TYPE_DECIMAL: return "DECIMAL"
+        case DUCKDB_TYPE_TIMESTAMP_S: return "TIMESTAMP_S"
+        case DUCKDB_TYPE_TIMESTAMP_MS: return "TIMESTAMP_MS"
+        case DUCKDB_TYPE_TIMESTAMP_NS: return "TIMESTAMP_NS"
+        case DUCKDB_TYPE_ENUM: return "ENUM"
+        case DUCKDB_TYPE_LIST: return "LIST"
+        case DUCKDB_TYPE_STRUCT: return "STRUCT"
+        case DUCKDB_TYPE_MAP: return "MAP"
+        case DUCKDB_TYPE_ARRAY: return "ARRAY"
+        case DUCKDB_TYPE_UUID: return "UUID"
+        case DUCKDB_TYPE_UNION: return "UNION"
+        case DUCKDB_TYPE_BIT: return "BIT"
+        case DUCKDB_TYPE_TIMESTAMP_TZ: return "TIMESTAMPTZ"
+        case DUCKDB_TYPE_TIME_TZ: return "TIMETZ"
+        case DUCKDB_TYPE_TIME_NS: return "TIME_NS"
+        case DUCKDB_TYPE_GEOMETRY: return "GEOMETRY"
+        default: return "VARCHAR"
+        }
+    }
+}
+
+struct DuckDBRawResult: @unchecked Sendable {
+    let columnNames: [String]
+    let columnTypeNames: [String]
+    let rows: [[String?]]
+    let rowsAffected: Int
+    let executionTime: TimeInterval
+    let isTruncated: Bool
+}
+
+// MARK: - Errors
+
+enum DuckDBDriverError: Error, LocalizedError {
+    case connectionFailed(String)
+    case notConnected
+    case queryFailed(String)
+    case unsupported(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionFailed(let message): return "DuckDB connection failed: \(message)"
+        case .notConnected: return "Not connected to DuckDB database"
+        case .queryFailed(let message): return "DuckDB query failed: \(message)"
+        case .unsupported(let message): return message
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -345,7 +345,7 @@ actor DuckDBActor {
         }
     }
 
-    private static func quoteIdentifier(_ identifier: String) -> String {
+    static func quoteIdentifier(_ identifier: String) -> String {
         "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -241,7 +241,7 @@ actor DuckDBActor {
                 name: name,
                 typeName: Self.typeName(for: type),
                 type: type,
-                castToText: Self.isUnrenderable(type)
+                castToText: Self.requiresTextCast(type)
             ))
         }
 
@@ -259,7 +259,7 @@ actor DuckDBActor {
 
         if plan.contains(where: { $0.castToText }) {
             duckdb_destroy_result(&result)
-            let wrapped = Self.buildWrappedQuery(originalQuery: sql, columns: plan.map(\.name), types: plan.map(\.type))
+            let wrapped = Self.castedQuery(originalQuery: sql, columns: plan)
             var recast = duckdb_result()
             if duckdb_query(connection, wrapped, &recast) == DuckDBError {
                 let message = duckdb_result_error(&recast).map { String(cString: $0) } ?? "Unknown DuckDB error"
@@ -332,47 +332,34 @@ actor DuckDBActor {
 
     // MARK: - Type Rendering
 
-    private static func isUnrenderable(_ type: duckdb_type) -> Bool {
-        switch type {
-        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY,
-             DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
-             DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM, DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT:
-            return true
-        default:
-            return false
+    static func castedQuery(originalQuery: String, columns: [DuckDBStreamColumn]) -> String {
+        let projection = columns.map { column in
+            column.castToText ? castExpression(for: column.type, column: column.name) : quoteIdentifier(column.name)
         }
-    }
-
-    private static func buildWrappedQuery(originalQuery: String, columns: [String], types: [duckdb_type]) -> String {
-        let castExpressions = columns.enumerated().map { index, name in
-            castExpression(for: types[index], column: name)
-        }
-        var trimmed = originalQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasSuffix(";") {
-            trimmed = String(trimmed.dropLast())
-        }
-        return "SELECT \(castExpressions.joined(separator: ", ")) FROM (\(trimmed)) AS _tp_cast"
+        return "SELECT \(projection.joined(separator: ", ")) FROM (\(stripTrailingSemicolon(originalQuery))) AS _tp_cast"
     }
 
     private static func castExpression(for type: duckdb_type, column: String) -> String {
         let quoted = quoteIdentifier(column)
-        switch type {
-        case DUCKDB_TYPE_GEOMETRY:
+        if type == DUCKDB_TYPE_GEOMETRY {
             return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
-        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ,
-             DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
-             DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM, DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT:
-            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
-        default:
-            return quoted
         }
+        return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
     }
 
     static func quoteIdentifier(_ identifier: String) -> String {
         "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 
-    private static func typeName(for type: duckdb_type) -> String {
+    static func stripTrailingSemicolon(_ query: String) -> String {
+        var trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix(";") {
+            trimmed = String(trimmed.dropLast())
+        }
+        return trimmed
+    }
+
+    static func typeName(for type: duckdb_type) -> String {
         switch type {
         case DUCKDB_TYPE_BOOLEAN: return "BOOLEAN"
         case DUCKDB_TYPE_TINYINT: return "TINYINT"

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -163,10 +163,13 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
 // MARK: - DuckDB Actor (thread-safe C API access)
 
 actor DuckDBActor {
-    private static let maxRows = 100_000
+    static let maxRows = 100_000
 
     private var database: duckdb_database?
-    private var connection: duckdb_connection?
+    var connection: duckdb_connection?
+
+    var streamResult: duckdb_result?
+    var streamColumns: [DuckDBStreamColumn] = []
 
     var connectionHandle: duckdb_connection? { connection }
 

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -12,6 +12,7 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     private let stateLock = NSLock()
     private var currentSchemaName = "main"
     private var securedURL: URL?
+    nonisolated(unsafe) private var interruptHandle: duckdb_connection?
 
     var supportsSchemas: Bool { true }
     var supportsTransactions: Bool { true }
@@ -35,9 +36,11 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
         try await actor.open(path: resolvedPath)
         try? await actor.query("SET autoinstall_known_extensions=false")
         try? await actor.query("SET autoload_known_extensions=false")
+        setInterruptHandle(await actor.connectionHandle)
     }
 
     func disconnect() async throws {
+        setInterruptHandle(nil)
         await actor.close()
         if let url = takeSecuredURL() {
             url.stopAccessingSecurityScopedResource()
@@ -100,7 +103,11 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func cancelCurrentQuery() async throws {
-        await actor.interrupt()
+        stateLock.lock()
+        let handle = interruptHandle
+        stateLock.unlock()
+        guard let handle else { return }
+        duckdb_interrupt(handle)
     }
 
     // MARK: - Transactions
@@ -132,6 +139,12 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
         stateLock.unlock()
     }
 
+    private func setInterruptHandle(_ handle: duckdb_connection?) {
+        stateLock.lock()
+        interruptHandle = handle
+        stateLock.unlock()
+    }
+
     private func setSecuredURL(_ url: URL) {
         stateLock.lock()
         securedURL = url
@@ -155,10 +168,7 @@ actor DuckDBActor {
     private var database: duckdb_database?
     private var connection: duckdb_connection?
 
-    func interrupt() {
-        guard let connection else { return }
-        duckdb_interrupt(connection)
-    }
+    var connectionHandle: duckdb_connection? { connection }
 
     func open(path: String) throws {
         var db: duckdb_database?
@@ -224,32 +234,30 @@ actor DuckDBActor {
             typeNames.append(Self.typeName(for: type))
         }
 
-        if types.contains(where: Self.isUnrenderable) {
+        if types.contains(where: Self.isUnrenderable),
+           var recast = Self.recastUnrenderable(connection: connection, sql: sql, columns: names, types: types) {
             duckdb_destroy_result(&result)
-            return try queryWithCasts(connection: connection, sql: sql, names: names, typeNames: typeNames, types: types, startTime: startTime)
+            defer { duckdb_destroy_result(&recast) }
+            return Self.extract(&recast, names: names, typeNames: typeNames, startTime: startTime)
         }
 
         defer { duckdb_destroy_result(&result) }
         return Self.extract(&result, names: names, typeNames: typeNames, startTime: startTime)
     }
 
-    private func queryWithCasts(
+    private static func recastUnrenderable(
         connection: duckdb_connection,
         sql: String,
-        names: [String],
-        typeNames: [String],
-        types: [duckdb_type],
-        startTime: Date
-    ) throws -> DuckDBRawResult {
-        let wrapped = Self.buildWrappedQuery(originalQuery: sql, columns: names, types: types)
+        columns: [String],
+        types: [duckdb_type]
+    ) -> duckdb_result? {
+        let wrapped = buildWrappedQuery(originalQuery: sql, columns: columns, types: types)
         var result = duckdb_result()
         if duckdb_query(connection, wrapped, &result) == DuckDBError {
-            let message = duckdb_result_error(&result).map { String(cString: $0) } ?? "Unknown DuckDB error"
             duckdb_destroy_result(&result)
-            throw DuckDBDriverError.queryFailed(message)
+            return nil
         }
-        defer { duckdb_destroy_result(&result) }
-        return Self.extract(&result, names: names, typeNames: typeNames, startTime: startTime)
+        return result
     }
 
     private static func extract(

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -232,95 +232,111 @@ actor DuckDBActor {
         }
 
         let columnCount = duckdb_column_count(&result)
-        var names: [String] = []
-        var typeNames: [String] = []
-        var types: [duckdb_type] = []
+        let rowsChanged = Int(duckdb_rows_changed(&result))
+        var plan: [DuckDBStreamColumn] = []
         for index in 0..<columnCount {
-            names.append(duckdb_column_name(&result, index).map { String(cString: $0) } ?? "column_\(index)")
+            let name = duckdb_column_name(&result, index).map { String(cString: $0) } ?? "column_\(index)"
             let type = duckdb_column_type(&result, index)
-            types.append(type)
-            typeNames.append(Self.typeName(for: type))
+            plan.append(DuckDBStreamColumn(
+                name: name,
+                typeName: Self.typeName(for: type),
+                type: type,
+                castToText: Self.isUnrenderable(type)
+            ))
         }
 
-        if types.contains(where: Self.isUnrenderable),
-           var recast = Self.recastUnrenderable(connection: connection, sql: sql, columns: names, types: types) {
+        if columnCount == 0 {
             duckdb_destroy_result(&result)
-            defer { duckdb_destroy_result(&recast) }
-            return Self.extract(&recast, names: names, typeNames: typeNames, startTime: startTime)
+            return DuckDBRawResult(
+                columnNames: [],
+                columnTypeNames: [],
+                rows: [],
+                rowsAffected: rowsChanged,
+                executionTime: Date().timeIntervalSince(startTime),
+                isTruncated: false
+            )
+        }
+
+        if plan.contains(where: { $0.castToText }) {
+            duckdb_destroy_result(&result)
+            let wrapped = Self.buildWrappedQuery(originalQuery: sql, columns: plan.map(\.name), types: plan.map(\.type))
+            var recast = duckdb_result()
+            if duckdb_query(connection, wrapped, &recast) == DuckDBError {
+                let message = duckdb_result_error(&recast).map { String(cString: $0) } ?? "Unknown DuckDB error"
+                duckdb_destroy_result(&recast)
+                throw DuckDBDriverError.queryFailed(message)
+            }
+            result = recast
         }
 
         defer { duckdb_destroy_result(&result) }
-        return Self.extract(&result, names: names, typeNames: typeNames, startTime: startTime)
+        return Self.decodeMaterialized(&result, plan: plan, rowsChanged: rowsChanged, startTime: startTime)
     }
 
-    private static func recastUnrenderable(
-        connection: duckdb_connection,
-        sql: String,
-        columns: [String],
-        types: [duckdb_type]
-    ) -> duckdb_result? {
-        let wrapped = buildWrappedQuery(originalQuery: sql, columns: columns, types: types)
-        var result = duckdb_result()
-        if duckdb_query(connection, wrapped, &result) == DuckDBError {
-            duckdb_destroy_result(&result)
-            return nil
-        }
-        return result
-    }
-
-    private static func extract(
+    private static func decodeMaterialized(
         _ result: inout duckdb_result,
-        names: [String],
-        typeNames: [String],
+        plan: [DuckDBStreamColumn],
+        rowsChanged: Int,
         startTime: Date
     ) -> DuckDBRawResult {
-        let columnCount = duckdb_column_count(&result)
-        let rowCount = duckdb_row_count(&result)
-        let rowsChanged = duckdb_rows_changed(&result)
-        let cappedRowCount = min(rowCount, UInt64(maxRows))
-
+        let options = StreamOptions(textTruncationBytes: Int.max, maxRows: maxRows)
         var rows: [[String?]] = []
-        rows.reserveCapacity(Int(cappedRowCount))
+        var truncated = false
 
-        for row in 0..<cappedRowCount {
-            var values: [String?] = []
-            values.reserveCapacity(Int(columnCount))
-            for col in 0..<columnCount {
-                if duckdb_value_is_null(&result, col, row) {
-                    values.append(nil)
-                } else if duckdb_column_type(&result, col) == DUCKDB_TYPE_BLOB {
-                    let blob = duckdb_value_blob(&result, col, row)
-                    if let pointer = blob.data {
-                        values.append(Data(bytes: pointer, count: Int(blob.size)).base64EncodedString())
-                    } else {
-                        values.append("")
-                    }
-                    duckdb_free(blob.data)
-                } else if let valuePointer = duckdb_value_varchar(&result, col, row) {
-                    values.append(String(cString: valuePointer))
-                    duckdb_free(valuePointer)
-                } else {
-                    values.append(nil)
-                }
+        chunks: while true {
+            var chunk = duckdb_fetch_chunk(result)
+            guard chunk != nil else { break }
+            defer { duckdb_destroy_data_chunk(&chunk) }
+
+            let size = duckdb_data_chunk_get_size(chunk)
+            var vectors: [duckdb_vector?] = []
+            for index in 0..<plan.count {
+                vectors.append(duckdb_data_chunk_get_vector(chunk, idx_t(index)))
             }
-            rows.append(values)
+            for row in 0..<size {
+                if rows.count >= maxRows {
+                    truncated = true
+                    break chunks
+                }
+                var values: [String?] = []
+                values.reserveCapacity(plan.count)
+                for index in 0..<plan.count {
+                    guard let vector = vectors[index] else {
+                        values.append(nil)
+                        continue
+                    }
+                    values.append(cellText(decodeCell(vector: vector, row: row, column: plan[index], options: options)))
+                }
+                rows.append(values)
+            }
         }
 
         return DuckDBRawResult(
-            columnNames: names,
-            columnTypeNames: typeNames,
+            columnNames: plan.map(\.name),
+            columnTypeNames: plan.map(\.typeName),
             rows: rows,
-            rowsAffected: Int(rowsChanged),
+            rowsAffected: rowsChanged,
             executionTime: Date().timeIntervalSince(startTime),
-            isTruncated: rowCount > UInt64(maxRows)
+            isTruncated: truncated
         )
+    }
+
+    private static func cellText(_ cell: Cell) -> String? {
+        switch cell {
+        case .null: return nil
+        case .text(let value): return value
+        case .truncatedText(let prefix, _, _): return prefix
+        case .binary: return nil
+        }
     }
 
     // MARK: - Type Rendering
 
     private static func isUnrenderable(_ type: duckdb_type) -> Bool {
         switch type {
-        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY:
+        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ, DUCKDB_TYPE_GEOMETRY,
+             DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
+             DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM, DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT:
             return true
         default:
             return false
@@ -343,7 +359,9 @@ actor DuckDBActor {
         switch type {
         case DUCKDB_TYPE_GEOMETRY:
             return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
-        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ:
+        case DUCKDB_TYPE_TIMESTAMP_TZ, DUCKDB_TYPE_TIME_TZ,
+             DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION,
+             DUCKDB_TYPE_DECIMAL, DUCKDB_TYPE_ENUM, DUCKDB_TYPE_INTERVAL, DUCKDB_TYPE_BIT:
             return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
         default:
             return quoted

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -173,6 +173,11 @@ actor DuckDBActor {
 
     var connectionHandle: duckdb_connection? { connection }
 
+    func interrupt() {
+        guard let connection else { return }
+        duckdb_interrupt(connection)
+    }
+
     func open(path: String) throws {
         var db: duckdb_database?
         var errorPtr: UnsafeMutablePointer<CChar>?

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -33,6 +33,8 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     func connect() async throws {
         let resolvedPath = try resolvePath()
         try await actor.open(path: resolvedPath)
+        try? await actor.query("SET autoinstall_known_extensions=false")
+        try? await actor.query("SET autoload_known_extensions=false")
     }
 
     func disconnect() async throws {

--- a/TableProMobile/TableProMobile/Helpers/DatabaseType+Mobile.swift
+++ b/TableProMobile/TableProMobile/Helpers/DatabaseType+Mobile.swift
@@ -9,7 +9,7 @@ extension DatabaseType {
         case .redshift: return "5439"
         case .redis: return "6379"
         case .mssql: return "1433"
-        case .sqlite: return ""
+        case .sqlite, .duckdb: return ""
         default: return "3306"
         }
     }
@@ -21,6 +21,7 @@ extension DatabaseType {
         case .postgresql: "PostgreSQL"
         case .redshift: "Redshift"
         case .sqlite: "SQLite"
+        case .duckdb: "DuckDB"
         case .redis: "Redis"
         case .mssql: "SQL Server"
         default: rawValue.uppercased()
@@ -32,6 +33,7 @@ extension DatabaseType {
         .mariadb,
         .postgresql,
         .sqlite,
+        .duckdb,
         .redis,
         .mssql
     ]

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -1711,7 +1711,11 @@
         }
       }
     },
+    "Enter a name for the new database file." : {
+
+    },
     "Enter a name for the new SQLite database." : {
+      "extractionState" : "stale",
       "localizations" : {
         "vi" : {
           "stringUnit" : {
@@ -2259,6 +2263,9 @@
         }
       }
     },
+    "In-Memory Database" : {
+
+    },
     "Indexes" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2302,6 +2309,9 @@
         }
       }
     },
+    "Insert" : {
+
+    },
     "Insert Row" : {
       "localizations" : {
         "vi" : {
@@ -2317,6 +2327,9 @@
           }
         }
       }
+    },
+    "Insert Row?" : {
+
     },
     "Keychain Warning" : {
       "localizations" : {
@@ -2511,6 +2524,9 @@
           }
         }
       }
+    },
+    "Mode" : {
+
     },
     "Name" : {
       "localizations" : {
@@ -3608,6 +3624,9 @@
         }
       }
     },
+    "Save Changes?" : {
+
+    },
     "Schema" : {
       "localizations" : {
         "vi" : {
@@ -4538,6 +4557,12 @@
           }
         }
       }
+    },
+    "This will insert a row into %@. Continue?" : {
+
+    },
+    "This will update a row in %@. Continue?" : {
+
     },
     "Truncate" : {
       "localizations" : {

--- a/TableProMobile/TableProMobile/Platform/FileBookmarkStore.swift
+++ b/TableProMobile/TableProMobile/Platform/FileBookmarkStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct FileBookmarkStore: Sendable {
+    private let suiteName: String?
+    private static let keyPrefix = "com.TablePro.fileBookmark."
+
+    init(suiteName: String? = nil) {
+        self.suiteName = suiteName
+    }
+
+    private var defaults: UserDefaults {
+        suiteName.flatMap(UserDefaults.init(suiteName:)) ?? .standard
+    }
+
+    func save(_ bookmark: Data, for id: UUID) {
+        defaults.set(bookmark, forKey: Self.keyPrefix + id.uuidString)
+    }
+
+    func bookmark(for id: UUID) -> Data? {
+        defaults.data(forKey: Self.keyPrefix + id.uuidString)
+    }
+
+    func delete(for id: UUID) {
+        defaults.removeObject(forKey: Self.keyPrefix + id.uuidString)
+    }
+}

--- a/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
@@ -3,10 +3,21 @@ import TableProDatabase
 import TableProModels
 
 final class IOSDriverFactory: DriverFactory {
+    private let bookmarkStore: FileBookmarkStore
+
+    init(bookmarkStore: FileBookmarkStore = FileBookmarkStore()) {
+        self.bookmarkStore = bookmarkStore
+    }
+
     func createDriver(for connection: DatabaseConnection, password: String?) throws -> any DatabaseDriver {
         switch connection.type {
         case .sqlite:
             return SQLiteDriver(path: connection.database)
+        case .duckdb:
+            let bookmark = connection.database == DuckDBDriver.inMemoryPath
+                ? nil
+                : bookmarkStore.bookmark(for: connection.id)
+            return DuckDBDriver(path: connection.database, bookmark: bookmark)
         case .mysql, .mariadb:
             return MySQLDriver(
                 host: connection.host,
@@ -42,6 +53,6 @@ final class IOSDriverFactory: DriverFactory {
     }
 
     func supportedTypes() -> [DatabaseType] {
-        [.sqlite, .mysql, .mariadb, .postgresql, .redshift, .redis, .mssql]
+        [.sqlite, .duckdb, .mysql, .mariadb, .postgresql, .redshift, .redis, .mssql]
     }
 }

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -314,8 +314,12 @@ final class ConnectionFormViewModel {
         let connection = buildConnection()
         var storageFailed = false
 
-        if type == .duckdb, let pendingBookmark {
-            bookmarkStore.save(pendingBookmark, for: connection.id)
+        if type == .duckdb {
+            if duckDBInMemory {
+                bookmarkStore.delete(for: connection.id)
+            } else if let pendingBookmark {
+                bookmarkStore.save(pendingBookmark, for: connection.id)
+            }
         }
 
         if !password.isEmpty {

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -52,6 +52,11 @@ final class ConnectionFormViewModel {
     // File picker output
     var selectedFileURL: URL?
     var newDatabaseName = ""
+    var duckDBInMemory = false {
+        didSet { onDuckDBInMemoryChange() }
+    }
+    private var pendingBookmark: Data?
+    private let bookmarkStore = FileBookmarkStore()
 
     // Async state
     private(set) var isTesting = false
@@ -95,6 +100,13 @@ final class ConnectionFormViewModel {
         if conn.type == .sqlite {
             selectedFileURL = URL(fileURLWithPath: conn.database)
         }
+        if conn.type == .duckdb {
+            if conn.database == DuckDBDriver.inMemoryPath {
+                duckDBInMemory = true
+            } else if !conn.database.isEmpty {
+                selectedFileURL = URL(fileURLWithPath: conn.database)
+            }
+        }
     }
 
     // MARK: - Computed
@@ -103,7 +115,14 @@ final class ConnectionFormViewModel {
         if type == .sqlite {
             return !database.isEmpty
         }
+        if type == .duckdb {
+            return duckDBInMemory || !database.isEmpty
+        }
         return !host.isEmpty
+    }
+
+    var isFileBased: Bool {
+        type == .sqlite || type == .duckdb
     }
 
     var isEditing: Bool { existingConnection != nil }
@@ -131,6 +150,18 @@ final class ConnectionFormViewModel {
         updateDefaultPort()
         selectedFileURL = nil
         database = ""
+        pendingBookmark = nil
+        duckDBInMemory = false
+    }
+
+    private func onDuckDBInMemoryChange() {
+        if duckDBInMemory {
+            selectedFileURL = nil
+            pendingBookmark = nil
+            database = DuckDBDriver.inMemoryPath
+        } else if database == DuckDBDriver.inMemoryPath {
+            database = ""
+        }
     }
 
     private func updateDefaultPort() {
@@ -149,6 +180,20 @@ final class ConnectionFormViewModel {
         database = destURL.path
         if name.isEmpty {
             name = destURL.deletingPathExtension().lastPathComponent
+        }
+    }
+
+    func handleDuckDBFilePicker(_ result: Result<[URL], Error>) {
+        guard case .success(let urls) = result, let url = urls.first else { return }
+        guard url.startAccessingSecurityScopedResource() else { return }
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        guard let data = try? url.bookmarkData() else { return }
+        pendingBookmark = data
+        selectedFileURL = url
+        database = url.path
+        if name.isEmpty {
+            name = url.deletingPathExtension().lastPathComponent
         }
     }
 
@@ -189,17 +234,21 @@ final class ConnectionFormViewModel {
     func clearSelectedFile() {
         selectedFileURL = nil
         database = ""
+        pendingBookmark = nil
     }
 
     func createNewDatabase() {
         guard !newDatabaseName.isEmpty else { return }
 
-        let safeName = newDatabaseName.hasSuffix(".db") ? newDatabaseName : "\(newDatabaseName).db"
+        let fileExtension = type == .duckdb ? "duckdb" : "db"
+        let suffix = ".\(fileExtension)"
+        let safeName = newDatabaseName.hasSuffix(suffix) ? newDatabaseName : "\(newDatabaseName)\(suffix)"
         guard let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
         let fileURL = documentsDir.appendingPathComponent(safeName)
 
         selectedFileURL = fileURL
         database = fileURL.path
+        pendingBookmark = nil
         if name.isEmpty {
             name = newDatabaseName
         }
@@ -264,6 +313,10 @@ final class ConnectionFormViewModel {
     func save(appState: AppState, secureStore: any SecureStore) -> DatabaseConnection? {
         let connection = buildConnection()
         var storageFailed = false
+
+        if type == .duckdb, let pendingBookmark {
+            bookmarkStore.save(pendingBookmark, for: connection.id)
+        }
 
         if !password.isEmpty {
             do {

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -18,6 +18,7 @@ struct ConnectionFormView: View {
 
     enum ActiveFilePicker: Identifiable {
         case sqliteDatabase
+        case duckdbDatabase
         case sshKey
         var id: Int { hashValue }
     }
@@ -50,11 +51,13 @@ struct ConnectionFormView: View {
 
                 if viewModel.type == .sqlite {
                     sqliteSection(viewModel: viewModel)
+                } else if viewModel.type == .duckdb {
+                    duckDBSection(viewModel: viewModel)
                 } else {
                     serverSection(viewModel: viewModel)
                 }
 
-                if viewModel.type != .sqlite {
+                if !viewModel.isFileBased {
                     Section {
                         if viewModel.type == .mssql {
                             // FreeTDS db-lib only honors on/off encryption (DBSETENCRYPT). Per-connection
@@ -90,13 +93,14 @@ struct ConnectionFormView: View {
             }
             .fileImporter(
                 isPresented: showFilePicker,
-                allowedContentTypes: activeFilePicker == .sqliteDatabase ? sqliteContentTypes : [.data],
+                allowedContentTypes: contentTypes(for: activeFilePicker),
                 allowsMultipleSelection: false
             ) { result in
                 let picker = pendingFilePicker
                 pendingFilePicker = nil
                 switch picker {
                 case .sqliteDatabase: viewModel.handleSQLiteFilePicker(result)
+                case .duckdbDatabase: viewModel.handleDuckDBFilePicker(result)
                 case .sshKey: viewModel.handleSSHKeyFilePicker(result)
                 case nil: break
                 }
@@ -106,7 +110,7 @@ struct ConnectionFormView: View {
                 Button("Create") { viewModel.createNewDatabase() }
                 Button("Cancel", role: .cancel) { viewModel.newDatabaseName = "" }
             } message: {
-                Text("Enter a name for the new SQLite database.")
+                Text("Enter a name for the new database file.")
             }
             .alert("Keychain Warning", isPresented: showCredentialError) {
                 Button("OK", role: .cancel) {}
@@ -191,24 +195,7 @@ struct ConnectionFormView: View {
     private func sqliteSection(viewModel: ConnectionFormViewModel) -> some View {
         Section("Database File") {
             if let url = viewModel.selectedFileURL {
-                HStack {
-                    Image(systemName: "doc.fill")
-                        .foregroundStyle(.blue)
-                    VStack(alignment: .leading) {
-                        Text(url.lastPathComponent)
-                            .font(.body)
-                        Text(url.deletingLastPathComponent().lastPathComponent)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Button {
-                        viewModel.clearSelectedFile()
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                selectedFileRow(url, viewModel: viewModel)
             }
 
             Button {
@@ -222,6 +209,59 @@ struct ConnectionFormView: View {
                 showNewDatabaseAlert = true
             } label: {
                 Label("Create New Database", systemImage: "plus.circle")
+            }
+        }
+    }
+
+    // MARK: - DuckDB Section
+
+    @ViewBuilder
+    private func duckDBSection(viewModel: ConnectionFormViewModel) -> some View {
+        @Bindable var viewModel = viewModel
+        Section("Mode") {
+            Toggle("In-Memory Database", isOn: $viewModel.duckDBInMemory)
+        }
+
+        if !viewModel.duckDBInMemory {
+            Section("Database File") {
+                if let url = viewModel.selectedFileURL {
+                    selectedFileRow(url, viewModel: viewModel)
+                }
+
+                Button {
+                    pendingFilePicker = .duckdbDatabase
+                    activeFilePicker = .duckdbDatabase
+                } label: {
+                    Label("Open Database File", systemImage: "folder")
+                }
+
+                Button {
+                    showNewDatabaseAlert = true
+                } label: {
+                    Label("Create New Database", systemImage: "plus.circle")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func selectedFileRow(_ url: URL, viewModel: ConnectionFormViewModel) -> some View {
+        HStack {
+            Image(systemName: "doc.fill")
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading) {
+                Text(url.lastPathComponent)
+                    .font(.body)
+                Text(url.deletingLastPathComponent().lastPathComponent)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                viewModel.clearSelectedFile()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -384,8 +424,21 @@ struct ConnectionFormView: View {
 
     // MARK: - Helpers
 
+    private func contentTypes(for picker: ActiveFilePicker?) -> [UTType] {
+        switch picker {
+        case .sqliteDatabase: return sqliteContentTypes
+        case .duckdbDatabase: return duckDBContentTypes
+        default: return [.data]
+        }
+    }
+
     private var sqliteContentTypes: [UTType] {
         let extensions = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
         return [UTType.database] + extensions.compactMap { UTType(filenameExtension: $0) } + [.data]
+    }
+
+    private var duckDBContentTypes: [UTType] {
+        let extensions = ["duckdb", "ddb"]
+        return extensions.compactMap { UTType(filenameExtension: $0) } + [.data]
     }
 }

--- a/TableProMobile/TableProMobileTests/ConnectionFormViewModelDuckDBTests.swift
+++ b/TableProMobile/TableProMobileTests/ConnectionFormViewModelDuckDBTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+import TableProModels
+@testable import TableProMobile
+
+@MainActor
+@Suite("ConnectionFormViewModel DuckDB")
+struct ConnectionFormViewModelDuckDBTests {
+    @Test("DuckDB is a file-based type")
+    func isFileBased() {
+        let vm = ConnectionFormViewModel()
+        vm.type = .duckdb
+        #expect(vm.isFileBased)
+    }
+
+    @Test("in-memory mode sets the database to the in-memory sentinel and allows saving")
+    func inMemoryEnablesSave() {
+        let vm = ConnectionFormViewModel()
+        vm.type = .duckdb
+        vm.duckDBInMemory = true
+
+        #expect(vm.database == DuckDBDriver.inMemoryPath)
+        #expect(vm.canSave)
+        #expect(vm.selectedFileURL == nil)
+    }
+
+    @Test("disabling in-memory clears the sentinel path")
+    func disablingInMemoryClearsPath() {
+        let vm = ConnectionFormViewModel()
+        vm.type = .duckdb
+        vm.duckDBInMemory = true
+        vm.duckDBInMemory = false
+
+        #expect(vm.database.isEmpty)
+        #expect(!vm.canSave)
+    }
+
+    @Test("create new database uses the .duckdb extension")
+    func createNewUsesDuckDBExtension() {
+        let vm = ConnectionFormViewModel()
+        vm.type = .duckdb
+        vm.newDatabaseName = "analytics"
+        vm.createNewDatabase()
+
+        #expect(vm.database.hasSuffix("analytics.duckdb"))
+        #expect(vm.canSave)
+    }
+
+    @Test("switching type away from DuckDB resets in-memory state")
+    func switchingTypeResets() {
+        let vm = ConnectionFormViewModel()
+        vm.type = .duckdb
+        vm.duckDBInMemory = true
+        vm.type = .mysql
+
+        #expect(!vm.duckDBInMemory)
+        #expect(vm.database.isEmpty)
+    }
+}

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
@@ -68,6 +68,21 @@ final class DuckDBDriverTests: XCTestCase {
         XCTAssertEqual(streamed.last, ["2000", "row2000"])
     }
 
+    func testExecuteRendersComplexAndScalarTypes() async throws {
+        let driver = try XCTUnwrap(driver)
+        let result = try await driver.execute(query: """
+            SELECT [1,2,3] AS lst, {'a':1,'b':2} AS strct, 12.34::DECIMAL(5,2) AS dec,
+            '550e8400-e29b-41d4-a716-446655440000'::UUID AS uid, DATE '2024-03-09' AS dt,
+            TIMESTAMP '2024-03-09 12:34:56' AS ts, 'abc'::BLOB AS payload
+            """)
+        XCTAssertEqual(result.rows.count, 1)
+        XCTAssertEqual(result.rows[0][0], "[1, 2, 3]")
+        XCTAssertEqual(result.rows[0][1], "{'a': 1, 'b': 2}")
+        XCTAssertEqual(result.rows[0][2], "12.34")
+        XCTAssertEqual(result.rows[0][3], "550e8400-e29b-41d4-a716-446655440000")
+        XCTAssertEqual(result.rows[0][4], "2024-03-09")
+    }
+
     func testPing() async throws {
         let driver = try XCTUnwrap(driver)
         let alive = try await driver.ping()

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
@@ -17,6 +17,57 @@ final class DuckDBDriverTests: XCTestCase {
         driver = nil
     }
 
+    private func streamedRows(_ driver: DuckDBDriver, _ query: String) async throws -> [[String?]] {
+        var rows: [[String?]] = []
+        for try await element in driver.executeStreaming(query: query, options: .default) {
+            if case .row(let row) = element {
+                rows.append(row.cells.map { cell -> String? in
+                    if case .null = cell { return nil }
+                    return cell.displayString
+                })
+            }
+        }
+        return rows
+    }
+
+    func testStreamingMatchesMaterializedAcrossTypes() async throws {
+        let driver = try XCTUnwrap(driver)
+        let query = """
+            SELECT
+                42::INTEGER AS i,
+                9223372036854775807::BIGINT AS big,
+                170141183460469231731687303715884105727::HUGEINT AS huge,
+                (-170141183460469231731687303715884105727)::HUGEINT AS huge_neg,
+                3.5::DOUBLE AS d,
+                true AS b,
+                'hello' AS s,
+                NULL::INTEGER AS n,
+                DATE '2024-03-09' AS dt,
+                TIMESTAMP '2024-03-09 12:34:56.789' AS tstamp,
+                'abc'::BLOB AS payload,
+                '550e8400-e29b-41d4-a716-446655440000'::UUID AS uid,
+                12.34::DECIMAL(5,2) AS dec,
+                [1, 2, 3] AS lst,
+                {'a': 1, 'b': 2} AS strct
+            """
+        let materialized = try await driver.execute(query: query)
+        let streamed = try await streamedRows(driver, query)
+
+        XCTAssertEqual(streamed.count, 1)
+        XCTAssertEqual(materialized.rows.count, 1)
+        XCTAssertEqual(streamed[0], materialized.rows[0], "streamed output must match the materialized path exactly")
+    }
+
+    func testStreamingMultiRowOrder() async throws {
+        let driver = try XCTUnwrap(driver)
+        _ = try await driver.execute(query: "CREATE TABLE nums (id INTEGER, label VARCHAR)")
+        _ = try await driver.execute(query: "INSERT INTO nums SELECT i, 'row' || i FROM range(1, 2001) t(i)")
+        let streamed = try await streamedRows(driver, "SELECT id, label FROM nums ORDER BY id")
+        XCTAssertEqual(streamed.count, 2_000)
+        XCTAssertEqual(streamed.first, ["1", "row1"])
+        XCTAssertEqual(streamed.last, ["2000", "row2000"])
+    }
+
     func testPing() async throws {
         let driver = try XCTUnwrap(driver)
         let alive = try await driver.ping()

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
@@ -47,6 +47,7 @@ final class DuckDBDriverTests: XCTestCase {
                 'abc'::BLOB AS payload,
                 '550e8400-e29b-41d4-a716-446655440000'::UUID AS uid,
                 12.34::DECIMAL(5,2) AS dec,
+                INTERVAL '1' MONTH AS iv,
                 [1, 2, 3] AS lst,
                 {'a': 1, 'b': 2} AS strct
             """

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
@@ -40,6 +40,21 @@ final class DuckDBDriverTests: XCTestCase {
         XCTAssertEqual(result.rows[1], ["2", "second", "false"])
     }
 
+    func testTimestampTzRendersAsText() async throws {
+        let driver = try XCTUnwrap(driver)
+        let result = try await driver.execute(query: "SELECT TIMESTAMPTZ '2024-01-02 03:04:05+00' AS ts")
+        XCTAssertEqual(result.rows.count, 1)
+        let value = try XCTUnwrap(result.rows[0][0])
+        XCTAssertTrue(value.contains("2024-01-02"), "expected rendered timestamptz, got \(value)")
+    }
+
+    func testCancelWithoutRunningQueryIsSafe() async throws {
+        let driver = try XCTUnwrap(driver)
+        try await driver.cancelCurrentQuery()
+        let alive = try await driver.ping()
+        XCTAssertTrue(alive)
+    }
+
     func testNullRendersAsNil() async throws {
         let driver = try XCTUnwrap(driver)
         let result = try await driver.execute(query: "SELECT NULL AS value")

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import TableProDatabase
+import TableProModels
+@testable import TableProMobile
+
+final class DuckDBDriverTests: XCTestCase {
+    private var driver: DuckDBDriver?
+
+    override func setUp() async throws {
+        let driver = DuckDBDriver(path: DuckDBDriver.inMemoryPath, bookmark: nil)
+        try await driver.connect()
+        self.driver = driver
+    }
+
+    override func tearDown() async throws {
+        try await driver?.disconnect()
+        driver = nil
+    }
+
+    func testPing() async throws {
+        let driver = try XCTUnwrap(driver)
+        let alive = try await driver.ping()
+        XCTAssertTrue(alive)
+    }
+
+    func testServerVersionIsReported() async throws {
+        let driver = try XCTUnwrap(driver)
+        XCTAssertNotNil(driver.serverVersion)
+    }
+
+    func testCreateInsertSelect() async throws {
+        let driver = try XCTUnwrap(driver)
+        _ = try await driver.execute(query: "CREATE TABLE items (id INTEGER PRIMARY KEY, label VARCHAR, active BOOLEAN)")
+        _ = try await driver.execute(query: "INSERT INTO items VALUES (1, 'first', true), (2, 'second', false)")
+
+        let result = try await driver.execute(query: "SELECT id, label, active FROM items ORDER BY id")
+        XCTAssertEqual(result.columns.map(\.name), ["id", "label", "active"])
+        XCTAssertEqual(result.rows.count, 2)
+        XCTAssertEqual(result.rows[0], ["1", "first", "true"])
+        XCTAssertEqual(result.rows[1], ["2", "second", "false"])
+    }
+
+    func testNullRendersAsNil() async throws {
+        let driver = try XCTUnwrap(driver)
+        let result = try await driver.execute(query: "SELECT NULL AS value")
+        XCTAssertEqual(result.rows.count, 1)
+        XCTAssertNil(result.rows[0][0])
+    }
+
+    func testFetchTablesAndColumns() async throws {
+        let driver = try XCTUnwrap(driver)
+        _ = try await driver.execute(query: "CREATE TABLE people (id INTEGER PRIMARY KEY, name VARCHAR NOT NULL)")
+
+        let tables = try await driver.fetchTables(schema: "main")
+        XCTAssertTrue(tables.contains { $0.name == "people" && $0.type == .table })
+
+        let columns = try await driver.fetchColumns(table: "people", schema: "main")
+        XCTAssertEqual(columns.map(\.name), ["id", "name"])
+        let idColumn = try XCTUnwrap(columns.first { $0.name == "id" })
+        XCTAssertTrue(idColumn.isPrimaryKey)
+        let nameColumn = try XCTUnwrap(columns.first { $0.name == "name" })
+        XCTAssertFalse(nameColumn.isNullable)
+    }
+
+    func testFetchSchemasIncludesMain() async throws {
+        let driver = try XCTUnwrap(driver)
+        let schemas = try await driver.fetchSchemas()
+        XCTAssertTrue(schemas.contains("main"))
+    }
+
+    func testViewIsReportedAsView() async throws {
+        let driver = try XCTUnwrap(driver)
+        _ = try await driver.execute(query: "CREATE TABLE base (n INTEGER)")
+        _ = try await driver.execute(query: "CREATE VIEW base_view AS SELECT n FROM base")
+
+        let tables = try await driver.fetchTables(schema: "main")
+        let view = try XCTUnwrap(tables.first { $0.name == "base_view" })
+        XCTAssertEqual(view.type, .view)
+    }
+
+    func testBlobIsBase64Encoded() async throws {
+        let driver = try XCTUnwrap(driver)
+        let result = try await driver.execute(query: "SELECT 'abc'::BLOB AS payload")
+        XCTAssertEqual(result.rows[0][0], Data("abc".utf8).base64EncodedString())
+    }
+}

--- a/TableProMobile/TableProMobileTests/FileBookmarkStoreTests.swift
+++ b/TableProMobile/TableProMobileTests/FileBookmarkStoreTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import TableProMobile
+
+@Suite("FileBookmarkStore")
+struct FileBookmarkStoreTests {
+    private func makeStore() -> (FileBookmarkStore, String) {
+        let suiteName = "test.fileBookmark.\(UUID().uuidString)"
+        return (FileBookmarkStore(suiteName: suiteName), suiteName)
+    }
+
+    @Test("saves and resolves a bookmark for a connection id")
+    func saveAndRead() {
+        let (store, suiteName) = makeStore()
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        let id = UUID()
+        let bookmark = Data("bookmark-bytes".utf8)
+        store.save(bookmark, for: id)
+
+        #expect(store.bookmark(for: id) == bookmark)
+    }
+
+    @Test("returns nil for an unknown connection id")
+    func missingReturnsNil() {
+        let (store, suiteName) = makeStore()
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        #expect(store.bookmark(for: UUID()) == nil)
+    }
+
+    @Test("delete removes a stored bookmark")
+    func deleteRemoves() {
+        let (store, suiteName) = makeStore()
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        let id = UUID()
+        store.save(Data("x".utf8), for: id)
+        store.delete(for: id)
+
+        #expect(store.bookmark(for: id) == nil)
+    }
+}

--- a/docs/databases/duckdb.mdx
+++ b/docs/databases/duckdb.mdx
@@ -42,7 +42,7 @@ Double-click any `.duckdb` file in Finder to open it directly in TablePro.
 
 The iOS app supports DuckDB too. In the connection form, pick DuckDB and either turn on **In-Memory Database** or open a `.duckdb`/`.ddb` file through the Files app. Opened files keep working across launches through a security-scoped bookmark, so edits write back to the original file.
 
-The iOS build links the `json`, `parquet`, and `icu` extensions. Extensions that download at runtime (such as `httpfs`) are not available on iOS. Large in-memory databases are bounded by the app's memory budget.
+The iOS build links the `core_functions`, `json`, `parquet`, and `icu` extensions. Runtime extension autoloading is off, so extensions that download on demand (such as `httpfs`) are not available on iOS. Large in-memory databases are bounded by the app's memory budget.
 
 ## Querying files directly
 

--- a/docs/databases/duckdb.mdx
+++ b/docs/databases/duckdb.mdx
@@ -38,6 +38,12 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 
 Double-click any `.duckdb` file in Finder to open it directly in TablePro.
 
+## DuckDB on iOS
+
+The iOS app supports DuckDB too. In the connection form, pick DuckDB and either turn on **In-Memory Database** or open a `.duckdb`/`.ddb` file through the Files app. Opened files keep working across launches through a security-scoped bookmark, so edits write back to the original file.
+
+The iOS build links the `json`, `parquet`, and `icu` extensions. Extensions that download at runtime (such as `httpfs`) are not available on iOS. Large in-memory databases are bounded by the app's memory budget.
+
 ## Querying files directly
 
 DuckDB can query CSV, Parquet, and JSON files directly with SQL:

--- a/scripts/build-duckdb-ios.sh
+++ b/scripts/build-duckdb-ios.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 #   DUCKDB_VERSION=v1.3.2 scripts/build-duckdb-ios.sh
 
 DUCKDB_VERSION="${1:-${DUCKDB_VERSION:-v1.5.2}}"
-CORE_EXTENSIONS="${CORE_EXTENSIONS:-json;parquet;icu}"
+CORE_EXTENSIONS="${CORE_EXTENSIONS:-core_functions;json;parquet;icu}"
 DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET:-15.0}"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/build-duckdb-ios.sh
+++ b/scripts/build-duckdb-ios.sh
@@ -109,6 +109,22 @@ build_platform() {
   fi
   # shellcheck disable=SC2086
   libtool -static -o "$out_lib" $archives
+
+  # DuckDB ships two definitions of ExtensionHelper::LoadAllExtensions: the real
+  # generated_extension_loader (registers the statically linked extensions) and
+  # dummy_static_extension_loader (a no-op fallback for builds without static
+  # extensions). Merging every archive pulls in both, and the linker can resolve
+  # the no-op one, leaving the extensions unregistered (DuckDB then tries to
+  # autoload them, which fails on iOS). Drop the dummy so only the real loader
+  # remains.
+  if ar -t "$out_lib" | grep -q '^dummy_static_extension_loader.cpp.o$'; then
+    ar -d "$out_lib" dummy_static_extension_loader.cpp.o
+    ranlib "$out_lib"
+    echo "Removed dummy_static_extension_loader from $out_lib"
+  else
+    echo "error: dummy_static_extension_loader not found in $out_lib; verify the loader merge" >&2
+    exit 1
+  fi
   echo "Merged $(echo "$archives" | wc -l | tr -d ' ') archives into $out_lib"
 }
 

--- a/scripts/build-duckdb-ios.sh
+++ b/scripts/build-duckdb-ios.sh
@@ -57,6 +57,28 @@ build_platform() {
   local platform="$1" archs="$2" out_lib="$3" duckdb_platform="$4"
   local build_dir="$WORK_DIR/build-$platform"
 
+  # The linked-extension registration in DuckDB core (extension_helper.cpp) is
+  # gated on GENERATED_EXTENSION_HEADERS plus a DUCKDB_EXTENSION_<NAME>_LINKED
+  # define per extension. CMake enables those only inside the extension/ subdir
+  # scope, which is processed after src/, so core compiles with the registration
+  # call sites disabled and the extensions never self-register (DuckDB then tries
+  # to autoload them, which fails on iOS). Enabling the defines globally makes
+  # core register the statically linked extensions at startup. The header gate
+  # pulls in <build>/codegen/include/generated_extension_headers.hpp, which
+  # includes each extension's entry header, so core also needs those include
+  # dirs. No force_load or runtime install needed.
+  local ext_root="$WORK_DIR/duckdb/extension"
+  local linked_defines="-DGENERATED_EXTENSION_HEADERS=1"
+  linked_defines+=" -DDUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED=1"
+  linked_defines+=" -DDUCKDB_EXTENSION_JSON_LINKED=1"
+  linked_defines+=" -DDUCKDB_EXTENSION_PARQUET_LINKED=1"
+  linked_defines+=" -DDUCKDB_EXTENSION_ICU_LINKED=1"
+  linked_defines+=" -I$build_dir/codegen/include"
+  linked_defines+=" -I$ext_root/core_functions/include"
+  linked_defines+=" -I$ext_root/json/include"
+  linked_defines+=" -I$ext_root/parquet/include"
+  linked_defines+=" -I$ext_root/icu/include"
+
   echo "Building DuckDB for PLATFORM=$platform (archs: $archs)..."
   cmake -S "$WORK_DIR/duckdb" -B "$build_dir" -G "Unix Makefiles" \
     -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN" \
@@ -66,6 +88,8 @@ build_platform() {
     -DENABLE_ARC=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DDUCKDB_EXPLICIT_PLATFORM="$duckdb_platform" \
+    -DCMAKE_C_FLAGS="$linked_defines" \
+    -DCMAKE_CXX_FLAGS="$linked_defines" \
     -DBUILD_SHELL=0 \
     -DBUILD_UNITTESTS=0 \
     -DBUILD_BENCHMARKS=0 \

--- a/scripts/build-duckdb-ios.sh
+++ b/scripts/build-duckdb-ios.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build DuckDB as an iOS xcframework for the TableProMobile app.
+#
+# Produces Libs/ios/DuckDB.xcframework with three slices:
+#   - ios-arm64                    (device)
+#   - ios-arm64_x86_64-simulator   (Apple Silicon + Intel simulators)
+#
+# DuckDB ships no official iOS binary, so we compile it from source with the
+# leetal/ios-cmake toolchain. Extensions (json, parquet, icu) are linked
+# statically. Remote extension autoloading/autoinstall is disabled: iOS apps
+# may not download executable code (App Store Review Guideline 2.5.2), and the
+# sandbox blocks it anyway.
+#
+# Requirements: macOS, Xcode command line tools, cmake, git, libtool, lipo.
+#
+# IMPORTANT: DUCKDB_VERSION must match the bundled macOS libduckdb.a so both
+# platforms behave identically. Confirm with the version shown in the app
+# (duckdb_library_version) on macOS, then pin the same tag here.
+#
+# Usage:
+#   scripts/build-duckdb-ios.sh [duckdb-version]
+#   DUCKDB_VERSION=v1.3.2 scripts/build-duckdb-ios.sh
+
+DUCKDB_VERSION="${1:-${DUCKDB_VERSION:-v1.5.2}}"
+CORE_EXTENSIONS="${CORE_EXTENSIONS:-json;parquet;icu}"
+DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET:-15.0}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$REPO_ROOT/Libs/ios"
+WORK_DIR="$(mktemp -d /tmp/duckdb-ios.XXXXXX)"
+TOOLCHAIN="$WORK_DIR/ios.toolchain.cmake"
+TOOLCHAIN_URL="https://raw.githubusercontent.com/leetal/ios-cmake/master/ios.toolchain.cmake"
+
+for tool in cmake git libtool lipo xcodebuild; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: '$tool' is required" >&2; exit 1; }
+done
+
+echo "Building DuckDB $DUCKDB_VERSION for iOS (extensions: $CORE_EXTENSIONS)"
+echo "Work dir: $WORK_DIR"
+
+echo "Fetching ios-cmake toolchain..."
+curl -fSL -o "$TOOLCHAIN" "$TOOLCHAIN_URL"
+
+echo "Cloning DuckDB $DUCKDB_VERSION..."
+git clone --depth 1 --branch "$DUCKDB_VERSION" https://github.com/duckdb/duckdb.git "$WORK_DIR/duckdb"
+
+# Build one DuckDB static library for a single ios-cmake PLATFORM value, then
+# merge DuckDB's per-component archives into a single fat .a.
+#
+# DUCKDB_EXPLICIT_PLATFORM is set: cross-compiled iOS binaries cannot run on the
+# macOS build host, so DuckDB's default "build and run a probe binary" platform
+# detection fails. The value only labels the build (extension autoloading is
+# off), so a descriptive string is enough.
+build_platform() {
+  local platform="$1" archs="$2" out_lib="$3" duckdb_platform="$4"
+  local build_dir="$WORK_DIR/build-$platform"
+
+  echo "Building DuckDB for PLATFORM=$platform (archs: $archs)..."
+  cmake -S "$WORK_DIR/duckdb" -B "$build_dir" -G "Unix Makefiles" \
+    -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN" \
+    -DPLATFORM="$platform" \
+    -DDEPLOYMENT_TARGET="$DEPLOYMENT_TARGET" \
+    -DENABLE_BITCODE=OFF \
+    -DENABLE_ARC=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DDUCKDB_EXPLICIT_PLATFORM="$duckdb_platform" \
+    -DBUILD_SHELL=0 \
+    -DBUILD_UNITTESTS=0 \
+    -DBUILD_BENCHMARKS=0 \
+    -DENABLE_EXTENSION_AUTOLOADING=0 \
+    -DENABLE_EXTENSION_AUTOINSTALL=0 \
+    -DCORE_EXTENSIONS="$CORE_EXTENSIONS"
+
+  cmake --build "$build_dir" --config Release -j "$(sysctl -n hw.ncpu)"
+
+  # DuckDB emits libduckdb_static.a plus one .a per linked extension and
+  # third-party dependency. Merge them all into a single archive.
+  local archives
+  archives=$(find "$build_dir" -name '*.a' -type f)
+  if [[ -z "$archives" ]]; then
+    echo "error: no static archives produced for $platform" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2086
+  libtool -static -o "$out_lib" $archives
+  echo "Merged $(echo "$archives" | wc -l | tr -d ' ') archives into $out_lib"
+}
+
+DEVICE_LIB="$WORK_DIR/libduckdb-device.a"
+SIM_ARM64_LIB="$WORK_DIR/libduckdb-sim-arm64.a"
+SIM_X86_LIB="$WORK_DIR/libduckdb-sim-x86_64.a"
+SIM_LIB="$WORK_DIR/libduckdb-sim.a"
+
+build_platform "OS64" "arm64" "$DEVICE_LIB" "ios_arm64"
+build_platform "SIMULATORARM64" "arm64" "$SIM_ARM64_LIB" "iossimulator_arm64"
+build_platform "SIMULATOR64" "x86_64" "$SIM_X86_LIB" "iossimulator_amd64"
+
+echo "Combining simulator slices..."
+lipo -create "$SIM_ARM64_LIB" "$SIM_X86_LIB" -output "$SIM_LIB"
+
+# The xcframework exposes the public C API header to consumers.
+HEADERS_DIR="$WORK_DIR/include"
+mkdir -p "$HEADERS_DIR"
+cp "$WORK_DIR/duckdb/src/include/duckdb.h" "$HEADERS_DIR/duckdb.h"
+
+echo "Creating xcframework..."
+rm -rf "$OUT_DIR/DuckDB.xcframework"
+mkdir -p "$OUT_DIR"
+xcodebuild -create-xcframework \
+  -library "$DEVICE_LIB" -headers "$HEADERS_DIR" \
+  -library "$SIM_LIB" -headers "$HEADERS_DIR" \
+  -output "$OUT_DIR/DuckDB.xcframework"
+
+echo
+echo "Done: $OUT_DIR/DuckDB.xcframework"
+echo
+echo "Next steps (these modify the libs-v1 release; run them yourself):"
+echo "  tar czf /tmp/tablepro-libs-ios-v1.tar.gz -C \"$REPO_ROOT/Libs/ios\" ."
+echo "  gh release upload libs-v1 /tmp/tablepro-libs-ios-v1.tar.gz --clobber --repo TableProApp/TablePro"
+echo
+echo "Then build TableProMobile in Xcode. Cleaning up $WORK_DIR"
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
Closes #1526.

Adds DuckDB to the iOS app: open `.duckdb`/`.ddb` files or run an in-memory database, matching the Mac app.

## Why this is structured differently from macOS

iOS can't load the macOS `.tableplugin` bundle at runtime (App Store Guideline 2.5.2 + the sandbox), so iOS compiles each driver into the app and links a static `xcframework`. This follows the exact pattern `SQLiteDriver` established. DuckDB was missing two things: an iOS DuckDB binary and an iOS driver. Both are added here.

## What's in the PR

- `DuckDBDriver` (+ `DuckDBDriver+Schema`): a `DatabaseDriver` implementation over the DuckDB C API, ported from the macOS plugin. Handles `:memory:`, security-scoped file access, schema/table/column/index/FK introspection, transactions, and TZ/GEOMETRY rendering.
- `CBridges/CDuckDB`: the C module map for `duckdb.h`.
- `FileBookmarkStore`: device-local (UserDefaults) security-scoped bookmarks, keyed by connection id. Kept out of the synced model and iCloud keychain, since a bookmark is meaningless on another device.
- Connection form: a DuckDB section with an in-memory toggle and a file picker for `.duckdb`/`.ddb`. Opened files keep working across launches; edits write back to the original file.
- `scripts/build-duckdb-ios.sh`: builds the iOS xcframework from DuckDB v1.5.2 (matches the bundled macOS lib) for device + simulator, linking `json`, `parquet`, and `icu`. Remote extension autoloading is off (`httpfs` and friends are not available on iOS).
- Wiring: `IOSDriverFactory`, `DatabaseType+Mobile`, `ConnectionCoordinator` schema support, bookmark cleanup on delete, `project.pbxproj` (xcframework link, `CDuckDB` include path, `-lc++`).

## Native library

`DuckDB.xcframework` is not in git (same as the other iOS xcframeworks); it lives in the `libs-v1` release. I rebuilt `tablepro-libs-ios-v1.tar.gz` with the new framework and uploaded it, and bumped the `ios-tests.yml` cache key so CI fetches the refreshed set. To rebuild locally: `scripts/build-duckdb-ios.sh`.

## Tests

- `DuckDBDriverTests`: in-memory integration (create/insert/select, null, blob base64, tables/columns/PK, views, schemas). No server or file needed, so it runs in CI.
- `FileBookmarkStoreTests`: save/resolve/delete round-trip.
- `ConnectionFormViewModelDuckDBTests`: in-memory toggle, file-based save, type reset.

## Notes

- The DuckDB static archive is large; the linked app binary is much smaller after dead-stripping.
- Large in-memory databases are bounded by the iOS per-app memory budget.