### PR TITLE
fix(editor): capture quoted identifiers in qualified table references

### DIFF
--- a/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
+++ b/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
@@ -247,14 +247,14 @@ final class SQLContextAnalyzer {
 
     private static let tableRefRegexes: [NSRegularExpression] = {
         let patterns = [
-            "(?i)\\bFROM\\s+[`\"']?([\\w.]+)[`\"']?" +
+            "(?i)\\bFROM\\s+[`\"']?([\\w.`\"']+)[`\"']?" +
             "(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
             "(?i)(?:LEFT|RIGHT|INNER|OUTER|CROSS|FULL)?\\s*(?:OUTER)?\\s*JOIN\\s+" +
-            "[`\"']?([\\w.]+)[`\"']?(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
-            "(?i)\\bUPDATE\\s+[`\"']?([\\w.]+)[`\"']?" +
+            "[`\"']?([\\w.`\"']+)[`\"']?(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
+            "(?i)\\bUPDATE\\s+[`\"']?([\\w.`\"']+)[`\"']?" +
             "(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
-            "(?i)\\bINSERT\\s+INTO\\s+[`\"']?([\\w.]+)[`\"']?",
-            "(?i)\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+\\w+\\s+ON\\s+[`\"']?([\\w.]+)[`\"']?"
+            "(?i)\\bINSERT\\s+INTO\\s+[`\"']?([\\w.`\"']+)[`\"']?",
+            "(?i)\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+\\w+\\s+ON\\s+[`\"']?([\\w.`\"']+)[`\"']?"
         ]
         return patterns.map { compileRegex($0) }
     }()
@@ -793,12 +793,13 @@ final class SQLContextAnalyzer {
 
                 let rawName = (query as NSString).substring(with: tableNSRange)
                 let tableName = Self.stripSchemaPrefix(rawName)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "`\"'"))
                 guard !Self.tableRefKeywords.contains(tableName.uppercased()) else { return }
 
                 let segments = rawName.split(separator: ".")
                 let schema = segments.count >= 2
                     ? String(segments[segments.count - 2])
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`\""))
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "`\"'"))
                     : nil
 
                 var alias: String?


### PR DESCRIPTION
## Summary

Fixes the `SQL Context Analyzer` failure currently red on `main` ("Strips quoting from the captured schema segment", added in the #1581 squash).

The table-reference regexes captured names with `([\w.]+)`, which cannot cross a quoted segment — `FROM "sales".orders` captured only `sales`, so the schema was lost and the test failed. The capture class now includes quote characters, and both the parsed table name and the schema segment strip `` ` ``, `"`, and `'`:

```sql
SELECT * FROM "sales".orders      -- schema=sales, table=orders ✓
SELECT * FROM db."schema"."tbl" t -- schema=schema, table=tbl, alias=t ✓
```

## Testing

- `SQLContextAnalyzerTests` (including the four schema-segment tests) and `SQLContextAnalyzerCaseInsensitiveTests` pass locally
- `swiftlint lint --strict` clean

Related: #1581, unblocks CI for #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)