### PR TITLE
fix(connections): detect DBeaver connections for import from any edition (#1628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clicking a table that's already open switches to its existing tab instead of opening a duplicate. (#1613)
 - MongoDB now connects over an SSH or Cloudflare tunnel instead of bypassing it and failing with a connection refused error. (#1621)
 - A plugin updated in Settings now stays marked Installed instead of showing the Update button again a few seconds later.
+- DBeaver connections are now found for import from any edition, including Ultimate, based on your DBeaver data rather than which app edition is installed. (#1628)
 
 ## [0.49.1] - 2026-06-06
 

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -18,14 +18,15 @@ struct DBeaverImporter: ForeignAppImporter {
     let appBundleIdentifier = "org.jkiss.dbeaver.core.product"
     let readsPasswordsFromKeychain = false
 
-    /// All known DBeaver Eclipse product identifiers. Community, Enterprise,
-    /// Ultimate, and Lite variants each register a different bundle ID, but
-    /// they all write to the same `~/Library/DBeaverData/workspace*`.
+    /// All known DBeaver product identifiers. Community, Enterprise, Ultimate,
+    /// and Lite variants each register a different bundle ID, but they all
+    /// write to the same `~/Library/DBeaverData/workspace*`.
     private static let knownBundleIdentifiers = [
         "org.jkiss.dbeaver.core.product",
         "org.jkiss.dbeaver.ee.core.product",
         "org.jkiss.dbeaver.ue.product",
-        "org.jkiss.dbeaver.lite.product"
+        "org.jkiss.dbeaver.lite.product",
+        "com.dbeaver.product.ultimate"
     ]
 
     /// Root directory containing DBeaver workspace folders. The actual
@@ -34,13 +35,21 @@ struct DBeaverImporter: ForeignAppImporter {
     var dbeaverDataRoot: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/DBeaverData")
 
+    var resolveAppURL: (_ bundleIdentifier: String) -> URL? = {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
+    }
+
     func installedAppURL() -> URL? {
         for bundleId in Self.knownBundleIdentifiers {
-            if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+            if let url = resolveAppURL(bundleId) {
                 return url
             }
         }
         return nil
+    }
+
+    func isAvailable() -> Bool {
+        installedAppURL() != nil || findDataSourcesFile() != nil
     }
 
     func connectionCount() -> Int {

--- a/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/DBeaverImporterTests.swift
@@ -25,6 +25,7 @@ struct DBeaverImporterTests {
 
         var imp = DBeaverImporter()
         imp.dbeaverDataRoot = tempDir
+        imp.resolveAppURL = { _ in nil }
         importer = imp
     }
 
@@ -167,17 +168,24 @@ struct DBeaverImporterTests {
 
     // MARK: - isAvailable
 
-    @Test("isAvailable returns true when data-sources.json exists")
+    @Test("isAvailable returns true when data-sources.json exists for any edition")
     func testIsAvailable_whenFileExists_returnsTrue() throws {
         try writeDataSources(makeDataSourcesJSON(connections: [:]))
         #expect(importer.isAvailable() == true)
     }
 
-    @Test("isAvailable returns false when file is missing")
+    @Test("isAvailable returns false when no app and no data exist")
     func testIsAvailable_whenFileMissing_returnsFalse() throws {
-        // Delete the file if it exists
         try? FileManager.default.removeItem(at: projectDir.appendingPathComponent("data-sources.json"))
         #expect(importer.isAvailable() == false)
+    }
+
+    @Test("isAvailable returns true when a DBeaver app is installed even without data")
+    func testIsAvailable_whenAppInstalledWithoutData_returnsTrue() throws {
+        try? FileManager.default.removeItem(at: projectDir.appendingPathComponent("data-sources.json"))
+        var imp = importer
+        imp.resolveAppURL = { _ in URL(fileURLWithPath: "/Applications/DBeaver.app") }
+        #expect(imp.isAvailable() == true)
     }
 
     // MARK: - connectionCount

--- a/docs/features/connection-sharing.mdx
+++ b/docs/features/connection-sharing.mdx
@@ -87,6 +87,8 @@ Groups and folders carry over.
 | DataGrip | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | From Keychain or `c.kdbx` |
 | Navicat | MySQL, MariaDB, PostgreSQL, SQLite, SQL Server, Oracle, MongoDB | Decrypted from `.ncx` file |
 
+DBeaver is detected from its data folder, so every edition is picked up: Community, Lite, Enterprise, Ultimate, and Team. The app doesn't need to be installed for its saved connections to import.
+
 DataGrip stores connections per project. TablePro imports the connections from the projects DataGrip is tracking (its recent projects), along with their SSH tunnel and SSL settings, and the SSH tunnel password when DataGrip saved one. If a connection is missing, open its project in DataGrip once so it returns to the recent list. Connections protected by a DataGrip master password can't be read.
 
 Navicat keeps its connections in an encrypted store that can't be read directly, so TablePro imports from an export instead. In Navicat, choose **File** > **Export Connections**, and turn on **Export Password** if you want passwords to come across. Pick the resulting `.ncx` file in TablePro. SSH tunnel and SSL settings carry over. A connection exported without its password imports without one, so you enter it the first time you connect.


### PR DESCRIPTION
Closes #1628.

## Problem

`DBeaverImporter` never overrode `isAvailable()`, so it fell through to the protocol default `installedAppURL() != nil`, which is gated entirely on a hardcoded bundle-ID allowlist. But the importer's real data lives at `~/Library/DBeaverData/workspace*/.../data-sources.json`, found by directory enumeration independent of edition. Any DBeaver edition whose bundle ID wasn't in the list (Ultimate, Team, future renames) showed "Not installed" and couldn't be imported, even with its connections on disk.

The reporter asked to add `com.dbeaver.product.ultimate` to the detector. That fixes one edition and leaves the same bug latent for every other. The sibling `DataGripImporter` in the same file already solved this shape (`installedAppURL() != nil || !locations().isEmpty`).

## Fix

- Override `isAvailable()` so it's true when the app is installed **or** a DBeaver data file exists. Detection now keys on the data the importer actually reads, so it's edition-agnostic and survives future bundle-ID renames.
- Add an injectable `resolveAppURL` closure (same pattern `TablePlusImporter` uses) so app detection is deterministic in tests instead of depending on what's installed on the machine.
- Keep `com.dbeaver.product.ultimate` in `knownBundleIdentifiers`, now correctly scoped to driving the app icon in the picker, not gatekeeping import.

## Tests

The existing `testIsAvailable_whenFileExists_returnsTrue` injects a temp data root and expects `true`, which only passed before if a real DBeaver happened to be installed; on clean CI it would fail. It already encoded the intended behavior. Both branches are now deterministic via injected `resolveAppURL`, plus a new test covers the app-present-no-data path.

## Docs / changelog

- `docs/features/connection-sharing.mdx`: note that DBeaver is detected from its data folder, so every edition is picked up.
- CHANGELOG entry under `[Unreleased]`.