### PR TITLE
fix(plugin-mysql): disable statement timeout for the export session duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - iCloud Sync between the iPhone and Mac apps: the iOS app now uses the Production CloudKit environment, so a development build no longer syncs into a separate database the Mac never reads.
+- Exports no longer fail mid-table on servers that enforce a statement time limit; the export session disables the limit and restores it afterwards, the same way mysqldump does. (#1633)
 
 ## [0.50.0] - 2026-06-09
 

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -587,14 +587,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Query Timeout
 
     func applyQueryTimeout(_ seconds: Int) async throws {
-        guard seconds > 0 else { return }
         do {
-            if isMariaDB {
-                _ = try await execute(query: "SET SESSION max_statement_time = \(seconds)")
-            } else {
-                let ms = seconds * 1_000
-                _ = try await execute(query: "SET SESSION max_execution_time = \(ms)")
-            }
+            _ = try await execute(query: mysqlQueryTimeoutStatement(seconds: seconds, isMariaDB: isMariaDB))
         } catch {
             Self.logger.warning("Failed to set query timeout: \(error.localizedDescription)")
         }

--- a/Plugins/MySQLDriverPlugin/MySQLQueryTimeoutStatement.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLQueryTimeoutStatement.swift
@@ -1,0 +1,11 @@
+//
+//  MySQLQueryTimeoutStatement.swift
+//  MySQLDriverPlugin
+//
+
+internal func mysqlQueryTimeoutStatement(seconds: Int, isMariaDB: Bool) -> String {
+    guard isMariaDB else {
+        return "SET SESSION max_execution_time = \(seconds * 1_000)"
+    }
+    return "SET SESSION max_statement_time = \(seconds)"
+}

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -466,6 +466,13 @@
 			);
 			target = 5A865000000000000 /* MySQLDriver */;
 		};
+		5A865000E00000000 /* Exceptions for "Plugins/MySQLDriverPlugin" folder in "TableProTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				MySQLQueryTimeoutStatement.swift,
+			);
+			target = 5ABCC5A62F43856700EAF3FC /* TableProTests */;
+		};
 		5A866000900000000 /* Exceptions for "Plugins/MongoDBDriverPlugin" folder in "MongoDBDriver" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -665,6 +672,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				5A865000900000000 /* Exceptions for "Plugins/MySQLDriverPlugin" folder in "MySQLDriver" target */,
+				5A865000E00000000 /* Exceptions for "Plugins/MySQLDriverPlugin" folder in "TableProTests" target */,
 			);
 			path = Plugins/MySQLDriverPlugin;
 			sourceTree = "<group>";

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -158,6 +158,7 @@ final class ExportService {
             )
         }
 
+        await suppressStatementTimeout(on: driver)
         let result: ExportFormatResult
         do {
             result = try await plugin.export(
@@ -167,14 +168,35 @@ final class ExportService {
                 progress: progress
             )
         } catch {
+            await restoreStatementTimeout(on: driver)
             state.errorMessage = error.localizedDescription
             throw error
         }
+        await restoreStatementTimeout(on: driver)
 
         state.processedRows = progress.processedRows
 
         if !result.warnings.isEmpty {
             state.warningMessage = result.warnings.joined(separator: "\n")
+        }
+    }
+
+    // MARK: - Statement Timeout
+
+    func suppressStatementTimeout(on driver: DatabaseDriver) async {
+        do {
+            try await driver.applyQueryTimeout(0)
+        } catch {
+            Self.logger.warning("Failed to disable statement timeout for export: \(error.localizedDescription)")
+        }
+    }
+
+    func restoreStatementTimeout(on driver: DatabaseDriver) async {
+        let timeout = AppSettingsManager.shared.general.queryTimeoutSeconds
+        do {
+            try await driver.applyQueryTimeout(timeout)
+        } catch {
+            Self.logger.warning("Failed to restore statement timeout after export: \(error.localizedDescription)")
         }
     }
 
@@ -304,6 +326,7 @@ final class ExportService {
             optionValues: plugin.defaultTableOptionValues()
         )
 
