### PR TITLE
fix(editor): refresh autocomplete when switching schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostgreSQL: the selected schema now stays applied to editor queries after an automatic reconnect, so unqualified table names keep resolving against it instead of falling back to the default schema. (#1540)
 - Import now detects the Setapp edition of TablePlus and reads connections from its data folder. It was reported as not installed before. (#1528)
 - Favorite keyword suggestions now show in the editor autocomplete when you type the keyword. They were being dropped before reaching the popup.
+- Editor autocomplete now refreshes when you switch schema, so it suggests the new schema's tables and columns instead of the previous one's.
 
 ## [0.47.0] - 2026-06-01
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -192,6 +192,7 @@ final class MainContentCoordinator {
     @ObservationIgnored private var terminationObserver: NSObjectProtocol?
     @ObservationIgnored private var postConnectCancellable: AnyCancellable?
     @ObservationIgnored private var externalFileModCancellable: AnyCancellable?
+    @ObservationIgnored private var schemaSwitchCancellable: AnyCancellable?
 
     var fileConflictRequest: FileConflictRequest?
 
@@ -423,6 +424,15 @@ final class MainContentCoordinator {
                 self.checkOpenTabsForExternalModification()
             }
 
+        schemaSwitchCancellable = services.appEvents.currentSchemaChanged
+            .receive(on: RunLoop.main)
+            .sink { [weak self] changedConnectionId in
+                guard let self, changedConnectionId == self.connectionId else { return }
+                Task { @MainActor in
+                    await self.refreshTables()
+                }
+            }
+
         self.filterCoordinator = FilterCoordinator(parent: self)
         self.queryExecutionCoordinator = QueryExecutionCoordinator(parent: self)
         self.paginationCoordinator = PaginationCoordinator(parent: self)
@@ -619,6 +629,7 @@ final class MainContentCoordinator {
         }
         postConnectCancellable = nil
         externalFileModCancellable = nil
+        schemaSwitchCancellable = nil
         fileWatcher?.stopWatching(connectionId: connectionId)
         fileWatcher = nil
         currentQueryTask?.cancel()


### PR DESCRIPTION
## Problem

After switching schema in the sidebar, the SQL editor's autocomplete kept suggesting tables and columns from the previous schema.

## Root cause

`DatabaseManager.switchSchema` fires `AppEvents.currentSchemaChanged`. The only subscriber was `SchemaService`, which reloads its own `@Observable` table store, so the sidebar updated. But the autocomplete provider (`SQLSchemaProvider`) is refreshed only through `MainContentCoordinator.reconcilePostSchemaLoad()` -> `provider.resetForDatabase(...)`, and that bridge is called only from `refreshTables()` and `loadSchema()`, never on a schema switch. So the shared provider stayed frozen on the old schema's `tables` and `columnCache`, and every editor tab kept serving stale completions. The same gap affected schema switches from the MCP/AI tools, not just the sidebar picker.

## Fix

`MainContentCoordinator` now subscribes to `currentSchemaChanged` (filtered to its connection) and runs the existing `refreshTables()` path on a switch. That reloads the schema-scoped table list, resets the shared autocomplete provider (clears the stale column cache and restarts a schema-scoped eager column load through the metadata pool, which is already keyed on the current schema), and prunes stale sidebar selection state.

The table reload shares `loadDedup` (keyed on connection id) with `SchemaService`'s own event-driven reload, so the two reloads triggered by the same event coalesce into a single `fetchTables`. Being reactive to the event, it also covers MCP/AI-driven switches.

## Tests

This is MainActor + Combine + actor wiring (the existing reconcile path has no unit coverage either), so it's verified manually: connect to PostgreSQL, switch schema, confirm autocomplete lists the new schema's tables/columns rather than the previous one's.
