### PR TITLE
refactor(plugin-postgresql): tidy search-path and centralize identifier/literal escaping

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
@@ -246,13 +246,11 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func createDatabase(_ request: PluginCreateDatabaseRequest) async throws {
-        let quotedName = request.name.replacingOccurrences(of: "\"", with: "\"\"")
-        _ = try await execute(query: "CREATE DATABASE \"\(quotedName)\"")
+        _ = try await execute(query: "CREATE DATABASE \(quoteIdentifier(request.name))")
     }
 
     func dropDatabase(name: String) async throws {
-        let quotedName = name.replacingOccurrences(of: "\"", with: "\"\"")
-        _ = try await execute(query: "DROP DATABASE \"\(quotedName)\"")
+        _ = try await execute(query: "DROP DATABASE \(quoteIdentifier(name))")
     }
 
     // MARK: - Query Helpers

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
@@ -8,8 +8,8 @@ import TableProPluginKit
 
 extension PostgreSQLPluginDriver {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
-        let safeSchema = escapeLiteralForColumns(currentSchema ?? "public")
-        let safeTable = escapeLiteralForColumns(table)
+        let safeSchema = escapeStringLiteral(currentSchema ?? "public")
+        let safeTable = escapeStringLiteral(table)
         let enumMap = try await fetchEnumLabelMap(schema: safeSchema)
         let caps = versionedCapabilities
         let identityProjection = caps.hasIdentityColumns ? "a.attidentity" : "NULL::text"
@@ -60,7 +60,7 @@ extension PostgreSQLPluginDriver {
     }
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
-        let safeSchema = escapeLiteralForColumns(currentSchema ?? "public")
+        let safeSchema = escapeStringLiteral(currentSchema ?? "public")
         let enumMap = try await fetchEnumLabelMap(schema: safeSchema)
         let caps = versionedCapabilities
         let identityProjection = caps.hasIdentityColumns ? "a.attidentity" : "NULL::text"
@@ -132,10 +132,6 @@ extension PostgreSQLPluginDriver {
             map[typeName, default: []].append(label)
         }
         return map
-    }
-
-    fileprivate func escapeLiteralForColumns(_ str: String) -> String {
-        str.replacingOccurrences(of: "'", with: "''")
     }
 
     fileprivate func mapPgColumnRow(

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -336,7 +336,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
         let safeTable = escapeLiteral(table)
-        let quotedTable = "\"\(table.replacingOccurrences(of: "\"", with: "\"\""))\""
+        let quotedTable = quoteIdentifier(table)
         let caps = versionedCapabilities
 
         let identityClause: String = caps.hasIdentityColumns ? """
@@ -431,7 +431,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         var parts = columnDefs
         parts.append(contentsOf: constraints)
 
-        let quotedSchema = "\"\(core.currentSchema.replacingOccurrences(of: "\"", with: "\"\""))\""
+        let quotedSchema = quoteIdentifier(core.currentSchema)
         let ddl = "CREATE TABLE \(quotedSchema).\(quotedTable) (\n  " +
             parts.joined(separator: ",\n  ") +
             "\n);"
@@ -599,9 +599,9 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             let incrementBy = row[4].asText ?? "1"
             let cycle = row[5].asText == "t" ? " CYCLE" : ""
             let lastValue = row.count > 6 ? row[6].asText : nil
-            let quotedSeqName = "\"\(seqName.replacingOccurrences(of: "\"", with: "\"\""))\""
-            let escapedSchemaForLiteral = schemaName.replacingOccurrences(of: "'", with: "''")
-            let escapedSeqForLiteral = seqName.replacingOccurrences(of: "'", with: "''")
+            let quotedSeqName = quoteIdentifier(seqName)
+            let escapedSchemaForLiteral = escapeStringLiteral(schemaName)
+            let escapedSeqForLiteral = escapeStringLiteral(seqName)
             var ddl = "CREATE SEQUENCE \(quotedSeqName) INCREMENT BY \(incrementBy)"
                 + " MINVALUE \(minVal) MAXVALUE \(maxVal)"
                 + " START WITH \(startVal)\(cycle);"
@@ -692,7 +692,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func createDatabase(_ request: PluginCreateDatabaseRequest) async throws {
-        let quotedName = request.name.replacingOccurrences(of: "\"", with: "\"\"")
+        let quotedName = quoteIdentifier(request.name)
 
         guard let encoding = request.values["encoding"] else {
             throw LibPQPluginError(
@@ -709,7 +709,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             )
         }
 
-        var sql = "CREATE DATABASE \"\(quotedName)\" ENCODING '\(encoding)'"
+        var sql = "CREATE DATABASE \(quotedName) ENCODING '\(encoding)'"
 
         let supportsProvider = versionedCapabilities.hasDatabaseICULocale
         let provider = supportsProvider ? (request.values["provider"] ?? "libc") : "libc"
@@ -789,8 +789,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func dropDatabase(name: String) async throws {
-        let escapedName = name.replacingOccurrences(of: "\"", with: "\"\"")
-        _ = try await execute(query: "DROP DATABASE \"\(escapedName)\"")
+        _ = try await execute(query: "DROP DATABASE \(quoteIdentifier(name))")
     }
 
     private struct Template1Defaults {

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -77,7 +77,10 @@ enum PostgreSQLSchemaQueries {
     }
 
     static func setSearchPath(toSchema schema: String) -> String {
-        let quotedIdentifier = schema.replacingOccurrences(of: "\"", with: "\"\"")
-        return "SET search_path TO \"\(quotedIdentifier)\", public"
+        let quotedIdentifier = "\"\(schema.replacingOccurrences(of: "\"", with: "\"\""))\""
+        guard schema != "public" else {
+            return "SET search_path TO \(quotedIdentifier)"
+        }
+        return "SET search_path TO \(quotedIdentifier), public"
     }
 }

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
@@ -295,8 +295,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
         let safeTable = escapeLiteral(table)
-        let quotedTable = "\"\(table.replacingOccurrences(of: "\"", with: "\"\""))\""
-        let quotedSchema = "\"\(core.currentSchema.replacingOccurrences(of: "\"", with: "\"\""))\""
+        let quotedTable = quoteIdentifier(table)
+        let quotedSchema = quoteIdentifier(core.currentSchema)
 
         do {
             let showResult = try await execute(query: "SHOW TABLE \(quotedSchema).\(quotedTable)")
@@ -508,14 +508,12 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             )
         }
 
-        let quotedName = request.name.replacingOccurrences(of: "\"", with: "\"\"")
-        let sql = "CREATE DATABASE \"\(quotedName)\" COLLATE \(collate)"
+        let sql = "CREATE DATABASE \(quoteIdentifier(request.name)) COLLATE \(collate)"
         _ = try await execute(query: sql)
     }
 
     func dropDatabase(name: String) async throws {
-        let escapedName = name.replacingOccurrences(of: "\"", with: "\"\"")
-        _ = try await execute(query: "DROP DATABASE \"\(escapedName)\"")
+        _ = try await execute(query: "DROP DATABASE \(quoteIdentifier(name))")
     }
 
     // MARK: - All Tables Metadata
@@ -537,5 +535,4 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         ORDER BY "table"
         """
     }
