### PR TITLE
fix(plugin-oracle): Oracle connections no longer crash on a server error under network encryption (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The autocomplete popup now filters in place as you type instead of closing and reopening on every keystroke. (#1608)
 - Syntax highlighting no longer disappears after formatting a query. (#1612)
 - The GitHub Copilot provider no longer shows a Max output tokens field it ignores, and picking a Copilot model no longer leaves a stray model ID field behind.
+- Oracle connections that use native network encryption no longer crash when a query hits a server error such as a missing table or a permission error; the real ORA error is shown and the connection keeps working. (#483)
 
 ## [0.49.1] - 2026-06-06
 

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -4768,7 +4768,7 @@
 			repositoryURL = "https://github.com/TableProApp/oracle-nio";
 			requirement = {
 				kind = revision;
-				revision = 04a4e5967bf4d96cadf66081ea5a22133fe403ea;
+				revision = 18a4872b16f6fb6919833f7897e75b0ea4d19428;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "04a4e5967bf4d96cadf66081ea5a22133fe403ea"
+        "revision" : "18a4872b16f6fb6919833f7897e75b0ea4d19428"
       }
     },
     {


### PR DESCRIPTION
Closes #483

## Problem

After the native network encryption work shipped (plugin v1.2.10), Oracle connections using encryption crashed whenever a query hit a server error such as a missing table or a permission error. Reported in #483 with a crash in `OracleBackendMessageDecoder.decode`.

The cause is in the oracle-nio driver: a server error delivered via an in-band break left the crypto-checksum keystream out of sync, so the error packet failed its integrity check, and the connection then crashed instead of surfacing the error. Full root cause and fix are in TableProApp/oracle-nio#4.

## Change

Bumps the oracle-nio pin to the fix and adds the changelog entry. No PluginKit ABI change.

## Depends on

TableProApp/oracle-nio#4 (the driver fix). The pin points at that branch commit; once #4 merges via a merge commit it stays reachable, or re-point the pin to the resulting `tablepro-main` SHA.

## After merge

Re-release the Oracle plugin (registry-only) so installed users pick up the fix.

## Verification

Against Oracle 23ai with encryption and checksum required: error queries now surface the real `ORA-00942 / 00936 / 01476 / 00904` and the connection keeps working; 110k-row queries run before and after errors; 0 crashes. 173 driver unit tests pass, including new coverage for the keystream reset and the no-crash error path.