### PR TITLE
fix(coordinator): activate the existing tab instead of opening a duplicate (#1613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
 - Syntax highlighting no longer disappears after formatting a query. (#1612)
 - The GitHub Copilot provider no longer shows a Max output tokens field it ignores, and picking a Copilot model no longer leaves a stray model ID field behind.
+- Clicking a table that's already open switches to its existing tab instead of opening a duplicate. (#1613)
 
 ## [0.49.1] - 2026-06-06
 

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -152,11 +152,7 @@ internal final class TabRouter {
                 } ?? true
                 return databaseMatches && schemaMatches
             }) else { continue }
-            coordinator.tabManager.selectedTabId = match.id
-            if let windowId = coordinator.windowId,
-               let window = WindowLifecycleMonitor.shared.window(for: windowId) {
-                window.makeKeyAndOrderFront(nil)
-            }
+            coordinator.selectTabAndFocusWindow(match.id)
             return true
         }
         return false

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -18,7 +18,6 @@ extension MainContentCoordinator {
     func openTableTab(
         _ table: TableInfo,
         showStructure: Bool = false,
-        redirectToSibling: Bool = false,
         forceNonPreview: Bool = false,
         activateGridFocus: Bool = false
     ) {
@@ -27,7 +26,6 @@ extension MainContentCoordinator {
             schema: table.schema,
             showStructure: showStructure,
             isView: table.type == .view,
-            redirectToSibling: redirectToSibling,
             forceNonPreview: forceNonPreview,
             activateGridFocus: activateGridFocus
         )
@@ -38,7 +36,6 @@ extension MainContentCoordinator {
         schema: String? = nil,
         showStructure: Bool = false,
         isView: Bool = false,
-        redirectToSibling: Bool = false,
         forceNonPreview: Bool = false,
         activateGridFocus: Bool = false
     ) {
@@ -59,18 +56,14 @@ extension MainContentCoordinator {
         let resolvedSchema = schema
         let createAsPreview = !forceNonPreview && AppSettingsManager.shared.tabs.enablePreviewTabs
 
-        // Fast path: if this table is already the active tab in the same database, skip all work
-        if let current = tabManager.selectedTab,
-           current.tabType == .table,
-           current.tableContext.tableName == tableName,
-           current.tableContext.databaseName == currentDatabase,
-           current.tableContext.schemaName == resolvedSchema {
-            if showStructure, let (_, tabIndex) = tabManager.selectedTabAndIndex {
-                tabManager.mutate(at: tabIndex) { $0.display.resultsViewMode = .structure }
-            }
-            if activateGridFocus {
-                focusActiveGrid()
-            }
+        if activateIfAlreadyOpen(
+            tableName: tableName,
+            databaseName: currentDatabase,
+            schemaName: resolvedSchema,
+            showStructure: showStructure,
+            activateGridFocus: activateGridFocus,
+            includeSiblings: navigationModel != .inPlace
+        ) {
             return
         }
 
@@ -96,28 +89,6 @@ extension MainContentCoordinator {
                 pendingGridFocusOnOpen = false
             }
             return
-        }
-
-        // Opt-in cross-window navigation: if requested (e.g. quick switcher),
-        // and another window already shows this table, focus that window.
-        // Default-off so sidebar clicks and other window-local actions stay
-        // window-local instead of stealing focus to a sibling.
-        if redirectToSibling {
-            for sibling in MainContentCoordinator.allActiveCoordinators()
-                where sibling !== self && sibling.connectionId == connectionId {
-                let hasMatch = sibling.tabManager.tabs.contains { tab in
-                    tab.tabType == .table
-                        && tab.tableContext.tableName == tableName
-                        && tab.tableContext.databaseName == currentDatabase
-                        && tab.tableContext.schemaName == resolvedSchema
-                }
-                guard hasMatch,
-                      let windowId = sibling.windowId,
-                      let window = WindowLifecycleMonitor.shared.window(for: windowId) else { continue }
-                pendingGridFocusOnOpen = false
-                window.makeKeyAndOrderFront(nil)
-                return
-            }
         }
 
         // If no tabs exist (empty state), add a table tab directly.
@@ -189,6 +160,50 @@ extension MainContentCoordinator {
             isPreview: createAsPreview
         )
         WindowManager.shared.openTab(payload: payload)
+    }
+
+    func activateIfAlreadyOpen(
+        tableName: String,
+        databaseName: String,
+        schemaName: String?,
+        showStructure: Bool,
+        activateGridFocus: Bool,
+        includeSiblings: Bool
+    ) -> Bool {
+        func matches(_ tab: QueryTab) -> Bool {
+            tab.tabType == .table
+                && tab.tableContext.tableName == tableName
+                && tab.tableContext.databaseName == databaseName
+                && tab.tableContext.schemaName == schemaName
+        }
+
+        if let match = tabManager.tabs.first(where: matches) {
+            if tabManager.selectedTabId != match.id {
+                tabManager.selectedTabId = match.id
+            }
+            applyStructureMode(showStructure, toTab: match.id, in: tabManager)
+            if activateGridFocus {
+                requestGridFocus()
+            }
+            return true
+        }
+
+        guard includeSiblings else { return false }
+
+        for sibling in MainContentCoordinator.allActiveCoordinators()
+            where sibling !== self && sibling.connectionId == connectionId {
+            guard let match = sibling.tabManager.tabs.first(where: matches) else { continue }
+            sibling.pendingGridFocusOnOpen = activateGridFocus
+            applyStructureMode(showStructure, toTab: match.id, in: sibling.tabManager)
+            sibling.selectTabAndFocusWindow(match.id)
+            return true
+        }
+        return false
+    }
+
+    private func applyStructureMode(_ showStructure: Bool, toTab tabId: UUID, in tabManager: QueryTabManager) {
+        guard showStructure, let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+        tabManager.mutate(at: index) { $0.display.resultsViewMode = .structure }
     }
 
     private func addFirstTableTab(

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QuickSwitcher.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QuickSwitcher.swift
@@ -15,10 +15,10 @@ extension MainContentCoordinator {
     func handleQuickSwitcherSelection(_ item: QuickSwitcherItem) {
         switch item.kind {
         case .table, .systemTable:
-            openTableTab(item.name, redirectToSibling: true, activateGridFocus: true)
+            openTableTab(item.name, activateGridFocus: true)
 
         case .view:
-            openTableTab(item.name, isView: true, redirectToSibling: true, activateGridFocus: true)
+            openTableTab(item.name, isView: true, activateGridFocus: true)
 
         case .database:
             Task {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -97,6 +97,13 @@ extension MainContentCoordinator {
         )
     }
 
+    func selectTabAndFocusWindow(_ tabId: UUID) {
+        tabManager.selectedTabId = tabId
+        guard let windowId,
+              let window = WindowLifecycleMonitor.shared.window(for: windowId) else { return }
+        window.makeKeyAndOrderFront(nil)
+    }
+
     // MARK: - Sidebar Sync
 
     /// Update the window-scoped sidebar selection so the active table tab

--- a/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
+++ b/TableProTests/Views/Main/MultiConnectionNavigationTests.swift
@@ -248,4 +248,58 @@ struct MultiConnectionNavigationTests {
         #expect(tabManagerB.tabs.count == tabCountBefore)
         #expect(tabManagerB.tabs.first?.tableContext.tableName == "orders")
     }
+
+    // MARK: - Cross-window deduplication (issue #1613)
+
+    @Test("openTableTab activates a sibling window's tab instead of duplicating when the table is already open")
+    @MainActor
+    func openTableTabActivatesSiblingInsteadOfDuplicating() throws {
+        let connectionId = UUID()
+        let (coordinatorA, tabManagerA) = makeCoordinator(id: connectionId, name: "Conn", database: "db_a")
+        let (coordinatorB, tabManagerB) = makeCoordinator(id: connectionId, name: "Conn", database: "db_a")
+        coordinatorA.registerEagerly()
+        coordinatorB.registerEagerly()
+        defer {
+            coordinatorA.teardown()
+            coordinatorB.teardown()
+        }
+
+        try tabManagerA.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "db_a")
+        try tabManagerA.addTableTab(tableName: "accounts", databaseType: .mysql, databaseName: "db_a")
+        #expect(tabManagerA.selectedTab?.tableContext.tableName == "accounts")
+        try tabManagerB.addTableTab(tableName: "orders", databaseType: .mysql, databaseName: "db_a")
+
+        coordinatorB.openTableTab("users")
+
+        #expect(tabManagerB.tabs.count == 1)
+        #expect(tabManagerB.tabs.first?.tableContext.tableName == "orders")
+        #expect(tabManagerA.selectedTab?.tableContext.tableName == "users")
+    }
+
+    @Test("openTableTab does not dedupe against a sibling on a different connection")
+    @MainActor
+    func openTableTabIgnoresSiblingOnDifferentConnection() throws {
+        let (coordinatorA, tabManagerA) = makeCoordinator(name: "ConnA", database: "db_a")
+        let (coordinatorB, tabManagerB) = makeCoordinator(name: "ConnB", database: "db_b")
+        coordinatorA.registerEagerly()
+        coordinatorB.registerEagerly()
+        defer {
+            coordinatorA.teardown()
+            coordinatorB.teardown()
+        }
+
+        try tabManagerA.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "db_a")
+
+        let activated = coordinatorB.activateIfAlreadyOpen(
+            tableName: "users",
+            databaseName: "db_b",
+            schemaName: nil,
+            showStructure: false,
+            activateGridFocus: false,
+            includeSiblings: true
+        )
+
+        #expect(activated == false)
+        #expect(tabManagerB.tabs.isEmpty)
+    }
 }

--- a/TableProTests/Views/Main/OpenTableTabTests.swift
+++ b/TableProTests/Views/Main/OpenTableTabTests.swift
@@ -194,6 +194,90 @@ struct OpenTableTabTests {
         #expect(tabManager.selectedTab?.isPreview == false)
     }
 
+    // MARK: - Activate already-open tab (issue #1613)
+
+    @Test("Clicking a table open in a non-selected tab selects it instead of duplicating")
+    @MainActor
+    func clickingTableInNonSelectedTabSelectsIt() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(tableName: "users", databaseType: connection.type, databaseName: "db_a")
+        try tabManager.addTableTab(tableName: "orders", databaseType: connection.type, databaseName: "db_a")
+        #expect(tabManager.tabs.count == 2)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
+
+        coordinator.openTableTab("users")
+
+        #expect(tabManager.tabs.count == 2)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+    }
+
+    @Test("activateIfAlreadyOpen returns false when no open tab matches")
+    @MainActor
+    func activateIfAlreadyOpenReturnsFalseWhenNoMatch() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(tableName: "orders", databaseType: connection.type, databaseName: "db_a")
+
+        let activated = coordinator.activateIfAlreadyOpen(
+            tableName: "users",
+            databaseName: "db_a",
+            schemaName: nil,
+            showStructure: false,
+            activateGridFocus: false,
+            includeSiblings: true
+        )
+
+        #expect(activated == false)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
+    }
+
+    @Test("activateIfAlreadyOpen selects an existing in-window tab and applies structure mode")
+    @MainActor
+    func activateIfAlreadyOpenSelectsExistingTabWithStructure() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(tableName: "users", databaseType: connection.type, databaseName: "db_a")
+        try tabManager.addTableTab(tableName: "orders", databaseType: connection.type, databaseName: "db_a")
+
+        let activated = coordinator.activateIfAlreadyOpen(
+            tableName: "users",
+            databaseName: "db_a",
+            schemaName: nil,
+            showStructure: true,
+            activateGridFocus: false,
+            includeSiblings: true
+        )
+
+        #expect(activated == true)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.selectedTab?.display.resultsViewMode == .structure)
+    }
+
     @MainActor
     private static func makeCoordinator() -> MainContentCoordinator {
         MainContentCoordinator(


### PR DESCRIPTION
Fixes #1613.

## Problem

With Table 1 open in one tab and Table 2 in another, clicking Table 1 in the sidebar again opened a second, duplicate Table 1 tab instead of switching to the one already open.

Repro: click Table 1, click Table 2, click Table 1 again -> duplicate Table 1 tab.

## Root cause

Each native window tab is its own `NSWindow` + `MainContentCoordinator` + `tabManager`. `openTableTab` already had a cross-window "focus the existing tab" scan, but it was gated behind a `redirectToSibling` parameter that only the quick switcher set. Sidebar clicks left it off, so a click on an already-open table fell through to `WindowManager.openTab` and created a duplicate. The pre-check also only looked at the selected tab, missing a match in a non-selected tab of the same window.

## Fix

Consolidated the duplicated "focus existing table tab" logic into one path that always runs, modeled on `NSDocumentController.openDocument` (if the item is already open, bring its window forward instead of opening a new one):

- New `activateIfAlreadyOpen(...)` runs first in `openTableTab`. It scans the current window first (full tab list, not just the selected tab), then sibling windows for the same connection, matching on `(table, database, schema)`. On a match it selects that tab and brings its window forward, then stops. Priority is now: activate existing -> reuse preview tab -> new tab, matching VS Code, Xcode, and DataGrip.
- New `selectTabAndFocusWindow(_:)` is the shared "select tab + makeKeyAndOrderFront" primitive. `TabRouter.focusExistingTableTab` (deep links) now uses it too, removing a second copy of the same logic.
- Removed the `redirectToSibling` parameter; the check is always on.
- The sibling scan is gated to the standard navigation model so Redis in-place navigation is unchanged.

This also fixes a latent bug the consolidation exposed: the old gated path focused a sibling window but never set its `selectedTabId`, so a multi-tab sibling could surface the wrong tab. The shared primitive does both.

## Tests

- Clicking a table open in a non-selected tab selects it instead of duplicating (the case that would have caught this bug).
- `openTableTab` activates a sibling window's existing tab instead of creating a new one, and does not dedupe across different connections.
- `activateIfAlreadyOpen` returns false on no match (falls through to creation) and applies structure mode when switching to an existing tab.

No docs change: behavior fix, no new shortcut, setting, or UI.
