### PR TITLE
perf(import): convert JSON array rows lazily during import

### DIFF
--- a/Plugins/JSONImportPlugin/JSONImportPlugin.swift
+++ b/Plugins/JSONImportPlugin/JSONImportPlugin.swift
@@ -70,10 +70,10 @@ final class JSONImportPlugin: ImportFormatPlugin, SettablePlugin {
                                      inserted: &inserted, skipped: &skipped, errors: &errors, maxErrors: maxErrors)
                 }
             } else {
-                let rows = try Self.parseRows(at: url, targetTable: sink.targetTable)
-                for (index, row) in rows.enumerated() {
+                let rawRows = try Self.parseRows(at: url, targetTable: sink.targetTable)
+                for (index, rawRow) in rawRows.enumerated() {
                     try progress.checkCancellation()
-                    try await insert(row, into: sink, at: index + 1, progress: progress,
+                    try await insert(Self.convertRow(rawRow), into: sink, at: index + 1, progress: progress,
                                      inserted: &inserted, skipped: &skipped, errors: &errors, maxErrors: maxErrors)
                 }
             }
@@ -145,10 +145,10 @@ final class JSONImportPlugin: ImportFormatPlugin, SettablePlugin {
         return convertRow(dict)
     }
 
-    static func parseRows(at url: URL, targetTable: String?) throws -> [[String: PluginCellValue]] {
+    static func parseRows(at url: URL, targetTable: String?) throws -> [[String: Any]] {
         let data = try Data(contentsOf: url)
         let object = try JSONSerialization.jsonObject(with: data)
-        return try extractRows(from: object, targetTable: targetTable).map(convertRow)
+        return try extractRows(from: object, targetTable: targetTable)
     }
 
     static func extractRows(from object: Any, targetTable: String?) throws -> [[String: Any]] {


### PR DESCRIPTION
Follow-up to #1536 (post-merge review).

`JSONImportPlugin.performImport` built the entire array import into a `[[String: PluginCellValue]]` buffer (`parseRows` did `extractRows(...).map(convertRow)`) before inserting any row. For a large `.json` array that's a full duplicate of the row collection held alongside the parsed object graph.

This converts each row to `PluginCellValue` lazily at insert time instead: `parseRows` now returns the raw `[[String: Any]]` and the loop calls `convertRow` per row. Peak memory drops by roughly that extra buffer. No behavior change.

Note: the deeper cost (the whole file + `JSONSerialization` object graph in memory) is inherent to the array path; NDJSON/JSONL already streams via `url.lines`. A streaming array parser would be a separate, larger change.

Tests unchanged (they exercise `extractRows`/`convertRow`/`parseRow` directly, none of which changed signature). Local full-suite validation was blocked by an unrelated DerivedData/SPM checkout issue on my machine; relying on CI's clean build here.