### PR TITLE
fix(connections): wait for the switcher popover to become key before focusing its search field

### DIFF
--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 private final class IntrinsicHeightSearchField: NSSearchField {
     var focusOnAppear = false
+    private var windowKeyObserver: NSObjectProtocol?
 
     override var intrinsicContentSize: NSSize {
         let cellHeight = cell?.cellSize.height ?? super.intrinsicContentSize.height
@@ -18,10 +19,34 @@ private final class IntrinsicHeightSearchField: NSSearchField {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        removeWindowKeyObserver()
         guard focusOnAppear, acceptsFirstResponder, let window else { return }
-        window.makeFirstResponder(self)
-        if !window.isKeyWindow {
-            window.makeKey()
+        if window.isKeyWindow {
+            window.makeFirstResponder(self)
+            return
+        }
+        windowKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.removeWindowKeyObserver()
+                self.window?.makeFirstResponder(self)
+            }
+        }
+    }
+
+    private func removeWindowKeyObserver() {
+        guard let token = windowKeyObserver else { return }
+        NotificationCenter.default.removeObserver(token)
+        windowKeyObserver = nil
+    }
+
+    deinit {
+        if let token = windowKeyObserver {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 }


### PR DESCRIPTION
Follow-up to #1596 (issue #1575).

## Problem

After #1596, typed text in the connection switcher's search field rendered on top of the "Search connections" placeholder: two text layers overlapping.

## Root cause

#1596 claimed first responder synchronously in `viewDidMoveToWindow` and forced `makeKey()`. That hook fires when the view is attached to the popover's window, before the popover is on screen. Editing began on a window that was not yet visible, so the search field cell never registered the editing session: it kept drawing its placeholder while the field editor drew the typed text over it.

## Fix

Drop the forced `makeKey()` and the early claim. Transient popovers become key on their own when shown, so the field now waits for the documented signal: if the window is already key (sheets), claim first responder immediately; otherwise claim once on `NSWindow.didBecomeKeyNotification`. The one-shot observer is removed after firing, when the view leaves the window, and on deinit.

Editing now starts only after the popover is on screen and key, which is the normal AppKit sequence, so the placeholder clears as soon as text is entered. The #1596 focus fix still holds: the filter field releases focus when the main window resigns key, and typing lands in the search field.

## Tests

- `swiftlint lint --strict` clean.
- No unit test: the change is AppKit window-lifecycle sequencing with no extractable pure logic. Manual verification below.

## Manual verification

1. Open the connection switcher and type: text replaces the placeholder, no overlap.
2. With a filter input focused, open the switcher: cursor lands in the search field, typing works.
3. Reopen the popover several times: focus lands correctly each time.
4. Database switcher (Cmd+K) and Quick Switcher (Cmd+Shift+O) still focus their search fields.

No CHANGELOG entry: this fixes behaviour that is itself still unreleased (folded into the existing #1575 entry).