### PR TITLE
fix: unit tests failing on the macOS test gate (autocomplete, password command, MCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running a PostgreSQL script with a `DO $$ ... $$` block or a dollar-quoted function body no longer fails with an unterminated dollar-quoted string error. (#1559)
 - AWS IAM connections no longer ask for a password on connect or reconnect. IAM supplies the credentials, so the prompt was never needed. The same now holds for any auth mode that replaces the password, such as a Postgres password file.
 - Oracle connection failures show the listener's actual reason (such as an unknown service name) instead of a generic "server closed the connection" message. (#483)
+- A connection password read from a command no longer fails with an empty-password error when the command finishes quickly; its full output is now captured.
 
 ## [0.48.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AWS IAM connections no longer ask for a password on connect or reconnect. IAM supplies the credentials, so the prompt was never needed. The same now holds for any auth mode that replaces the password, such as a Postgres password file.
 - Oracle connection failures show the listener's actual reason (such as an unknown service name) instead of a generic "server closed the connection" message. (#483)
 - A connection password read from a command no longer fails with an empty-password error when the command finishes quickly; its full output is now captured.
+- A cancelled MCP query request returns a cancelled error instead of an invalid-parameters error, and emits an initial progress notification when it starts.
 
 ## [0.48.0] - 2026-06-02
 

--- a/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
+++ b/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
@@ -246,15 +246,15 @@ final class SQLContextAnalyzer {
     private static let cteCommaRegex = compileRegex("(?i),\\s*([\\w]+)\\s+AS\\s*\\(")
 
     private static let tableRefRegexes: [NSRegularExpression] = {
+        let segment = "[`\"']?\\w+[`\"']?"
+        let path = "(\(segment)(?:\\.\(segment))*)"
+        let alias = "(?:\\s+(?:AS\\s+)?[`\"']?(\\w+)[`\"']?)?"
         let patterns = [
-            "(?i)\\bFROM\\s+[`\"']?([\\w.]+)[`\"']?" +
-            "(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
-            "(?i)(?:LEFT|RIGHT|INNER|OUTER|CROSS|FULL)?\\s*(?:OUTER)?\\s*JOIN\\s+" +
-            "[`\"']?([\\w.]+)[`\"']?(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
-            "(?i)\\bUPDATE\\s+[`\"']?([\\w.]+)[`\"']?" +
-            "(?:\\s+(?:AS\\s+)?[`\"']?([\\w]+)[`\"']?)?",
-            "(?i)\\bINSERT\\s+INTO\\s+[`\"']?([\\w.]+)[`\"']?",
-            "(?i)\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+\\w+\\s+ON\\s+[`\"']?([\\w.]+)[`\"']?"
+            "(?i)\\bFROM\\s+\(path)\(alias)",
+            "(?i)(?:LEFT|RIGHT|INNER|OUTER|CROSS|FULL)?\\s*(?:OUTER)?\\s*JOIN\\s+\(path)\(alias)",
+            "(?i)\\bUPDATE\\s+\(path)\(alias)",
+            "(?i)\\bINSERT\\s+INTO\\s+\(path)",
+            "(?i)\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+\\w+\\s+ON\\s+\(path)"
         ]
         return patterns.map { compileRegex($0) }
     }()
@@ -767,15 +767,7 @@ final class SQLContextAnalyzer {
         "JOIN", "ON", "AND", "OR", "WHERE", "SELECT", "FROM", "AS"
     ]
 
-    /// Strip schema prefix from a potentially schema-qualified name
-    private static func stripSchemaPrefix(_ raw: String) -> String {
-        let ns = raw as NSString
-        let dotRange = ns.range(of: ".", options: .backwards)
-        guard dotRange.location != NSNotFound else { return raw }
-        let start = dotRange.location + 1
-        guard start < ns.length else { return raw }
-        return ns.substring(from: start)
-    }
+    private static let identifierQuoteChars = CharacterSet(charactersIn: "`\"'")
 
     /// Extract all table references (table names and aliases) from the query
     private func extractTableReferences(from query: String) -> [TableReference] {
@@ -792,14 +784,13 @@ final class SQLContextAnalyzer {
                 guard tableNSRange.location != NSNotFound else { return }
 
                 let rawName = (query as NSString).substring(with: tableNSRange)
-                let tableName = Self.stripSchemaPrefix(rawName)
+                let segments = rawName.split(separator: ".").map {
+                    String($0).trimmingCharacters(in: Self.identifierQuoteChars)
+                }
+                guard let tableName = segments.last, !tableName.isEmpty else { return }
                 guard !Self.tableRefKeywords.contains(tableName.uppercased()) else { return }
 
-                let segments = rawName.split(separator: ".")
-                let schema = segments.count >= 2
-                    ? String(segments[segments.count - 2])
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`\""))
-                    : nil
+                let schema = segments.count >= 2 ? segments[segments.count - 2] : nil
 
                 var alias: String?
                 if match.numberOfRanges > 2 {

--- a/TablePro/Core/MCP/Protocol/Tools/ExecuteQueryTool.swift
+++ b/TablePro/Core/MCP/Protocol/Tools/ExecuteQueryTool.swift
@@ -77,6 +77,9 @@ public struct ExecuteQueryTool: MCPToolImplementation {
             throw MCPProtocolError.invalidParams(detail: "Query exceeds 100KB limit")
         }
 
+        try await throwIfCancelled(context)
+        await context.progress.emit(progress: 0.0, total: 1.0, message: "Connecting")
+
         let meta = try await ToolConnectionMetadata.resolve(connectionId: connectionId)
 
         guard !QueryClassifier.isMultiStatement(query, databaseType: meta.databaseType) else {
@@ -84,9 +87,6 @@ public struct ExecuteQueryTool: MCPToolImplementation {
                 detail: "Multi-statement queries are not supported. Send one statement at a time."
             )
         }
-
-        try await throwIfCancelled(context)
-        await context.progress.emit(progress: 0.0, total: 1.0, message: "Connecting")
 
         if let database {
             _ = try await services.connectionBridge.switchDatabase(

--- a/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
+++ b/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
@@ -130,6 +130,11 @@ enum PasswordSourceResolver {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
 
+            let remainingStdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            if !remainingStdout.isEmpty { stdoutCollector.append(remainingStdout) }
+            let remainingStderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            if !remainingStderr.isEmpty { stderrCollector.append(remainingStderr) }
+
             if stdoutCollector.overflowed {
                 throw ResolutionError.outputTooLarge
             }


### PR DESCRIPTION
The macOS test gate had four failing assertions across three suites. None of them are in code the open Snowflake PR (#1580) touches, so they were already red on `main` and turned the gate red on every PR. Each fix is in source, not the tests.

## Fixes

**`fix(editor)`: quoted schema in qualified table references**
The table-reference regex matched an optional quote, then `[\w.]+`, then an optional quote. For `FROM "sales".orders` the opening quote was consumed first, the character class stopped at the closing quote, and `.orders` was dropped, so the analyzer recorded a table named `sales`. The capture now matches optionally-quoted dotted segments and strips quotes per segment for both the table and the schema.
Fixes `SQLContextAnalyzerTests.testSchemaSegmentQuotingStripped`.

**`fix(connections)`: full output of a fast password command**
`resolveCommand` read stdout through a `readabilityHandler` and stopped at `waitUntilExit`. For a small, fast command the only chunk could arrive after the handler was removed, so the password came back empty (`.emptyPassword`). It now drains the remaining stdout and stderr after the process exits, the same pattern used elsewhere in the app.
Fixes `PasswordSourceResolverTests.commandPreservesSpaces`.

**`fix(mcp)`: cancellation and progress before the connection lookup**
`ToolConnectionMetadata.resolve` ran before the cancellation check and the first progress emit, so a request that was already cancelled returned `invalidParams` and no progress notification fired. The early cancellation check and the initial progress emit now run before the connection is resolved.
Fixes `ExecuteQueryToolTests.cancellationPropagates` and `progressEmittedWhenTokenPresent`.

## Verification

`xcodebuild test` on the three suites: `** TEST SUCCEEDED **`, 322 cases, 0 failures, 0 recorded issues. `swiftlint lint --strict` on the changed files: clean.

The autocomplete fix folds into the unreleased #1581 entry, so it has no separate changelog line; the other two are added under Fixed.
