### PR TITLE
fix(editor): restore highlighting after format and refactor editor sync state (#1612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cancelling a SQLite query no longer races a disconnect happening at the same moment. (#1610)
 - Typing in the query editor no longer erases characters or drops focus on each keystroke, a timing-dependent bug most visible on macOS 15. (#1608)
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
+- Syntax highlighting no longer disappears after formatting a query. (#1612)
 
 ## [0.49.1] - 2026-06-06
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Model/SuggestionViewModel.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Model/SuggestionViewModel.swift
@@ -19,6 +19,7 @@ final class SuggestionViewModel: ObservableObject {
 
     var itemsRequestTask: Task<Void, Never>?
     weak var activeTextView: TextViewController?
+    private(set) var isApplyingCompletion = false
 
     weak var delegate: CodeSuggestionDelegate?
 
@@ -83,6 +84,8 @@ final class SuggestionViewModel: ObservableObject {
         isManualTrigger: Bool = false,
         showWindowOnParent: @escaping @MainActor (NSWindow, NSRect) -> Void
     ) {
+        guard !isApplyingCompletion else { return }
+
         self.activeTextView = nil
         self.delegate = nil
         itemsRequestTask?.cancel()
@@ -142,6 +145,8 @@ final class SuggestionViewModel: ObservableObject {
         position: CursorPosition,
         close: () -> Void
     ) {
+        guard !isApplyingCompletion else { return }
+
         if activeTextView !== textView {
             itemsRequestTask?.cancel()
             itemsRequestTask = nil
@@ -173,11 +178,13 @@ final class SuggestionViewModel: ObservableObject {
         guard let activeTextView else {
             return
         }
+        isApplyingCompletion = true
         self.delegate?.completionWindowApplyCompletion(
             item: item,
             textView: activeTextView,
             cursorPosition: activeTextView.cursorPositions.first
         )
+        isApplyingCompletion = false
         onApply?()
     }
 
@@ -187,6 +194,7 @@ final class SuggestionViewModel: ObservableObject {
         items.removeAll()
         selectedIndex = 0
         activeTextView = nil
+        delegate?.completionWindowDidClose()
         delegate = nil
     }
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Highlighter.swift
@@ -9,6 +9,13 @@ import Foundation
 import SwiftTreeSitter
 
 extension TextViewController {
+    /// Tears down and rebuilds the highlighter for the text view's current storage.
+    ///
+    /// Ends with an explicit `invalidate()` so the rebuilt highlighter queries the
+    /// visible text immediately. A fresh highlighter only highlights in response to
+    /// triggers (an edit, a frame change, or an invalidation); after a mid-session
+    /// storage swap such as `setText`, none of those is guaranteed to fire, and
+    /// without this the document stays unstyled until the next layout change.
     package func setUpHighlighter() {
         if let highlighter {
             textView.removeStorageDelegate(highlighter)
@@ -24,6 +31,7 @@ extension TextViewController {
         )
         textView.addStorageDelegate(highlighter)
         self.highlighter = highlighter
+        highlighter.invalidate()
     }
 
     /// Sets new highlight providers. Recognizes when objects move in the array or are removed or inserted.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/RepresentableSyncPhase.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/RepresentableSyncPhase.swift
@@ -1,0 +1,59 @@
+//
+//  RepresentableSyncPhase.swift
+//  CodeEditSourceEditor
+//
+//  Tracks which side of the SwiftUI representable boundary originated the
+//  change currently being synchronized, replacing the pair of booleans the
+//  coordinator previously juggled. The states are mutually exclusive by
+//  construction: an editor change can never be marked while a representable
+//  value is being applied, and a representable value is never applied while
+//  an editor change is pending.
+//
+
+import Foundation
+
+@MainActor
+final class RepresentableSyncPhase {
+    enum Phase: Equatable {
+        case idle
+        case editorChangePending
+        case applyingRepresentableValue
+    }
+
+    private(set) var phase: Phase = .idle
+
+    var isEditorChangePending: Bool {
+        phase == .editorChangePending
+    }
+
+    var isApplyingRepresentableValue: Bool {
+        phase == .applyingRepresentableValue
+    }
+
+    /// Latches that the editor originated a change. The next representable
+    /// update pass consumes this instead of pushing its own values down.
+    /// Ignored while a representable value is being applied, since editor
+    /// notifications fired during a programmatic application are echoes,
+    /// not user edits.
+    func markEditorChange() {
+        guard phase != .applyingRepresentableValue else { return }
+        phase = .editorChangePending
+    }
+
+    /// Returns whether an editor change was pending and resets to idle.
+    @discardableResult
+    func consumePendingEditorChange() -> Bool {
+        guard phase == .editorChangePending else { return false }
+        phase = .idle
+        return true
+    }
+
+    /// Runs `body` with the phase marked as applying a representable value,
+    /// so editor notifications fired by the application itself are ignored.
+    func applyRepresentableValue(_ body: () -> Void) {
+        let previous = phase
+        phase = .applyingRepresentableValue
+        body()
+        phase = previous
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
@@ -14,10 +14,8 @@ extension SourceEditor {
     @MainActor
     public class Coordinator: NSObject {
         private weak var controller: TextViewController?
-        var isUpdatingFromRepresentable: Bool = false
-        var isUpdateFromTextView: Bool = false
-        var text: TextAPI
-        var lastSyncedText: String?
+        let phase = RepresentableSyncPhase()
+        let textSync: TextBindingSync
         @Binding var editorState: SourceEditorState
 
         private(set) var highlightProviders: [any HighlightProviding]
@@ -25,12 +23,9 @@ extension SourceEditor {
         private var cancellables: Set<AnyCancellable> = []
 
         init(text: TextAPI, editorState: Binding<SourceEditorState>, highlightProviders: [any HighlightProviding]?) {
-            self.text = text
+            self.textSync = TextBindingSync(text: text, phase: phase)
             self._editorState = editorState
             self.highlightProviders = highlightProviders ?? [TreeSitterClient()]
-            if case .binding(let binding) = text {
-                self.lastSyncedText = binding.wrappedValue
-            }
             super.init()
         }
 
@@ -123,62 +118,11 @@ extension SourceEditor {
             self.highlightProviders = highlightProviders
         }
 
-        private var textBindingTask: Task<Void, Never>?
-
         @objc func textViewDidChangeText(_ notification: Notification) {
             guard let textView = notification.object as? TextView else {
                 return
             }
-            guard !isUpdatingFromRepresentable else { return }
-            guard case .binding(let binding) = text else { return }
-
-            // For large documents, debounce the binding writeback to avoid
-            // copying megabytes of text into SwiftUI on every keystroke.
-            let docLength = textView.textStorage.length
-            // Set flag immediately so SwiftUI's updateNSViewController knows
-            // the text view is the source of truth during the debounce window.
-            isUpdateFromTextView = true
-            if docLength > 500_000 {
-                textBindingTask?.cancel()
-                textBindingTask = Task { @MainActor [weak self, weak textView] in
-                    try? await Task.sleep(for: .milliseconds(150))
-                    guard !Task.isCancelled, let self, let textView else { return }
-                    guard case .binding(let currentBinding) = self.text else { return }
-                    let newText = textView.string
-                    self.lastSyncedText = newText
-                    currentBinding.wrappedValue = newText
-                }
-            } else {
-                let newText = textView.string
-                lastSyncedText = newText
-                binding.wrappedValue = newText
-            }
-        }
-
-        /// Pushes an external binding change down into the text view. The text view's
-        /// content wins while one of its own edits is still in flight: `isUpdateFromTextView`
-        /// is set the moment the text view mutates, before SwiftUI re-renders, so a render
-        /// that still carries a stale binding snapshot is skipped entirely and user typing
-        /// is never clobbered by a stale binding.
-        ///
-        /// Uses `setText` rather than `replaceCharacters` on purpose: `replaceCharacters`
-        /// is the user-edit path. It is gated on `isEditable`, runs mutation filters, and
-        /// fires suggestion triggers, none of which should happen for a programmatic
-        /// whole-document replacement. `setText` clearing the undo stack matches the
-        /// new-document semantics of that replacement.
-        ///
-        /// Must go through `TextViewController.setText`, not `textView.setText`: the
-        /// controller-level call rebuilds the highlighter for the replacement storage.
-        /// Calling the text view directly leaves tree-sitter state for the old document
-        /// and highlighting never recovers.
-        func syncBindingText(_ newValue: String, controller: TextViewController) {
-            guard !isUpdateFromTextView else { return }
-            guard newValue != lastSyncedText else { return }
-            textBindingTask?.cancel()
-            isUpdatingFromRepresentable = true
-            controller.setText(newValue)
-            isUpdatingFromRepresentable = false
-            lastSyncedText = newValue
+            textSync.editorTextDidChange(textView)
         }
 
         @objc func textControllerCursorsDidUpdate(_ notification: Notification) {
@@ -223,8 +167,8 @@ extension SourceEditor {
         }
 
         private func updateState(_ modifyCallback: (inout SourceEditorState) -> Void) {
-            guard !isUpdatingFromRepresentable else { return }
-            self.isUpdateFromTextView = true
+            guard !phase.isApplyingRepresentableValue else { return }
+            phase.markEditorChange()
             modifyCallback(&editorState)
         }
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
@@ -166,12 +166,17 @@ extension SourceEditor {
         /// fires suggestion triggers, none of which should happen for a programmatic
         /// whole-document replacement. `setText` clearing the undo stack matches the
         /// new-document semantics of that replacement.
+        ///
+        /// Must go through `TextViewController.setText`, not `textView.setText`: the
+        /// controller-level call rebuilds the highlighter for the replacement storage.
+        /// Calling the text view directly leaves tree-sitter state for the old document
+        /// and highlighting never recovers.
         func syncBindingText(_ newValue: String, controller: TextViewController) {
             guard !isUpdateFromTextView else { return }
             guard newValue != lastSyncedText else { return }
             textBindingTask?.cancel()
             isUpdatingFromRepresentable = true
-            controller.textView.setText(newValue)
+            controller.setText(newValue)
             isUpdatingFromRepresentable = false
             lastSyncedText = newValue
         }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
@@ -134,18 +134,15 @@ public struct SourceEditor: NSViewControllerRepresentable {
 
         context.coordinator.updateHighlightProviders(highlightProviders)
 
-        context.coordinator.text = text
+        context.coordinator.textSync.text = text
         if case .binding(let binding) = text {
-            context.coordinator.syncBindingText(binding.wrappedValue, controller: controller)
+            context.coordinator.textSync.applyRepresentableText(binding.wrappedValue, controller: controller)
         }
 
-        // Prevent infinite loop of update notifications
-        if context.coordinator.isUpdateFromTextView {
-            context.coordinator.isUpdateFromTextView = false
-        } else {
-            context.coordinator.isUpdatingFromRepresentable = true
-            updateControllerWithState(state, controller: controller)
-            context.coordinator.isUpdatingFromRepresentable = false
+        if !context.coordinator.phase.consumePendingEditorChange() {
+            context.coordinator.phase.applyRepresentableValue {
+                updateControllerWithState(state, controller: controller)
+            }
         }
 
         // Do manual diffing to reduce the amount of reloads.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/TextBindingSync.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/TextBindingSync.swift
@@ -1,0 +1,88 @@
+//
+//  TextBindingSync.swift
+//  CodeEditSourceEditor
+//
+//  Owns the two-way synchronization between a SwiftUI text binding and the
+//  text view: editor edits are written back to the binding (debounced for
+//  large documents), and external binding changes are pushed down into the
+//  editor. The shared ``RepresentableSyncPhase`` decides which side wins
+//  when both have changes in flight.
+//
+
+import AppKit
+import CodeEditTextView
+import SwiftUI
+
+@MainActor
+final class TextBindingSync {
+    private static let writebackDebounceThreshold = 500_000
+    private static let writebackDebounce: Duration = .milliseconds(150)
+
+    var text: SourceEditor.TextAPI
+    private(set) var lastSyncedText: String?
+
+    private let phase: RepresentableSyncPhase
+    private var writebackTask: Task<Void, Never>?
+
+    init(text: SourceEditor.TextAPI, phase: RepresentableSyncPhase) {
+        self.text = text
+        self.phase = phase
+        if case .binding(let binding) = text {
+            lastSyncedText = binding.wrappedValue
+        }
+    }
+
+    /// Writes an editor-originated text change back to the binding.
+    ///
+    /// Marks the phase before writing so the representable update pass that
+    /// the binding write triggers cannot clobber the editor with a stale
+    /// snapshot. For large documents the writeback is debounced to avoid
+    /// copying megabytes into SwiftUI on every keystroke; the phase is still
+    /// marked immediately so the editor stays the source of truth during the
+    /// debounce window.
+    func editorTextDidChange(_ textView: TextView) {
+        guard !phase.isApplyingRepresentableValue else { return }
+        guard case .binding(let binding) = text else { return }
+
+        phase.markEditorChange()
+
+        guard textView.textStorage.length > Self.writebackDebounceThreshold else {
+            let newText = textView.string
+            lastSyncedText = newText
+            binding.wrappedValue = newText
+            return
+        }
+
+        writebackTask?.cancel()
+        writebackTask = Task { @MainActor [weak self, weak textView] in
+            try? await Task.sleep(for: Self.writebackDebounce)
+            guard !Task.isCancelled, let self, let textView else { return }
+            guard case .binding(let currentBinding) = self.text else { return }
+            let newText = textView.string
+            self.lastSyncedText = newText
+            currentBinding.wrappedValue = newText
+        }
+    }
+
+    /// Pushes an external binding change down into the text view. The editor's
+    /// content wins while one of its own edits is still in flight, so user
+    /// typing is never clobbered by a stale binding snapshot.
+    ///
+    /// Routes through `TextViewController.setText` on purpose. The text-view
+    /// level `replaceCharacters` is the user-edit path: it is gated on
+    /// `isEditable`, runs mutation filters, and fires suggestion triggers,
+    /// none of which should happen for a programmatic whole-document
+    /// replacement. The controller-level call also rebuilds the highlighter
+    /// for the replacement storage; calling the text view directly leaves
+    /// tree-sitter state for the old document and highlighting never recovers.
+    func applyRepresentableText(_ newValue: String, controller: TextViewController) {
+        guard !phase.isEditorChangePending else { return }
+        guard newValue != lastSyncedText else { return }
+
+        writebackTask?.cancel()
+        phase.applyRepresentableValue {
+            controller.setText(newValue)
+        }
+        lastSyncedText = newValue
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/CodeSuggestion/SuggestionApplyTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/CodeSuggestion/SuggestionApplyTests.swift
@@ -26,6 +26,54 @@ final class SuggestionApplyTests: XCTestCase {
     }
 
     @MainActor
+    func test_apply_ignoresTriggersFiredByTheInsertionItself() throws {
+        let model = SuggestionViewModel()
+        let textViewController = Mock.textViewController(theme: Mock.theme())
+        let delegate = StubSuggestionDelegate()
+        let item = StubSuggestionEntry(label: "users")
+
+        model.activeTextView = textViewController
+        model.delegate = delegate
+        model.items = [item]
+        model.selectedIndex = 0
+
+        var closeCount = 0
+        delegate.applyHook = { [weak model] in
+            guard let model else { return }
+            XCTAssertTrue(model.isApplyingCompletion)
+            model.cursorsUpdated(
+                textView: textViewController,
+                delegate: delegate,
+                position: CursorPosition(range: NSRange(location: 5, length: 0))
+            ) { closeCount += 1 }
+            model.showCompletions(
+                textView: textViewController,
+                delegate: delegate,
+                cursorPosition: CursorPosition(range: NSRange(location: 5, length: 0))
+            ) { _, _ in }
+        }
+
+        model.applySelectedItem(item: item)
+
+        XCTAssertEqual(closeCount, 0)
+        XCTAssertNil(model.itemsRequestTask)
+        XCTAssertFalse(model.isApplyingCompletion)
+        XCTAssertEqual(model.items.map(\.label), ["users"])
+    }
+
+    @MainActor
+    func test_willClose_notifiesDelegateOnce() throws {
+        let model = SuggestionViewModel()
+        let delegate = StubSuggestionDelegate()
+        model.delegate = delegate
+
+        model.willClose()
+
+        XCTAssertEqual(delegate.didCloseCount, 1)
+        XCTAssertNil(model.delegate)
+    }
+
+    @MainActor
     func test_apply_skipsCallbackWhenActiveTextViewIsNil() throws {
         let model = SuggestionViewModel()
         let delegate = StubSuggestionDelegate()
@@ -78,6 +126,8 @@ final class SuggestionApplyTests: XCTestCase {
 
 private final class StubSuggestionDelegate: CodeSuggestionDelegate {
     var applyCallCount = 0
+    var didCloseCount = 0
+    var applyHook: (@MainActor () -> Void)?
 
     func completionSuggestionsRequested(
         textView: TextViewController,
@@ -94,12 +144,18 @@ private final class StubSuggestionDelegate: CodeSuggestionDelegate {
         nil
     }
 
+    @MainActor
     func completionWindowApplyCompletion(
         item: CodeSuggestionEntry,
         textView: TextViewController,
         cursorPosition: CursorPosition?
     ) {
         applyCallCount += 1
+        applyHook?()
+    }
+
+    func completionWindowDidClose() {
+        didCloseCount += 1
     }
 }
 

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/RepresentableSyncPhaseTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/RepresentableSyncPhaseTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import CodeEditSourceEditor
+
+final class RepresentableSyncPhaseTests: XCTestCase {
+    @MainActor
+    func test_startsIdle() {
+        let phase = RepresentableSyncPhase()
+
+        XCTAssertEqual(phase.phase, .idle)
+        XCTAssertFalse(phase.isEditorChangePending)
+        XCTAssertFalse(phase.isApplyingRepresentableValue)
+    }
+
+    @MainActor
+    func test_markEditorChangeLatchesUntilConsumed() {
+        let phase = RepresentableSyncPhase()
+
+        phase.markEditorChange()
+        phase.markEditorChange()
+
+        XCTAssertTrue(phase.isEditorChangePending)
+        XCTAssertTrue(phase.consumePendingEditorChange())
+        XCTAssertEqual(phase.phase, .idle)
+    }
+
+    @MainActor
+    func test_consumeWithoutPendingChangeReturnsFalse() {
+        let phase = RepresentableSyncPhase()
+
+        XCTAssertFalse(phase.consumePendingEditorChange())
+        XCTAssertEqual(phase.phase, .idle)
+    }
+
+    @MainActor
+    func test_markDuringRepresentableApplicationIsIgnored() {
+        let phase = RepresentableSyncPhase()
+
+        phase.applyRepresentableValue {
+            phase.markEditorChange()
+            XCTAssertTrue(phase.isApplyingRepresentableValue)
+        }
+
+        XCTAssertEqual(phase.phase, .idle)
+        XCTAssertFalse(phase.isEditorChangePending)
+    }
+
+    @MainActor
+    func test_applyRepresentableValueRestoresPriorPhase() {
+        let phase = RepresentableSyncPhase()
+        phase.markEditorChange()
+
+        phase.applyRepresentableValue {
+            XCTAssertTrue(phase.isApplyingRepresentableValue)
+        }
+
+        XCTAssertTrue(phase.isEditorChangePending)
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
@@ -159,6 +159,49 @@ final class SourceEditorBindingSyncTests: XCTestCase {
     }
 
     @MainActor
+    func test_syncRebuildsHighlighterForReplacementStorage() {
+        var bound = "select * from users"
+        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
+        controller.textView.setText("select * from users")
+        controller.setUpHighlighter()
+        let highlighterBefore = controller.highlighter
+        XCTAssertNotNil(highlighterBefore)
+
+        bound = "SELECT\n    *\nFROM\n    users"
+        coordinator.syncBindingText(bound, controller: controller)
+
+        XCTAssertEqual(controller.textView.string, "SELECT\n    *\nFROM\n    users")
+        XCTAssertNotNil(controller.highlighter)
+        XCTAssertNotIdentical(controller.highlighter, highlighterBefore)
+    }
+
+    @MainActor
+    func test_syncQueriesHighlightsForReplacementStorage() {
+        let provider = HighlighterTests.MockHighlightProvider()
+        let providerController = TextViewController(
+            string: "select * from users",
+            language: .html,
+            configuration: Mock.config(),
+            cursorPositions: [],
+            highlightProviders: [provider]
+        )
+        providerController.loadView()
+        providerController.view.frame = NSRect(x: 0, y: 0, width: 1_000, height: 1_000)
+        providerController.view.layoutSubtreeIfNeeded()
+
+        let setUpsBefore = provider.setUpCount
+        let queriesBefore = provider.queryCount
+
+        var bound = "select * from users"
+        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
+        bound = "SELECT\n    *\nFROM\n    users"
+        coordinator.syncBindingText(bound, controller: providerController)
+
+        XCTAssertGreaterThan(provider.setUpCount, setUpsBefore)
+        XCTAssertGreaterThan(provider.queryCount, queriesBefore)
+    }
+
+    @MainActor
     func test_repeatedSyncWithSameValueLeavesTextViewUntouched() {
         var bound = "stable"
         let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorBindingSyncTests.swift
@@ -34,10 +34,10 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         controller.textView.setText("initial")
 
         bound = "updated"
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
 
         XCTAssertEqual(controller.textView.string, "updated")
-        XCTAssertEqual(coordinator.lastSyncedText, "updated")
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, "updated")
     }
 
     @MainActor
@@ -46,10 +46,10 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
         controller.textView.setText("in-flight user edit")
 
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
 
         XCTAssertEqual(controller.textView.string, "in-flight user edit")
-        XCTAssertEqual(coordinator.lastSyncedText, "before edit")
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, "before edit")
     }
 
     @MainActor
@@ -63,8 +63,8 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         )
 
         XCTAssertEqual(bound, "typed text")
-        XCTAssertEqual(coordinator.lastSyncedText, "typed text")
-        XCTAssertTrue(coordinator.isUpdateFromTextView)
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, "typed text")
+        XCTAssertTrue(coordinator.phase.isEditorChangePending)
     }
 
     @MainActor
@@ -73,14 +73,15 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         var setterCallCount = 0
         let coordinator = makeCoordinator(get: { bound }, set: { bound = $0; setterCallCount += 1 })
         controller.textView.setText("stale")
-        coordinator.isUpdatingFromRepresentable = true
 
-        coordinator.textViewDidChangeText(
-            Notification(name: TextView.textDidChangeNotification, object: controller.textView)
-        )
+        coordinator.phase.applyRepresentableValue {
+            coordinator.textViewDidChangeText(
+                Notification(name: TextView.textDidChangeNotification, object: controller.textView)
+            )
+        }
 
         XCTAssertEqual(setterCallCount, 0)
-        XCTAssertFalse(coordinator.isUpdateFromTextView)
+        XCTAssertFalse(coordinator.phase.isEditorChangePending)
         XCTAssertEqual(bound, "external")
     }
 
@@ -96,30 +97,14 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         )
 
         XCTAssertEqual(bound, "")
-        XCTAssertTrue(coordinator.isUpdateFromTextView)
+        XCTAssertTrue(coordinator.phase.isEditorChangePending)
 
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
         XCTAssertEqual(controller.textView.string, largeText)
 
         try await Task.sleep(for: .milliseconds(300))
         XCTAssertEqual(bound, largeText)
-        XCTAssertEqual(coordinator.lastSyncedText, largeText)
-    }
-
-    @MainActor
-    func test_syncShorterTextDropsOutOfBoundsSelection() {
-        var bound = "select * from table"
-        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
-        controller.textView.setText("select * from table")
-        controller.textView.selectionManager.setSelectedRange(NSRange(location: 19, length: 0))
-
-        bound = "ab"
-        coordinator.syncBindingText(bound, controller: controller)
-
-        XCTAssertEqual(controller.textView.string, "ab")
-        for selection in controller.textView.selectionManager.textSelections {
-            XCTAssertLessThanOrEqual(selection.range.max, 2)
-        }
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, largeText)
     }
 
     @MainActor
@@ -132,12 +117,12 @@ final class SourceEditorBindingSyncTests: XCTestCase {
             Notification(name: TextView.textDidChangeNotification, object: controller.textView)
         )
         XCTAssertEqual(bound, "s")
-        XCTAssertTrue(coordinator.isUpdateFromTextView)
+        XCTAssertTrue(coordinator.phase.isEditorChangePending)
 
-        coordinator.syncBindingText("", controller: controller)
+        coordinator.textSync.applyRepresentableText("", controller: controller)
 
         XCTAssertEqual(controller.textView.string, "s")
-        XCTAssertEqual(coordinator.lastSyncedText, "s")
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, "s")
     }
 
     @MainActor
@@ -149,13 +134,13 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         coordinator.textViewDidChangeText(
             Notification(name: TextView.textDidChangeNotification, object: controller.textView)
         )
-        coordinator.isUpdateFromTextView = false
+        coordinator.phase.consumePendingEditorChange()
 
         bound = "SELECT 1"
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
 
         XCTAssertEqual(controller.textView.string, "SELECT 1")
-        XCTAssertEqual(coordinator.lastSyncedText, "SELECT 1")
+        XCTAssertEqual(coordinator.textSync.lastSyncedText, "SELECT 1")
     }
 
     @MainActor
@@ -168,7 +153,7 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         XCTAssertNotNil(highlighterBefore)
 
         bound = "SELECT\n    *\nFROM\n    users"
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
 
         XCTAssertEqual(controller.textView.string, "SELECT\n    *\nFROM\n    users")
         XCTAssertNotNil(controller.highlighter)
@@ -195,10 +180,26 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         var bound = "select * from users"
         let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
         bound = "SELECT\n    *\nFROM\n    users"
-        coordinator.syncBindingText(bound, controller: providerController)
+        coordinator.textSync.applyRepresentableText(bound, controller: providerController)
 
         XCTAssertGreaterThan(provider.setUpCount, setUpsBefore)
         XCTAssertGreaterThan(provider.queryCount, queriesBefore)
+    }
+
+    @MainActor
+    func test_syncShorterTextDropsOutOfBoundsSelection() {
+        var bound = "select * from table"
+        let coordinator = makeCoordinator(get: { bound }, set: { bound = $0 })
+        controller.textView.setText("select * from table")
+        controller.textView.selectionManager.setSelectedRange(NSRange(location: 19, length: 0))
+
+        bound = "ab"
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
+
+        XCTAssertEqual(controller.textView.string, "ab")
+        for selection in controller.textView.selectionManager.textSelections {
+            XCTAssertLessThanOrEqual(selection.range.max, 2)
+        }
     }
 
     @MainActor
@@ -208,7 +209,7 @@ final class SourceEditorBindingSyncTests: XCTestCase {
         controller.textView.setText("stable")
         let storageBefore = controller.textView.textStorage
 
-        coordinator.syncBindingText(bound, controller: controller)
+        coordinator.textSync.applyRepresentableText(bound, controller: controller)
 
         XCTAssertIdentical(controller.textView.textStorage, storageBefore)
         XCTAssertEqual(controller.textView.string, "stable")

--- a/TablePro/Views/Editor/SQLCompletionAdapter.swift
+++ b/TablePro/Views/Editor/SQLCompletionAdapter.swift
@@ -18,12 +18,20 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
 
     // MARK: - Properties
 
+    private struct CompletionSession {
+        enum Phase {
+            case intermediate
+            case final
+        }
+
+        var phase: Phase
+        var context: CompletionContext
+    }
+
     private var completionEngine: CompletionEngine?
     private var favoriteKeywords: [String: (name: String, query: String)] = [:]
-    private var suppressNextCompletion = false
-    private var currentCompletionContext: CompletionContext?
-    private var debounceGeneration: UInt64 = 0
-    private let debounceNanoseconds: UInt64 = 50_000_000  // 50ms
+    private var session: CompletionSession?
+    private let debounceNanoseconds: UInt64 = 50_000_000
 
     // MARK: - Initialization
 
@@ -71,18 +79,13 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
             return nil
         }
 
-        if suppressNextCompletion {
-            suppressNextCompletion = false
+        seedIntermediateSessionIfNeeded(textView: textView, cursorPosition: cursorPosition)
+
+        do {
+            try await Task.sleep(nanoseconds: debounceNanoseconds)
+        } catch {
             return nil
         }
-
-        seedKeywordContextIfNeeded(textView: textView, cursorPosition: cursorPosition)
-
-        // Debounce: wait briefly and check if a newer request arrived
-        debounceGeneration &+= 1
-        let myGeneration = debounceGeneration
-        try? await Task.sleep(nanoseconds: debounceNanoseconds)
-        guard myGeneration == debounceGeneration else { return nil }
 
         let liveCursorPosition = textView.cursorPositions.first ?? cursorPosition
         let nsText = (textView.textView.textStorage?.string ?? "") as NSString
@@ -118,7 +121,7 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         guard let context = await completionEngine.getCompletions(
             text: text,
             cursorPosition: adjustedOffset
-        ) else {
+        ), !Task.isCancelled else {
             return nil
         }
 
@@ -138,13 +141,16 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         }
 
         // Adjust replacement range from window-relative back to document coordinates
-        self.currentCompletionContext = CompletionContext(
-            items: context.items,
-            replacementRange: NSRange(
-                location: context.replacementRange.location + windowStart,
-                length: context.replacementRange.length
-            ),
-            sqlContext: context.sqlContext
+        session = CompletionSession(
+            phase: .final,
+            context: CompletionContext(
+                items: context.items,
+                replacementRange: NSRange(
+                    location: context.replacementRange.location + windowStart,
+                    length: context.replacementRange.length
+                ),
+                sqlContext: context.sqlContext
+            )
         )
 
         let entries: [CodeSuggestionEntry] = context.items.map { item in
@@ -154,8 +160,8 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         return (windowPosition: liveCursorPosition, items: entries)
     }
 
-    private func seedKeywordContextIfNeeded(textView: TextViewController, cursorPosition: CursorPosition) {
-        guard currentCompletionContext == nil, let completionEngine else { return }
+    private func seedIntermediateSessionIfNeeded(textView: TextViewController, cursorPosition: CursorPosition) {
+        guard session == nil, let completionEngine else { return }
 
         let keywordItems = completionEngine.keywordCompletions()
         guard !keywordItems.isEmpty else { return }
@@ -165,17 +171,20 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
               offset >= 0, offset <= nsText.length else { return }
 
         let prefixStart = SQLTokenBoundary.segmentStart(in: nsText, endingAt: offset)
-        currentCompletionContext = CompletionContext(
-            items: keywordItems,
-            replacementRange: NSRange(location: prefixStart, length: offset - prefixStart),
-            sqlContext: SQLContext(
-                clauseType: .unknown,
-                prefix: "",
-                prefixRange: prefixStart..<offset,
-                dotPrefix: nil,
-                tableReferences: [],
-                isInsideString: false,
-                isInsideComment: false
+        session = CompletionSession(
+            phase: .intermediate,
+            context: CompletionContext(
+                items: keywordItems,
+                replacementRange: NSRange(location: prefixStart, length: offset - prefixStart),
+                sqlContext: SQLContext(
+                    clauseType: .unknown,
+                    prefix: "",
+                    prefixRange: prefixStart..<offset,
+                    dotPrefix: nil,
+                    tableReferences: [],
+                    isInsideString: false,
+                    isInsideComment: false
+                )
             )
         )
     }
@@ -184,7 +193,7 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         textView: TextViewController,
         cursorPosition: CursorPosition
     ) -> [CodeSuggestionEntry]? {
-        guard let context = currentCompletionContext,
+        guard let context = session?.context,
               let provider = completionEngine?.provider else { return nil }
 
         let offset = cursorPosition.range.location
@@ -205,15 +214,17 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         return ranked.isEmpty ? nil : ranked.map { SQLSuggestionEntry(item: $0) }
     }
 
+    func completionWindowDidClose() {
+        session = nil
+    }
+
     func completionWindowApplyCompletion(
         item: CodeSuggestionEntry,
         textView: TextViewController,
         cursorPosition: CursorPosition?
     ) {
         guard let entry = item as? SQLSuggestionEntry,
-              let context = currentCompletionContext else { return }
-
-        suppressNextCompletion = true
+              let context = session?.context else { return }
 
         let replaceRange = SQLTokenBoundary.replacementRange(
             in: textView.textView.textStorage?.string as NSString?,


### PR DESCRIPTION
Fixes #1612. Also carries the behavior-neutral refactor of the editor sync and completion state that #1608/#1612 exposed. Replaces #1615.

## Part 1: fix for #1612 (highlighting lost after Format)

Two layers:

1. `syncBindingText` called the TextView-level `textView.setText(...)`, bypassing `TextViewController.setText(_:)`, the documented controller-level path that rebuilds the highlighter for the replacement storage. The old highlighter kept tree-sitter state for the dead document.
2. Rebuilding alone is not enough: a fresh `Highlighter` only queries when triggered (an edit, a frame/bounds notification, or `invalidate()`). Initial load works because the first layout pass fires `frameDidChangeNotification`; after a mid-session storage swap no trigger is guaranteed. `setUpHighlighter()` now ends with `highlighter.invalidate()`, making "after setup, the editor is highlighted" an invariant instead of a timing accident.

Tests: `test_syncRebuildsHighlighterForReplacementStorage`, `test_syncQueriesHighlightsForReplacementStorage` (mock provider proves the rebuilt highlighter is re-set-up AND re-queried; fails with the route-through change alone).

## Part 2: refactor of text binding sync (package)

The coordinator juggled four pieces of implicit state (`isUpdatingFromRepresentable`, `isUpdateFromTextView`, `lastSyncedText`, `textBindingTask`); both recent bugs were interactions between them. Now:

- `RepresentableSyncPhase`: explicit origin state machine (`idle` / `editorChangePending` / `applyingRepresentableValue`). The mutual exclusion the booleans only implied is enforced by construction.
- `TextBindingSync`: single owner of writeback (sync + large-doc debounce) and push-down, carrying the documented invariants (editor wins while its edit is in flight; push-down routes through `TextViewController.setText`).
- Coordinator and `updateNSViewController` shrink to thin delegation.

All 11 binding-sync behavior tests pass unchanged in meaning (retargeted in the same commit), plus 5 new state-machine transition tests.

## Part 3: refactor of completion sessions (package + app)

- `SQLCompletionAdapter` replaces three ad-hoc fields (`currentCompletionContext` that was never cleared, `suppressNextCompletion`, a hand-rolled debounce generation counter) with one `CompletionSession` carrying an explicit phase (`intermediate` keyword seed -> `final` full result), the immediate-sync-then-async-refine shape `NSTextSuggestionsDelegate` documents.
- Debounce dedup now uses cooperative task cancellation; cancelled requests stop at the sleep instead of computing results nobody reads.
- Apply-time trigger suppression moves into `SuggestionViewModel` (`isApplyingCompletion` around the delegate apply call), fixing it for every delegate instead of each adapter keeping its own flag.
- `completionWindowDidClose()` was declared on the delegate protocol but never invoked; `willClose()` now calls it, and the adapter uses it to end the session, so context no longer leaks across popups.

New tests: trigger-during-apply ignored, `willClose` notifies the delegate once. All 6 app autocomplete suites pass (366 cases).

## Manual checks worth doing

Type (popup filters per keystroke), accept with Tab/Return (no flicker after accept), Format (highlighting survives), Clear, JSON viewer session.