### PR TITLE
fix(connections): connect MongoDB over SSH and Cloudflare tunnels (#1621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
 - Syntax highlighting no longer disappears after formatting a query. (#1612)
 - The GitHub Copilot provider no longer shows a Max output tokens field it ignores, and picking a Copilot model no longer leaves a stray model ID field behind.
+- MongoDB now connects over an SSH or Cloudflare tunnel instead of bypassing it and failing with a connection refused error. (#1621)
 
 ## [0.49.1] - 2026-06-06
 

--- a/TablePro/Core/Database/DatabaseManager+Tunnel.swift
+++ b/TablePro/Core/Database/DatabaseManager+Tunnel.swift
@@ -13,7 +13,10 @@ extension DatabaseManager {
     /// Rewrite a connection to point at the local tunnel endpoint. A 127.0.0.1
     /// certificate can't satisfy hostname verification, so verify modes drop to
     /// `.required` while keeping encryption; cert paths are cleared and pgpass keeps
-    /// the original host/port. Shared by the SSH and Cloudflare tunnel paths.
+    /// the original host/port. A tunnel forwards a single local port, so MongoDB's
+    /// seed list is collapsed to that endpoint and a direct connection is forced,
+    /// stopping replica set discovery from reaching members behind the tunnel.
+    /// Shared by the SSH and Cloudflare tunnel paths.
     func tunneledConnection(from connection: DatabaseConnection, localPort: Int) -> DatabaseConnection {
         var tunnelSSL = connection.sslConfig
         if tunnelSSL.isEnabled {
@@ -29,6 +32,10 @@ extension DatabaseManager {
         if connection.usePgpass {
             effectiveFields["pgpassOriginalHost"] = connection.host
             effectiveFields["pgpassOriginalPort"] = String(connection.port)
+        }
+        if connection.type.pluginTypeId == "MongoDB", !connection.usesMongoSrv {
+            effectiveFields["mongoHosts"] = nil
+            effectiveFields["mongoParam_directConnection"] = "true"
         }
 
         return DatabaseConnection(

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -361,6 +361,10 @@ struct DatabaseConnection: Identifiable, Hashable {
         set { additionalFields["mongoUseSrv"] = newValue ? "true" : "" }
     }
 
+    var usesMongoSrv: Bool {
+        mongoUseSrv || host.hasSuffix(".mongodb.net")
+    }
+
     var mongoAuthMechanism: String? {
         get { additionalFields["mongoAuthMechanism"]?.nilIfEmpty }
         set { additionalFields["mongoAuthMechanism"] = newValue ?? "" }

--- a/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
@@ -104,7 +104,7 @@ struct GeneralPaneView: View {
                 if hostsValue.contains(",") {
                     Section {
                         Label(
-                            String(localized: "SSH tunneling only forwards the first host. Other replica set members must be directly reachable from the SSH server."),
+                            String(localized: "Over an SSH tunnel, TablePro connects directly to the first host. Replica set failover is not available."),
                             systemImage: "exclamationmark.triangle"
                         )
                         .font(.caption)

--- a/TableProTests/Core/Database/DatabaseManagerTunnelTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerTunnelTests.swift
@@ -4,9 +4,9 @@
 //
 
 import Foundation
+@testable import TablePro
 import TableProPluginKit
 import Testing
-@testable import TablePro
 
 @Suite("DatabaseManager tunnel rewrite")
 @MainActor
@@ -26,5 +26,53 @@ struct DatabaseManagerTunnelTests {
         #expect(tunneled.host == "127.0.0.1")
         #expect(tunneled.port == 61_234)
         #expect(tunneled.passwordSource == .env(variable: "DB_PASS"))
+    }
+
+    @Test("Tunneled MongoDB collapses the seed list and forces a direct connection")
+    func tunnelForcesMongoDirectConnection() {
+        let connection = DatabaseConnection(
+            name: "mongo",
+            host: "primary.internal",
+            port: 27_017,
+            type: .mongodb,
+            additionalFields: ["mongoHosts": "primary.internal:27017,secondary.internal:27017"]
+        )
+
+        let tunneled = DatabaseManager.shared.tunneledConnection(from: connection, localPort: 62_000)
+
+        #expect(tunneled.host == "127.0.0.1")
+        #expect(tunneled.port == 62_000)
+        #expect(tunneled.additionalFields["mongoHosts"] == nil)
+        #expect(tunneled.additionalFields["mongoParam_directConnection"] == "true")
+    }
+
+    @Test("Tunneled MongoDB leaves SRV connections untouched")
+    func tunnelLeavesMongoSrvUntouched() {
+        let connection = DatabaseConnection(
+            name: "atlas",
+            host: "cluster0.example.com",
+            port: 27_017,
+            type: .mongodb,
+            additionalFields: ["mongoHosts": "cluster0.example.com", "mongoUseSrv": "true"]
+        )
+
+        let tunneled = DatabaseManager.shared.tunneledConnection(from: connection, localPort: 62_000)
+
+        #expect(tunneled.additionalFields["mongoHosts"] == "cluster0.example.com")
+        #expect(tunneled.additionalFields["mongoParam_directConnection"] == nil)
+    }
+
+    @Test("Tunneled non-MongoDB connection gets no direct-connection override")
+    func tunnelLeavesNonMongoUntouched() {
+        let connection = DatabaseConnection(
+            name: "pg",
+            host: "db.internal",
+            port: 5_432,
+            type: .postgresql
+        )
+
+        let tunneled = DatabaseManager.shared.tunneledConnection(from: connection, localPort: 62_000)
+
+        #expect(tunneled.additionalFields["mongoParam_directConnection"] == nil)
     }
 }


### PR DESCRIPTION
Fixes #1621

## Problem

A MongoDB connection over an SSH (or Cloudflare) tunnel fails to connect. The SSH section's own "Test connection" passes, but the General-section test and a real connect fail with:

```
No suitable servers found (`serverSelectionTryOnce` set): [connection refused calling hello on 'localhost:27017']. Topology type: Single
```

## Root cause

`tunneledConnection()` rewrites a connection's `host`/`port` to the local tunnel endpoint (`127.0.0.1:<localPort>`), but the MongoDB driver prefers `additionalFields["mongoHosts"]` over `host`/`port`, and that field still holds the original `localhost:27017`. Every MongoDB connection always has `mongoHosts` populated, even single-host ones, so the driver dials the original address and bypasses the tunnel.

The SSH-section "Test connection" only checks the libssh2 handshake, which is why it passes while the actual driver connect fails.

## Why not just clear `mongoHosts`

Clearing the seed list alone fixes the single-host case but leaves replica sets broken: with a single seed and no `directConnection`, the driver defaults to topology discovery, runs `hello`, learns the members' advertised hostnames, and connects to those directly, escaping the tunnel. A tunnel forwards one local port, so the correct behavior is a direct connection to that one node. This is also the documented way mature clients (Studio 3T, NoSQLBooster, the PyMongo docs) reach MongoDB through a tunnel.

## Fix

In `tunneledConnection()`, for a non-SRV MongoDB connection:

- clear `mongoHosts` so the driver uses the rewritten `127.0.0.1:<localPort>`
- set `directConnection=true` so topology discovery does not leave the tunnel
- skip SRV/Atlas connections (`directConnection` is invalid with an SRV URI, and an IP cannot satisfy SRV/TLS; tunnel + SRV is not supported regardless)

Applies to both SSH and Cloudflare tunnels via the shared helper.

`directConnection=true` means the client talks only to the tunneled node: no replica set failover, and writes require that node to be the primary. That is inherent to single-port tunneling and is strictly better than failing to connect. The multi-host SSH warning in the connection form was updated to match.

## Changes

- `DatabaseManager+Tunnel.swift`: collapse the MongoDB seed list to the tunnel endpoint and force a direct connection
- `DatabaseConnection.swift`: `usesMongoSrv` helper mirroring the driver's SRV detection
- `GeneralPaneView.swift`: corrected the multi-host tunnel warning
- `DatabaseManagerTunnelTests.swift`: tests for the rewrite, the SRV skip, and the non-MongoDB no-op

No PluginKit ABI change; host app only.

## Tests

```
xcodebuild -project TablePro.xcodeproj -scheme TablePro test \
  -skipPackagePluginValidation \
  -only-testing:TableProTests/DatabaseManagerTunnelTests
```
