### PR TITLE
refactor(plugins): consolidate connect-time driver readiness and tidy binary selection

### DIFF
--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -400,27 +400,7 @@ enum DatabaseDriverFactory {
         passwordOverride: String? = nil,
         awaitPlugins: Bool
     ) async throws -> DatabaseDriver {
-        let pluginId = connection.type.pluginTypeId
-        if PluginManager.shared.driverPlugin(for: connection.type) == nil,
-           !PluginManager.shared.hasFinishedInitialLoad {
-            logger.info("Plugin '\(pluginId)' not loaded yet, waiting for background load")
-            await PluginManager.shared.waitForInitialLoad()
-        }
-        if PluginManager.shared.driverPlugin(for: connection.type) == nil,
-           PluginManager.shared.hasOutdatedRejectedPlugin(forTypeId: pluginId) {
-            logger.info("Plugin '\(pluginId)' is installed but outdated, updating it before connect")
-            await PluginManager.shared.ensurePluginReady(forTypeId: pluginId)
-        }
-        if PluginManager.shared.driverPlugin(for: connection.type) == nil,
-           connection.type.isDownloadablePlugin,
-           !PluginManager.shared.hasOutdatedRejectedPlugin(forTypeId: pluginId) {
-            logger.info("Plugin '\(pluginId)' not installed, installing on demand before connect")
-            do {
-                try await PluginManager.shared.installMissingPlugin(for: connection.type) { _ in }
-            } catch {
-                logger.warning("On-demand install for '\(pluginId)' did not complete: \(error.localizedDescription)")
-            }
-        }
+        await PluginManager.shared.prepareForConnecting(to: connection.type)
         return try await createDriverFromPlugin(for: connection, passwordOverride: passwordOverride)
     }
 

--- a/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
+++ b/TablePro/Core/Plugins/PluginManager+AutoUpdate.swift
@@ -276,6 +276,26 @@ extension PluginManager {
         rejectedPlugins.first { $0.isOutdated && $0.providedDatabaseTypeIds.contains(typeId) }?.reason
     }
 
