### PR TITLE
fix(ios): pin iCloud Sync to the Production CloudKit environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- iCloud Sync between the iPhone and Mac apps: the iOS app now uses the Production CloudKit environment, so a development build no longer syncs into a separate database the Mac never reads.
+
 ## [0.50.0] - 2026-06-09
 
 ### Added

--- a/TableProMobile/TableProMobile/TableProMobileRelease.entitlements
+++ b/TableProMobile/TableProMobile/TableProMobileRelease.entitlements
@@ -10,6 +10,8 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.icloud-container-environment</key>
+	<string>Production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.TablePro.TableProMobile</string>

--- a/TableProTests/Core/Sync/EntitlementsEnvironmentParityTests.swift
+++ b/TableProTests/Core/Sync/EntitlementsEnvironmentParityTests.swift
@@ -1,0 +1,53 @@
+//
+//  EntitlementsEnvironmentParityTests.swift
+//  TableProTests
+//
+//  Guards the CloudKit environment pin. The Mac and iOS apps must both target
+//  the Production environment, or a development iOS build talks to the
+//  Development database while the Mac talks to Production and sync silently
+//  moves nothing across devices.
+//
+
+import Foundation
+import Testing
+
+@Suite("CloudKit environment entitlement parity")
+struct EntitlementsEnvironmentParityTests {
+    private static let environmentKey = "com.apple.developer.icloud-container-environment"
+    private static let macEntitlements = "TablePro/TablePro.entitlements"
+    private static let iosEntitlements = "TableProMobile/TableProMobile/TableProMobileRelease.entitlements"
+
+    @Test("Mac app pins the Production CloudKit environment")
+    func macTargetsProduction() throws {
+        try #expect(environment(in: Self.macEntitlements) == "Production")
+    }
+
+    @Test("iOS app pins the Production CloudKit environment")
+    func iosTargetsProduction() throws {
+        try #expect(environment(in: Self.iosEntitlements) == "Production")
+    }
+
+    private func environment(in relativePath: String) throws -> String? {
+        let url = try repoRoot().appendingPathComponent(relativePath)
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let entitlements = try #require(plist as? [String: Any], "Entitlements at \(relativePath) is not a dictionary")
+        return entitlements[Self.environmentKey] as? String
+    }
+
+    private func repoRoot(file: StaticString = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            let marker = directory.appendingPathComponent("TablePro.xcodeproj")
+            if FileManager.default.fileExists(atPath: marker.path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw EntitlementsParityError.repoRootNotFound
+    }
+
+    private enum EntitlementsParityError: Error {
+        case repoRootNotFound
+    }
+}


### PR DESCRIPTION
## Problem

iCloud Sync between the iPhone and Mac apps reports success on both devices but moves no data. Logs show the Mac pulling `0 changed` and both sides logging "Sync completed successfully".

## Root cause

The Mac app pins `com.apple.developer.icloud-container-environment = Production` (added in `5dcb668c`). The iOS app's entitlements never got that key. Per Apple's docs, a development-signed build with the key absent defaults to the **Development** CloudKit environment, while the Mac (and any TestFlight/App Store build) uses **Production**.

Same Apple ID, same container `iCloud.com.TablePro`, same zone `TableProSync`, but two separate backing databases. Each device creates the zone, pushes, and pulls successfully against its own environment, so each reports success while nothing crosses between Development and Production.

## Fix

Add the missing key to the iOS entitlements, mirroring the Mac. App Store/TestFlight builds are unaffected (they were always Production); development iPhone builds now use Production too.

## Test

`EntitlementsEnvironmentParityTests` parses both entitlement plists and asserts each pins Production. It fails if either app drifts. Runs without CloudKit or a network. Passing locally.

## Migration note

After updating, reinstall the iOS build. If the iPhone still shows nothing, toggle iCloud Sync off/on once on the Mac to force-push existing data into Production.