### PR TITLE
fix(editor): re-highlight the document after a programmatic text replacement (#1612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cancelling a SQLite query no longer races a disconnect happening at the same moment. (#1610)
 - Typing in the query editor no longer erases characters or drops focus on each keystroke, a timing-dependent bug most visible on macOS 15. (#1608)
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
+- Syntax highlighting no longer disappears after formatting a query. (#1612)
 
 ## [0.49.1] - 2026-06-06
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
@@ -9,6 +9,13 @@ import Foundation
 import SwiftTreeSitter
 
 extension TextViewController {
+    /// Tears down and rebuilds the highlighter for the text view's current storage.
+    ///
+    /// Ends with an explicit `invalidate()` so the rebuilt highlighter queries the
+    /// visible text immediately. A fresh highlighter only highlights in response to
+    /// triggers (an edit, a frame change, or an invalidation); after a mid-session
+    /// storage swap such as `setText`, none of those is guaranteed to fire, and
+    /// without this the document stays unstyled until the next layout change.
     package func setUpHighlighter() {
         if let highlighter {
             textView.removeStorageDelegate(highlighter)
@@ -24,6 +31,7 @@ extension TextViewController {
         )
         textView.addStorageDelegate(highlighter)
         self.highlighter = highlighter
+        highlighter.invalidate()
     }
 
     /// Sets new highlight providers. Recognizes when objects move in the array or are removed or inserted.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
@@ -166,12 +166,17 @@ extension SourceEditor {
         /// fires suggestion triggers, none of which should happen for a programmatic
         /// whole-document replacement. `setText` clearing the undo stack matches the
         /// new-document semantics of that replacement.
+        ///
+        /// Must go through `TextViewController.setText`, not `textView.setText`: the
+        /// controller-level call rebuilds the highlighter for the replacement storage.
+        /// Calling the text view directly leaves tree-sitter state for the old document
+        /// and highlighting never recovers.
         func syncBindingText(_ newValue: String, controller: TextViewController) {
             guard !isUpdateFromTextView else { return }
             guard newValue != lastSyncedText else { return }
             textBindingTask?.cancel()
             isUpdatingFromRepresentable = true
-            controller.textView.setText(newValue)
+            controller.setText(newValue)
             isUpdatingFromRepresentable = false
             lastSyncedText = newValue
         }

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
@@ -159,6 +159,49 @@ final class SourceEditorBindingSyncTests: XCTestCase {
     }
 
     @MainActor
+    func test_syncRebuildsHighlighterForReplacementStorage() {
+        var bound = "select * from users"
+        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
+        controller.textView.setText("select * from users")
+        controller.setUpHighlighter()
+        let highlighterBefore = controller.highlighter
+        XCTAssertNotNil(highlighterBefore)
+
+        bound = "SELECT\n    *\nFROM\n    users"
+        coordinator.syncBindingText(bound, controller: controller)
+
+        XCTAssertEqual(controller.textView.string, "SELECT\n    *\nFROM\n    users")
+        XCTAssertNotNil(controller.highlighter)
+        XCTAssertNotIdentical(controller.highlighter, highlighterBefore)
+    }
+
+    @MainActor
+    func test_syncQueriesHighlightsForReplacementStorage() {
+        let provider = HighlighterTests.MockHighlightProvider()
+        let providerController = TextViewController(
+            string: "select * from users",
+            language: .html,
+            configuration: Mock.config(),
+            cursorPositions: [],
+            highlightProviders: [provider]
+        )
+        providerController.loadView()
+        providerController.view.frame = NSRect(x: 0, y: 0, width: 1_000, height: 1_000)
+        providerController.view.layoutSubtreeIfNeeded()
+
+        let setUpsBefore = provider.setUpCount
+        let queriesBefore = provider.queryCount
+
+        var bound = "select * from users"
+        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
+        bound = "SELECT\n    *\nFROM\n    users"
+        coordinator.syncBindingText(bound, controller: providerController)
+
+        XCTAssertGreaterThan(provider.setUpCount, setUpsBefore)
+        XCTAssertGreaterThan(provider.queryCount, queriesBefore)
+    }
+
+    @MainActor
     func test_repeatedSyncWithSameValueLeavesTextViewUntouched() {
         var bound = "stable"
         let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })


### PR DESCRIPTION
Fixes #1612.

## Problem

Clicking Format replaced the query text and all syntax highlighting disappeared, never recovering. With #1611 merged, Format flows exclusively through the binding push-down (`syncBindingText` -> `setText`), which made the loss deterministic.

## Root cause, two layers

1. `syncBindingText` called the TextView-level `textView.setText(...)`, bypassing `TextViewController.setText(_:)`, which is the documented controller-level path and rebuilds the highlighter for the replacement storage. The old highlighter kept tree-sitter state for the dead document.
2. Rebuilding alone is not enough: a fresh `Highlighter` only queries when triggered (an edit, a frame/bounds notification, or `invalidate()`). Initial load works because the first layout pass fires `frameDidChangeNotification`; after a mid-session storage swap no trigger is guaranteed, so the rebuilt highlighter sat idle and the document stayed plain.

## Fix

- `syncBindingText` routes through `controller.setText(newValue)` so the highlighter is rebuilt for the new storage.
- `setUpHighlighter()` now ends with `highlighter.invalidate()`, making "after setup, the editor is highlighted" an invariant for every caller instead of a timing accident.

## Tests

- `test_syncRebuildsHighlighterForReplacementStorage`: the highlighter instance is rebuilt on a binding push-down.
- `test_syncQueriesHighlightsForReplacementStorage`: a mock provider proves the rebuilt highlighter is re-set-up AND re-queried; this test fails with the route-through change alone.
- All existing binding-sync and highlighter tests pass.

## Note

The issue also asks for a minify counterpart to Format; that is a feature request and should be tracked separately.