### PR TITLE
fix(plugin-postgresql): keep the selected schema applied after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PostgreSQL: the selected schema now stays applied to editor queries after an automatic reconnect, so unqualified table names keep resolving against it instead of falling back to the default schema. (#1540)
 - Import now detects the Setapp edition of TablePlus and reads connections from its data folder. It was reported as not installed before. (#1528)
 - Favorite keyword suggestions now show in the editor autocomplete when you type the keyword. They were being dropped before reaching the popup.
 

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -14,6 +14,7 @@ final class LibPQDriverCore: @unchecked Sendable {
     private var libpqConnection: LibPQPluginConnection?
 
     var currentSchema: String = "public"
+    private var selectedSchema: String?
 
     var onPostConnect: (@Sendable () async -> Void)?
 
@@ -45,7 +46,18 @@ final class LibPQDriverCore: @unchecked Sendable {
             currentSchema = schema
         }
 
+        if let selectedSchema,
+           (try? await pqConn.executeQuery(PostgreSQLSchemaQueries.setSearchPath(toSchema: selectedSchema))) != nil {
+            currentSchema = selectedSchema
+        }
+
         await onPostConnect?()
+    }
+
+    func applySchema(_ schema: String) async throws {
+        _ = try await execute(query: PostgreSQLSchemaQueries.setSearchPath(toSchema: schema))
+        selectedSchema = schema
+        currentSchema = schema
     }
 
     func disconnect() {
@@ -180,9 +192,7 @@ extension LibPQBackedDriver {
     }
 
     func switchSchema(to schema: String) async throws {
-        let escapedName = schema.replacingOccurrences(of: "\"", with: "\"\"")
-        _ = try await core.execute(query: "SET search_path TO \"\(escapedName)\", public")
-        core.currentSchema = schema
+        try await core.applySchema(schema)
     }
 
     var currentSchema: String? { core.currentSchema }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -75,4 +75,9 @@ enum PostgreSQLSchemaQueries {
 
         return unions.joined(separator: "\nUNION ALL\n") + "\nORDER BY table_name"
     }
+
+    static func setSearchPath(toSchema schema: String) -> String {
+        let quotedIdentifier = schema.replacingOccurrences(of: "\"", with: "\"\"")
+        return "SET search_path TO \"\(quotedIdentifier)\", public"
+    }
 }

--- a/TableProTests/Plugins/PostgreSQLSearchPathTests.swift
+++ b/TableProTests/Plugins/PostgreSQLSearchPathTests.swift
@@ -1,0 +1,43 @@
+//
+//  PostgreSQLSearchPathTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@Suite("PostgreSQLSchemaQueries.setSearchPath")
+struct PostgreSQLSearchPathTests {
+    @Test("quotes the schema as an identifier and keeps public on the path")
+    func plainSchema() {
+        #expect(
+            PostgreSQLSchemaQueries.setSearchPath(toSchema: "analytics")
+                == "SET search_path TO \"analytics\", public"
+        )
+    }
+
+    @Test("preserves mixed-case schema names with identifier quoting")
+    func mixedCaseSchema() {
+        #expect(
+            PostgreSQLSchemaQueries.setSearchPath(toSchema: "MySchema")
+                == "SET search_path TO \"MySchema\", public"
+        )
+    }
+
+    @Test("doubles embedded double quotes so the name stays a single identifier")
+    func schemaWithEmbeddedQuote() {
+        #expect(
+            PostgreSQLSchemaQueries.setSearchPath(toSchema: "wei\"rd")
+                == "SET search_path TO \"wei\"\"rd\", public"
+        )
+    }
+
+    @Test("neutralizes a quote-break injection attempt")
+    func injectionAttempt() {
+        let malicious = "public\"; DROP TABLE users; --"
+        #expect(
+            PostgreSQLSchemaQueries.setSearchPath(toSchema: malicious)
+                == "SET search_path TO \"public\"\"; DROP TABLE users; --\", public"
+        )
+    }
+}


### PR DESCRIPTION
Closes #1540.

## Problem

When a schema is selected in TablePro (sidebar picker or the database tree), unqualified table names in the editor stop resolving against it, so the user has to prefix every table (`myschema.users`).

## Root cause

Selecting a schema already runs `SET search_path TO "schema", public` on the main connection, and editor queries run on that same connection, so it works at first. But `LibPQDriverCore` silently reconnects on connection loss (`executeWithReconnect` -> `reconnect()` -> `connect()`). `connect()` re-probes `current_schema()` (the server default) and never re-applies the user's selection. PostgreSQL drops idle connections routinely, so the first query after a pause triggers a silent reconnect, the `search_path` reverts, and from then on unqualified queries resolve to the wrong schema. The reconnect is invisible to the layers that would otherwise re-apply the schema, so their recovery never fires.

## Fix

The driver core now remembers the user-selected schema and re-applies it whenever a physical connection is established, so `search_path` stays in sync with the selection across every reconnect path (silent core reconnect, health-monitor, future).

- `LibPQDriverCore` stores `selectedSchema` (distinct from the server-reported `currentSchema`). `connect()` re-applies it after the `current_schema()` probe, updating `currentSchema` only if the apply succeeds. A new `applySchema(_:)` records the selection only after the `SET` succeeds, so a failed switch can't poison later reconnects.
- `switchSchema` routes through `applySchema`, removing the duplicated inline escaping.
- The `SET search_path` statement is built by a pure `PostgreSQLSchemaQueries.setSearchPath(toSchema:)` with identifier quoting (doubles `"`), so a schema name with quotes can't break out of the identifier.

This covers PostgreSQL, Redshift, and CockroachDB (shared `LibPQDriverCore`). No PluginKit protocol change, so no ABI bump. The metadata connection pool already scopes its own connections per schema, so introspection is unaffected.

## Tests

`PostgreSQLSearchPathTests` covers the statement builder: plain schema, mixed case, an embedded double quote, and a quote-break injection attempt. It runs in the test target via the existing `PluginTestSources` symlink (no libpq dependency). The reconnect-restore behavior needs a live PostgreSQL connection, so it is verified at runtime rather than in unit tests.

## Notes

- Oracle has the same gap in its own plugin (`ALTER SESSION SET CURRENT_SCHEMA`); left as a follow-up since it is a separate registry plugin with its own release.
- `statement_timeout` (`applyQueryTimeout`) has the same reset-on-silent-reconnect pattern. Out of scope here, worth a separate fix.