+    func prepareForConnecting(to type: DatabaseType) async {
+        let typeId = type.pluginTypeId
+        if driverPlugin(for: type) == nil, !hasFinishedInitialLoad {
+            Self.logger.info("Plugin '\(typeId)' not loaded yet, waiting for background load")
+            await waitForInitialLoad()
+        }
+        if driverPlugin(for: type) == nil, hasOutdatedRejectedPlugin(forTypeId: typeId) {
+            Self.logger.info("Plugin '\(typeId)' is installed but outdated, updating it before connect")
+            await ensurePluginReady(forTypeId: typeId)
+        }
+        if driverPlugin(for: type) == nil, type.isDownloadablePlugin, !hasOutdatedRejectedPlugin(forTypeId: typeId) {
+            Self.logger.info("Plugin '\(typeId)' not installed, installing on demand before connect")
+            do {
+                try await installMissingPlugin(for: type) { _ in }
+            } catch {
+                Self.logger.warning("On-demand install for '\(typeId)' did not complete: \(error.localizedDescription)")
+            }
+        }
+    }
+
     func ensurePluginReady(forTypeId typeId: String) async {
         if reconciliationActive, let task = reconciliationTask {
             await task.value
@@ -287,6 +307,8 @@ extension PluginManager {
     private func reconcileOutdated(matchingTypeId typeId: String) async {
         let targets = rejectedPlugins.filter { $0.isOutdated && $0.providedDatabaseTypeIds.contains(typeId) }
         guard !targets.isEmpty else { return }
+        reconciliationActive = true
+        defer { reconciliationActive = false }
         await RegistryClient.shared.fetchManifest(forceRefresh: true)
         guard let manifest = RegistryClient.shared.manifest else { return }
         for target in targets {

--- a/TablePro/Core/Plugins/Registry/RegistryModels.swift
+++ b/TablePro/Core/Plugins/Registry/RegistryModels.swift
@@ -108,16 +108,18 @@ extension RegistryPlugin {
         currentKitVersion: Int,
         minimumKitVersion: Int
     ) throws -> RegistryBinary {
-        let compatible = binaries
+        let highestInRange = binaries
             .filter { $0.architecture == arch }
-            .filter { binary in
-                guard let kit = binary.pluginKitVersion else { return false }
-                return kit >= minimumKitVersion && kit <= currentKitVersion
+            .compactMap { binary -> (binary: RegistryBinary, kit: Int)? in
+                guard let kit = binary.pluginKitVersion, kit >= minimumKitVersion, kit <= currentKitVersion else {
+                    return nil
+                }
+                return (binary, kit)
             }
-            .max { ($0.pluginKitVersion ?? 0) < ($1.pluginKitVersion ?? 0) }
+            .max { $0.kit < $1.kit }
 
-        if let compatible {
-            return compatible
+        if let highestInRange {
+            return highestInRange.binary
         }
 
         throw PluginError.noCompatibleBinary

--- a/TableProTests/Core/Plugins/PluginManagerReconciliationTests.swift
+++ b/TableProTests/Core/Plugins/PluginManagerReconciliationTests.swift
@@ -49,7 +49,7 @@ struct PluginManagerReconciliationTests {
         )
     }
 
-    private func makeRegistryPlugin(id: String = "com.example.driver", kitVersions: [Int]) -> RegistryPlugin {
+    private func makeRegistryPlugin(id: String = "com.example.driver", kitVersions: [Int]) throws -> RegistryPlugin {
         let arch = PluginArchitecture.current.rawValue
         let binaries = kitVersions
             .map { "{\"architecture\": \"\(arch)\", \"downloadURL\": \"https://x\", \"sha256\": \"deadbeef\", \"pluginKitVersion\": \($0)}" }
@@ -65,7 +65,7 @@ struct PluginManagerReconciliationTests {
             "binaries": [\(binaries)]
         }
         """
-        return try! JSONDecoder().decode(RegistryPlugin.self, from: Data(json.utf8))
+        return try JSONDecoder().decode(RegistryPlugin.self, from: Data(json.utf8))
     }
 
     private func kind(_ action: RejectedPluginAction) -> String {
@@ -78,8 +78,8 @@ struct PluginManagerReconciliationTests {
     }
 
     @Test("rejectedAction awaits while the manifest is still loading")
-    func rejectedActionAwaitsWithoutManifest() {
-        let plugin = makeRegistryPlugin(kitVersions: [18])
+    func rejectedActionAwaitsWithoutManifest() throws {
+        let plugin = try makeRegistryPlugin(kitVersions: [18])
         let action = PluginManager.rejectedAction(
             registryPlugin: plugin, manifestLoaded: false, currentKitVersion: 18, minimumKitVersion: 18
         )
@@ -95,8 +95,8 @@ struct PluginManagerReconciliationTests {
     }
 
     @Test("rejectedAction offers an update when a current-kit binary exists")
-    func rejectedActionUpdateAvailable() {
-        let plugin = makeRegistryPlugin(kitVersions: [17, 18])
+    func rejectedActionUpdateAvailable() throws {
+        let plugin = try makeRegistryPlugin(kitVersions: [17, 18])
         let action = PluginManager.rejectedAction(
             registryPlugin: plugin, manifestLoaded: true, currentKitVersion: 18, minimumKitVersion: 18
         )
@@ -104,8 +104,8 @@ struct PluginManagerReconciliationTests {
     }
 
     @Test("rejectedAction offers an update for a resilient older-kit binary under a newer app")
-    func rejectedActionUpdateAvailableForwardCompat() {
-        let plugin = makeRegistryPlugin(kitVersions: [18])
+    func rejectedActionUpdateAvailableForwardCompat() throws {
+        let plugin = try makeRegistryPlugin(kitVersions: [18])
         let action = PluginManager.rejectedAction(
             registryPlugin: plugin, manifestLoaded: true, currentKitVersion: 19, minimumKitVersion: 18
         )
@@ -113,8 +113,8 @@ struct PluginManagerReconciliationTests {
     }
 
     @Test("rejectedAction asks for an app update when only a newer-kit binary exists")
-    func rejectedActionRequiresAppUpdate() {
-        let plugin = makeRegistryPlugin(kitVersions: [18, 19])
+    func rejectedActionRequiresAppUpdate() throws {
+        let plugin = try makeRegistryPlugin(kitVersions: [18, 19])
         let action = PluginManager.rejectedAction(
             registryPlugin: plugin, manifestLoaded: true, currentKitVersion: 17, minimumKitVersion: 17
         )
@@ -122,8 +122,8 @@ struct PluginManagerReconciliationTests {
     }
 
     @Test("rejectedAction awaits when only pre-floor binaries are published")
-    func rejectedActionAwaitsForOlderKits() {
-        let plugin = makeRegistryPlugin(kitVersions: [16, 17])
+    func rejectedActionAwaitsForOlderKits() throws {
+        let plugin = try makeRegistryPlugin(kitVersions: [16, 17])
         let action = PluginManager.rejectedAction(
             registryPlugin: plugin, manifestLoaded: true, currentKitVersion: 18, minimumKitVersion: 18
         )

--- a/scripts/check-registry-readiness.py
+++ b/scripts/check-registry-readiness.py
@@ -6,6 +6,10 @@ Run this before tagging an app release so the app can never ship ahead of its
 plugin binaries. With range-aware binary selection an additive PluginKit bump
 needs no re-publish (an older resilient binary still serves), so this only fails
 after a breaking bump that raised the floor and left the registry behind.
+
+The gate reads the raw GitHub origin, not the jsDelivr CDN that clients use, so
+it sees the manifest the moment the registry push lands rather than waiting out
+(or racing) the CDN edge cache.
 """
 
 import argparse
@@ -13,7 +17,7 @@ import json
 import sys
 import urllib.request
 
-DEFAULT_MANIFEST_URL = "https://cdn.jsdelivr.net/gh/TableProApp/plugins@main/plugins.json"
+DEFAULT_MANIFEST_URL = "https://raw.githubusercontent.com/TableProApp/plugins/main/plugins.json"
 
 
 def fetch_manifest(url, retries=4):


### PR DESCRIPTION
Follow-up cleanups on top of the merged #1555 (self-heal incompatible drivers at connect). No user-facing behavior change.

## What changed

**Connect-time readiness moved to PluginManager.** `DatabaseDriverFactory.createDriver` had three near-identical `if driverPlugin == nil { ... }` blocks reaching into `PluginManager` internals across the layer boundary (wait for load, reconcile outdated, install missing). Extracted them into one `PluginManager.prepareForConnecting(to:)`. The factory now just asks the manager to make the driver ready. Same behavior, fewer cross-layer reach-ins.

**Guard against overlapping reconciliation.** `reconcileOutdated` (the connect path) did not set `reconciliationActive`, so a network-reachability change could start a parallel `runReconciliationLoop` mutating the same `reconciliationAttempts` and `rejectedPlugins`. It now sets the flag for its duration with a `defer` reset, so the existing `!reconciliationActive` guard in `retriggerReconciliation` blocks the overlap.

**Cleaner binary selection.** `resolvedBinary` picked the max with `?? 0`, a branch that never ran because nil `pluginKitVersion` was already filtered out. Rewrote with `compactMap` to a `(binary, kit)` tuple so the comparator works on a non-optional value.

**Release gate reads the origin, not the CDN.** `check-registry-readiness.py` now fetches the raw GitHub manifest instead of the jsDelivr CDN. The gate sees the manifest the moment the registry push lands rather than racing or waiting out the edge cache. Clients still use jsDelivr.

**Tests.** `makeRegistryPlugin` is now `throws` instead of `try!`; the four callers thread `try`.

## Testing
- Build succeeds on top of current main.
- PluginManagerReconciliationTests, RegistryBinarySelectionTests, and PluginInstallerHelpersTests pass.