### PR TITLE
feat: associate .psql and .pgsql files with the SQL editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - BigQuery datasets can be switched from the toolbar, the Cmd+K switcher, and the File menu, including creating and dropping datasets. (#509)
+- `.psql` and `.pgsql` files are now associated with TablePro and open in the SQL editor, alongside `.sql`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - BigQuery datasets can be switched from the toolbar, the Cmd+K switcher, and the File menu, including creating and dropping datasets. (#509)
-- `.psql` and `.pgsql` files are now associated with TablePro and open in the SQL editor, alongside `.sql`.
+- `.psql` and `.pgsql` files now open in the SQL editor like `.sql`: Finder double-click, the open and save panels, and linked SQL folders all accept them. (#1641)
 
 ### Changed
 

--- a/TablePro/Core/Services/Infrastructure/SQLFileService.swift
+++ b/TablePro/Core/Services/Infrastructure/SQLFileService.swift
@@ -13,6 +13,13 @@ import UniformTypeIdentifiers
 enum SQLFileService {
     private static let logger = Logger(subsystem: "com.TablePro", category: "SQLFileService")
 
+    static let supportedExtensions: Set<String> = ["sql", "psql", "pgsql"]
+
+    private static var allowedContentTypes: [UTType] {
+        let types = Set(supportedExtensions.compactMap { UTType(filenameExtension: $0) })
+        return types.isEmpty ? [.plainText] : Array(types)
+    }
+
     /// Reads a SQL file from disk.
     static func readFile(url: URL) async throws -> String {
         try await Task.detached {
@@ -34,7 +41,7 @@ enum SQLFileService {
     @MainActor
     static func showOpenPanel() async -> [URL]? {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "sql") ?? .plainText]
+        panel.allowedContentTypes = allowedContentTypes
         panel.allowsMultipleSelection = true
         panel.message = String(localized: "Select SQL files to open")
         let response = await panel.begin()
@@ -46,7 +53,7 @@ enum SQLFileService {
     @MainActor
     static func showSavePanel(suggestedName: String = "query.sql") async -> URL? {
         let panel = NSSavePanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "sql") ?? .plainText]
+        panel.allowedContentTypes = allowedContentTypes
         panel.canCreateDirectories = true
         panel.nameFieldStringValue = suggestedName
         panel.message = String(localized: "Save SQL file")

--- a/TablePro/Core/Services/Infrastructure/URLClassifier.swift
+++ b/TablePro/Core/Services/Infrastructure/URLClassifier.swift
@@ -28,7 +28,7 @@ internal enum URLClassifier {
         if ext == "tablepro" {
             return .success(.openConnectionShare(url))
         }
-        if ext == "sql" {
+        if SQLFileService.supportedExtensions.contains(ext) {
             return .success(.openSQLFile(url))
         }
         if PluginManager.shared.allInspectorFileExtensions.contains(ext) {

--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -152,7 +152,7 @@ internal final class SQLFolderWatcher {
         var indexed: [LinkedSQLIndex.IndexedFile] = []
 
         for case let url as URL in enumerator {
-            guard url.pathExtension.lowercased() == "sql" else { continue }
+            guard SQLFileService.supportedExtensions.contains(url.pathExtension.lowercased()) else { continue }
 
             let resourceValues = try? url.resourceValues(forKeys: [
                 .isRegularFileKey, .contentModificationDateKey, .fileSizeKey

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -14,6 +14,8 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>sql</string>
+				<string>psql</string>
+				<string>pgsql</string>
 			</array>
 			<key>CFBundleTypeIconSystemGenerated</key>
 			<true/>
@@ -154,6 +156,8 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>sql</string>
+					<string>psql</string>
+					<string>pgsql</string>
 				</array>
 			</dict>
 		</dict>

--- a/TableProTests/Core/Services/Infrastructure/URLClassifierTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/URLClassifierTests.swift
@@ -50,9 +50,9 @@ struct URLClassifierTests {
         #expect(intent == nil)
     }
 
-    @Test("SQL file routes to openSQLFile")
-    func routesSQLFile() {
-        let sqlURL = URL(fileURLWithPath: "/tmp/query.sql")
+    @Test("SQL file routes to openSQLFile", arguments: ["sql", "psql", "pgsql", "PSQL"])
+    func routesSQLFile(ext: String) {
+        let sqlURL = URL(fileURLWithPath: "/tmp/query.\(ext)")
         let intent = URLClassifier.classify(sqlURL)
         guard case .some(.success(.openSQLFile(let routed))) = intent else {
             Issue.record("Expected .openSQLFile, got \(String(describing: intent))")


### PR DESCRIPTION
## What

Adds `.psql` and `.pgsql` to the SQL File document type so PostgreSQL script files open in TablePro's SQL editor, the same as `.sql`.

## Why

`.psql` (the `psql` client) and `.pgsql` (VS Code's PostgreSQL default) are the conventional extensions for PostgreSQL SQL scripts. They're plain SQL, so they belong under the existing `org.iso.sql` type rather than falling back to a dynamic UTI with no handler. Today double-clicking one of these files doesn't route to TablePro.

## Changes

- `TablePro/Info.plist`: add `psql` and `pgsql` to
  - the SQL File `CFBundleDocumentTypes` → `CFBundleTypeExtensions`
  - the `org.iso.sql` imported-type `UTTypeTagSpecification` → `public.filename-extension`
- `CHANGELOG.md`: note under `[Unreleased] → Added`

Both extensions map to the existing `org.iso.sql` UTI — no new UTI or driver work. Scoped deliberately to the standard-SQL Postgres extensions; dialect-specific ones (`.hql`, `.cql`) and overloaded ones (`.ddl`) are intentionally left out.

## Checklist

- [x] Tests added or updated — n/a (no file-association test harness exists; change is a static Info.plist declaration, validated with `plutil -lint`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs updated — no user-facing docs page enumerates associated file extensions
- [x] User-facing strings localized — n/a
- [x] No SwiftLint/SwiftFormat violations — no Swift changed