### PR TITLE
fix(coordinator): reload table data on refresh while a query is in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - iCloud Sync between the iPhone and Mac apps: the iOS app now uses the Production CloudKit environment, so a development build no longer syncs into a separate database the Mac never reads.
 - Exports no longer fail mid-table on servers that enforce a statement time limit; the export session disables the limit and restores it afterwards, the same way mysqldump does. (#1633)
+- Refreshing a table now reloads its data even when the previous load is still running; before, the refresh was silently dropped and the grid kept stale rows. (#1637)
 
 ### Security
 

--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -20,7 +20,6 @@ final class DataTabGridDelegate: DataGridViewDelegate {
     var onAddRow: (() -> Void)?
     var onUndoInsert: ((Int) -> Void)?
     var onFilterColumn: ((String) -> Void)?
-    var onRefresh: (() -> Void)?
 
     // MARK: - DataGridViewDelegate
 
@@ -42,10 +41,6 @@ final class DataTabGridDelegate: DataGridViewDelegate {
 
     func dataGridFilterColumn(_ columnName: String) {
         onFilterColumn?(columnName)
-    }
-
-    func dataGridRefresh() {
-        onRefresh?()
     }
 
     func dataGridDeleteRows(_ indices: Set<Int>) {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -44,7 +44,6 @@ struct MainEditorContentView: View {
     let onFilterColumn: (String) -> Void
     let onApplyFilters: ([TableFilter]) -> Void
     let onClearFilters: () -> Void
-    let onRefresh: () -> Void
 
     // Pagination callbacks
     let onFirstPage: () -> Void
@@ -182,7 +181,6 @@ struct MainEditorContentView: View {
         dataTabDelegate.onSortStateChanged = onSortStateChanged
         dataTabDelegate.onUndoInsert = onUndoInsert
         dataTabDelegate.onFilterColumn = onFilterColumn
-        dataTabDelegate.onRefresh = onRefresh
     }
 
     private func refreshDataTabDelegateMutableRefs() {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -33,7 +33,7 @@ extension MainContentCoordinator {
                     // Query tabs should not auto-execute on refresh (use Cmd+Enter to execute)
                     if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
                        tab.tabType == .table {
-                        currentQueryTask?.cancel()
+                        cancelCurrentQuery()
                         rebuildTableQuery(at: tabIndex)
                         runQuery()
                     }
@@ -42,7 +42,7 @@ extension MainContentCoordinator {
         } else {
             if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
                tab.tabType == .table {
-                currentQueryTask?.cancel()
+                cancelCurrentQuery()
                 rebuildTableQuery(at: tabIndex)
                 runQuery()
             }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -526,13 +526,24 @@ final class MainContentCoordinator {
     }
 
     func refreshTables() async {
-        guard let driver = services.databaseManager.driver(for: connectionId) else { return }
         schemaColumns.removeAll()
-        await services.schemaService.reload(
-            connectionId: connectionId,
-            driver: driver,
-            connection: connection
-        )
+        let schemaService = services.schemaService
+        let connectionId = connectionId
+        let connection = connection
+        do {
+            try await services.databaseManager.withMetadataDriver(
+                connectionId: connectionId,
+                workload: .bulk
+            ) { driver in
+                await schemaService.reload(
+                    connectionId: connectionId,
+                    driver: driver,
+                    connection: connection
+                )
+            }
+        } catch {
+            Self.logger.warning("Schema refresh failed: \(error.localizedDescription, privacy: .public)")
+        }
         await reconcilePostSchemaLoad()
     }
 

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -470,9 +470,6 @@ struct MainContentView: View {
             onClearFilters: {
                 coordinator.clearFiltersAndReload()
             },
-            onRefresh: {
-                coordinator.runQuery()
-            },
             onFirstPage: {
                 coordinator.goToFirstPage()
             },

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -27,7 +27,6 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridCanClearResults() -> Bool
     func dataGridHideColumn(_ columnName: String)
     func dataGridShowAllColumns()
-    func dataGridRefresh()
     func dataGridVisualState(forRow row: Int) -> RowVisualState?
     func dataGridRowView(for tableView: NSTableView, row: Int, coordinator: TableViewCoordinator) -> NSTableRowView?
     func dataGridEmptySpaceMenu() -> NSMenu?
@@ -56,7 +55,6 @@ extension DataGridViewDelegate {
     func dataGridCanClearResults() -> Bool { false }
     func dataGridHideColumn(_ columnName: String) {}
     func dataGridShowAllColumns() {}
-    func dataGridRefresh() {}
     func dataGridVisualState(forRow row: Int) -> RowVisualState? { nil }
     func dataGridRowView(for tableView: NSTableView, row: Int, coordinator: TableViewCoordinator) -> NSTableRowView? { nil }
     func dataGridEmptySpaceMenu() -> NSMenu? { nil }

--- a/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
@@ -1,0 +1,166 @@
+//
+//  MainContentCoordinatorRefreshTests.swift
+//  TableProTests
+//
+//  Tests for handleRefresh, the entry point behind the Refresh toolbar
+//  button and Cmd+R. Regression coverage for #1637: a refresh issued while
+//  a query was in flight was silently dropped because the in-flight
+//  cancellation cleared isExecuting asynchronously.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("MainContentCoordinator handleRefresh")
+@MainActor
+struct MainContentCoordinatorRefreshTests {
+    private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return (coordinator, tabManager)
+    }
+
+    private func addTableTab(
+        to tabManager: QueryTabManager,
+        tableName: String = "users",
+        query: String = "SELECT * FROM users"
+    ) -> UUID {
+        var tab = QueryTab(
+            title: tableName,
+            query: query,
+            tabType: .table,
+            tableName: tableName
+        )
+        tab.tableContext.isEditable = true
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab.id
+    }
+
+    private func addQueryTab(
+        to tabManager: QueryTabManager,
+        title: String = "Query 1",
+        query: String = "SELECT 1"
+    ) -> UUID {
+        let tab = QueryTab(title: title, query: query, tabType: .query)
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab.id
+    }
+
+    private func simulateInFlightQuery(
+        _ coordinator: MainContentCoordinator,
+        _ tabManager: QueryTabManager,
+        at index: Int
+    ) -> Task<Void, Never> {
+        let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
+        coordinator.currentQueryTask = inFlight
+        tabManager.tabs[index].execution.isExecuting = true
+        tabManager.tabs[index].execution.lastExecutedAt = Date()
+        return inFlight
+    }
+
+    @Test("Refresh while a query is in flight cancels it and starts a new execution")
+    func refreshWithInFlightQueryStartsNewExecution() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        let staleTask = simulateInFlightQuery(coordinator, tabManager, at: idx)
+        let initialGeneration = coordinator.queryGeneration
+
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+        defer { coordinator.currentQueryTask?.cancel() }
+
+        #expect(staleTask.isCancelled == true)
+        #expect(coordinator.queryGeneration == initialGeneration + 2)
+        #expect(coordinator.currentQueryTask != nil)
+        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+    }
+
+    @Test("Refresh on an idle table tab starts an execution")
+    func refreshOnIdleTabStartsExecution() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].execution.lastExecutedAt = Date()
+        let initialGeneration = coordinator.queryGeneration
+
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+        defer { coordinator.currentQueryTask?.cancel() }
+
+        #expect(coordinator.queryGeneration == initialGeneration + 2)
+        #expect(coordinator.currentQueryTask != nil)
+        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+    }
+
+    @Test("Refresh rebuilds the table query from current state before executing")
+    func refreshRebuildsQuery() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager, query: "SELECT outdated FROM users")
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].execution.lastExecutedAt = Date()
+
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+        defer { coordinator.currentQueryTask?.cancel() }
+
+        #expect(tabManager.tabs[idx].content.query != "SELECT outdated FROM users")
+        #expect(tabManager.tabs[idx].content.query.contains("users"))
+    }
+
+    @Test("Refresh on a query tab does not execute or cancel anything")
+    func refreshOnQueryTabIsNoOp() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addQueryTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
+        defer { inFlight.cancel() }
+        coordinator.currentQueryTask = inFlight
+        tabManager.tabs[idx].execution.isExecuting = true
+        let initialGeneration = coordinator.queryGeneration
+
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+
+        #expect(inFlight.isCancelled == false)
+        #expect(coordinator.queryGeneration == initialGeneration)
+        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+    }
+
+    @Test("Refresh in structure view leaves execution state untouched")
+    func refreshInStructureViewIsNoOp() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].display.resultsViewMode = .structure
+        let staleTask = simulateInFlightQuery(coordinator, tabManager, at: idx)
+        defer { staleTask.cancel() }
+        let initialGeneration = coordinator.queryGeneration
+
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+
+        #expect(staleTask.isCancelled == false)
+        #expect(coordinator.queryGeneration == initialGeneration)
+        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+    }
+}


### PR DESCRIPTION
Fixes #1637.

## Problem

Clicking Refresh (toolbar or Cmd+R) on an open table tab did nothing when a query was still running. Rows inserted from another client never showed up; the only workaround was closing and reopening the tab.

## Root cause

`handleRefresh` cancelled the in-flight task with `currentQueryTask?.cancel()` and called `runQuery()` on the next line. Cancellation is cooperative: the `isExecuting` flag is only cleared inside the cancelled task, on a later run-loop turn. So `runQuery()` hit its `!isExecuting` guard and returned early. The refresh SELECT never ran, with no log and no user feedback. This fired whenever a query was in flight at refresh time: slow queries, the initial load still running, or rapid repeated refreshes.

## Fix

- `handleRefresh` now calls `cancelCurrentQuery()`, the existing synchronous primitive that cancels and nils the task, bumps `queryGeneration`, and clears `isExecuting` before the new query starts. Both the direct branch and the pending-changes branch are covered.
- `refreshTables()` now fetches schema metadata through `withMetadataDriver(workload: .bulk)` instead of the main connection driver, so the schema reload no longer contends with the data SELECT on the same socket (same isolation rule as the rest of background introspection since #1483).
- Removed the dead `dataGridRefresh()` delegate path and its `onRefresh` plumbing. It had no callers and skipped `rebuildTableQuery`, so it would have refreshed with a stale query if ever wired up.

## Tests

New `MainContentCoordinatorRefreshTests` (5 tests, all passing):
- regression: refresh during an in-flight query cancels it and starts a new execution
- refresh on an idle table tab starts an execution
- refresh rebuilds the table query from current filter/sort/pagination state
- refresh on a query tab is a no-op
- refresh in structure view leaves execution state untouched

The pending-changes confirmation branch shares the same three-line sequence but goes through an NSAlert, so it is not covered by a deterministic unit test.

`swiftlint lint --strict` clean on changed files.