### PR TITLE
fix(datagrid): keep status bar controls clear of the window resize corner (#1569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The results status bar has a divider above it and balanced left and right margins, and its loading spinner matches the size of the other controls. (#1569)
 - Custom keyboard shortcuts now work on non-US keyboard layouts, and shifted symbols like Cmd+[ record correctly.
 - The Keyboard settings list is grouped by where shortcuts act (Editor, Data Grid, Navigation, Connections), and each changed shortcut has its own reset button.
 - Conflict detection now checks live macOS system shortcuts and the editor's built-in commands, and lets the same key serve the editor and the data grid because focus decides which one runs.
@@ -31,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pagination and other status bar buttons no longer get blocked by the window resize zone in the bottom-right corner. (#1569)
+- VoiceOver now reads clear labels for the Columns button, Filters toggle, and loading indicators in the results status bar. (#1569)
+- The custom rows-per-page popover now points at the page-size menu instead of the center of the pagination controls. (#1569)
 - DynamoDB AWS Profile auth now reads `~/.aws/config` as well as `~/.aws/credentials` and supports `credential_process`, matching the AWS CLI. Profiles defined only in `~/.aws/config`, including SSO and credential-process profiles, no longer fail with "profile not found". (#1567)
 - Query result columns now follow the order in the SELECT. Adding or removing a column no longer leaves new columns stuck at the end of the grid. (#1565)
 - JSON file import works again. It failed to load in 0.48.0.

--- a/TablePro/Models/Query/StatusBarSnapshot.swift
+++ b/TablePro/Models/Query/StatusBarSnapshot.swift
@@ -1,0 +1,59 @@
+//
+//  StatusBarSnapshot.swift
+//  TablePro
+//
+
+import Foundation
+
+struct StatusBarSnapshot: Equatable {
+    let tabId: UUID?
+    let tabType: TabType?
+    let hasRows: Bool
+    let hasColumns: Bool
+    let rowCount: Int
+    let hasTableName: Bool
+    let pagination: PaginationState
+    let statusMessage: String?
+
+    init(
+        tabId: UUID?,
+        tabType: TabType?,
+        hasRows: Bool,
+        hasColumns: Bool,
+        rowCount: Int,
+        hasTableName: Bool,
+        pagination: PaginationState,
+        statusMessage: String?
+    ) {
+        self.tabId = tabId
+        self.tabType = tabType
+        self.hasRows = hasRows
+        self.hasColumns = hasColumns
+        self.rowCount = rowCount
+        self.hasTableName = hasTableName
+        self.pagination = pagination
+        self.statusMessage = statusMessage
+    }
+
+    init(tab: QueryTab?, tableRows: TableRows?) {
+        self.init(
+            tabId: tab?.id,
+            tabType: tab?.tabType,
+            hasRows: !(tableRows?.rows.isEmpty ?? true),
+            hasColumns: !(tableRows?.columns.isEmpty ?? true),
+            rowCount: tableRows?.rows.count ?? 0,
+            hasTableName: tab?.tableContext.tableName != nil,
+            pagination: tab?.pagination ?? PaginationState(),
+            statusMessage: tab?.execution.statusMessage
+        )
+    }
+
+    var showsPaginationControls: Bool {
+        if let total = pagination.totalRowCount, total > 0 { return true }
+        return isPagedWithUnknownTotal
+    }
+
+    var isPagedWithUnknownTotal: Bool {
+        pagination.currentPage > 1 || rowCount >= pagination.pageSize
+    }
+}

--- a/TablePro/Views/Components/PaginationControlsView.swift
+++ b/TablePro/Views/Components/PaginationControlsView.swift
@@ -30,9 +30,6 @@ struct PaginationControlsView: View {
             pageSizeMenu
             navigationCluster
         }
-        .popover(isPresented: $showCustomPopover, arrowEdge: .top) {
-            customPageSizePopover
-        }
     }
 
     // MARK: - Page Size Menu
@@ -62,6 +59,13 @@ struct PaginationControlsView: View {
         .controlSize(.small)
         .help(String(localized: "Rows per page"))
         .accessibilityLabel(String(localized: "Rows per page"))
+        .overlay(alignment: .bottom) {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .popover(isPresented: $showCustomPopover, arrowEdge: .top) {
+                    customPageSizePopover
+                }
+        }
     }
 
     private var pageSizeBinding: Binding<Int> {
@@ -96,6 +100,7 @@ struct PaginationControlsView: View {
             if pagination.isLoading {
                 ProgressView()
                     .controlSize(.small)
+                    .accessibilityLabel(String(localized: "Loading page"))
             }
 
             navButton(

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -501,6 +501,7 @@ struct MainEditorContentView: View {
             }
 
             if tab.display.explainText == nil {
+                Divider()
                 statusBar(tab: tab)
             }
         }
@@ -744,25 +745,31 @@ struct MainEditorContentView: View {
         return MainStatusBarView(
             snapshot: StatusBarSnapshot(tab: tab, tableRows: resolvedRows),
             filterState: tab.filterState,
-            hiddenColumns: tab.columnLayout.hiddenColumns,
-            allColumns: coordinator.columnsForVisibilityPicker(for: tab, resultColumns: resolvedRows.columns),
             selectedRowIndices: selectionState.indices,
             viewMode: resultsViewModeBinding(for: tab),
-            onFirstPage: onFirstPage,
-            onPreviousPage: onPreviousPage,
-            onNextPage: onNextPage,
-            onLastPage: onLastPage,
-            onPageSizeChange: onPageSizeChange,
-            onShowAll: onShowAll,
-            onGoToPage: onGoToPage,
-            onToggleColumn: { coordinator.toggleColumnVisibility($0) },
-            onShowAllColumns: { coordinator.showAllColumns() },
-            onHideAllColumns: { coordinator.hideAllColumns($0) },
+            paginationCallbacks: PaginationCallbacks(
+                onFirst: onFirstPage,
+                onPrevious: onPreviousPage,
+                onNext: onNextPage,
+                onLast: onLastPage,
+                onPageSizeChange: onPageSizeChange,
+                onShowAll: onShowAll,
+                onGoToPage: onGoToPage
+            ),
+            columnState: StatusBarColumnState(
+                hidden: tab.columnLayout.hiddenColumns,
+                all: coordinator.columnsForVisibilityPicker(for: tab, resultColumns: resolvedRows.columns),
+                onToggle: { coordinator.toggleColumnVisibility($0) },
+                onShowAll: { coordinator.showAllColumns() },
+                onHideAll: { coordinator.hideAllColumns($0) }
+            ),
+            structureState: StatusBarStructureState(
+                footer: coordinator.structureFooterState,
+                onAdd: { coordinator.structureActions?.addRow?() },
+                onRemove: { coordinator.structureActions?.removeRow?() }
+            ),
             onToggleFilters: { coordinator.toggleFilterPanel() },
-            onFetchAll: { coordinator.fetchAllRows() },
-            structureFooterState: coordinator.structureFooterState,
-            onStructureAdd: { coordinator.structureActions?.addRow?() },
-            onStructureRemove: { coordinator.structureActions?.removeRow?() }
+            onFetchAll: { coordinator.fetchAllRows() }
         )
     }
 

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -7,65 +7,42 @@
 
 import SwiftUI
 
-struct StatusBarSnapshot: Equatable {
-    let tabId: UUID?
-    let tabType: TabType?
-    let hasRows: Bool
-    let hasColumns: Bool
-    let rowCount: Int
-    let hasTableName: Bool
-    let pagination: PaginationState
-    let statusMessage: String?
+struct PaginationCallbacks {
+    let onFirst: () -> Void
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+    let onLast: () -> Void
+    let onPageSizeChange: (Int) -> Void
+    let onShowAll: () -> Void
+    let onGoToPage: (Int) -> Void
+}
 
-    init(tab: QueryTab?, tableRows: TableRows?) {
-        self.tabId = tab?.id
-        self.tabType = tab?.tabType
-        self.hasRows = !(tableRows?.rows.isEmpty ?? true)
-        self.hasColumns = !(tableRows?.columns.isEmpty ?? true)
-        self.rowCount = tableRows?.rows.count ?? 0
-        self.hasTableName = tab?.tableContext.tableName != nil
-        self.pagination = tab?.pagination ?? PaginationState()
-        self.statusMessage = tab?.execution.statusMessage
-    }
+struct StatusBarColumnState {
+    let hidden: Set<String>
+    let all: [String]
+    let onToggle: (String) -> Void
+    let onShowAll: () -> Void
+    let onHideAll: ([String]) -> Void
+}
+
+struct StatusBarStructureState {
+    let footer: StructureFooterState
+    let onAdd: () -> Void
+    let onRemove: () -> Void
 }
 
 struct MainStatusBarView: View {
     let snapshot: StatusBarSnapshot
     let filterState: TabFilterState
-    let hiddenColumns: Set<String>
-    let allColumns: [String]
     let selectedRowIndices: Set<Int>
     @Binding var viewMode: ResultsViewMode
+    let paginationCallbacks: PaginationCallbacks
+    let columnState: StatusBarColumnState
+    let structureState: StatusBarStructureState
+    let onToggleFilters: () -> Void
+    let onFetchAll: (() -> Void)?
 
     @State private var showColumnPopover = false
-
-    // Pagination callbacks
-    let onFirstPage: () -> Void
-    let onPreviousPage: () -> Void
-    let onNextPage: () -> Void
-    let onLastPage: () -> Void
-    let onPageSizeChange: (Int) -> Void
-    let onShowAll: () -> Void
-    let onGoToPage: (Int) -> Void
-
-    // Column visibility callbacks
-    let onToggleColumn: (String) -> Void
-    let onShowAllColumns: () -> Void
-    let onHideAllColumns: ([String]) -> Void
-
-    // Filter visibility callback
-    let onToggleFilters: () -> Void
-
-    // Truncated result callback
-    var onFetchAll: (() -> Void)?
-
-    // Structure-mode footer accessory (Add/Remove buttons)
-    let structureFooterState: StructureFooterState?
-    let onStructureAdd: (() -> Void)?
-    let onStructureRemove: (() -> Void)?
-
-    private var hasHiddenColumns: Bool { !hiddenColumns.isEmpty }
-    private var hiddenCount: Int { hiddenColumns.count }
 
     private var isStructureMode: Bool { viewMode == .structure }
     private var showsDataChrome: Bool { !isStructureMode }
@@ -77,6 +54,14 @@ struct MainStatusBarView: View {
             return label
         }
         return "\(label) (\(combo.displayString))"
+    }
+
+    private var columnsAccessibilityLabel: String {
+        guard !columnState.hidden.isEmpty else {
+            return String(localized: "Columns")
+        }
+        let visible = columnState.all.count - columnState.hidden.count
+        return String(format: String(localized: "%d of %d columns visible"), visible, columnState.all.count)
     }
 
     var body: some View {
@@ -110,12 +95,14 @@ struct MainStatusBarView: View {
                 HStack(spacing: 4) {
                     if snapshot.pagination.isLoadingMore {
                         ProgressView()
-                            .controlSize(.mini)
+                            .controlSize(.small)
+                            .accessibilityHidden(true)
                         Text("Loading…")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                            .accessibilityLabel(String(localized: "Loading more rows"))
                     } else {
-                        Text(rowInfoText)
+                        Text(snapshot.rowInfoText(selectedCount: selectedRowIndices.count))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -149,8 +136,8 @@ struct MainStatusBarView: View {
             Spacer()
 
             HStack(spacing: 8) {
-                if isStructureMode, let state = structureFooterState, state.isActive {
-                    structureFooterControls(state: state)
+                if isStructureMode, structureState.footer.isActive {
+                    structureFooterControls(state: structureState.footer)
                 }
 
                 if showsDataChrome {
@@ -159,25 +146,26 @@ struct MainStatusBarView: View {
                             showColumnPopover.toggle()
                         } label: {
                             HStack(spacing: 4) {
-                                Image(systemName: hasHiddenColumns
+                                Image(systemName: !columnState.hidden.isEmpty
                                         ? "eye.slash.circle.fill"
                                         : "eye.circle")
                                 Text("Columns")
-                                if hasHiddenColumns {
-                                    let visible = allColumns.count - hiddenCount
-                                    Text("(\(visible)/\(allColumns.count))")
+                                if !columnState.hidden.isEmpty {
+                                    let visible = columnState.all.count - columnState.hidden.count
+                                    Text("(\(visible)/\(columnState.all.count))")
                                         .foregroundStyle(.secondary)
                                 }
                             }
                         }
                         .controlSize(.small)
-                        .popover(isPresented: $showColumnPopover) {
+                        .accessibilityLabel(columnsAccessibilityLabel)
+                        .popover(isPresented: $showColumnPopover, arrowEdge: .top) {
                             ColumnVisibilityPopover(
-                                columns: allColumns,
-                                hiddenColumns: hiddenColumns,
-                                onToggleColumn: onToggleColumn,
-                                onShowAll: onShowAllColumns,
-                                onHideAll: onHideAllColumns
+                                columns: columnState.all,
+                                hiddenColumns: columnState.hidden,
+                                onToggleColumn: columnState.onToggle,
+                                onShowAll: columnState.onShowAll,
+                                onHideAll: columnState.onHideAll
                             )
                         }
                     }
@@ -201,25 +189,28 @@ struct MainStatusBarView: View {
                         .toggleStyle(.button)
                         .controlSize(.small)
                         .help(filterToggleHelp)
+                        .accessibilityLabel(String(localized: "Filters"))
+                        .accessibilityAddTraits(filterState.isVisible ? .isSelected : [])
                     }
 
-                    if snapshot.tabType == .table, snapshot.hasTableName, showsPaginationControls {
+                    if snapshot.tabType == .table, snapshot.hasTableName, snapshot.showsPaginationControls {
                         PaginationControlsView(
                             pagination: snapshot.pagination,
                             loadedRowCount: snapshot.rowCount,
-                            onFirst: onFirstPage,
-                            onPrevious: onPreviousPage,
-                            onNext: onNextPage,
-                            onLast: onLastPage,
-                            onPageSizeChange: onPageSizeChange,
-                            onShowAll: onShowAll,
-                            onGoToPage: onGoToPage
+                            onFirst: paginationCallbacks.onFirst,
+                            onPrevious: paginationCallbacks.onPrevious,
+                            onNext: paginationCallbacks.onNext,
+                            onLast: paginationCallbacks.onLast,
+                            onPageSizeChange: paginationCallbacks.onPageSizeChange,
+                            onShowAll: paginationCallbacks.onShowAll,
+                            onGoToPage: paginationCallbacks.onGoToPage
                         )
                     }
                 }
             }
         }
-        .padding(.horizontal, 0)
+        .padding(.leading, 8)
+        .padding(.trailing, 20)
         .padding(.vertical, 4)
         .background(Color(nsColor: .controlBackgroundColor))
         .onChange(of: snapshot.tabId) { _, _ in
@@ -231,7 +222,7 @@ struct MainStatusBarView: View {
     private func structureFooterControls(state: StructureFooterState) -> some View {
         ControlGroup {
             Button {
-                onStructureAdd?()
+                structureState.onAdd()
             } label: {
                 Label(state.addLabel, systemImage: "plus")
                     .labelStyle(.iconOnly)
@@ -241,7 +232,7 @@ struct MainStatusBarView: View {
             .disabled(!state.canAdd)
 
             Button {
-                onStructureRemove?()
+                structureState.onRemove()
             } label: {
                 Label(state.removeLabel, systemImage: "minus")
                     .labelStyle(.iconOnly)
@@ -253,46 +244,5 @@ struct MainStatusBarView: View {
         .controlGroupStyle(.navigation)
         .controlSize(.small)
         .fixedSize()
-    }
-
-    private var showsPaginationControls: Bool {
-        if let total = snapshot.pagination.totalRowCount, total > 0 { return true }
-        return isPagedWithUnknownTotal
-    }
-
-    private var isPagedWithUnknownTotal: Bool {
-        let pagination = snapshot.pagination
-        return pagination.currentPage > 1 || snapshot.rowCount >= pagination.pageSize
-    }
-
-    private var rowInfoText: String {
-        let loadedCount = snapshot.rowCount
-        let selectedCount = selectedRowIndices.count
-        let pagination = snapshot.pagination
-        let total = pagination.totalRowCount
-
-        if selectedCount > 0 {
-            if selectedCount == loadedCount {
-                return String(format: String(localized: "All %d rows selected"), loadedCount)
-            } else {
-                return String(format: String(localized: "%d of %d rows selected"), selectedCount, loadedCount)
-            }
-        } else if snapshot.tabType == .query && pagination.hasMoreRows {
-            let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
-            return String(format: String(localized: "Showing %@ rows"), formattedCount)
-        } else if snapshot.tabType == .table, let total = total, total > 0 {
-            let formattedTotal = total.formatted(.number.grouping(.automatic))
-            let prefix = pagination.isApproximateRowCount ? "~" : ""
-
-            return String(format: String(localized: "%d-%d of %@%@ rows"), pagination.rangeStart, pagination.rangeEnd, prefix, formattedTotal)
-        } else if snapshot.tabType == .table, isPagedWithUnknownTotal {
-            let rangeEnd = pagination.currentOffset + loadedCount
-            return String(format: String(localized: "%d-%d of ? rows"), pagination.rangeStart, rangeEnd)
-        } else if loadedCount > 0 {
-            let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
-            return String(format: String(localized: "%@ rows"), formattedCount)
-        } else {
-            return String(localized: "No rows")
-        }
     }
 }

--- a/TablePro/Views/Main/Child/StatusBarSnapshot+RowInfo.swift
+++ b/TablePro/Views/Main/Child/StatusBarSnapshot+RowInfo.swift
@@ -1,0 +1,38 @@
+//
+//  StatusBarSnapshot+RowInfo.swift
+//  TablePro
+//
+
+import Foundation
+
+extension StatusBarSnapshot {
+    func rowInfoText(selectedCount: Int) -> String {
+        let loadedCount = rowCount
+        let total = pagination.totalRowCount
+
+        if selectedCount > 0 {
+            if selectedCount == loadedCount {
+                return String(format: String(localized: "All %d rows selected"), loadedCount)
+            }
+            return String(format: String(localized: "%d of %d rows selected"), selectedCount, loadedCount)
+        }
+        if tabType == .query, pagination.hasMoreRows {
+            let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
+            return String(format: String(localized: "Showing %@ rows"), formattedCount)
+        }
+        if tabType == .table, let total, total > 0 {
+            let formattedTotal = total.formatted(.number.grouping(.automatic))
+            let prefix = pagination.isApproximateRowCount ? "~" : ""
+            return String(format: String(localized: "%d-%d of %@%@ rows"), pagination.rangeStart, pagination.rangeEnd, prefix, formattedTotal)
+        }
+        if tabType == .table, isPagedWithUnknownTotal {
+            let rangeEnd = pagination.currentOffset + loadedCount
+            return String(format: String(localized: "%d-%d of ? rows"), pagination.rangeStart, rangeEnd)
+        }
+        if loadedCount > 0 {
+            let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
+            return String(format: String(localized: "%@ rows"), formattedCount)
+        }
+        return String(localized: "No rows")
+    }
+}

--- a/TablePro/Views/Results/ColumnVisibilityPopover.swift
+++ b/TablePro/Views/Results/ColumnVisibilityPopover.swift
@@ -14,9 +14,6 @@ struct ColumnVisibilityPopover: View {
 
     @State private var searchText = ""
 
-    private var hasHiddenColumns: Bool { !hiddenColumns.isEmpty }
-    private var hiddenCount: Int { hiddenColumns.count }
-
     private var filteredColumns: [String] {
         if searchText.isEmpty {
             return columns
@@ -41,11 +38,11 @@ struct ColumnVisibilityPopover: View {
     }
 
     private var headerTitle: String {
-        let visible = columns.count - hiddenCount
-        if hasHiddenColumns {
-            return "\(visible) of \(columns.count)"
+        guard !hiddenColumns.isEmpty else {
+            return String(localized: "Columns")
         }
-        return String(localized: "Columns")
+        let visible = columns.count - hiddenColumns.count
+        return String(format: String(localized: "%d of %d"), visible, columns.count)
     }
 
     private var header: some View {
@@ -59,12 +56,12 @@ struct ColumnVisibilityPopover: View {
             Button("Show All") { onShowAll() }
                 .buttonStyle(.link)
                 .controlSize(.small)
-                .disabled(!hasHiddenColumns)
+                .disabled(hiddenColumns.isEmpty)
 
             Button("Hide All") { onHideAll(columns) }
                 .buttonStyle(.link)
                 .controlSize(.small)
-                .disabled(hiddenCount == columns.count)
+                .disabled(hiddenColumns.count == columns.count)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/TableProTests/Models/StatusBarSnapshotTests.swift
+++ b/TableProTests/Models/StatusBarSnapshotTests.swift
@@ -1,0 +1,104 @@
+//
+//  StatusBarSnapshotTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("StatusBarSnapshot")
+struct StatusBarSnapshotTests {
+    private func makeSnapshot(
+        tabType: TabType? = .table,
+        rowCount: Int = 0,
+        pagination: PaginationState = PaginationState(),
+        statusMessage: String? = nil
+    ) -> StatusBarSnapshot {
+        StatusBarSnapshot(
+            tabId: UUID(),
+            tabType: tabType,
+            hasRows: rowCount > 0,
+            hasColumns: rowCount > 0,
+            rowCount: rowCount,
+            hasTableName: true,
+            pagination: pagination,
+            statusMessage: statusMessage
+        )
+    }
+
+    @Test("Pagination controls show when a positive total is known")
+    func showsPaginationWithKnownTotal() {
+        let snapshot = makeSnapshot(rowCount: 1_000, pagination: PaginationState(totalRowCount: 5_000, pageSize: 1_000))
+        #expect(snapshot.showsPaginationControls)
+    }
+
+    @Test("Single page with unknown total hides pagination")
+    func hidesPaginationOnSinglePage() {
+        let snapshot = makeSnapshot(rowCount: 10, pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 1))
+        #expect(!snapshot.isPagedWithUnknownTotal)
+        #expect(!snapshot.showsPaginationControls)
+    }
+
+    @Test("Page beyond the first is treated as paged with unknown total")
+    func pagedWhenBeyondFirstPage() {
+        let snapshot = makeSnapshot(rowCount: 50, pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 2, currentOffset: 50))
+        #expect(snapshot.isPagedWithUnknownTotal)
+        #expect(snapshot.showsPaginationControls)
+    }
+
+    @Test("A full first page with unknown total is treated as paged")
+    func pagedWhenFirstPageIsFull() {
+        let snapshot = makeSnapshot(rowCount: 50, pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 1))
+        #expect(snapshot.isPagedWithUnknownTotal)
+    }
+
+    @Test("No rows reports an empty state")
+    func rowInfoNoRows() {
+        let snapshot = makeSnapshot(rowCount: 0)
+        #expect(snapshot.rowInfoText(selectedCount: 0) == String(localized: "No rows"))
+    }
+
+    @Test("Selecting every loaded row reports the all-selected text")
+    func rowInfoAllSelected() {
+        let snapshot = makeSnapshot(rowCount: 5)
+        #expect(snapshot.rowInfoText(selectedCount: 5) == String(format: String(localized: "All %d rows selected"), 5))
+    }
+
+    @Test("Selecting some rows reports the partial-selection text")
+    func rowInfoPartialSelection() {
+        let snapshot = makeSnapshot(rowCount: 5)
+        #expect(snapshot.rowInfoText(selectedCount: 2) == String(format: String(localized: "%d of %d rows selected"), 2, 5))
+    }
+
+    @Test("A table with a known total reports the offset range")
+    func rowInfoTableRange() {
+        let snapshot = makeSnapshot(
+            rowCount: 1_000,
+            pagination: PaginationState(totalRowCount: 5_000, pageSize: 1_000, currentPage: 3, currentOffset: 2_000)
+        )
+        let text = snapshot.rowInfoText(selectedCount: 0)
+        #expect(text.contains("2001-3000"))
+    }
+
+    @Test("A paged table with unknown total reports a question mark for the total")
+    func rowInfoUnknownTotalRange() {
+        let snapshot = makeSnapshot(
+            rowCount: 50,
+            pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 2, currentOffset: 50)
+        )
+        let text = snapshot.rowInfoText(selectedCount: 0)
+        #expect(text.contains("51-100"))
+        #expect(text.contains("?"))
+    }
+
+    @Test("A truncated query reports the showing-rows text")
+    func rowInfoTruncatedQuery() {
+        var pagination = PaginationState(pageSize: 1_000)
+        pagination.hasMoreRows = true
+        let snapshot = makeSnapshot(tabType: .query, rowCount: 1_000, pagination: pagination)
+        let text = snapshot.rowInfoText(selectedCount: 0)
+        #expect(text.contains("1,000") || text.contains("1000"))
+    }
+}

--- a/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
+++ b/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
@@ -18,24 +18,31 @@ struct MainStatusBarLayoutTests {
         let view = MainStatusBarView(
             snapshot: StatusBarSnapshot(tab: nil, tableRows: nil),
             filterState: TabFilterState(),
-            hiddenColumns: [],
-            allColumns: [],
             selectedRowIndices: [],
             viewMode: .constant(.data),
-            onFirstPage: {},
-            onPreviousPage: {},
-            onNextPage: {},
-            onLastPage: {},
-            onPageSizeChange: { _ in },
-            onShowAll: {},
-            onGoToPage: { _ in },
-            onToggleColumn: { _ in },
-            onShowAllColumns: {},
-            onHideAllColumns: { _ in },
+            paginationCallbacks: PaginationCallbacks(
+                onFirst: {},
+                onPrevious: {},
+                onNext: {},
+                onLast: {},
+                onPageSizeChange: { _ in },
+                onShowAll: {},
+                onGoToPage: { _ in }
+            ),
+            columnState: StatusBarColumnState(
+                hidden: [],
+                all: [],
+                onToggle: { _ in },
+                onShowAll: {},
+                onHideAll: { _ in }
+            ),
+            structureState: StatusBarStructureState(
+                footer: StructureFooterState(),
+                onAdd: {},
+                onRemove: {}
+            ),
             onToggleFilters: {},
-            structureFooterState: nil,
-            onStructureAdd: nil,
-            onStructureRemove: nil
+            onFetchAll: nil
         )
         #expect(type(of: view.body) != Never.self)
     }


### PR DESCRIPTION
Fixes #1569.

## Problem
The last-page pagination button, and the other trailing status bar controls, sat flush in the bottom-right window corner where macOS reserves a 19x19pt live-resize grip. Hovering showed the diagonal resize cursor and the click resized the window instead of activating the button.

## Fix
- Inset the status bar so its controls clear the resize corner: trailing 20pt (the macOS content-margin convention, clears the ~10pt grip reach), plus a leading 8pt for balance.
- Add a divider above the status bar so it reads as separate from the data grid.

## Status bar cleanup (same area)
- VoiceOver now has explicit labels for the Columns button, the Filters toggle (with a selected trait), and the loading indicators.
- The custom rows-per-page popover now anchors to the page-size menu instead of the center of the pagination controls.
- The loading spinner uses the same control size as the rest of the bar.
- The column visibility popover header is now localizable.

## Refactor
- Moved `StatusBarSnapshot` to `Models/Query` (Foundation only). It now carries the pagination-visibility predicates, and the row-info text formatting lives in a view-layer extension.
- Collapsed `MainStatusBarView`'s 21-parameter initializer into three callback/state bundles.
- Made the structure-footer inputs non-optional (they are never nil in production) and removed duplicated helpers and section comments.

## Tests
- Added `StatusBarSnapshotTests` covering the row-info text branches and the pagination-visibility predicates.
- The resize-corner inset is layout-only. A UI test asserting the button is inset from the window corner needs database-fixture infrastructure that `TableProUITests` does not have yet, so it is not included.

## Verify when running
The custom rows-per-page popover opens from a menu item. Confirm it presents; it anchors to a stable zero-size overlay on the page-size button.
