### PR TITLE
feat(editor): complete database, schema, and table segments in qualified names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- SQL autocomplete completes database, schema, and table names at each segment of qualified names for schema-organized connections (Snowflake, BigQuery), fetches tables of unopened schemas on demand, resolves alias columns for schema-qualified tables, and suggests the active connection's full dialect function list.
 - Each filter row has a checkbox to turn it on or off and an Apply button to filter by just that row. The main Apply runs every active filter, and disabled filters stay in the panel for later. (#1561)
 - Importing connections from other apps now detects duplicates by host, port, database, and username, and lets you replace, add a copy, or skip each one before import.
 

--- a/TablePro/Core/Autocomplete/SQLCompletionItem.swift
+++ b/TablePro/Core/Autocomplete/SQLCompletionItem.swift
@@ -210,6 +210,26 @@ extension SQLCompletionItem {
         )
     }
 
+    /// Create a schema-name completion item
+    static func schemaName(_ name: String) -> SQLCompletionItem {
+        SQLCompletionItem(
+            label: name,
+            kind: .schema,
+            insertText: name,
+            detail: String(localized: "Schema")
+        )
+    }
+
+    /// Create a database-name completion item
+    static func databaseName(_ name: String) -> SQLCompletionItem {
+        SQLCompletionItem(
+            label: name,
+            kind: .schema,
+            insertText: name,
+            detail: String(localized: "Database")
+        )
+    }
+
     /// Create a column completion item
     static func column(
         _ name: String,

--- a/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
@@ -103,6 +103,17 @@ final class SQLCompletionProvider {
         return (limited, context)
     }
 
+    /// Generic SQL functions plus the active dialect's own functions (deduplicated).
+    private func functionItems() -> [SQLCompletionItem] {
+        var items = SQLKeywords.functionItems()
+        guard let dialect = cachedDialect, !dialect.functions.isEmpty else { return items }
+        var seen = Set(items.map { $0.label.uppercased() })
+        for name in dialect.functions.sorted() where seen.insert(name.uppercased()).inserted {
+            items.append(SQLCompletionItem.function(name, signature: "\(name)(…)"))
+        }
+        return items
+    }
+
     // MARK: - Candidate Generation
 
     /// Get candidate completions based on context
@@ -111,11 +122,23 @@ final class SQLCompletionProvider {
     ) async -> [SQLCompletionItem] {
         var items: [SQLCompletionItem] = []
 
-        // If we have a dot prefix, we're looking for columns of a specific table
+        // If we have a dot prefix, resolve it as table/alias columns first, then as
+        // a schema (suggest its tables) or database (suggest its schemas). The
+        // namespace fallback also covers aliases that spuriously resolve to a
+        // schema name parsed out of the FROM clause itself.
         if let dotPrefix = context.dotPrefix {
-            // Resolve the table name from alias or direct reference
             if let tableName = await schemaProvider.resolveAlias(dotPrefix, in: context.tableReferences) {
-                items = await schemaProvider.columnCompletionItems(for: tableName)
+                let schema = context.tableReferences.first {
+                    $0.tableName.caseInsensitiveCompare(tableName) == .orderedSame
+                }?.schema
+                items = await schemaProvider.columnCompletionItems(for: tableName, schema: schema)
+            }
+            if items.isEmpty {
+                if await schemaProvider.isKnownSchema(dotPrefix) {
+                    items = await schemaProvider.tableCompletionItems(inSchema: dotPrefix)
+                } else if await schemaProvider.isKnownDatabase(dotPrefix) {
+                    items = await schemaProvider.schemaCompletionItems()
+                }
             }
             return items
         }
@@ -123,8 +146,9 @@ final class SQLCompletionProvider {
         // Add items based on clause type
         switch context.clauseType {
         case .from, .join:
-            // Tables + JOIN/clause transition keywords
+            // Tables + schema/database names + JOIN/clause transition keywords
             items = await schemaProvider.tableCompletionItems()
+            items += await schemaProvider.namespaceCompletionItems()
             items += filterKeywords([
                 "INNER JOIN", "LEFT JOIN", "RIGHT JOIN", "FULL JOIN",
                 "LEFT OUTER JOIN", "RIGHT OUTER JOIN", "FULL OUTER JOIN",
@@ -166,7 +190,7 @@ final class SQLCompletionProvider {
                 }
                 // Function-arg items: columns, functions, value keywords
                 items += await columnItems(for: context.tableReferences)
-                items += SQLKeywords.functionItems()
+                items += functionItems()
                 items += filterKeywords(["NULL", "TRUE", "FALSE"])
                 if funcName.uppercased() != "COUNT" {
                     items += filterKeywords(["DISTINCT"])
@@ -192,7 +216,7 @@ final class SQLCompletionProvider {
                     ))
                 }
                 items += await columnItems(for: context.tableReferences)
-                items += SQLKeywords.functionItems()
+                items += functionItems()
                 items += filterKeywords([
                     "DISTINCT", "ALL", "AS", "FROM", "CASE", "WHEN",
                     "INTO", "UNION", "INTERSECT", "EXCEPT"
@@ -205,7 +229,7 @@ final class SQLCompletionProvider {
             // Add qualified column suggestions (table.column) for join conditions
             for ref in context.tableReferences {
                 let qualifier = ref.alias ?? ref.tableName
-                let cols = await schemaProvider.columnCompletionItems(for: ref.tableName)
+                let cols = await schemaProvider.columnCompletionItems(for: ref.tableName, schema: ref.schema)
                 for col in cols {
                     items.append(SQLCompletionItem(
                         label: "\(qualifier).\(col.label)",
@@ -232,7 +256,7 @@ final class SQLCompletionProvider {
                 "ANY", "ALL", "SOME", "REGEXP", "RLIKE", "SIMILAR TO",
                 "IS NULL", "IS NOT NULL"
             ])
-            items += SQLKeywords.functionItems()
+            items += functionItems()
             // Clause transitions after WHERE conditions
             items += filterKeywords([
                 "ORDER BY", "GROUP BY", "HAVING", "LIMIT",
@@ -259,19 +283,19 @@ final class SQLCompletionProvider {
         case .set:
             // Columns for UPDATE SET clause + transition keywords
             if let firstTable = context.tableReferences.first {
-                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName)
+                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName, schema: firstTable.schema)
             }
             items += filterKeywords(["WHERE", "RETURNING"])
 
         case .insertColumns:
             // Columns for INSERT column list
             if let firstTable = context.tableReferences.first {
-                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName)
+                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName, schema: firstTable.schema)
             }
 
         case .values:
             // Functions and keywords for VALUES + post-values transitions
-            items = SQLKeywords.functionItems()
+            items = functionItems()
             items += filterKeywords([
                 "NULL", "DEFAULT", "TRUE", "FALSE",
                 "ON CONFLICT", "ON DUPLICATE KEY UPDATE", "RETURNING"
@@ -297,7 +321,7 @@ final class SQLCompletionProvider {
                 items.append(distinctItem)
             }
             items += await columnItems(for: context.tableReferences)
-            items += SQLKeywords.functionItems()
+            items += functionItems()
             if isCountFunction {
                 // DISTINCT already added above with boosted priority
                 items += filterKeywords(["NULL", "TRUE", "FALSE"])
@@ -310,13 +334,13 @@ final class SQLCompletionProvider {
             items += await columnItems(for: context.tableReferences)
             items += filterKeywords(["WHEN", "THEN", "ELSE", "END", "AND", "OR", "IS", "NULL", "TRUE", "FALSE"])
             items += SQLKeywords.operatorItems()
-            items += SQLKeywords.functionItems()
+            items += functionItems()
 
         case .inList:
             // Inside IN (...) list - suggest values, subqueries, columns
             items += await columnItems(for: context.tableReferences)
             items += filterKeywords(["SELECT", "NULL", "TRUE", "FALSE"])
-            items += SQLKeywords.functionItems()
+            items += functionItems()
 
         case .limit:
             // After LIMIT/OFFSET - typically just numbers, but could include variables
@@ -335,7 +359,7 @@ final class SQLCompletionProvider {
         case .alterTableColumn:
             // After ALTER TABLE tablename DROP/MODIFY/CHANGE/RENAME or AFTER/BEFORE - suggest column names
             if let firstTable = context.tableReferences.first {
-                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName)
+                items = await schemaProvider.columnCompletionItems(for: firstTable.tableName, schema: firstTable.schema)
             }
 
         case .createTable:

--- a/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLCompletionProvider.swift
@@ -16,6 +16,7 @@ final class SQLCompletionProvider {
     private let schemaProvider: SQLSchemaProvider
     private var databaseType: DatabaseType?
     private var cachedDialect: SQLDialectDescriptor?
+    private var cachedFunctionItems: [SQLCompletionItem]?
     private var cachedStatementCompletions: [CompletionEntry] = []
     private var favoriteKeywords: [String: (name: String, query: String)] = [:]
 
@@ -51,6 +52,7 @@ final class SQLCompletionProvider {
     func setDatabaseType(_ type: DatabaseType, dialect: SQLDialectDescriptor? = nil, statementCompletions: [CompletionEntry] = []) {
         self.databaseType = type
         self.cachedDialect = dialect
+        self.cachedFunctionItems = nil
         self.cachedStatementCompletions = statementCompletions
     }
 
@@ -104,13 +106,17 @@ final class SQLCompletionProvider {
     }
 
     /// Generic SQL functions plus the active dialect's own functions (deduplicated).
+    /// Cached per dialect; invalidated in `setDatabaseType`.
     private func functionItems() -> [SQLCompletionItem] {
+        if let cachedFunctionItems { return cachedFunctionItems }
         var items = SQLKeywords.functionItems()
-        guard let dialect = cachedDialect, !dialect.functions.isEmpty else { return items }
-        var seen = Set(items.map { $0.label.uppercased() })
-        for name in dialect.functions.sorted() where seen.insert(name.uppercased()).inserted {
-            items.append(SQLCompletionItem.function(name, signature: "\(name)(…)"))
+        if let dialect = cachedDialect, !dialect.functions.isEmpty {
+            var seen = Set(items.map { $0.label.uppercased() })
+            for name in dialect.functions.sorted() where seen.insert(name.uppercased()).inserted {
+                items.append(SQLCompletionItem.function(name, signature: "\(name)(…)"))
+            }
         }
+        cachedFunctionItems = items
         return items
     }
 

--- a/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
+++ b/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
@@ -55,6 +55,13 @@ enum SQLClauseType {
 internal struct TableReference: Hashable, Sendable {
     let tableName: String
     let alias: String?
+    let schema: String?
+
+    init(tableName: String, alias: String?, schema: String? = nil) {
+        self.tableName = tableName
+        self.alias = alias
+        self.schema = schema
+    }
 
     /// Returns the identifier that should be used to reference this table
     var identifier: String {
@@ -788,6 +795,12 @@ final class SQLContextAnalyzer {
                 let tableName = Self.stripSchemaPrefix(rawName)
                 guard !Self.tableRefKeywords.contains(tableName.uppercased()) else { return }
 
+                let segments = rawName.split(separator: ".")
+                let schema = segments.count >= 2
+                    ? String(segments[segments.count - 2])
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "`\""))
+                    : nil
+
                 var alias: String?
                 if match.numberOfRanges > 2 {
                     let aliasNSRange = match.range(at: 2)
@@ -801,7 +814,7 @@ final class SQLContextAnalyzer {
                     }
                 }
 
-                let ref = TableReference(tableName: tableName, alias: alias)
+                let ref = TableReference(tableName: tableName, alias: alias, schema: schema)
                 if seen.insert(ref).inserted {
                     references.append(ref)
                 }

--- a/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
@@ -346,7 +346,7 @@ actor SQLSchemaProvider {
         var matching = tables.filter { $0.schema?.caseInsensitiveCompare(schema) == .orderedSame }
         if matching.isEmpty, let fetchSchemaTables = metadataSource?.fetchSchemaTables {
             if let fetched = try? await fetchSchemaTables(schema), !fetched.isEmpty {
-                matching = fetched
+                matching = fetched.filter { belongsToSchema($0, schema) }
                 mergeTables(fetched)
             }
         }
@@ -354,6 +354,11 @@ actor SQLSchemaProvider {
         return await MainActor.run {
             tableData.map { SQLCompletionItem.table($0.name, isView: $0.isView) }
         }
+    }
+
+    private func belongsToSchema(_ table: TableInfo, _ schema: String) -> Bool {
+        guard let tableSchema = table.schema, !tableSchema.isEmpty else { return true }
+        return tableSchema.caseInsensitiveCompare(schema) == .orderedSame
     }
 
     private func mergeTables(_ newTables: [TableInfo]) {

--- a/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
+++ b/TablePro/Core/Autocomplete/SQLSchemaProvider.swift
@@ -26,9 +26,23 @@ actor SQLSchemaProvider {
     private var eagerColumnTask: Task<Void, Never>?
 
     struct ColumnMetadataSource: Sendable {
-        let fetchColumns: @Sendable (_ table: String) async throws -> [ColumnInfo]
+        let fetchColumns: @Sendable (_ table: String, _ schema: String?) async throws -> [ColumnInfo]
         let fetchAllColumns: @Sendable () async throws -> [String: [ColumnInfo]]
+        let fetchSchemaTables: (@Sendable (_ schema: String) async throws -> [TableInfo])?
+
+        init(
+            fetchColumns: @escaping @Sendable (_ table: String, _ schema: String?) async throws -> [ColumnInfo],
+            fetchAllColumns: @escaping @Sendable () async throws -> [String: [ColumnInfo]],
+            fetchSchemaTables: (@Sendable (_ schema: String) async throws -> [TableInfo])? = nil
+        ) {
+            self.fetchColumns = fetchColumns
+            self.fetchAllColumns = fetchAllColumns
+            self.fetchSchemaTables = fetchSchemaTables
+        }
     }
+
+    private var knownSchemas: [String] = []
+    private var knownDatabases: [String] = []
 
     private weak var cachedDriver: (any DatabaseDriver)?
     private let metadataSource: ColumnMetadataSource?
@@ -95,8 +109,8 @@ actor SQLSchemaProvider {
     }
 
     /// Get columns for a specific table (with LRU caching)
-    func getColumns(for tableName: String) async -> [ColumnInfo] {
-        let key = tableName.lowercased()
+    func getColumns(for tableName: String, schema: String? = nil) async -> [ColumnInfo] {
+        let key = [schema?.lowercased(), tableName.lowercased()].compactMap(\.self).joined(separator: ".")
 
         if let cached = columnCache[key] {
             columnAccessOrder.removeAll { $0 == key }
@@ -107,9 +121,11 @@ actor SQLSchemaProvider {
         do {
             let columns: [ColumnInfo]
             if let metadataSource {
-                columns = try await metadataSource.fetchColumns(tableName)
+                columns = try await metadataSource.fetchColumns(tableName, schema)
             } else if let driver = cachedDriver {
-                columns = try await driver.fetchColumns(table: tableName)
+                columns = schema != nil
+                    ? try await driver.fetchColumns(table: tableName, schema: schema)
+                    : try await driver.fetchColumns(table: tableName)
             } else {
                 return []
             }
@@ -293,9 +309,63 @@ actor SQLSchemaProvider {
         }
     }
 
+    func setNamespaces(schemas: [String], databases: [String]) {
+        knownSchemas = schemas
+        knownDatabases = databases
+    }
+
+    func isKnownSchema(_ name: String) -> Bool {
+        knownSchemas.contains { $0.caseInsensitiveCompare(name) == .orderedSame }
+    }
+
+    func isKnownDatabase(_ name: String) -> Bool {
+        knownDatabases.contains { $0.caseInsensitiveCompare(name) == .orderedSame }
+    }
+
+    /// Schema names only — suggested after a database-qualified dot (e.g. "ANALYTICS_PROD.").
+    func schemaCompletionItems() async -> [SQLCompletionItem] {
+        let schemas = knownSchemas
+        return await MainActor.run {
+            schemas.map { SQLCompletionItem.schemaName($0) }
+        }
+    }
+
+    /// Databases + schemas — suggested alongside tables in FROM/JOIN contexts.
+    func namespaceCompletionItems() async -> [SQLCompletionItem] {
+        let schemas = knownSchemas
+        let databases = knownDatabases
+        return await MainActor.run {
+            databases.map { SQLCompletionItem.databaseName($0) }
+                + schemas.map { SQLCompletionItem.schemaName($0) }
+        }
+    }
+
+    /// Tables of one schema — suggested after a schema-qualified dot (e.g. "DBT_MARTS.").
+    /// Falls back to fetching from the database when that schema's tables aren't loaded yet.
+    func tableCompletionItems(inSchema schema: String) async -> [SQLCompletionItem] {
+        var matching = tables.filter { $0.schema?.caseInsensitiveCompare(schema) == .orderedSame }
+        if matching.isEmpty, let fetchSchemaTables = metadataSource?.fetchSchemaTables {
+            if let fetched = try? await fetchSchemaTables(schema), !fetched.isEmpty {
+                matching = fetched
+                mergeTables(fetched)
+            }
+        }
+        let tableData = matching.map { (name: $0.name, isView: $0.type == .view) }
+        return await MainActor.run {
+            tableData.map { SQLCompletionItem.table($0.name, isView: $0.isView) }
+        }
+    }
+
+    private func mergeTables(_ newTables: [TableInfo]) {
+        var seen = Set(tables.map(\.id))
+        for table in newTables where seen.insert(table.id).inserted {
+            tables.append(table)
+        }
+    }
+
     /// Get completion items for columns of a specific table
-    func columnCompletionItems(for tableName: String) async -> [SQLCompletionItem] {
-        let columns = await getColumns(for: tableName)
+    func columnCompletionItems(for tableName: String, schema: String? = nil) async -> [SQLCompletionItem] {
+        let columns = await getColumns(for: tableName, schema: schema)
         let columnData = columns.map { col in
             (name: col.name, type: col.dataType, isPK: col.isPrimaryKey,
              isNullable: col.isNullable, defaultValue: col.defaultValue, comment: col.comment)
@@ -321,7 +391,7 @@ actor SQLSchemaProvider {
 
         let hasMultipleRefs = references.count > 1
         for ref in references {
-            let columns = await getColumns(for: ref.tableName)
+            let columns = await getColumns(for: ref.tableName, schema: ref.schema)
             let refId = ref.identifier
             for column in columns {
                 let label = hasMultipleRefs ? "\(refId).\(column.name)" : column.name

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -64,14 +64,22 @@ final class SchemaProviderRegistry {
             return existing
         }
         let source = SQLSchemaProvider.ColumnMetadataSource(
-            fetchColumns: { table in
+            fetchColumns: { table, schema in
                 try await DatabaseManager.shared.withMetadataDriver(connectionId: connectionId) { driver in
-                    try await driver.fetchColumns(table: table)
+                    if let schema {
+                        return try await driver.fetchColumns(table: table, schema: schema)
+                    }
+                    return try await driver.fetchColumns(table: table)
                 }
             },
             fetchAllColumns: {
                 try await DatabaseManager.shared.withMetadataDriver(connectionId: connectionId, workload: .bulk) { driver in
                     try await driver.fetchAllColumns()
+                }
+            },
+            fetchSchemaTables: { schema in
+                try await DatabaseManager.shared.withMetadataDriver(connectionId: connectionId) { driver in
+                    try await driver.fetchTables(schema: schema)
                 }
             }
         )

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -90,6 +90,21 @@ final class SchemaService {
         return []
     }
 
+    /// Flat tables plus the union of every loaded per-schema table list. For
+    /// hierarchicalSchema plugins the flat list is empty and this is the only
+    /// way to see tables across schemas (e.g. for autocomplete).
+    func allLoadedTables(for connectionId: UUID) -> [TableInfo] {
+        var result = tables(for: connectionId)
+        var seen = Set(result.map(\.id))
+        for state in (perSchemaStates[connectionId] ?? [:]).values {
+            guard case .loaded(let schemaTables) = state else { continue }
+            for table in schemaTables where seen.insert(table.id).inserted {
+                result.append(table)
+            }
+        }
+        return result
+    }
+
     func loadSchemaTables(connectionId: UUID, schema: String, driver: DatabaseDriver) async {
         if case .loaded = schemaState(for: connectionId, schema: schema) { return }
         setPerSchemaState(.loading, connectionId: connectionId, schema: schema)

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -584,11 +584,16 @@ final class MainContentCoordinator {
     /// Push the SchemaService table list into the autocomplete provider and prune sidebar
     /// state for tables that no longer exist.
     private func reconcilePostSchemaLoad() async {
-        guard case .loaded(let tables) = services.schemaService.state(for: connectionId) else { return }
+        guard case .loaded = services.schemaService.state(for: connectionId) else { return }
+        let tables = services.schemaService.allLoadedTables(for: connectionId)
         if let driver = services.databaseManager.driver(for: connectionId),
            let provider = services.schemaProviderRegistry.provider(for: connectionId) {
             let currentDb = services.databaseManager.session(for: connectionId)?.activeDatabase
             await provider.resetForDatabase(currentDb, tables: tables, driver: driver)
+            await provider.setNamespaces(
+                schemas: services.schemaService.schemas(for: connectionId),
+                databases: currentDb.map { [$0] } ?? []
+            )
         }
 
         guard let vm = sidebarViewModel else { return }

--- a/TableProTests/Core/Autocomplete/SQLContextAnalyzerTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLContextAnalyzerTests.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+@testable import TablePro
 import TableProPluginKit
 import Testing
-@testable import TablePro
 
 @Suite("SQL Context Analyzer")
 struct SQLContextAnalyzerTests {
@@ -933,5 +933,35 @@ struct SQLContextAnalyzerTests {
         let context = analyzer.analyze(query: query, cursorPosition: 9)
         #expect(context.tableReferences.contains { $0.tableName == "users" })
         #expect(context.tableReferences.contains { $0.tableName == "orders" })
+    }
+
+    // MARK: - Schema Segment Tests
+
+    @Test("Captures schema from schema-qualified table reference")
+    func testSchemaQualifiedReference() {
+        let context = analyzer.analyze(query: "SELECT * FROM sales.orders o", cursorPosition: 28)
+        #expect(context.tableReferences.contains {
+            $0.tableName == "orders" && $0.schema == "sales" && $0.alias == "o"
+        })
+    }
+
+    @Test("Captures middle schema segment from database-qualified table reference")
+    func testDatabaseSchemaQualifiedReference() {
+        let context = analyzer.analyze(query: "SELECT * FROM analytics.sales.orders", cursorPosition: 36)
+        #expect(context.tableReferences.contains {
+            $0.tableName == "orders" && $0.schema == "sales"
+        })
+    }
+
+    @Test("Leaves schema nil for an unqualified table reference")
+    func testUnqualifiedReferenceHasNoSchema() {
+        let context = analyzer.analyze(query: "SELECT * FROM orders", cursorPosition: 20)
+        #expect(context.tableReferences.contains { $0.tableName == "orders" && $0.schema == nil })
+    }
+
+    @Test("Strips quoting from the captured schema segment")
+    func testSchemaSegmentQuotingStripped() {
+        let context = analyzer.analyze(query: "SELECT * FROM \"sales\".orders", cursorPosition: 28)
+        #expect(context.tableReferences.contains { $0.tableName == "orders" && $0.schema == "sales" })
     }
 }

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -12,15 +12,17 @@ import Testing
 
 // MARK: - Mock Driver
 
-private final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
+final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     let connection: DatabaseConnection
     var status: ConnectionStatus = .connected
     var serverVersion: String? { nil }
 
     var tablesToReturn: [TableInfo] = []
+    var schemaTablesToReturn: [String: [TableInfo]] = [:]
     var columnsToReturn: [String: [ColumnInfo]] = [:]
     var fetchColumnsCallCount = 0
     var fetchColumnsCalls: [String] = []
+    var fetchSchemaTablesCalls: [String] = []
 
     init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
         self.connection = connection
@@ -47,6 +49,12 @@ private final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
     func fetchTables() async throws -> [TableInfo] {
         tablesToReturn
+    }
+
+    func fetchTables(schema: String?) async throws -> [TableInfo] {
+        guard let schema else { return tablesToReturn }
+        fetchSchemaTablesCalls.append(schema)
+        return schemaTablesToReturn[schema] ?? tablesToReturn
     }
 
     func fetchColumns(table: String) async throws -> [ColumnInfo] {
@@ -366,5 +374,128 @@ struct SQLSchemaProviderTests {
         let columns = await provider.getColumns(for: "users")
         #expect(columns.first?.name == "eager_source")
         #expect(driver.fetchColumnsCallCount == 0)
+    }
+
+    // MARK: - Namespaces (database/schema segments)
+
+    @Test("isKnownSchema and isKnownDatabase match case-insensitively")
+    func knownNamespaceLookupIsCaseInsensitive() async {
+        let provider = SQLSchemaProvider()
+        await provider.setNamespaces(schemas: ["DBT_MARTS"], databases: ["ANALYTICS_PROD"])
+
+        #expect(await provider.isKnownSchema("dbt_marts"))
+        #expect(await provider.isKnownSchema("DBT_MARTS"))
+        #expect(!(await provider.isKnownSchema("unknown")))
+        #expect(await provider.isKnownDatabase("analytics_prod"))
+        #expect(!(await provider.isKnownDatabase("dbt_marts")))
+    }
+
+    @Test("namespaceCompletionItems lists databases and schemas")
+    func namespaceCompletionItemsListsBoth() async {
+        let provider = SQLSchemaProvider()
+        await provider.setNamespaces(schemas: ["sales", "hr"], databases: ["prod"])
+
+        let labels = await provider.namespaceCompletionItems().map(\.label)
+        #expect(Set(labels) == ["prod", "sales", "hr"])
+        #expect(await provider.namespaceCompletionItems().allSatisfy { $0.kind == .schema })
+    }
+
+    @Test("schemaCompletionItems lists schemas only")
+    func schemaCompletionItemsListsSchemasOnly() async {
+        let provider = SQLSchemaProvider()
+        await provider.setNamespaces(schemas: ["sales", "hr"], databases: ["prod"])
+
+        let labels = await provider.schemaCompletionItems().map(\.label)
+        #expect(Set(labels) == ["sales", "hr"])
+    }
+
+    @Test("tableCompletionItems filters already-loaded tables by schema")
+    func tableCompletionItemsFiltersLoadedBySchema() async {
+        let driver = MockDatabaseDriver()
+        let provider = SQLSchemaProvider()
+        await provider.resetForDatabase(
+            "db",
+            tables: [
+                TableInfo(name: "orders", type: .table, rowCount: 0, schema: "sales"),
+                TableInfo(name: "leads", type: .table, rowCount: 0, schema: "sales"),
+                TableInfo(name: "employees", type: .table, rowCount: 0, schema: "hr")
+            ],
+            driver: driver
+        )
+
+        let labels = await provider.tableCompletionItems(inSchema: "sales").map(\.label)
+        #expect(Set(labels) == ["orders", "leads"])
+    }
+
+    @Test("tableCompletionItems fetches a schema's tables on demand when not loaded")
+    func tableCompletionItemsFetchesOnDemand() async {
+        let source = SQLSchemaProvider.ColumnMetadataSource(
+            fetchColumns: { _, _ in [] },
+            fetchAllColumns: { [:] },
+            fetchSchemaTables: { schema in
+                [TableInfo(name: "fact_orders", type: .table, rowCount: 0, schema: schema)]
+            }
+        )
+        let provider = SQLSchemaProvider(metadataSource: source)
+
+        let labels = await provider.tableCompletionItems(inSchema: "marts").map(\.label)
+        #expect(labels == ["fact_orders"])
+    }
+
+    @Test("tableCompletionItems drops fetched tables that belong to a different schema")
+    func tableCompletionItemsDefensivelyFiltersFetched() async {
+        let source = SQLSchemaProvider.ColumnMetadataSource(
+            fetchColumns: { _, _ in [] },
+            fetchAllColumns: { [:] },
+            fetchSchemaTables: { _ in
+                [
+                    TableInfo(name: "in_schema", type: .table, rowCount: 0, schema: "marts"),
+                    TableInfo(name: "other_schema", type: .table, rowCount: 0, schema: "staging"),
+                    TableInfo(name: "untagged", type: .table, rowCount: 0, schema: nil)
+                ]
+            }
+        )
+        let provider = SQLSchemaProvider(metadataSource: source)
+
+        let labels = await provider.tableCompletionItems(inSchema: "marts").map(\.label)
+        #expect(Set(labels) == ["in_schema", "untagged"])
+    }
+
+    @Test("getColumns threads the schema through to the metadata source and caches per schema")
+    func getColumnsThreadsSchemaAndCachesPerSchema() async {
+        let recorder = CallRecorder()
+        let source = SQLSchemaProvider.ColumnMetadataSource(
+            fetchColumns: { table, schema in
+                recorder.record("\(schema ?? "nil").\(table)")
+                return [TestFixtures.makeColumnInfo(name: "\(schema ?? "nil")_col")]
+            },
+            fetchAllColumns: { [:] }
+        )
+        let provider = SQLSchemaProvider(metadataSource: source)
+
+        let sales = await provider.getColumns(for: "orders", schema: "sales")
+        let hr = await provider.getColumns(for: "orders", schema: "hr")
+        _ = await provider.getColumns(for: "orders", schema: "sales")
+
+        #expect(sales.first?.name == "sales_col")
+        #expect(hr.first?.name == "hr_col")
+        #expect(recorder.calls == ["sales.orders", "hr.orders"])
+    }
+}
+
+private final class CallRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    func record(_ value: String) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+
+    var calls: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
     }
 }

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -339,7 +339,7 @@ struct SQLSchemaProviderTests {
         let driver = MockDatabaseDriver()
         driver.columnsToReturn = ["users": [TestFixtures.makeColumnInfo(name: "from_driver")]]
         let source = SQLSchemaProvider.ColumnMetadataSource(
-            fetchColumns: { _ in [TestFixtures.makeColumnInfo(name: "from_source")] },
+            fetchColumns: { _, _ in [TestFixtures.makeColumnInfo(name: "from_source")] },
             fetchAllColumns: { [:] }
         )
         let provider = SQLSchemaProvider(metadataSource: source)
@@ -355,7 +355,7 @@ struct SQLSchemaProviderTests {
         let driver = MockDatabaseDriver()
         driver.columnsToReturn = ["users": [TestFixtures.makeColumnInfo(name: "from_driver")]]
         let source = SQLSchemaProvider.ColumnMetadataSource(
-            fetchColumns: { _ in [TestFixtures.makeColumnInfo(name: "lazy_source")] },
+            fetchColumns: { _, _ in [TestFixtures.makeColumnInfo(name: "lazy_source")] },
             fetchAllColumns: { ["users": [TestFixtures.makeColumnInfo(name: "eager_source")]] }
         )
         let provider = SQLSchemaProvider(metadataSource: source)

--- a/TableProTests/Core/Services/Query/SchemaServiceTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaServiceTests.swift
@@ -1,0 +1,61 @@
+//
+//  SchemaServiceTests.swift
+//  TableProTests
+//
+//  Tests for SchemaService aggregation across per-schema table lists.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("SchemaService")
+@MainActor
+struct SchemaServiceTests {
+    @Test("allLoadedTables unions tables across loaded per-schema lists")
+    func allLoadedTablesUnionsPerSchema() async {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        driver.schemaTablesToReturn = [
+            "sales": [
+                TableInfo(name: "orders", type: .table, rowCount: 0, schema: "sales"),
+                TableInfo(name: "leads", type: .table, rowCount: 0, schema: "sales")
+            ],
+            "hr": [
+                TableInfo(name: "employees", type: .table, rowCount: 0, schema: "hr")
+            ]
+        ]
+
+        let service = SchemaService()
+        await service.loadSchemaTables(connectionId: connectionId, schema: "sales", driver: driver)
+        await service.loadSchemaTables(connectionId: connectionId, schema: "hr", driver: driver)
+
+        let names = Set(service.allLoadedTables(for: connectionId).map(\.name))
+        #expect(names == ["orders", "leads", "employees"])
+    }
+
+    @Test("allLoadedTables deduplicates tables that share an id across schema states")
+    func allLoadedTablesDeduplicatesById() async {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        let shared = TableInfo(name: "orders", type: .table, rowCount: 0, schema: "sales")
+        driver.schemaTablesToReturn = [
+            "sales": [shared],
+            "mirror": [shared]
+        ]
+
+        let service = SchemaService()
+        await service.loadSchemaTables(connectionId: connectionId, schema: "sales", driver: driver)
+        await service.loadSchemaTables(connectionId: connectionId, schema: "mirror", driver: driver)
+
+        let matching = service.allLoadedTables(for: connectionId).filter { $0.id == shared.id }
+        #expect(matching.count == 1)
+    }
+
+    @Test("allLoadedTables is empty for a connection with no loaded state")
+    func allLoadedTablesEmptyWhenNothingLoaded() {
+        let service = SchemaService()
+        #expect(service.allLoadedTables(for: UUID()).isEmpty)
+    }
+}

--- a/docs/features/autocomplete.mdx
+++ b/docs/features/autocomplete.mdx
@@ -152,6 +152,17 @@ SELECT * FROM public.|  -- Tables in public schema
 
 Schema-qualified names like `public.users` resolve correctly in FROM, JOIN, UPDATE, INSERT INTO, and CREATE INDEX.
 
+For databases organized as database → schema → table (Snowflake, BigQuery), every segment completes — including tables of schemas you haven't opened in the sidebar, which are fetched on demand:
+
+```sql
+SELECT * FROM ANALYTICS_|                      -- databases
+SELECT * FROM ANALYTICS_PROD.|                 -- schemas
+SELECT * FROM ANALYTICS_PROD.DBT_MARTS.|       -- tables in that schema
+SELECT * FROM ANALYTICS_PROD.DBT_MARTS.ORDERS o WHERE o.|  -- columns
+```
+
+Functions from the connection's SQL dialect (e.g. `CONVERT_TIMEZONE` on Snowflake, `SAFE_CAST` on BigQuery) appear in the popup alongside the common SQL functions.
+
 ## Context-Aware Suggestions
 
 What appears depends on where your cursor is:


### PR DESCRIPTION
## Summary

Improves SQL autocomplete for connections that organize objects as database → schema → table (BigQuery today, Snowflake with #1580):

- For hierarchical-schema plugins the completion feed previously received an empty table list (`SchemaService.runHierarchicalLoad` publishes `.loaded([])` and per-schema tables never reached `SQLSchemaProvider`); it now receives the union of all loaded per-schema tables plus schema and database names
- Qualified names complete at every segment: `ANALYTICS_PR` → database, `ANALYTICS_PROD.` → schemas, `ANALYTICS_PROD.DBT_MARTS.` → tables — including schemas never expanded in the sidebar, fetched on demand through the metadata pool
- Alias column completion respects schema-qualified tables: `FROM db.schema.orders o WHERE o.` previously fetched columns from the *active* schema and came back empty; `TableReference` now carries the schema segment end to end
- The completion popup includes the active connection's dialect function list — previously dialect functions only fed syntax highlighting while the popup used a small generic set. This benefits every database plugin (e.g. `SAFE_CAST` on BigQuery, `JSONB_AGG` on PostgreSQL)

No behavior change for flat-schema connections beyond the dialect functions appearing in completions.

## Testing

- Live-verified against Snowflake and BigQuery-style hierarchical browsing: segment completion, on-demand schema tables, schema-qualified alias columns, dialect functions in the popup
- All five autocomplete test suites pass in isolation (605 cases); the order-dependent failures of `testProviderAcceptsDatabaseType` / `testMySQLProviderTypes` when suites run together reproduce identically on `main` and predate this PR
- `swiftlint lint --strict` clean on all changed files

## Checklist

- [x] Tests updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated (`docs/features/autocomplete.mdx`)
- [x] User-facing strings localized (n/a — no new UI strings)
- [x] No SwiftLint violations

Related: #1420, #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)