### PR TITLE
fix(toolbar): anchor the connection and refresh actions at the leading edge

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -78,6 +78,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
             .sidebarTrackingSeparator,
             Self.connectionGroup,
             Self.refreshSaveGroup,
+            .flexibleSpace,
             Self.principal,
             .flexibleSpace,
             Self.quickSwitcher,


### PR DESCRIPTION
Follow-up to #1543 / #1479.

## Problem

After centering the connection chip with `centeredItemIdentifiers`, the connection and refresh/save buttons clustered in the middle next to the chip instead of sitting at the leading edge, leaving the area after the window title empty.

## Cause

`connectionGroup` and `refreshSaveGroup` were contiguous with `principal` (no space between them and the centered item). When `centeredItemIdentifiers` centers `principal`, items directly adjacent to it with no `flexibleSpace` separator are drawn attached to the centered chip, so they rode into the center.

## Fix

Restore a `flexibleSpace` between `refreshSaveGroup` and `principal`, so there is a flexible space on both sides of the chip:

```
sidebarToggle, .sidebarTrackingSeparator, connectionGroup, refreshSaveGroup,
.flexibleSpace, principal, .flexibleSpace,
quickSwitcher, newTab, previewSQL, inspector
```

The two flexible spaces separate the three zones; `centeredItemIdentifiers = [principal]` still does the actual centering, so it stays robust against the visible window title. Result: connection/refresh/save anchored left, chip centered, view actions right.