-
 }

--- a/TableProTests/Plugins/PostgreSQLSearchPathTests.swift
+++ b/TableProTests/Plugins/PostgreSQLSearchPathTests.swift
@@ -16,6 +16,14 @@ struct PostgreSQLSearchPathTests {
         )
     }
 
+    @Test("omits the redundant public fallback when public is the selected schema")
+    func publicSchema() {
+        #expect(
+            PostgreSQLSchemaQueries.setSearchPath(toSchema: "public")
+                == "SET search_path TO \"public\""
+        )
+    }
+
     @Test("preserves mixed-case schema names with identifier quoting")
     func mixedCaseSchema() {
         #expect(


### PR DESCRIPTION
## What

Two related cleanups in the PostgreSQL plugin's SQL generation.

1. **Redundant `public` entry.** When the selected schema is `public`, the search-path builder emitted `SET search_path TO "public", public`. This collapses it to `SET search_path TO "public"`. Every non-public schema still gets `"schema", public`, and the quote-doubling injection guard is unchanged.
2. **Centralized quoting/escaping.** Identifier quoting (`"name"` with doubled inner quotes) was hand-rolled in ~10 spots across `PostgreSQLPluginDriver`, `RedshiftPluginDriver`, and `CockroachPluginDriver`. Those now call the shared `quoteIdentifier(_:)` from TableProPluginKit. Duplicated literal escaping (`'` -> `''`), including a `fileprivate escapeLiteralForColumns`, now routes through the canonical `escapeStringLiteral(_:)`.

## Why

A user asked why, after switching to a non-public schema, the SQL editor can still query other schemas unqualified. Investigation confirmed this is correct PostgreSQL behavior, not a bug: `search_path` is a name-resolution order, not an access boundary, and the `, public` fallback is the principled choice (dropping it breaks unqualified extension functions/types in `public` and buys zero security). The only real defect was the redundant `"public", public` token, plus the scattered copy-paste of escaping logic that the framework already provides in one audited place.

## Behavior

- Identifier quoting is byte-identical to the hand-rolled code, so DDL and CREATE/DROP DATABASE output is unchanged.
- `escapeStringLiteral` also strips null bytes (the old `escapeLiteralForColumns` did not). This is a defensive improvement with no practical effect: PostgreSQL identifiers cannot contain null bytes.
- `PostgreSQLSchemaQueries.setSearchPath` keeps its own quoting on purpose. That enum is a standalone, separately unit-tested SQL builder, deliberately decoupled from any driver instance, so it does not depend on the instance `quoteIdentifier`.

## Tests

Added `publicSchema()` to `PostgreSQLSearchPathTests` locking in the no-redundancy output. Existing mixed-case, embedded-quote, and injection tests still pass (they take the non-public branch). The quoting/escaping consolidation is behavior-preserving and covered by existing DDL generation paths.

No CHANGELOG or docs entry: no user-facing behavior change.