+        await suppressStatementTimeout(on: driver)
         let result: ExportFormatResult
         do {
             result = try await plugin.export(
@@ -313,9 +336,11 @@ final class ExportService {
                 progress: progress
             )
         } catch {
+            await restoreStatementTimeout(on: driver)
             state.errorMessage = error.localizedDescription
             throw error
         }
+        await restoreStatementTimeout(on: driver)
 
         state.processedRows = progress.processedRows
 

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -23,6 +23,7 @@ final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var fetchColumnsCallCount = 0
     var fetchColumnsCalls: [String] = []
     var fetchSchemaTablesCalls: [String] = []
+    var applyQueryTimeoutValues: [Int] = []
 
     init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
         self.connection = connection
@@ -33,7 +34,9 @@ final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
     func testConnection() async throws -> Bool { true }
 
-    func applyQueryTimeout(_ seconds: Int) async throws {}
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        applyQueryTimeoutValues.append(seconds)
+    }
 
     func execute(query: String) async throws -> QueryResult {
         QueryResult(columns: [], columnTypes: [], rows: [], rowsAffected: 0, executionTime: 0, error: nil)

--- a/TableProTests/Core/Services/ExportServiceTimeoutTests.swift
+++ b/TableProTests/Core/Services/ExportServiceTimeoutTests.swift
@@ -1,0 +1,43 @@
+//
+//  ExportServiceTimeoutTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("ExportService Statement Timeout")
+struct ExportServiceTimeoutTests {
+    private func makeService(driver: MockDatabaseDriver) -> ExportService {
+        ExportService(driver: driver, databaseType: .mysql)
+    }
+
+    @Test("suppressStatementTimeout disables the timeout on the driver")
+    func suppressSendsZero() async {
+        let driver = MockDatabaseDriver()
+        let service = makeService(driver: driver)
+        await service.suppressStatementTimeout(on: driver)
+        #expect(driver.applyQueryTimeoutValues == [0])
+    }
+
+    @Test("restoreStatementTimeout re-applies the configured timeout")
+    func restoreSendsConfiguredTimeout() async {
+        let driver = MockDatabaseDriver()
+        let service = makeService(driver: driver)
+        await service.restoreStatementTimeout(on: driver)
+        let configured = AppSettingsManager.shared.general.queryTimeoutSeconds
+        #expect(driver.applyQueryTimeoutValues == [configured])
+    }
+
+    @Test("Suppress then restore sends disable followed by the configured timeout")
+    func suppressThenRestore() async {
+        let driver = MockDatabaseDriver()
+        let service = makeService(driver: driver)
+        await service.suppressStatementTimeout(on: driver)
+        await service.restoreStatementTimeout(on: driver)
+        let configured = AppSettingsManager.shared.general.queryTimeoutSeconds
+        #expect(driver.applyQueryTimeoutValues == [0, configured])
+    }
+}

--- a/TableProTests/Plugins/MySQLQueryTimeoutTests.swift
+++ b/TableProTests/Plugins/MySQLQueryTimeoutTests.swift
@@ -1,0 +1,33 @@
+//
+//  MySQLQueryTimeoutTests.swift
+//  TableProTests
+//
+
+import Testing
+
+@Suite("MySQL Query Timeout Statement")
+struct MySQLQueryTimeoutTests {
+    @Test("Zero disables the statement timeout on MariaDB")
+    func zeroDisablesMariaDBTimeout() {
+        let statement = mysqlQueryTimeoutStatement(seconds: 0, isMariaDB: true)
+        #expect(statement == "SET SESSION max_statement_time = 0")
+    }
+
+    @Test("Zero disables the execution timeout on MySQL")
+    func zeroDisablesMySQLTimeout() {
+        let statement = mysqlQueryTimeoutStatement(seconds: 0, isMariaDB: false)
+        #expect(statement == "SET SESSION max_execution_time = 0")
+    }
+
+    @Test("MariaDB timeout is expressed in seconds")
+    func mariaDBTimeoutUsesSeconds() {
+        let statement = mysqlQueryTimeoutStatement(seconds: 30, isMariaDB: true)
+        #expect(statement == "SET SESSION max_statement_time = 30")
+    }
+
+    @Test("MySQL timeout is expressed in milliseconds")
+    func mySQLTimeoutUsesMilliseconds() {
+        let statement = mysqlQueryTimeoutStatement(seconds: 30, isMariaDB: false)
+        #expect(statement == "SET SESSION max_execution_time = 30000")
+    }
+}


### PR DESCRIPTION
Fixes #1633.

## Problem

Exporting SQL on MariaDB hosts that set a global `max_statement_time` (common on shared hosting, often 5-30s) killed the export's streamed `SELECT *` with `[1969] Query execution was interrupted (max_statement_time exceeded) (SQLSTATE: 70100)`.

Two bugs combined:

1. `MySQLPluginDriver.applyQueryTimeout(0)` had `guard seconds > 0 else { return }`, so "No limit" in app settings never sent `SET SESSION max_statement_time = 0`. The server's global limit stayed in force.
2. `ExportService` never configured the session before streaming a dump, so even a user-configured timeout could not outlast the export. With `mysql_use_result` the statement stays executing on the server until the client drains all rows, so the timer covers the whole dump.

mariadb-dump fixed this exact problem in 2022 (MDEV-18702) by setting `MAX_STATEMENT_TIME=0` for its dump session. TablePro now does the same.

## Fix

- New `mysqlQueryTimeoutStatement(seconds:isMariaDB:)` builds the session statement: `SET SESSION max_statement_time = N` on MariaDB (seconds), `SET SESSION max_execution_time = N*1000` on MySQL (milliseconds). Zero disables on both. Settable by any user, no privilege needed, session overrides global.
- `applyQueryTimeout` no longer swallows zero.
- `ExportService` disables the statement timeout before `plugin.export(...)` and restores the configured timeout on both success and error paths, in table export and streaming-query export. The export monopolizes the driver's serial queue, so no interactive query runs under the suppressed timeout.
- CSV, JSON, XLSX, and MQL exports share this path and get the fix for free. PostgreSQL exports too: `SET statement_timeout = '0'` already handled zero correctly, only the lifecycle call was missing.

## Tests

- `MySQLQueryTimeoutTests`: statement builder for both flavors, zero and nonzero. The builder is compiled into both the plugin and `TableProTests` (same pattern as `JSONImportParsing.swift`), so the tests run instead of being dead-gated behind `canImport`.
- `ExportServiceTimeoutTests`: suppress sends 0, restore sends the configured timeout, ordering is `[0, configured]`.
- `SQLSchemaProviderTests` mock now records timeout calls; full suite still passes.

No PluginKit ABI impact: only concrete implementations changed, no protocol or transfer type touched. No version bump.

Behavior note: connections configured with "No limit" now send one extra `SET SESSION ... = 0` statement at connect time, which is the intended meaning of that setting.