### PR TITLE
feat(ai): Sign in with ChatGPT subscription (Codex OAuth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sign in with ChatGPT to power AI chat and inline suggestions from your ChatGPT subscription (Plus, Pro, Business, or Enterprise) without an API key. Existing Codex CLI logins can be imported. (#1617)
 - libSQL / Turso connections can open a local database file: pick Local File mode in the connection form, browse to the file, and work with it offline, transactions included. (#1607)
 
 ### Fixed
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing in the query editor no longer erases characters or drops focus on each keystroke, a timing-dependent bug most visible on macOS 15. (#1608)
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
 - Syntax highlighting no longer disappears after formatting a query. (#1612)
+- The GitHub Copilot provider no longer shows a Max output tokens field it ignores, and picking a Copilot model no longer leaves a stray model ID field behind.
 
 ## [0.49.1] - 2026-06-06
 

--- a/TablePro/Core/AI/AIProvider.swift
+++ b/TablePro/Core/AI/AIProvider.swift
@@ -83,8 +83,8 @@ enum AIProviderError: Error, LocalizedError {
     }
 }
 
-extension ChatTransport {
-    func collectErrorBody(from bytes: URLSession.AsyncBytes) async throws -> String {
+extension AIProvider {
+    static func collectErrorBody(from bytes: URLSession.AsyncBytes) async throws -> String {
         var body = ""
         var truncated = false
         for try await line in bytes.lines {

--- a/TablePro/Core/AI/AnthropicProvider.swift
+++ b/TablePro/Core/AI/AnthropicProvider.swift
@@ -35,45 +35,14 @@ final class AnthropicProvider: ChatTransport {
         turns: [ChatTurnWire],
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task {
-                do {
-                    let request = try buildMessagesRequest(turns: turns, options: options)
-                    let (bytes, response) = try await session.bytes(for: request)
-
-                    guard let httpResponse = response as? HTTPURLResponse else {
-                        throw AIProviderError.networkError("Invalid response")
-                    }
-
-                    guard httpResponse.statusCode == 200 else {
-                        let errorBody = try await collectErrorBody(from: bytes)
-                        throw AIProviderError.mapHTTPError(
-                            statusCode: httpResponse.statusCode,
-                            body: errorBody
-                        )
-                    }
-
-                    var state = AnthropicStreamState()
-                    for try await line in bytes.lines {
-                        if Task.isCancelled { break }
-                        guard let json = Self.decodeStreamLine(line) else { continue }
-                        let events = try Self.parseChunk(json, state: &state)
-                        for event in events { continuation.yield(event) }
-                    }
-                    if let usage = state.finalUsageEvent() {
-                        continuation.yield(usage)
-                    }
-
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
-        }
+        SSEEventStream.make(
+            session: session,
+            buildRequest: { [self] in try buildMessagesRequest(turns: turns, options: options) },
+            decodeLine: { Self.decodeStreamLine($0) },
+            makeState: { AnthropicStreamState() },
+            parse: { try Self.parseChunk($0, state: &$1) },
+            finalEvents: { state in state.finalUsageEvent().map { [$0] } ?? [] }
+        )
     }
 
     func fetchAvailableModels() async throws -> [String] {

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodex.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodex.swift
@@ -1,0 +1,43 @@
+//
+//  ChatGPTCodex.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ChatGPTCodex {
+    static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    static let issuer = "https://auth.openai.com"
+    static let authorizeEndpoint = "\(issuer)/oauth/authorize"
+    static let tokenEndpoint = "\(issuer)/oauth/token"
+    static let revokeEndpoint = "\(issuer)/oauth/revoke"
+    static let redirectPort: UInt16 = 1_455
+    static let redirectURI = "http://localhost:1455/auth/callback"
+    static let scope = "openid profile email offline_access api.connectors.read api.connectors.invoke"
+    static let backendBaseURL = "https://chatgpt.com/backend-api/codex"
+    static let originator = "codex_cli_rs"
+    static let userAgent = "codex_cli_rs/0.1.0"
+    static let authClaimsNamespace = "https://api.openai.com/auth"
+    static let profileClaimsNamespace = "https://api.openai.com/profile"
+    static let curatedModelIDs = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+}
+
+enum ChatGPTCodexBase64URL {
+    static func encode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func decode(_ string: String) -> Data? {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexCLIImporter.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexCLIImporter.swift
@@ -1,0 +1,53 @@
+//
+//  ChatGPTCodexCLIImporter.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ChatGPTCodexCLIImporter {
+    enum ImportError: Error, LocalizedError {
+        case fileNotFound
+        case invalidFormat
+
+        var errorDescription: String? {
+            switch self {
+            case .fileNotFound:
+                return String(localized: "No Codex CLI login found. Run codex login first, then try again.")
+            case .invalidFormat:
+                return String(localized: "The Codex CLI login could not be read.")
+            }
+        }
+    }
+
+    static func loadTokens(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) throws -> ChatGPTCodexTokens {
+        let url = home.appending(path: ".codex/auth.json")
+        guard let data = try? Data(contentsOf: url) else {
+            throw ImportError.fileNotFound
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tokensObject = json["tokens"] as? [String: Any],
+              let accessToken = tokensObject["access_token"] as? String, !accessToken.isEmpty,
+              let idToken = tokensObject["id_token"] as? String else {
+            throw ImportError.invalidFormat
+        }
+        let refreshToken = tokensObject["refresh_token"] as? String ?? ""
+        let claims = try? ChatGPTCodexJWT.decodeClaims(from: idToken)
+        let accountID = tokensObject["account_id"] as? String ?? claims?.accountID ?? ""
+        guard !accountID.isEmpty else {
+            throw ImportError.invalidFormat
+        }
+        let expiresAt = ChatGPTCodexJWT.expiration(from: accessToken) ?? Date()
+        return ChatGPTCodexTokens(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            idToken: idToken,
+            accountID: accountID,
+            email: claims?.email ?? "",
+            planType: claims?.planType,
+            expiresAt: expiresAt
+        )
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexCallbackServer.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexCallbackServer.swift
@@ -1,0 +1,198 @@
+//
+//  ChatGPTCodexCallbackServer.swift
+//  TablePro
+//
+//  Ephemeral loopback HTTP server that captures the OAuth authorization code
+//  redirected to http://localhost:1455/auth/callback during ChatGPT sign-in.
+//
+
+import Foundation
+import Network
+import os
+
+final class ChatGPTCodexCallbackServer: @unchecked Sendable {
+    enum ServerError: Error, LocalizedError {
+        case portInUse
+        case timedOut
+        case stateMismatch
+
+        var errorDescription: String? {
+            switch self {
+            case .portInUse:
+                return String(localized: "Port 1455 is in use. Quit the Codex CLI or another sign-in and try again.")
+            case .timedOut:
+                return String(localized: "Sign-in timed out. Please try again.")
+            case .stateMismatch:
+                return String(localized: "Sign-in could not be verified. Please try again.")
+            }
+        }
+    }
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexCallbackServer")
+    private static let timeout: TimeInterval = 300
+
+    private let expectedState: String
+    private let lock = NSLock()
+    private var listener: NWListener?
+    private var connection: NWConnection?
+    private var readyContinuation: CheckedContinuation<Void, Error>?
+    private var codeContinuation: CheckedContinuation<String, Error>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(expectedState: String) {
+        self.expectedState = expectedState
+    }
+
+    func start() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            lock.withLock { readyContinuation = continuation }
+            do {
+                try startListener()
+            } catch {
+                lock.withLock { readyContinuation = nil }
+                continuation.resume(throwing: ServerError.portInUse)
+            }
+        }
+    }
+
+    func waitForCode() async throws -> String {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            lock.withLock { codeContinuation = continuation }
+            let task = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(Self.timeout * 1_000_000_000))
+                self?.finishCode(.failure(ServerError.timedOut))
+            }
+            lock.withLock { timeoutTask = task }
+        }
+    }
+
+    func stop() {
+        let (task, conn, lst): (Task<Void, Never>?, NWConnection?, NWListener?) = lock.withLock {
+            let values = (timeoutTask, connection, listener)
+            timeoutTask = nil
+            connection = nil
+            listener = nil
+            return values
+        }
+        task?.cancel()
+        conn?.cancel()
+        lst?.cancel()
+    }
+
+    private func startListener() throws {
+        guard let port = NWEndpoint.Port(rawValue: ChatGPTCodex.redirectPort) else {
+            throw ServerError.portInUse
+        }
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: port)
+
+        let listener = try NWListener(using: parameters)
+        lock.withLock { self.listener = listener }
+
+        listener.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.finishReady(.success(()))
+            case .failed(let error):
+                Self.logger.error("Callback listener failed: \(error.localizedDescription, privacy: .public)")
+                self?.finishReady(.failure(ServerError.portInUse))
+                self?.finishCode(.failure(ServerError.portInUse))
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handleConnection(connection)
+        }
+        listener.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func handleConnection(_ newConnection: NWConnection) {
+        lock.withLock { connection = newConnection }
+        newConnection.stateUpdateHandler = { [weak self] state in
+            if case .ready = state {
+                self?.readRequest(from: newConnection)
+            }
+        }
+        newConnection.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func readRequest(from connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16_384) { [weak self] content, _, isComplete, error in
+            guard let self else { return }
+            if error != nil {
+                connection.cancel()
+                return
+            }
+            guard let data = content, let request = String(data: data, encoding: .utf8),
+                  let query = Self.parseCallback(request) else {
+                if isComplete {
+                    connection.cancel()
+                } else {
+                    self.readRequest(from: connection)
+                }
+                return
+            }
+            let matches = query.state == self.expectedState
+            Self.send(html: matches ? Self.successPage : Self.failurePage, to: connection)
+            self.finishCode(matches ? .success(query.code) : .failure(ServerError.stateMismatch))
+        }
+    }
+
+    private func finishReady(_ result: Result<Void, Error>) {
+        let continuation: CheckedContinuation<Void, Error>? = lock.withLock {
+            let pending = readyContinuation
+            readyContinuation = nil
+            return pending
+        }
+        continuation?.resume(with: result)
+    }
+
+    private func finishCode(_ result: Result<String, Error>) {
+        let continuation: CheckedContinuation<String, Error>? = lock.withLock {
+            let pending = codeContinuation
+            codeContinuation = nil
+            return pending
+        }
+        guard let continuation else { return }
+        continuation.resume(with: result)
+        stop()
+    }
+
+    private static func parseCallback(_ request: String) -> (code: String, state: String)? {
+        guard let requestLine = request.components(separatedBy: "\r\n").first,
+              let target = requestLine.components(separatedBy: " ").dropFirst().first,
+              let components = URLComponents(string: "http://127.0.0.1\(target)"),
+              let items = components.queryItems,
+              let code = items.first(where: { $0.name == "code" })?.value,
+              let state = items.first(where: { $0.name == "state" })?.value else {
+            return nil
+        }
+        return (code, state)
+    }
+
+    private static func send(html: String, to connection: NWConnection) {
+        let body = Array(html.utf8)
+        let headers = "HTTP/1.1 200 OK\r\n"
+            + "Content-Type: text/html; charset=utf-8\r\n"
+            + "Content-Length: \(body.count)\r\n"
+            + "Connection: close\r\n\r\n"
+        var response = Data(headers.utf8)
+        response.append(contentsOf: body)
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    private static let successPage = """
+    <!doctype html><html><head><meta charset="utf-8"><title>TablePro</title></head>
+    <body style="font-family:-apple-system,Helvetica,Arial,sans-serif;text-align:center;padding-top:80px">
+    <h2>Signed in to ChatGPT</h2><p>You can return to TablePro.</p></body></html>
+    """
+
+    private static let failurePage = """
+    <!doctype html><html><head><meta charset="utf-8"><title>TablePro</title></head>
+    <body style="font-family:-apple-system,Helvetica,Arial,sans-serif;text-align:center;padding-top:80px">
+    <h2>Sign-in failed</h2><p>Please return to TablePro and try again.</p></body></html>
+    """
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexJWT.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexJWT.swift
@@ -1,0 +1,56 @@
+//
+//  ChatGPTCodexJWT.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ChatGPTCodexJWT {
+    enum DecodeError: Error, LocalizedError {
+        case malformed
+        case invalidPayload
+        case missingAccountID
+
+        var errorDescription: String? {
+            switch self {
+            case .malformed, .invalidPayload:
+                return String(localized: "The ChatGPT sign-in token could not be read.")
+            case .missingAccountID:
+                return String(localized: "The ChatGPT account could not be identified.")
+            }
+        }
+    }
+
+    static func decodeClaims(from idToken: String) throws -> ChatGPTCodexClaims {
+        let payload = try payloadObject(from: idToken)
+        let authClaims = payload[ChatGPTCodex.authClaimsNamespace] as? [String: Any]
+        let profileClaims = payload[ChatGPTCodex.profileClaimsNamespace] as? [String: Any]
+
+        guard let accountID = authClaims?["chatgpt_account_id"] as? String, !accountID.isEmpty else {
+            throw DecodeError.missingAccountID
+        }
+        let email = profileClaims?["email"] as? String
+            ?? payload["email"] as? String
+            ?? ""
+        let planType = authClaims?["chatgpt_plan_type"] as? String
+        return ChatGPTCodexClaims(accountID: accountID, email: email, planType: planType)
+    }
+
+    static func expiration(from token: String) -> Date? {
+        guard let payload = try? payloadObject(from: token),
+              let exp = payload["exp"] as? Double else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: exp)
+    }
+
+    private static func payloadObject(from token: String) throws -> [String: Any] {
+        let segments = token.split(separator: ".")
+        guard segments.count >= 2 else { throw DecodeError.malformed }
+        guard let data = ChatGPTCodexBase64URL.decode(String(segments[1])),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DecodeError.invalidPayload
+        }
+        return payload
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexModels.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexModels.swift
@@ -1,0 +1,39 @@
+//
+//  ChatGPTCodexModels.swift
+//  TablePro
+//
+
+import Foundation
+
+struct ChatGPTCodexTokens: Codable, Equatable, Sendable {
+    var accessToken: String
+    var refreshToken: String
+    var idToken: String
+    var accountID: String
+    var email: String
+    var planType: String?
+    var expiresAt: Date
+
+    static let expirySkew: TimeInterval = 60
+
+    var isExpired: Bool {
+        Date() >= expiresAt.addingTimeInterval(-Self.expirySkew)
+    }
+}
+
+struct ChatGPTCodexClaims: Equatable, Sendable {
+    let accountID: String
+    let email: String
+    let planType: String?
+}
+
+struct ChatGPTCodexTokenResponse: Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let idToken: String
+    let expiresAt: Date
+}
+
+protocol ChatGPTCodexTokenRefreshing: Sendable {
+    func refresh(refreshToken: String) async throws -> ChatGPTCodexTokenResponse
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexOAuthClient.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexOAuthClient.swift
@@ -1,0 +1,136 @@
+//
+//  ChatGPTCodexOAuthClient.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+final class ChatGPTCodexOAuthClient: ChatGPTCodexTokenRefreshing {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexOAuthClient")
+
+    private let session: URLSession
+
+    init(session: URLSession = URLSession(configuration: .ephemeral)) {
+        self.session = session
+    }
+
+    func authorizeURL(pkce: ChatGPTCodexPKCE) -> URL? {
+        var components = URLComponents(string: ChatGPTCodex.authorizeEndpoint)
+        components?.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: ChatGPTCodex.clientID),
+            URLQueryItem(name: "redirect_uri", value: ChatGPTCodex.redirectURI),
+            URLQueryItem(name: "scope", value: ChatGPTCodex.scope),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "id_token_add_organizations", value: "true"),
+            URLQueryItem(name: "originator", value: ChatGPTCodex.originator),
+            URLQueryItem(name: "state", value: pkce.state)
+        ]
+        return components?.url
+    }
+
+    func exchangeCode(code: String, verifier: String) async throws -> ChatGPTCodexTokenResponse {
+        let form = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": ChatGPTCodex.redirectURI,
+            "client_id": ChatGPTCodex.clientID,
+            "code_verifier": verifier
+        ]
+        return try await postToken(form: form, fallbackRefreshToken: "")
+    }
+
+    func refresh(refreshToken: String) async throws -> ChatGPTCodexTokenResponse {
+        let form = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": ChatGPTCodex.clientID,
+            "scope": ChatGPTCodex.scope
+        ]
+        return try await postToken(form: form, fallbackRefreshToken: refreshToken)
+    }
+
+    func revoke(refreshToken: String) async {
+        guard !refreshToken.isEmpty, let url = URL(string: ChatGPTCodex.revokeEndpoint) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formBody([
+            "token": refreshToken,
+            "client_id": ChatGPTCodex.clientID
+        ])
+        _ = try? await session.data(for: request)
+    }
+
+    private func postToken(
+        form: [String: String],
+        fallbackRefreshToken: String
+    ) async throws -> ChatGPTCodexTokenResponse {
+        guard let url = URL(string: ChatGPTCodex.tokenEndpoint) else {
+            throw AIProviderError.invalidEndpoint(ChatGPTCodex.tokenEndpoint)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formBody(form)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            Self.logger.warning("ChatGPT token request failed: \(error.localizedDescription, privacy: .public)")
+            throw AIProviderError.networkError(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AIProviderError.networkError("Invalid response")
+        }
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AIProviderError.mapHTTPError(
+                statusCode: httpResponse.statusCode,
+                body: body,
+                treatForbiddenAsAuthFailure: true
+            )
+        }
+        return try Self.parseTokenResponse(data, fallbackRefreshToken: fallbackRefreshToken)
+    }
+
+    static func parseTokenResponse(
+        _ data: Data,
+        fallbackRefreshToken: String
+    ) throws -> ChatGPTCodexTokenResponse {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String, !accessToken.isEmpty else {
+            throw AIProviderError.authenticationFailed(String(localized: "ChatGPT did not return an access token."))
+        }
+        let idToken = json["id_token"] as? String ?? ""
+        let refreshToken = json["refresh_token"] as? String ?? fallbackRefreshToken
+        let expiresAt = resolveExpiry(json: json, accessToken: accessToken)
+        return ChatGPTCodexTokenResponse(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            idToken: idToken,
+            expiresAt: expiresAt
+        )
+    }
+
+    private static func resolveExpiry(json: [String: Any], accessToken: String) -> Date {
+        if let expiresIn = json["expires_in"] as? Double {
+            return Date().addingTimeInterval(expiresIn)
+        }
+        if let expiration = ChatGPTCodexJWT.expiration(from: accessToken) {
+            return expiration
+        }
+        return Date().addingTimeInterval(3_600)
+    }
+
+    private static func formBody(_ form: [String: String]) -> Data {
+        var components = URLComponents()
+        components.queryItems = form.map { URLQueryItem(name: $0.key, value: $0.value) }
+        return components.percentEncodedQuery?.data(using: .utf8) ?? Data()
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexPKCE.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexPKCE.swift
@@ -1,0 +1,33 @@
+//
+//  ChatGPTCodexPKCE.swift
+//  TablePro
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+struct ChatGPTCodexPKCE: Sendable {
+    let verifier: String
+    let challenge: String
+    let state: String
+
+    init() {
+        let verifier = Self.randomURLSafeString(byteCount: 32)
+        self.verifier = verifier
+        self.state = Self.randomURLSafeString(byteCount: 32)
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        self.challenge = ChatGPTCodexBase64URL.encode(Data(digest))
+    }
+
+    static func randomURLSafeString(byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        if SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes) != errSecSuccess {
+            var generator = SystemRandomNumberGenerator()
+            for index in bytes.indices {
+                bytes[index] = UInt8.random(in: .min ... .max, using: &generator)
+            }
+        }
+        return ChatGPTCodexBase64URL.encode(Data(bytes))
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexProvider.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexProvider.swift
@@ -1,0 +1,124 @@
+//
+//  ChatGPTCodexProvider.swift
+//  TablePro
+//
+
+import Foundation
+
+final class ChatGPTCodexProvider: ChatTransport {
+    static let defaultInstructions = "You are a coding assistant helping with SQL and database tasks."
+
+    private let model: String
+    private let tokenStore: ChatGPTCodexTokenStore
+    private let session: URLSession
+    private let sessionID = UUID().uuidString
+
+    init(
+        model: String,
+        tokenStore: ChatGPTCodexTokenStore = .shared,
+        session: URLSession = URLSession(configuration: .ephemeral)
+    ) {
+        self.model = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.tokenStore = tokenStore
+        self.session = session
+    }
+
+    func streamChat(
+        turns: [ChatTurnWire],
+        options: ChatTransportOptions
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        ResponsesEventStream.make(
+            session: session,
+            treatForbiddenAsAuthFailure: true,
+            buildRequest: { [self] in try await buildRequest(turns: turns, options: options, stream: true) },
+            refreshOnUnauthorized: { [tokenStore] in _ = try await tokenStore.forceRefresh() }
+        )
+    }
+
+    func fetchAvailableModels() async throws -> [String] {
+        ChatGPTCodex.curatedModelIDs
+    }
+
+    func testConnection() async throws -> Bool {
+        let testModel = model.isEmpty ? ChatGPTCodex.curatedModelIDs[0] : model
+        let testOptions = ChatTransportOptions(model: testModel)
+        let testTurn = ChatTurnWire(role: .user, blocks: [.text("Hi")])
+        let request = try await buildRequest(turns: [testTurn], options: testOptions, stream: false)
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { return false }
+        if httpResponse.statusCode == 200 || httpResponse.statusCode == 400 {
+            return true
+        }
+        if httpResponse.statusCode == 401 {
+            throw AIProviderError.authenticationFailed("")
+        }
+        let body = String(data: data, encoding: .utf8) ?? ""
+        throw AIProviderError.mapHTTPError(statusCode: httpResponse.statusCode, body: body)
+    }
+
+    private func buildRequest(
+        turns: [ChatTurnWire],
+        options: ChatTransportOptions,
+        stream: Bool
+    ) async throws -> URLRequest {
+        let accessToken = try await tokenStore.validAccessToken()
+        let accountID = await tokenStore.accountID() ?? ""
+        guard let url = URL(string: "\(ChatGPTCodex.backendBaseURL)/responses") else {
+            throw AIProviderError.invalidEndpoint(ChatGPTCodex.backendBaseURL)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        for (field, value) in Self.requestHeaders(accessToken: accessToken, accountID: accountID, sessionID: sessionID) {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        let body = try Self.requestBody(turns: turns, options: options, stream: stream)
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func requestHeaders(accessToken: String, accountID: String, sessionID: String) -> [String: String] {
+        var headers = [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(accessToken)",
+            "session-id": sessionID,
+            "originator": ChatGPTCodex.originator,
+            "User-Agent": ChatGPTCodex.userAgent
+        ]
+        if !accountID.isEmpty {
+            headers["ChatGPT-Account-ID"] = accountID
+        }
+        return headers
+    }
+
+    static func requestBody(
+        turns: [ChatTurnWire],
+        options: ChatTransportOptions,
+        stream: Bool
+    ) throws -> [String: Any] {
+        var body: [String: Any] = [
+            "model": options.model,
+            "input": try OpenAIResponsesProvider.encodeInput(turns: turns),
+            "store": false,
+            "stream": stream,
+            "instructions": instructions(for: options)
+        ]
+
+        if let effort = options.reasoningEffort {
+            body["reasoning"] = ["effort": effort.openAIWireValue, "summary": "auto"]
+            body["include"] = ["reasoning.encrypted_content"]
+        }
+
+        if !options.tools.isEmpty {
+            body["tools"] = try options.tools.map(OpenAIResponsesProvider.encodeToolSpec(_:))
+        }
+
+        return body
+    }
+
+    private static func instructions(for options: ChatTransportOptions) -> String {
+        if let prompt = options.systemPrompt, !prompt.isEmpty {
+            return prompt
+        }
+        return defaultInstructions
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexService.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexService.swift
@@ -1,0 +1,110 @@
+//
+//  ChatGPTCodexService.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+import os
+
+@MainActor @Observable
+final class ChatGPTCodexService {
+    static let shared = ChatGPTCodexService()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexService")
+
+    enum AuthState: Sendable, Equatable {
+        case signedOut
+        case signingIn
+        case signedIn(email: String, planType: String?)
+
+        var isSignedIn: Bool {
+            if case .signedIn = self { return true }
+            return false
+        }
+    }
+
+    private(set) var authState: AuthState = .signedOut
+    private(set) var errorMessage: String?
+
+    @ObservationIgnored private let tokenStore: ChatGPTCodexTokenStore
+    @ObservationIgnored private let oauthClient: ChatGPTCodexOAuthClient
+
+    init(
+        tokenStore: ChatGPTCodexTokenStore = .shared,
+        oauthClient: ChatGPTCodexOAuthClient = ChatGPTCodexOAuthClient()
+    ) {
+        self.tokenStore = tokenStore
+        self.oauthClient = oauthClient
+    }
+
+    func refreshAuthState() async {
+        if let tokens = await tokenStore.currentTokens() {
+            authState = .signedIn(email: tokens.email, planType: tokens.planType)
+        } else {
+            authState = .signedOut
+        }
+    }
+
+    func signIn() async {
+        errorMessage = nil
+        authState = .signingIn
+
+        let pkce = ChatGPTCodexPKCE()
+        guard let authorizeURL = oauthClient.authorizeURL(pkce: pkce) else {
+            failSignIn(AIProviderError.invalidEndpoint(ChatGPTCodex.authorizeEndpoint))
+            return
+        }
+
+        let server = ChatGPTCodexCallbackServer(expectedState: pkce.state)
+        do {
+            try await server.start()
+            NSWorkspace.shared.open(authorizeURL)
+            let code = try await server.waitForCode()
+            let response = try await oauthClient.exchangeCode(code: code, verifier: pkce.verifier)
+            let claims = try ChatGPTCodexJWT.decodeClaims(from: response.idToken)
+            let tokens = ChatGPTCodexTokens(
+                accessToken: response.accessToken,
+                refreshToken: response.refreshToken,
+                idToken: response.idToken,
+                accountID: claims.accountID,
+                email: claims.email,
+                planType: claims.planType,
+                expiresAt: response.expiresAt
+            )
+            await tokenStore.save(tokens)
+            authState = .signedIn(email: claims.email, planType: claims.planType)
+            Self.logger.info("ChatGPT sign-in succeeded")
+        } catch {
+            server.stop()
+            failSignIn(error)
+        }
+    }
+
+    func importFromCodexCLI() async {
+        errorMessage = nil
+        do {
+            let tokens = try ChatGPTCodexCLIImporter.loadTokens()
+            await tokenStore.save(tokens)
+            authState = .signedIn(email: tokens.email, planType: tokens.planType)
+            Self.logger.info("Imported ChatGPT session from Codex CLI")
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func signOut() async {
+        if let tokens = await tokenStore.currentTokens() {
+            await oauthClient.revoke(refreshToken: tokens.refreshToken)
+        }
+        await tokenStore.clear()
+        authState = .signedOut
+        errorMessage = nil
+    }
+
+    private func failSignIn(_ error: Error) {
+        Self.logger.error("ChatGPT sign-in failed: \(error.localizedDescription, privacy: .public)")
+        errorMessage = error.localizedDescription
+        authState = .signedOut
+    }
+}

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexTokenStore.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexTokenStore.swift
@@ -1,0 +1,127 @@
+//
+//  ChatGPTCodexTokenStore.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+actor ChatGPTCodexTokenStore {
+    static let shared = ChatGPTCodexTokenStore()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexTokenStore")
+    private static let storageKey = "com.TablePro.aioauth.chatgptCodex"
+
+    private let keychain: KeychainStoring
+    private let refresher: ChatGPTCodexTokenRefreshing
+    private var cached: ChatGPTCodexTokens?
+    private var refreshTask: Task<ChatGPTCodexTokens, Error>?
+
+    init(
+        keychain: KeychainStoring = KeychainHelper.shared,
+        refresher: ChatGPTCodexTokenRefreshing = ChatGPTCodexOAuthClient()
+    ) {
+        self.keychain = keychain
+        self.refresher = refresher
+    }
+
+    func currentTokens() -> ChatGPTCodexTokens? {
+        loadTokens()
+    }
+
+    func accountID() -> String? {
+        loadTokens()?.accountID
+    }
+
+    func isSignedIn() -> Bool {
+        loadTokens() != nil
+    }
+
+    func save(_ tokens: ChatGPTCodexTokens) {
+        persist(tokens)
+    }
+
+    func clear() {
+        cached = nil
+        refreshTask?.cancel()
+        refreshTask = nil
+        keychain.delete(forKey: Self.storageKey)
+    }
+
+    func validAccessToken() async throws -> String {
+        guard let tokens = loadTokens() else {
+            throw AIProviderError.authenticationFailed(String(localized: "Not signed in to ChatGPT."))
+        }
+        if !tokens.isExpired {
+            return tokens.accessToken
+        }
+        return try await refresh(using: tokens.refreshToken).accessToken
+    }
+
+    func forceRefresh() async throws -> String {
+        guard let tokens = loadTokens() else {
+            throw AIProviderError.authenticationFailed(String(localized: "Not signed in to ChatGPT."))
+        }
+        return try await refresh(using: tokens.refreshToken).accessToken
+    }
+
+    private func refresh(using refreshToken: String) async throws -> ChatGPTCodexTokens {
+        if let refreshTask {
+            return try await refreshTask.value
+        }
+        let task = Task<ChatGPTCodexTokens, Error> {
+            let response = try await refresher.refresh(refreshToken: refreshToken)
+            return persistRefreshed(response)
+        }
+        refreshTask = task
+        defer { refreshTask = nil }
+        do {
+            return try await task.value
+        } catch {
+            if case AIProviderError.authenticationFailed = error {
+                Self.logger.notice("ChatGPT refresh rejected; clearing stored session")
+                clear()
+            }
+            throw error
+        }
+    }
+
+    private func persistRefreshed(_ response: ChatGPTCodexTokenResponse) -> ChatGPTCodexTokens {
+        let previous = loadTokens()
+        let claims = response.idToken.isEmpty ? nil : try? ChatGPTCodexJWT.decodeClaims(from: response.idToken)
+        let tokens = ChatGPTCodexTokens(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken.isEmpty ? (previous?.refreshToken ?? "") : response.refreshToken,
+            idToken: response.idToken.isEmpty ? (previous?.idToken ?? "") : response.idToken,
+            accountID: claims?.accountID ?? previous?.accountID ?? "",
+            email: claims?.email ?? previous?.email ?? "",
+            planType: claims?.planType ?? previous?.planType,
+            expiresAt: response.expiresAt
+        )
+        persist(tokens)
+        return tokens
+    }
+
+    private func persist(_ tokens: ChatGPTCodexTokens) {
+        cached = tokens
+        guard let data = try? JSONEncoder().encode(tokens),
+              let json = String(data: data, encoding: .utf8) else {
+            Self.logger.error("Failed to encode ChatGPT tokens for Keychain")
+            return
+        }
+        keychain.writeString(json, forKey: Self.storageKey)
+    }
+
+    private func loadTokens() -> ChatGPTCodexTokens? {
+        if let cached {
+            return cached
+        }
+        guard case .found(let json) = keychain.readStringResult(forKey: Self.storageKey),
+              let data = json.data(using: .utf8),
+              let tokens = try? JSONDecoder().decode(ChatGPTCodexTokens.self, from: data) else {
+            return nil
+        }
+        cached = tokens
+        return tokens
+    }
+}

--- a/TablePro/Core/AI/GeminiProvider.swift
+++ b/TablePro/Core/AI/GeminiProvider.swift
@@ -25,50 +25,15 @@ final class GeminiProvider: ChatTransport {
         turns: [ChatTurnWire],
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task {
-                do {
-                    let request = try buildStreamRequest(turns: turns, options: options)
-                    let (bytes, response) = try await session.bytes(for: request)
-
-                    guard let httpResponse = response as? HTTPURLResponse else {
-                        throw AIProviderError.networkError("Invalid response")
-                    }
-
-                    guard httpResponse.statusCode == 200 else {
-                        let errorBody = try await collectErrorBody(from: bytes)
-                        throw AIProviderError.mapHTTPError(
-                            statusCode: httpResponse.statusCode,
-                            body: errorBody,
-                            treatForbiddenAsAuthFailure: true
-                        )
-                    }
-
-                    var state = GeminiStreamState()
-                    for try await line in bytes.lines {
-                        if Task.isCancelled { break }
-                        guard let json = Self.decodeStreamLine(line) else { continue }
-                        let events = Self.parseChunk(
-                            json,
-                            state: &state,
-                            idGenerator: { UUID().uuidString }
-                        )
-                        for event in events { continuation.yield(event) }
-                    }
-                    if let usage = state.finalUsageEvent() {
-                        continuation.yield(usage)
-                    }
-
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
-        }
+        SSEEventStream.make(
+            session: session,
+            treatForbiddenAsAuthFailure: true,
+            buildRequest: { [self] in try buildStreamRequest(turns: turns, options: options) },
+            decodeLine: { Self.decodeStreamLine($0) },
+            makeState: { GeminiStreamState() },
+            parse: { Self.parseChunk($0, state: &$1, idGenerator: { UUID().uuidString }) },
+            finalEvents: { state in state.finalUsageEvent().map { [$0] } ?? [] }
+        )
     }
 
     private static let knownModels = [

--- a/TablePro/Core/AI/OAuthProviderService.swift
+++ b/TablePro/Core/AI/OAuthProviderService.swift
@@ -1,0 +1,67 @@
+//
+//  OAuthProviderService.swift
+//  TablePro
+//
+
+import Foundation
+
+enum OAuthAuthState: Sendable, Equatable {
+    case signedOut
+    case signingIn
+    case signedIn(identity: String)
+
+    var isSignedIn: Bool {
+        if case .signedIn = self { return true }
+        return false
+    }
+}
+
+enum OAuthFlowKind: Sendable, Equatable {
+    case deviceCode
+    case browserRedirect
+}
+
+@MainActor
+protocol OAuthProviderService: AnyObject {
+    var oauthState: OAuthAuthState { get }
+}
+
+enum OAuthProviderRegistry {
+    @MainActor
+    static func service(for type: AIProviderType) -> (any OAuthProviderService)? {
+        switch type {
+        case .copilot:
+            return CopilotService.shared
+        case .chatgptCodex:
+            return ChatGPTCodexService.shared
+        default:
+            return nil
+        }
+    }
+}
+
+extension CopilotService: OAuthProviderService {
+    var oauthState: OAuthAuthState {
+        switch authState {
+        case .signedOut:
+            return .signedOut
+        case .signingIn:
+            return .signingIn
+        case .signedIn(let username):
+            return .signedIn(identity: username)
+        }
+    }
+}
+
+extension ChatGPTCodexService: OAuthProviderService {
+    var oauthState: OAuthAuthState {
+        switch authState {
+        case .signedOut:
+            return .signedOut
+        case .signingIn:
+            return .signingIn
+        case .signedIn(let email, _):
+            return .signedIn(identity: email)
+        }
+    }
+}

--- a/TablePro/Core/AI/OpenAICompatibleProvider.swift
+++ b/TablePro/Core/AI/OpenAICompatibleProvider.swift
@@ -42,52 +42,18 @@ final class OpenAICompatibleProvider: ChatTransport {
         turns: [ChatTurnWire],
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task {
-                do {
-                    let request = try buildChatCompletionRequest(turns: turns, options: options)
-                    let (bytes, response) = try await session.bytes(for: request)
-
-                    guard let httpResponse = response as? HTTPURLResponse else {
-                        throw AIProviderError.networkError("Invalid response")
-                    }
-
-                    guard httpResponse.statusCode == 200 else {
-                        let errorBody = try await collectErrorBody(from: bytes)
-                        throw AIProviderError.mapHTTPError(
-                            statusCode: httpResponse.statusCode,
-                            body: errorBody
-                        )
-                    }
-
-                    var state = OpenAIStreamState()
-                    for try await line in bytes.lines {
-                        if Task.isCancelled { break }
-                        guard let json = Self.decodeStreamLine(line, providerType: self.providerType) else {
-                            if line == "data: [DONE]" { break }
-                            continue
-                        }
-                        let result = Self.parseChunk(json, state: &state)
-                        for event in result.events { continuation.yield(event) }
-                        if result.shouldBreak { break }
-                    }
-                    if let reasoningEnd = state.flushReasoningEnd() {
-                        continuation.yield(reasoningEnd)
-                    }
-                    if let usage = state.finalUsageEvent() {
-                        continuation.yield(usage)
-                    }
-
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
+        let providerType = self.providerType
+        return SSEEventStream.make(
+            session: session,
+            buildRequest: { [self] in try buildChatCompletionRequest(turns: turns, options: options) },
+            decodeLine: { Self.decodeStreamLine($0, providerType: providerType) },
+            makeState: { OpenAIStreamState() },
+            parse: { Self.parseChunk($0, state: &$1).events },
+            finalEvents: { state in
+                var state = state
+                return [state.flushReasoningEnd(), state.finalUsageEvent()].compactMap { $0 }
             }
-
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
-        }
+        )
     }
 
     static func decodeStreamLine(_ line: String, providerType: AIProviderType) -> [String: Any]? {

--- a/TablePro/Core/AI/OpenAIResponsesProvider.swift
+++ b/TablePro/Core/AI/OpenAIResponsesProvider.swift
@@ -33,43 +33,10 @@ final class OpenAIResponsesProvider: ChatTransport {
         turns: [ChatTurnWire],
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task {
-                do {
-                    let request = try buildRequest(turns: turns, options: options, stream: true)
-                    let (bytes, response) = try await session.bytes(for: request)
-
-                    guard let httpResponse = response as? HTTPURLResponse else {
-                        throw AIProviderError.networkError("Invalid response")
-                    }
-                    guard httpResponse.statusCode == 200 else {
-                        let errorBody = try await collectErrorBody(from: bytes)
-                        throw AIProviderError.mapHTTPError(
-                            statusCode: httpResponse.statusCode,
-                            body: errorBody
-                        )
-                    }
-
-                    var state = ResponsesStreamState()
-                    for try await line in bytes.lines {
-                        if Task.isCancelled { break }
-                        guard let json = Self.decodeStreamLine(line) else { continue }
-                        let events = try Self.parseEvent(json, state: &state)
-                        for event in events { continuation.yield(event) }
-                    }
-                    if let usage = state.finalUsageEvent() {
-                        continuation.yield(usage)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
-        }
+        ResponsesEventStream.make(
+            session: session,
+            buildRequest: { [self] in try buildRequest(turns: turns, options: options, stream: true) }
+        )
     }
 
     func fetchAvailableModels() async throws -> [String] {
@@ -189,6 +156,7 @@ final class OpenAIResponsesProvider: ChatTransport {
                     items.append([
                         "type": "reasoning",
                         "id": opaque.itemID,
+                        "summary": [Any](),
                         "encrypted_content": opaque.value
                     ])
                 case .text(let text):
@@ -347,6 +315,10 @@ final class OpenAIResponsesProvider: ChatTransport {
             case "function_call":
                 guard let callID = item["call_id"] as? String,
                       state.openFunctionCallIDs.remove(callID) != nil else { return [] }
+                if !state.functionCallArgDeltaIDs.contains(callID),
+                   let arguments = item["arguments"] as? String, !arguments.isEmpty {
+                    return [.toolUseDelta(id: callID, inputJSONDelta: arguments), .toolUseEnd(id: callID)]
+                }
                 return [.toolUseEnd(id: callID)]
             default:
                 return []
@@ -354,6 +326,7 @@ final class OpenAIResponsesProvider: ChatTransport {
         case "response.function_call_arguments.delta":
             guard let callID = json["call_id"] as? String ?? json["item_id"] as? String,
                   let delta = json["delta"] as? String, !delta.isEmpty else { return [] }
+            state.functionCallArgDeltaIDs.insert(callID)
             return [.toolUseDelta(id: callID, inputJSONDelta: delta)]
         case "response.refusal.delta":
             if let delta = json["delta"] as? String, !delta.isEmpty {
@@ -392,6 +365,7 @@ struct ResponsesStreamState {
     var outputTokens: Int = 0
     var openReasoningItemIDs: Set<String> = []
     var openFunctionCallIDs: Set<String> = []
+    var functionCallArgDeltaIDs: Set<String> = []
 
     func finalUsageEvent() -> ChatStreamEvent? {
         guard inputTokens > 0 || outputTokens > 0 else { return nil }

--- a/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
+++ b/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
@@ -6,13 +6,17 @@
 import Foundation
 
 struct AIProviderCapabilities: OptionSet, Sendable {
-    let rawValue: UInt8
+    let rawValue: UInt16
 
     static let chat = AIProviderCapabilities(rawValue: 1 << 0)
     static let inline = AIProviderCapabilities(rawValue: 1 << 1)
     static let models = AIProviderCapabilities(rawValue: 1 << 2)
     static let reasoning = AIProviderCapabilities(rawValue: 1 << 3)
     static let images = AIProviderCapabilities(rawValue: 1 << 4)
+    static let endpointConfigurable = AIProviderCapabilities(rawValue: 1 << 5)
+    static let nameConfigurable = AIProviderCapabilities(rawValue: 1 << 6)
+    static let maxOutputTokens = AIProviderCapabilities(rawValue: 1 << 7)
+    static let modelListFetchable = AIProviderCapabilities(rawValue: 1 << 8)
 }
 
 struct CuratedModel: Sendable, Identifiable, Equatable {
@@ -42,10 +46,17 @@ struct AIProviderDescriptor: Sendable {
     let capabilities: AIProviderCapabilities
     let symbolName: String
     let curatedModels: [CuratedModel]
+    let showsTelemetryToggle: Bool
+    let defaultTelemetryEnabled: Bool
+    let oauthFlowKind: OAuthFlowKind?
     let makeProvider: @Sendable (AIProviderConfig, String?) -> ChatTransport
 
     var supportsReasoning: Bool { capabilities.contains(.reasoning) }
     var supportsImages: Bool { capabilities.contains(.images) }
+    var allowsEndpointConfiguration: Bool { capabilities.contains(.endpointConfigurable) }
+    var allowsNameConfiguration: Bool { capabilities.contains(.nameConfigurable) }
+    var allowsMaxOutputTokens: Bool { capabilities.contains(.maxOutputTokens) }
+    var fetchesModelList: Bool { capabilities.contains(.modelListFetchable) }
 
     func curatedModel(forID id: String) -> CuratedModel? {
         curatedModels.first(where: { $0.id == id })
@@ -67,6 +78,9 @@ struct AIProviderDescriptor: Sendable {
         capabilities: AIProviderCapabilities,
         symbolName: String,
         curatedModels: [CuratedModel] = [],
+        showsTelemetryToggle: Bool = false,
+        defaultTelemetryEnabled: Bool = false,
+        oauthFlowKind: OAuthFlowKind? = nil,
         makeProvider: @escaping @Sendable (AIProviderConfig, String?) -> ChatTransport
     ) {
         self.typeID = typeID
@@ -76,6 +90,9 @@ struct AIProviderDescriptor: Sendable {
         self.capabilities = capabilities
         self.symbolName = symbolName
         self.curatedModels = curatedModels
+        self.showsTelemetryToggle = showsTelemetryToggle
+        self.defaultTelemetryEnabled = defaultTelemetryEnabled
+        self.oauthFlowKind = oauthFlowKind
         self.makeProvider = makeProvider
     }
 }

--- a/TablePro/Core/AI/Registry/AIProviderRegistration.swift
+++ b/TablePro/Core/AI/Registry/AIProviderRegistration.swift
@@ -14,7 +14,7 @@ enum AIProviderRegistration {
             displayName: "Claude",
             defaultEndpoint: "https://api.anthropic.com",
             requiresAPIKey: true,
-            capabilities: [.chat, .models, .reasoning, .images],
+            capabilities: [.chat, .models, .reasoning, .images, .endpointConfigurable, .maxOutputTokens, .modelListFetchable],
             symbolName: "brain",
             curatedModels: claudeCuratedModels,
             makeProvider: { config, apiKey in
@@ -35,7 +35,7 @@ enum AIProviderRegistration {
             displayName: "Gemini",
             defaultEndpoint: "https://generativelanguage.googleapis.com",
             requiresAPIKey: true,
-            capabilities: [.chat, .models],
+            capabilities: [.chat, .models, .endpointConfigurable, .maxOutputTokens, .modelListFetchable],
             symbolName: "wand.and.stars",
             makeProvider: { config, apiKey in
                 GeminiProvider(
@@ -51,7 +51,7 @@ enum AIProviderRegistration {
             displayName: AIProviderType.openAI.displayName,
             defaultEndpoint: AIProviderType.openAI.defaultEndpoint,
             requiresAPIKey: true,
-            capabilities: [.chat, .models, .reasoning, .images],
+            capabilities: [.chat, .models, .reasoning, .images, .endpointConfigurable, .maxOutputTokens, .modelListFetchable],
             symbolName: iconForType(.openAI),
             curatedModels: openAICuratedModels,
             makeProvider: { config, apiKey in
@@ -65,12 +65,18 @@ enum AIProviderRegistration {
         ))
 
         for type in [AIProviderType.openRouter, .openCode, .ollama, .custom] {
+            var capabilities: AIProviderCapabilities = [
+                .chat, .models, .endpointConfigurable, .maxOutputTokens, .modelListFetchable
+            ]
+            if type == .custom {
+                capabilities.insert(.nameConfigurable)
+            }
             registry.register(AIProviderDescriptor(
                 typeID: type.rawValue,
                 displayName: type.displayName,
                 defaultEndpoint: type.defaultEndpoint,
                 requiresAPIKey: type.authStyle == .apiKey,
-                capabilities: [.chat, .models],
+                capabilities: capabilities,
                 symbolName: iconForType(type),
                 makeProvider: { config, apiKey in
                     OpenAICompatibleProvider(
@@ -89,11 +95,49 @@ enum AIProviderRegistration {
             displayName: "GitHub Copilot",
             defaultEndpoint: "",
             requiresAPIKey: false,
-            capabilities: [.chat, .models],
+            capabilities: [.chat, .models, .modelListFetchable],
             symbolName: AIProviderType.copilot.symbolName,
+            showsTelemetryToggle: true,
+            defaultTelemetryEnabled: true,
+            oauthFlowKind: .deviceCode,
             makeProvider: { _, _ in CopilotChatProvider() }
         ))
+
+        registry.register(AIProviderDescriptor(
+            typeID: AIProviderType.chatgptCodex.rawValue,
+            displayName: AIProviderType.chatgptCodex.displayName,
+            defaultEndpoint: "",
+            requiresAPIKey: false,
+            capabilities: [.chat, .inline, .models, .reasoning],
+            symbolName: AIProviderType.chatgptCodex.symbolName,
+            curatedModels: chatGPTCodexCuratedModels,
+            oauthFlowKind: .browserRedirect,
+            makeProvider: { config, _ in
+                ChatGPTCodexProvider(model: config.model)
+            }
+        ))
     }
+
+    private static let chatGPTCodexCuratedModels: [CuratedModel] = [
+        CuratedModel(
+            id: "gpt-5.5",
+            displayName: "GPT-5.5",
+            supportedEffortLevels: ReasoningEffort.allCases,
+            defaultEffort: .medium
+        ),
+        CuratedModel(
+            id: "gpt-5.4",
+            displayName: "GPT-5.4",
+            supportedEffortLevels: [.low, .medium, .high],
+            defaultEffort: .medium
+        ),
+        CuratedModel(
+            id: "gpt-5.4-mini",
+            displayName: "GPT-5.4 Mini",
+            supportedEffortLevels: ReasoningEffort.allCases,
+            defaultEffort: .medium
+        )
+    ]
 
     private static let openAICuratedModels: [CuratedModel] = [
         CuratedModel(

--- a/TablePro/Core/AI/ResponsesEventStream.swift
+++ b/TablePro/Core/AI/ResponsesEventStream.swift
@@ -1,0 +1,26 @@
+//
+//  ResponsesEventStream.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ResponsesEventStream {
+    static func make(
+        session: URLSession,
+        treatForbiddenAsAuthFailure: Bool = false,
+        buildRequest: @escaping @Sendable () async throws -> URLRequest,
+        refreshOnUnauthorized: (@Sendable () async throws -> Void)? = nil
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        SSEEventStream.make(
+            session: session,
+            treatForbiddenAsAuthFailure: treatForbiddenAsAuthFailure,
+            buildRequest: buildRequest,
+            decodeLine: { OpenAIResponsesProvider.decodeStreamLine($0) },
+            makeState: { ResponsesStreamState() },
+            parse: { try OpenAIResponsesProvider.parseEvent($0, state: &$1) },
+            finalEvents: { state in state.finalUsageEvent().map { [$0] } ?? [] },
+            refreshOnUnauthorized: refreshOnUnauthorized
+        )
+    }
+}

--- a/TablePro/Core/AI/SSEEventStream.swift
+++ b/TablePro/Core/AI/SSEEventStream.swift
@@ -1,0 +1,62 @@
+//
+//  SSEEventStream.swift
+//  TablePro
+//
+
+import Foundation
+
+enum SSEEventStream {
+    static func make<State>(
+        session: URLSession,
+        treatForbiddenAsAuthFailure: Bool = false,
+        buildRequest: @escaping @Sendable () async throws -> URLRequest,
+        decodeLine: @escaping @Sendable (String) -> [String: Any]?,
+        makeState: @escaping @Sendable () -> State,
+        parse: @escaping @Sendable ([String: Any], inout State) throws -> [ChatStreamEvent],
+        finalEvents: @escaping @Sendable (State) -> [ChatStreamEvent] = { _ in [] },
+        refreshOnUnauthorized: (@Sendable () async throws -> Void)? = nil
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var (bytes, response) = try await session.bytes(for: buildRequest())
+                    if (response as? HTTPURLResponse)?.statusCode == 401,
+                       let refreshOnUnauthorized {
+                        try await refreshOnUnauthorized()
+                        (bytes, response) = try await session.bytes(for: buildRequest())
+                    }
+
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw AIProviderError.networkError("Invalid response")
+                    }
+                    guard httpResponse.statusCode == 200 else {
+                        let body = try await AIProvider.collectErrorBody(from: bytes)
+                        throw AIProviderError.mapHTTPError(
+                            statusCode: httpResponse.statusCode,
+                            body: body,
+                            treatForbiddenAsAuthFailure: treatForbiddenAsAuthFailure
+                        )
+                    }
+
+                    var state = makeState()
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+                        guard let json = decodeLine(line) else { continue }
+                        let events = try parse(json, &state)
+                        for event in events { continuation.yield(event) }
+                    }
+                    for final in finalEvents(state) {
+                        continuation.yield(final)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}

--- a/TablePro/Models/AI/AIModels.swift
+++ b/TablePro/Models/AI/AIModels.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
     case copilot
+    case chatgptCodex
     case claude
     case openAI
     case openRouter
@@ -21,27 +22,29 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
 
     var displayName: String {
         switch self {
-        case .copilot:    return "GitHub Copilot"
-        case .claude:     return "Claude"
-        case .openAI:     return "OpenAI"
-        case .openRouter: return "OpenRouter"
-        case .gemini:     return "Gemini"
-        case .ollama:     return "Ollama"
-        case .openCode:   return "OpenCode Zen"
-        case .custom:     return String(localized: "Custom")
+        case .copilot:      return "GitHub Copilot"
+        case .chatgptCodex: return "ChatGPT"
+        case .claude:       return "Claude"
+        case .openAI:       return "OpenAI"
+        case .openRouter:   return "OpenRouter"
+        case .gemini:       return "Gemini"
+        case .ollama:       return "Ollama"
+        case .openCode:     return "OpenCode Zen"
+        case .custom:       return String(localized: "Custom")
         }
     }
 
     var defaultEndpoint: String {
         switch self {
-        case .copilot:    return ""
-        case .claude:     return "https://api.anthropic.com"
-        case .openAI:     return "https://api.openai.com"
-        case .openRouter: return "https://openrouter.ai/api"
-        case .gemini:     return "https://generativelanguage.googleapis.com"
-        case .ollama:     return "http://localhost:11434"
-        case .openCode:   return "https://opencode.ai/zen"
-        case .custom:     return ""
+        case .copilot:      return ""
+        case .chatgptCodex: return ""
+        case .claude:       return "https://api.anthropic.com"
+        case .openAI:       return "https://api.openai.com"
+        case .openRouter:   return "https://openrouter.ai/api"
+        case .gemini:       return "https://generativelanguage.googleapis.com"
+        case .ollama:       return "http://localhost:11434"
+        case .openCode:     return "https://opencode.ai/zen"
+        case .custom:       return ""
         }
     }
 
@@ -53,23 +56,25 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
 
     var authStyle: AuthStyle {
         switch self {
-        case .copilot:  return .oauth
-        case .ollama:   return .none
-        case .openCode: return .optionalApiKey
-        default:        return .apiKey
+        case .copilot:      return .oauth
+        case .chatgptCodex: return .oauth
+        case .ollama:       return .none
+        case .openCode:     return .optionalApiKey
+        default:            return .apiKey
         }
     }
 
     var symbolName: String {
         switch self {
-        case .copilot:    return "chevron.left.forwardslash.chevron.right"
-        case .claude:     return "brain"
-        case .openAI:     return "cpu"
-        case .openRouter: return "globe"
-        case .gemini:     return "wand.and.stars"
-        case .ollama:     return "desktopcomputer"
-        case .openCode:   return "sparkles"
-        case .custom:     return "server.rack"
+        case .copilot:      return "chevron.left.forwardslash.chevron.right"
+        case .chatgptCodex: return "bubble.left.and.bubble.right"
+        case .claude:       return "brain"
+        case .openAI:       return "cpu"
+        case .openRouter:   return "globe"
+        case .gemini:       return "wand.and.stars"
+        case .ollama:       return "desktopcomputer"
+        case .openCode:     return "sparkles"
+        case .custom:       return "server.rack"
         }
     }
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -4466,6 +4466,9 @@
         }
       }
     },
+    "Access uses your ChatGPT subscription (Plus, Pro, Business, or Enterprise) and follows OpenAI's terms. This is an unofficial interface that may change." : {
+
+    },
     "Account" : {
       "localizations" : {
         "tr" : {
@@ -10965,6 +10968,9 @@
           }
         }
       }
+    },
+    "ChatGPT did not return an access token." : {
+
     },
     "Check for Updates..." : {
       "localizations" : {
@@ -30306,6 +30312,9 @@
         }
       }
     },
+    "Import from Codex CLI" : {
+
+    },
     "Import from DDL" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -38652,6 +38661,9 @@
         }
       }
     },
+    "No Codex CLI login found. Run codex login first, then try again." : {
+
+    },
     "No Columns Defined" : {
       "localizations" : {
         "tr" : {
@@ -40637,6 +40649,9 @@
         }
       }
     },
+    "Not signed in to ChatGPT." : {
+
+    },
     "Not signed in to GitHub Copilot" : {
       "localizations" : {
         "tr" : {
@@ -42103,6 +42118,9 @@
           }
         }
       }
+    },
+    "Opening your browser to sign in…" : {
+
     },
     "Operation cancelled by user" : {
       "localizations" : {
@@ -43877,6 +43895,9 @@
         }
       }
     },
+    "Plan: %@" : {
+
+    },
     "Planning: %.3fms" : {
       "localizations" : {
         "tr" : {
@@ -44478,6 +44499,9 @@
           }
         }
       }
+    },
+    "Port 1455 is in use. Quit the Codex CLI or another sign-in and try again." : {
+
     },
     "Port is already in use. Try a different port or close the other process." : {
       "localizations" : {
@@ -54816,6 +54840,9 @@
         }
       }
     },
+    "Sign in to use your ChatGPT subscription" : {
+
+    },
     "Sign In with Browser..." : {
       "localizations" : {
         "tr" : {
@@ -54837,6 +54864,9 @@
           }
         }
       }
+    },
+    "Sign in with ChatGPT" : {
+
     },
     "Sign in with GitHub" : {
       "localizations" : {
@@ -54904,6 +54934,9 @@
         }
       }
     },
+    "Sign-in could not be verified. Please try again." : {
+
+    },
     "Sign-in timed out" : {
       "localizations" : {
         "tr" : {
@@ -54925,6 +54958,12 @@
           }
         }
       }
+    },
+    "Sign-in timed out. Please try again." : {
+
+    },
+    "Signed in" : {
+
     },
     "Signed In" : {
       "localizations" : {
@@ -59774,6 +59813,12 @@
         }
       }
     },
+    "The ChatGPT account could not be identified." : {
+
+    },
+    "The ChatGPT sign-in token could not be read." : {
+
+    },
     "The Cloudflare tunnel did not become ready in time: %@" : {
       "localizations" : {
         "tr" : {
@@ -59861,6 +59906,9 @@
           }
         }
       }
+    },
+    "The Codex CLI login could not be read." : {
+
     },
     "The destructive query to execute" : {
       "localizations" : {

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -27,6 +27,8 @@ struct AIProviderDetailSheet: View {
     @State private var copilotService = CopilotService.shared
     @State private var copilotErrorMessage: String?
 
+    @State private var chatGPTCodexService = ChatGPTCodexService.shared
+
     @State private var showRemoveConfirmation = false
 
     enum TestResult: Equatable {
@@ -82,9 +84,16 @@ struct AIProviderDetailSheet: View {
             }
             .onAppear {
                 if draft.type == .copilot {
-                    Task { await ensureCopilotRunning() }
+                    Task {
+                        await ensureCopilotRunning()
+                        fetchModels()
+                    }
+                } else {
+                    if draft.type == .chatgptCodex {
+                        Task { await chatGPTCodexService.refreshAuthState() }
+                    }
+                    fetchModels()
                 }
-                fetchModels()
             }
             .onDisappear {
                 cancelTasks()
@@ -135,7 +144,14 @@ struct AIProviderDetailSheet: View {
         case .apiKey, .optionalApiKey:
             apiKeyAuthSection
         case .oauth:
-            copilotAuthSection
+            switch descriptor?.oauthFlowKind {
+            case .deviceCode:
+                copilotAuthSection
+            case .browserRedirect:
+                chatGPTCodexAuthSection
+            case .none:
+                EmptyView()
+            }
         case .none:
             EmptyView()
         }
@@ -244,6 +260,78 @@ struct AIProviderDetailSheet: View {
         }
     }
 
+    private var chatGPTCodexAuthSection: some View {
+        Section {
+            switch chatGPTCodexService.authState {
+            case .signedOut:
+                chatGPTCodexSignInRows
+
+            case .signingIn:
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Opening your browser to sign in…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+            case .signedIn(let email, let planType):
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Label(chatGPTCodexSignedInLabel(email: email), systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Spacer()
+                        Button(String(localized: "Sign Out")) {
+                            Task { await chatGPTCodexService.signOut() }
+                        }
+                    }
+                    if let planType, !planType.isEmpty {
+                        Text(String(format: String(localized: "Plan: %@"), planType))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let message = chatGPTCodexService.errorMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(3)
+            }
+        } header: {
+            Text("Account")
+        } footer: {
+            Text("Access uses your ChatGPT subscription (Plus, Pro, Business, or Enterprise) and follows OpenAI's terms. This is an unofficial interface that may change.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var chatGPTCodexSignInRows: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Sign in to use your ChatGPT subscription")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button(String(localized: "Sign in with ChatGPT")) {
+                    Task { await chatGPTCodexService.signIn() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Button(String(localized: "Import from Codex CLI")) {
+                Task { await chatGPTCodexService.importFromCodexCLI() }
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+        }
+    }
+
+    private func chatGPTCodexSignedInLabel(email: String) -> String {
+        email.isEmpty
+            ? String(localized: "Signed in")
+            : String(format: String(localized: "Signed in as %@"), email)
+    }
+
     @ViewBuilder
     private var statusRow: some View {
         switch copilotService.status {
@@ -274,10 +362,10 @@ struct AIProviderDetailSheet: View {
     private var connectionSection: some View {
         if shouldShowConnectionSection {
             Section {
-                if draft.type == .custom {
+                if allowsNameField {
                     TextField(String(localized: "Name"), text: $draft.name)
                 }
-                if draft.type != .copilot {
+                if allowsEndpointField {
                     TextField(String(localized: "Endpoint"), text: $draft.endpoint)
                         .onChange(of: draft.endpoint) {
                             scheduleFetchModels()
@@ -290,8 +378,16 @@ struct AIProviderDetailSheet: View {
         }
     }
 
+    private var allowsNameField: Bool {
+        descriptor?.allowsNameConfiguration == true
+    }
+
+    private var allowsEndpointField: Bool {
+        descriptor?.allowsEndpointConfiguration == true
+    }
+
     private var shouldShowConnectionSection: Bool {
-        draft.type != .copilot
+        allowsNameField || allowsEndpointField
     }
 
     // MARK: - Model
@@ -315,6 +411,7 @@ struct AIProviderDetailSheet: View {
 
     private var isCustomModel: Bool {
         !curatedModels.contains(where: { $0.id == draft.model })
+            && !fetchedModels.contains(draft.model)
     }
 
     private var modelSection: some View {
@@ -436,21 +533,34 @@ struct AIProviderDetailSheet: View {
 
     // MARK: - Advanced
 
+    @ViewBuilder
     private var advancedSection: some View {
-        Section {
-            HStack {
-                Text("Max output tokens")
-                Spacer()
-                TextField("", text: maxOutputTokensBinding)
-                    .frame(width: 100)
-                    .multilineTextAlignment(.trailing)
+        if showsMaxOutputTokens || showsTelemetryToggle {
+            Section {
+                if showsMaxOutputTokens {
+                    HStack {
+                        Text("Max output tokens")
+                        Spacer()
+                        TextField("", text: maxOutputTokensBinding)
+                            .frame(width: 100)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
+                if showsTelemetryToggle {
+                    Toggle("Send telemetry to GitHub", isOn: $draft.telemetryEnabled)
+                }
+            } header: {
+                Text("Advanced")
             }
-            if draft.type == .copilot {
-                Toggle("Send telemetry to GitHub", isOn: $draft.telemetryEnabled)
-            }
-        } header: {
-            Text("Advanced")
         }
+    }
+
+    private var showsMaxOutputTokens: Bool {
+        descriptor?.allowsMaxOutputTokens == true
+    }
+
+    private var showsTelemetryToggle: Bool {
+        descriptor?.showsTelemetryToggle == true
     }
 
     private var maxOutputTokensBinding: Binding<String> {
@@ -526,6 +636,14 @@ struct AIProviderDetailSheet: View {
     }
 
     private func fetchModels() {
+        guard descriptor?.fetchesModelList == true else {
+            fetchedModels = []
+            modelFetchError = nil
+            if draft.model.isEmpty, let first = curatedModels.first {
+                draft.model = first.id
+            }
+            return
+        }
         if draft.type.authStyle == .apiKey,
            apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             fetchedModels = []

--- a/TablePro/Views/Settings/AISettingsView.swift
+++ b/TablePro/Views/Settings/AISettingsView.swift
@@ -14,7 +14,7 @@ struct AISettingsView: View {
     @State private var editingProviderID: UUID?
     @State private var addingProviderType: AIProviderType?
     @State private var pendingDeleteID: UUID?
-    @State private var copilotService = CopilotService.shared
+    @State private var chatGPTCodexService = ChatGPTCodexService.shared
     @State private var providersWithKey: Set<UUID> = []
 
     var body: some View {
@@ -31,6 +31,7 @@ struct AISettingsView: View {
         }
         .formStyle(.grouped)
         .task { refreshKeyAvailability() }
+        .task { await chatGPTCodexService.refreshAuthState() }
         .onChange(of: settings.providers.map(\.id)) {
             refreshKeyAvailability()
         }
@@ -213,7 +214,9 @@ struct AISettingsView: View {
     }
 
     private var orderedAddableTypes: [AIProviderType] {
-        [.copilot, .claude, .openAI, .openRouter, .openCode, .gemini, .ollama]
+        AIProviderType.allCases.filter { type in
+            type != .custom && AIProviderRegistry.shared.descriptor(for: type.rawValue) != nil
+        }
     }
 
     // MARK: - Inline Suggestions
@@ -311,7 +314,7 @@ struct AISettingsView: View {
     private func statusText(for provider: AIProviderConfig) -> String {
         switch provider.type.authStyle {
         case .oauth:
-            return copilotStatusText()
+            return oauthStatusText(for: provider.type)
         case .apiKey, .optionalApiKey:
             if provider.type == .custom {
                 return customStatusText(for: provider)
@@ -333,10 +336,12 @@ struct AISettingsView: View {
         }
     }
 
-    private func copilotStatusText() -> String {
-        switch copilotService.authState {
-        case .signedIn(let username):
-            return String(format: String(localized: "Signed in as %@"), username)
+    private func oauthStatusText(for type: AIProviderType) -> String {
+        switch OAuthProviderRegistry.service(for: type)?.oauthState ?? .signedOut {
+        case .signedIn(let identity):
+            return identity.isEmpty
+                ? String(localized: "Signed in")
+                : String(format: String(localized: "Signed in as %@"), identity)
         case .signingIn:
             return String(localized: "Signing in…")
         case .signedOut:
@@ -367,14 +372,15 @@ struct AISettingsView: View {
     // MARK: - Mutations
 
     private func makeNewProvider(type: AIProviderType) -> AIProviderConfig {
-        AIProviderConfig(
+        let descriptor = AIProviderRegistry.shared.descriptor(for: type.rawValue)
+        return AIProviderConfig(
             id: UUID(),
             name: "",
             type: type,
             model: "",
             endpoint: type.defaultEndpoint,
             maxOutputTokens: nil,
-            telemetryEnabled: type == .copilot ? true : false
+            telemetryEnabled: descriptor?.defaultTelemetryEnabled ?? false
         )
     }
 

--- a/TableProTests/Core/AI/AIProviderCapabilitiesTests.swift
+++ b/TableProTests/Core/AI/AIProviderCapabilitiesTests.swift
@@ -1,0 +1,64 @@
+//
+//  AIProviderCapabilitiesTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AIProviderDescriptor capabilities")
+struct AIProviderCapabilitiesTests {
+    init() {
+        AIProviderRegistration.registerAll()
+    }
+
+    private func descriptor(_ type: AIProviderType) -> AIProviderDescriptor? {
+        AIProviderRegistry.shared.descriptor(for: type.rawValue)
+    }
+
+    @Test("Copilot hides max output tokens and endpoint, shows telemetry, fetches a live model list")
+    func copilotCapabilities() {
+        let copilot = descriptor(.copilot)
+        #expect(copilot?.allowsMaxOutputTokens == false)
+        #expect(copilot?.allowsEndpointConfiguration == false)
+        #expect(copilot?.allowsNameConfiguration == false)
+        #expect(copilot?.showsTelemetryToggle == true)
+        #expect(copilot?.defaultTelemetryEnabled == true)
+        #expect(copilot?.fetchesModelList == true)
+    }
+
+    @Test("ChatGPT Codex hides max output tokens and endpoint, uses curated models only")
+    func chatgptCodexCapabilities() {
+        let codex = descriptor(.chatgptCodex)
+        #expect(codex?.allowsMaxOutputTokens == false)
+        #expect(codex?.allowsEndpointConfiguration == false)
+        #expect(codex?.fetchesModelList == false)
+        #expect(codex?.showsTelemetryToggle == false)
+        #expect(codex?.curatedModels.isEmpty == false)
+    }
+
+    @Test("HTTP API-key providers accept max output tokens, a configurable endpoint, and model fetch")
+    func standardHTTPProviders() {
+        for type in [AIProviderType.openAI, .claude, .gemini, .openRouter, .ollama] {
+            let provider = descriptor(type)
+            #expect(provider?.allowsMaxOutputTokens == true, "\(type.rawValue) should accept max output tokens")
+            #expect(provider?.allowsEndpointConfiguration == true, "\(type.rawValue) should allow endpoint config")
+            #expect(provider?.fetchesModelList == true, "\(type.rawValue) should fetch a model list")
+        }
+    }
+
+    @Test("Only the custom provider allows the name field")
+    func nameFieldOnlyForCustom() {
+        #expect(descriptor(.custom)?.allowsNameConfiguration == true)
+        #expect(descriptor(.openAI)?.allowsNameConfiguration == false)
+        #expect(descriptor(.copilot)?.allowsNameConfiguration == false)
+    }
+
+    @Test("Telemetry toggle is exclusive to Copilot")
+    func telemetryToggleOnlyForCopilot() {
+        for type in [AIProviderType.openAI, .claude, .gemini, .chatgptCodex, .custom, .ollama] {
+            #expect(descriptor(type)?.showsTelemetryToggle == false, "\(type.rawValue) must not show telemetry")
+        }
+    }
+}

--- a/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
+++ b/TableProTests/Core/AI/AIProviderFactoryResolveTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import TableProPluginKit
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 @Suite("AIProviderFactory.resolve")
@@ -118,6 +118,22 @@ struct AIProviderFactoryResolveTests {
         let resolved = AIProviderFactory.resolve(settings: settings)
         #expect(resolved?.config.id == target.id)
         #expect(resolved?.config.type == .gemini)
+    }
+
+    @Test("Returns a ChatGPTCodexProvider for an active ChatGPT oauth provider")
+    func resolvesChatGPTCodexProvider() {
+        AIProviderRegistration.registerAll()
+        let provider = makeProvider(type: .chatgptCodex, model: "gpt-5.5")
+        defer { AIProviderFactory.invalidateCache(for: provider.id) }
+        let settings = AISettings(
+            enabled: true,
+            providers: [provider],
+            activeProviderID: provider.id
+        )
+        let resolved = AIProviderFactory.resolve(settings: settings)
+        #expect(resolved != nil)
+        #expect(resolved?.config.type == .chatgptCodex)
+        #expect(resolved?.provider is ChatGPTCodexProvider)
     }
 
     @Test("Empty model string passes through to ResolvedProvider")

--- a/TableProTests/Core/AI/ChatGPTCodexJWTTests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexJWTTests.swift
@@ -1,0 +1,63 @@
+//
+//  ChatGPTCodexJWTTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatGPTCodexJWT")
+struct ChatGPTCodexJWTTests {
+    private func makeIDToken(
+        accountID: String?,
+        email: String?,
+        plan: String?,
+        exp: Double? = nil
+    ) throws -> String {
+        var auth: [String: Any] = [:]
+        if let accountID { auth["chatgpt_account_id"] = accountID }
+        if let plan { auth["chatgpt_plan_type"] = plan }
+        var profile: [String: Any] = [:]
+        if let email { profile["email"] = email }
+        var payload: [String: Any] = [
+            "https://api.openai.com/auth": auth,
+            "https://api.openai.com/profile": profile
+        ]
+        if let exp { payload["exp"] = exp }
+        let header = ChatGPTCodexBase64URL.encode(Data(#"{"alg":"none"}"#.utf8))
+        let body = ChatGPTCodexBase64URL.encode(try JSONSerialization.data(withJSONObject: payload))
+        return "\(header).\(body).signature"
+    }
+
+    @Test("Extracts account id, email, and plan from namespaced claims")
+    func extractsClaims() throws {
+        let token = try makeIDToken(accountID: "acct_42", email: "dev@example.com", plan: "plus")
+        let claims = try ChatGPTCodexJWT.decodeClaims(from: token)
+        #expect(claims.accountID == "acct_42")
+        #expect(claims.email == "dev@example.com")
+        #expect(claims.planType == "plus")
+    }
+
+    @Test("Missing account id throws")
+    func missingAccountIDThrows() throws {
+        let token = try makeIDToken(accountID: nil, email: "dev@example.com", plan: "plus")
+        #expect(throws: ChatGPTCodexJWT.DecodeError.self) {
+            _ = try ChatGPTCodexJWT.decodeClaims(from: token)
+        }
+    }
+
+    @Test("Malformed token throws")
+    func malformedThrows() {
+        #expect(throws: ChatGPTCodexJWT.DecodeError.self) {
+            _ = try ChatGPTCodexJWT.decodeClaims(from: "not-a-jwt")
+        }
+    }
+
+    @Test("Reads expiry from the exp claim")
+    func readsExpiry() throws {
+        let token = try makeIDToken(accountID: "a", email: "e", plan: nil, exp: 2_000_000_000)
+        let expiry = ChatGPTCodexJWT.expiration(from: token)
+        #expect(expiry == Date(timeIntervalSince1970: 2_000_000_000))
+    }
+}

--- a/TableProTests/Core/AI/ChatGPTCodexPKCETests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexPKCETests.swift
@@ -1,0 +1,45 @@
+//
+//  ChatGPTCodexPKCETests.swift
+//  TableProTests
+//
+
+import CryptoKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatGPTCodexPKCE")
+struct ChatGPTCodexPKCETests {
+    @Test("Verifier length is within the RFC 7636 range")
+    func verifierLength() {
+        let pkce = ChatGPTCodexPKCE()
+        #expect(pkce.verifier.count >= 43)
+        #expect(pkce.verifier.count <= 128)
+    }
+
+    @Test("Challenge is the base64url SHA-256 of the verifier")
+    func challengeMatchesVerifier() {
+        let pkce = ChatGPTCodexPKCE()
+        let digest = SHA256.hash(data: Data(pkce.verifier.utf8))
+        let expected = ChatGPTCodexBase64URL.encode(Data(digest))
+        #expect(pkce.challenge == expected)
+    }
+
+    @Test("Challenge and state contain no base64 padding or unsafe characters")
+    func urlSafeOutput() {
+        let pkce = ChatGPTCodexPKCE()
+        for value in [pkce.verifier, pkce.challenge, pkce.state] {
+            #expect(!value.contains("="))
+            #expect(!value.contains("+"))
+            #expect(!value.contains("/"))
+        }
+    }
+
+    @Test("Each instance produces a distinct verifier and state")
+    func uniquePerInstance() {
+        let first = ChatGPTCodexPKCE()
+        let second = ChatGPTCodexPKCE()
+        #expect(first.verifier != second.verifier)
+        #expect(first.state != second.state)
+    }
+}

--- a/TableProTests/Core/AI/ChatGPTCodexProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexProviderEncodingTests.swift
@@ -1,0 +1,71 @@
+//
+//  ChatGPTCodexProviderEncodingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatGPTCodexProvider request encoding")
+struct ChatGPTCodexProviderEncodingTests {
+    @Test("Headers carry bearer token, account id, and Codex originator")
+    func headersIncludeAccountAndOriginator() {
+        let headers = ChatGPTCodexProvider.requestHeaders(
+            accessToken: "tok-123",
+            accountID: "acct-9",
+            sessionID: "sess-1"
+        )
+        #expect(headers["Authorization"] == "Bearer tok-123")
+        #expect(headers["ChatGPT-Account-ID"] == "acct-9")
+        #expect(headers["session-id"] == "sess-1")
+        #expect(headers["originator"] == "codex_cli_rs")
+        #expect(headers["User-Agent"] == ChatGPTCodex.userAgent)
+    }
+
+    @Test("Empty account id omits the ChatGPT-Account-ID header")
+    func emptyAccountOmitsHeader() {
+        let headers = ChatGPTCodexProvider.requestHeaders(
+            accessToken: "tok",
+            accountID: "",
+            sessionID: "sess"
+        )
+        #expect(headers["ChatGPT-Account-ID"] == nil)
+    }
+
+    @Test("Body sends store=false, stream flag, and the system prompt as instructions")
+    func bodyUsesSystemPrompt() throws {
+        let turn = ChatTurnWire(role: .user, blocks: [.text("hi")])
+        let options = ChatTransportOptions(model: "gpt-5.5", systemPrompt: "schema context")
+        let body = try ChatGPTCodexProvider.requestBody(turns: [turn], options: options, stream: true)
+        #expect(body["model"] as? String == "gpt-5.5")
+        #expect(body["store"] as? Bool == false)
+        #expect(body["stream"] as? Bool == true)
+        #expect(body["instructions"] as? String == "schema context")
+        #expect(body["input"] != nil)
+    }
+
+    @Test("Body omits max_output_tokens, which the Codex backend rejects")
+    func bodyOmitsMaxOutputTokens() throws {
+        let turn = ChatTurnWire(role: .user, blocks: [.text("hi")])
+        let options = ChatTransportOptions(model: "gpt-5.5", maxOutputTokens: 4_096)
+        let body = try ChatGPTCodexProvider.requestBody(turns: [turn], options: options, stream: true)
+        #expect(body["max_output_tokens"] == nil)
+    }
+
+    @Test("Body falls back to default instructions when no system prompt is set")
+    func bodyDefaultInstructions() throws {
+        let turn = ChatTurnWire(role: .user, blocks: [.text("hi")])
+        let options = ChatTransportOptions(model: "gpt-5.5")
+        let body = try ChatGPTCodexProvider.requestBody(turns: [turn], options: options, stream: false)
+        #expect(body["instructions"] as? String == ChatGPTCodexProvider.defaultInstructions)
+        #expect(body["stream"] as? Bool == false)
+    }
+
+    @Test("Available models returns the curated subscription list without a network call")
+    func curatedModels() async throws {
+        let provider = ChatGPTCodexProvider(model: "")
+        let models = try await provider.fetchAvailableModels()
+        #expect(models == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"])
+    }
+}

--- a/TableProTests/Core/AI/ChatGPTCodexRegistrationTests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexRegistrationTests.swift
@@ -1,0 +1,34 @@
+//
+//  ChatGPTCodexRegistrationTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ChatGPTCodex provider registration")
+struct ChatGPTCodexRegistrationTests {
+    @Test("ChatGPT Codex uses the OAuth auth style")
+    func authStyleIsOAuth() {
+        #expect(AIProviderType.chatgptCodex.authStyle == .oauth)
+    }
+
+    @Test("ChatGPT Codex is a known provider type")
+    func isKnownType() {
+        #expect(AIProviderType.allCases.contains(.chatgptCodex))
+        #expect(AIProviderType(rawValue: "chatgptCodex") == .chatgptCodex)
+    }
+
+    @Test("Registry builds a ChatGPTCodexProvider for the descriptor")
+    func descriptorMakesCodexProvider() {
+        AIProviderRegistration.registerAll()
+        let descriptor = AIProviderRegistry.shared.descriptor(for: AIProviderType.chatgptCodex.rawValue)
+        #expect(descriptor != nil)
+        #expect(descriptor?.requiresAPIKey == false)
+
+        let config = AIProviderConfig(type: .chatgptCodex, model: "gpt-5.5")
+        let provider = descriptor?.makeProvider(config, nil)
+        #expect(provider is ChatGPTCodexProvider)
+    }
+}

--- a/TableProTests/Core/AI/ChatGPTCodexTokenStoreTests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexTokenStoreTests.swift
@@ -1,0 +1,131 @@
+//
+//  ChatGPTCodexTokenStoreTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+private actor FakeRefresher: ChatGPTCodexTokenRefreshing {
+    private(set) var callCount = 0
+    private let response: ChatGPTCodexTokenResponse
+    private let delayNanos: UInt64
+
+    init(response: ChatGPTCodexTokenResponse, delayNanos: UInt64 = 0) {
+        self.response = response
+        self.delayNanos = delayNanos
+    }
+
+    func refresh(refreshToken: String) async throws -> ChatGPTCodexTokenResponse {
+        callCount += 1
+        if delayNanos > 0 {
+            try? await Task.sleep(nanoseconds: delayNanos)
+        }
+        return response
+    }
+}
+
+@Suite("ChatGPTCodexTokenStore")
+struct ChatGPTCodexTokenStoreTests {
+    private func tokens(
+        refresh: String = "r",
+        expiresIn: TimeInterval,
+        account: String = "acct"
+    ) -> ChatGPTCodexTokens {
+        ChatGPTCodexTokens(
+            accessToken: "access",
+            refreshToken: refresh,
+            idToken: "",
+            accountID: account,
+            email: "dev@example.com",
+            planType: "plus",
+            expiresAt: Date().addingTimeInterval(expiresIn)
+        )
+    }
+
+    private func response(
+        access: String,
+        refresh: String,
+        expiresIn: TimeInterval
+    ) -> ChatGPTCodexTokenResponse {
+        ChatGPTCodexTokenResponse(
+            accessToken: access,
+            refreshToken: refresh,
+            idToken: "",
+            expiresAt: Date().addingTimeInterval(expiresIn)
+        )
+    }
+
+    @Test("Saved tokens round-trip through Keychain storage")
+    func saveAndLoadRoundTrip() async {
+        let store = ChatGPTCodexTokenStore(
+            keychain: InMemoryKeychain(),
+            refresher: FakeRefresher(response: response(access: "a", refresh: "r", expiresIn: 600))
+        )
+        await store.save(tokens(expiresIn: 600))
+        let loaded = await store.currentTokens()
+        #expect(loaded?.accessToken == "access")
+        #expect(loaded?.accountID == "acct")
+        #expect(await store.isSignedIn())
+    }
+
+    @Test("A valid token is returned without refreshing")
+    func notExpiredSkipsRefresh() async throws {
+        let refresher = FakeRefresher(response: response(access: "new", refresh: "r2", expiresIn: 600))
+        let store = ChatGPTCodexTokenStore(keychain: InMemoryKeychain(), refresher: refresher)
+        await store.save(tokens(expiresIn: 600))
+        let token = try await store.validAccessToken()
+        #expect(token == "access")
+        #expect(await refresher.callCount == 0)
+    }
+
+    @Test("A token inside the 60s skew window triggers a refresh")
+    func expirySkewTriggersRefresh() async throws {
+        let refresher = FakeRefresher(response: response(access: "fresh", refresh: "r2", expiresIn: 600))
+        let store = ChatGPTCodexTokenStore(keychain: InMemoryKeychain(), refresher: refresher)
+        await store.save(tokens(expiresIn: 30))
+        let token = try await store.validAccessToken()
+        #expect(token == "fresh")
+        #expect(await refresher.callCount == 1)
+    }
+
+    @Test("A rotated refresh token is persisted")
+    func refreshTokenRotationPersisted() async throws {
+        let refresher = FakeRefresher(response: response(access: "fresh", refresh: "rotated", expiresIn: 600))
+        let store = ChatGPTCodexTokenStore(keychain: InMemoryKeychain(), refresher: refresher)
+        await store.save(tokens(refresh: "old", expiresIn: -10))
+        _ = try await store.validAccessToken()
+        let current = await store.currentTokens()
+        #expect(current?.refreshToken == "rotated")
+    }
+
+    @Test("Concurrent callers share a single refresh")
+    func singleFlightRefresh() async throws {
+        let refresher = FakeRefresher(
+            response: response(access: "fresh", refresh: "r2", expiresIn: 600),
+            delayNanos: 80_000_000
+        )
+        let store = ChatGPTCodexTokenStore(keychain: InMemoryKeychain(), refresher: refresher)
+        await store.save(tokens(expiresIn: -10))
+        try await withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0..<8 {
+                group.addTask { try await store.validAccessToken() }
+            }
+            for try await _ in group {}
+        }
+        #expect(await refresher.callCount == 1)
+    }
+
+    @Test("Clearing removes the stored session")
+    func clearRemovesTokens() async {
+        let store = ChatGPTCodexTokenStore(
+            keychain: InMemoryKeychain(),
+            refresher: FakeRefresher(response: response(access: "a", refresh: "r", expiresIn: 600))
+        )
+        await store.save(tokens(expiresIn: 600))
+        await store.clear()
+        #expect(await store.currentTokens() == nil)
+        #expect(await store.isSignedIn() == false)
+    }
+}

--- a/TableProTests/Core/AI/OAuthProviderServiceTests.swift
+++ b/TableProTests/Core/AI/OAuthProviderServiceTests.swift
@@ -1,0 +1,37 @@
+//
+//  OAuthProviderServiceTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("OAuth provider abstraction")
+@MainActor
+struct OAuthProviderServiceTests {
+    @Test("Registry dispatches OAuth providers to a service and others to nil")
+    func registryDispatch() {
+        #expect(OAuthProviderRegistry.service(for: .copilot) != nil)
+        #expect(OAuthProviderRegistry.service(for: .chatgptCodex) != nil)
+        #expect(OAuthProviderRegistry.service(for: .claude) == nil)
+        #expect(OAuthProviderRegistry.service(for: .openAI) == nil)
+        #expect(OAuthProviderRegistry.service(for: .ollama) == nil)
+    }
+
+    @Test("Each OAuth provider declares its sign-in flow kind")
+    func oauthFlowKinds() {
+        AIProviderRegistration.registerAll()
+        let registry = AIProviderRegistry.shared
+        #expect(registry.descriptor(for: AIProviderType.copilot.rawValue)?.oauthFlowKind == .deviceCode)
+        #expect(registry.descriptor(for: AIProviderType.chatgptCodex.rawValue)?.oauthFlowKind == .browserRedirect)
+        #expect(registry.descriptor(for: AIProviderType.claude.rawValue)?.oauthFlowKind == nil)
+    }
+
+    @Test("OAuthAuthState identity readout")
+    func authStateIdentity() {
+        #expect(OAuthAuthState.signedIn(identity: "dev@example.com").isSignedIn)
+        #expect(!OAuthAuthState.signingIn.isSignedIn)
+        #expect(!OAuthAuthState.signedOut.isSignedIn)
+    }
+}

--- a/TableProTests/Core/AI/OpenAIResponsesProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/OpenAIResponsesProviderEncodingTests.swift
@@ -59,6 +59,7 @@ struct OpenAIResponsesProviderEncodingTests {
         #expect(items[0]["type"] as? String == "reasoning", "Reasoning item must come before its function_call")
         #expect(items[0]["id"] as? String == "rs_real_abc", "Reasoning item id must round-trip from server")
         #expect(items[0]["encrypted_content"] as? String == "BLOB=")
+        #expect((items[0]["summary"] as? [Any])?.isEmpty == true, "Reasoning item must carry a summary array for the Codex backend")
         #expect(items[1]["type"] as? String == "function_call")
         #expect(items[1]["call_id"] as? String == "call_1")
         #expect(items[1]["name"] as? String == "ping")

--- a/TableProTests/Core/AI/OpenAIResponsesProviderParserTests.swift
+++ b/TableProTests/Core/AI/OpenAIResponsesProviderParserTests.swift
@@ -117,6 +117,64 @@ struct OpenAIResponsesProviderParserTests {
         #expect(delta == #"{"query":"#)
     }
 
+    @Test("output_item.done function_call without arg deltas emits the complete arguments")
+    func functionCallDoneEmitsCompleteArguments() throws {
+        var state = ResponsesStreamState()
+        _ = try parse([
+            "type": "response.output_item.added",
+            "item": ["type": "function_call", "call_id": "call_xyz", "name": "execute_query"]
+        ], state: &state)
+        let events = try parse([
+            "type": "response.output_item.done",
+            "item": [
+                "type": "function_call",
+                "call_id": "call_xyz",
+                "name": "execute_query",
+                "arguments": #"{"query":"SELECT 1"}"#
+            ]
+        ], state: &state)
+        guard case .toolUseDelta(let id, let delta) = events.first else {
+            Issue.record("expected toolUseDelta with the complete arguments; got \(events)")
+            return
+        }
+        #expect(id == "call_xyz")
+        #expect(delta == #"{"query":"SELECT 1"}"#)
+        guard case .toolUseEnd(let endID) = events.last else {
+            Issue.record("expected toolUseEnd; got \(events)")
+            return
+        }
+        #expect(endID == "call_xyz")
+    }
+
+    @Test("output_item.done function_call after arg deltas does not duplicate arguments")
+    func functionCallDoneSkipsArgumentsWhenStreamed() throws {
+        var state = ResponsesStreamState()
+        _ = try parse([
+            "type": "response.output_item.added",
+            "item": ["type": "function_call", "call_id": "call_xyz", "name": "execute_query"]
+        ], state: &state)
+        _ = try parse([
+            "type": "response.function_call_arguments.delta",
+            "call_id": "call_xyz",
+            "delta": #"{"query":"SELECT 1"}"#
+        ], state: &state)
+        let events = try parse([
+            "type": "response.output_item.done",
+            "item": [
+                "type": "function_call",
+                "call_id": "call_xyz",
+                "name": "execute_query",
+                "arguments": #"{"query":"SELECT 1"}"#
+            ]
+        ], state: &state)
+        #expect(events.count == 1)
+        guard case .toolUseEnd(let id) = events.first else {
+            Issue.record("expected only toolUseEnd; got \(events)")
+            return
+        }
+        #expect(id == "call_xyz")
+    }
+
     @Test("completed event captures usage tokens")
     func completedCapturesUsage() throws {
         var state = ResponsesStreamState()

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -88,9 +88,9 @@ The provider used by default. Override it per turn from the model picker in the 
 
 ### Providers
 
-List of configured providers. Click a row to open its detail sheet, or pick **Add Provider…** to add one. The choices are GitHub Copilot (OAuth device flow), Claude, OpenAI, OpenRouter, Gemini, Ollama (no auth, local), and a custom OpenAI-compatible endpoint.
+List of configured providers. Click a row to open its detail sheet, or pick **Add Provider…** to add one. The choices are GitHub Copilot (OAuth device flow), ChatGPT (sign in with your subscription), Claude, OpenAI, OpenRouter, Gemini, Ollama (no auth, local), and a custom OpenAI-compatible endpoint.
 
-API keys are stored in the macOS Keychain. Removing a provider deletes its key.
+API keys and ChatGPT tokens are stored in the macOS Keychain. Removing a provider deletes its key.
 
 ### Inline Suggestions
 

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Assistant
-description: "Built-in AI for SQL: chat with tool calling, inline suggestions, explain, optimize, fix-error. 8 providers."
+description: "Built-in AI for SQL: chat with tool calling, inline suggestions, explain, optimize, fix-error. 9 providers."
 ---
 
 # AI Assistant
@@ -28,8 +28,8 @@ Open **Settings** (`Cmd+,`) > **AI**. The tab is modeled on Xcode's Intelligence
 
 ### Add a Provider
 
-1. Click **Add Provider...** and pick a type: GitHub Copilot, Claude, OpenAI, OpenRouter, OpenCode Zen, Gemini, Ollama, or a custom OpenAI-compatible endpoint.
-2. Enter the API key, or run device-flow sign-in for Copilot.
+1. Click **Add Provider...** and pick a type: GitHub Copilot, ChatGPT, Claude, OpenAI, OpenRouter, OpenCode Zen, Gemini, Ollama, or a custom OpenAI-compatible endpoint.
+2. Enter the API key, or sign in for Copilot and ChatGPT.
 3. Enter a model name, or pick one from the fetched list. Click **Reload** if needed.
 4. Click **Test Connection**.
 
@@ -44,6 +44,12 @@ The active provider handles every AI request. Override it per turn from the [mod
 Add Copilot like any other provider. The detail sheet runs GitHub's device-flow sign-in: enter the displayed code on github.com to authorize. The Copilot language server starts when you add a Copilot provider and stops when you remove it.
 
 Copilot supports tool calling through GitHub's `conversation/registerTools` bridge. Tool calls go through the same approval flow as the other providers.
+
+### ChatGPT
+
+Sign in with your ChatGPT account to use the Codex quota included with Plus, Pro, Business, and Enterprise plans, with no API key. The detail sheet opens your browser to sign in, then captures the redirect on a local callback. Tokens are stored in the macOS Keychain and refreshed automatically. If you already use the Codex CLI, click **Import from Codex CLI** to reuse that login.
+
+The active provider then serves chat and inline suggestions from the subscription models (GPT-5.5, GPT-5.4, GPT-5.4 Mini). This uses an unofficial OpenAI interface that may change, and access follows OpenAI's terms.
 
 ## Chat
 


### PR DESCRIPTION
Closes #1617.

Adds "Sign in with ChatGPT" so users on a ChatGPT Plus, Pro, Business, or Enterprise plan can use their included Codex quota for AI chat and inline SQL suggestions without an API key. The work also refactors the AI provider subsystem so the new provider drops in cleanly instead of adding more per-type special cases.

## Feature: Sign in with ChatGPT (Codex OAuth)

- PKCE Authorization Code flow against `auth.openai.com` using the Codex CLI public client, with an RFC 8252 loopback capture on `127.0.0.1:1455` (ASWebAuthenticationSession cannot capture a localhost redirect). Opens the default browser, so an existing chatgpt.com session signs in with one click.
- Tokens stored in the macOS Keychain, refreshed automatically by an actor with single-flight refresh and refresh-token rotation. Sign out revokes the token.
- "Import from Codex CLI" reuses an existing `~/.codex/auth.json` login.
- Chat and inline suggestions are served from the subscription models (GPT-5.5, GPT-5.4, GPT-5.4 Mini). Requests go to `chatgpt.com/backend-api/codex/responses` with the account id and Codex headers.
- The settings sign-in section states that access needs a paid subscription, follows OpenAI's terms, and uses an unofficial interface that may change. Tokens are never pooled across users.

Three Codex backend dialect differences were found and fixed in the shared Responses layer (so the OpenAI provider benefits too): `max_output_tokens` removed, reasoning items now carry `summary`, and tool-call arguments are recovered from the `output_item.done` event when the backend keys argument deltas by `item_id` instead of `call_id`.

## Refactor: AI provider subsystem (3 stages)

**Stage 1 - capability-driven settings UI.** Added descriptor capabilities (`endpointConfigurable`, `nameConfigurable`, `maxOutputTokens`, `modelListFetchable`) plus telemetry flags, and rewired the settings UI to read them instead of ~10 hardcoded `if type == X` checks. Fixes three Copilot bugs: a stray model-ID field when picking a model, a Max output tokens field Copilot ignores, and a transient model-fetch error on opening settings.

**Stage 2 - OAuth abstraction.** Added an `OAuthProviderService` protocol, an `OAuthAuthState`, a registry, and a `descriptor.oauthFlowKind`, so provider status text and the auth section dispatch through them. A third OAuth provider can no longer silently fall back to the Copilot UI; it becomes a compile error instead.

**Stage 3 - shared SSE streaming.** Added a generic `SSEEventStream.make` scaffold. All five HTTP providers (Anthropic, Gemini, OpenAICompatible, OpenAIResponses, ChatGPTCodex) now share one streaming loop. Each provider's wire-format parser stays separate (no leaky union). Removed ~150 lines of duplicated scaffolding and a dead extension.

The one place left as an explicit type check is the Copilot LSP start/stop lifecycle in `AppSettingsManager`. It is a real side effect for the only provider with a background process, not a UI-dispatch hack, so a generic hook used by a single provider was not worth it.

## Tests

New and updated unit tests cover the capability matrix, the OAuth registry and flow kinds, PKCE, JWT claim extraction, token store expiry/single-flight/rotation, Codex request encoding, and the tool-call argument recovery. Existing parser and encoding tests are unchanged since the parse methods were not touched.

## Notes for review

- macOS native: AppKit/SwiftUI, Network.framework loopback, Keychain, CryptoKit. No web views, no third-party deps.
- Subscription access is an undocumented OpenAI surface and can change without notice. Only the ChatGPT provider depends on it; other providers are unaffected.
- Docs and CHANGELOG updated.
