### PR TITLE
fix(toolbar): center the connection chip with the visible window title

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -34,6 +34,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         self.managedToolbar.displayMode = .iconOnly
         self.managedToolbar.allowsUserCustomization = true
         self.managedToolbar.autosavesConfiguration = true
+        self.managedToolbar.centeredItemIdentifiers = [Self.principal]
     }
 
     func invalidate() {
@@ -77,7 +78,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
             .sidebarTrackingSeparator,
             Self.connectionGroup,
             Self.refreshSaveGroup,
-            .flexibleSpace,
             Self.principal,
             .flexibleSpace,
             Self.quickSwitcher,


### PR DESCRIPTION
Follow-up to #1479.

## Problem

After #1479 made the window title visible (`titleVisibility = .visible` on the `.unified` toolbar), every toolbar item jumped to the right edge: the leading group, the centered connection chip, and the trailing actions all bunched up on the right, with a large empty gap after the title.

## Cause

The toolbar centered the connection chip (`principal`) by bracketing it with two `.flexibleSpace` items. That splits the toolbar's free width in half to center the chip, which only works while the window title is hidden. With the title now drawn in the leading area of the same unified toolbar row, it takes a greedy chunk of leading width, the flexible-space split no longer balances against the real leading edge, and everything after the title collapses to the trailing edge.

## Fix

Use `NSToolbar.centeredItemIdentifiers` (macOS 13+, the app targets 14.0), which centers an item relative to the window independently of the title and the other items. The two `.flexibleSpace` items around `principal` are replaced with a single `.flexibleSpace` that pushes the trailing action cluster right.

Layout is now: leading group on the left, connection chip centered, actions on the right, coexisting with the visible title.

`centeredItemIdentifiers` is applied at runtime, so it re-centers the chip even for a toolbar whose autosaved configuration still holds the old arrangement.