### PR TITLE
Refresh (Cmd+R): fix self-cancelling reload, scope to focused window, coalesce rapid presses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switcher, menus, and alerts now use each database's own container name: Dataset for BigQuery, Keyspace for Cassandra and ScyllaDB. (#509)
 - Refresh (Cmd+R) now acts only on the focused window's connection, instead of also reloading views and clearing autocomplete caches for every other open connection.
+- Holding Cmd+R no longer queues a backlog of refreshes that kept running after the key was released; refresh fires once per key press, and rapid presses collapse into a single reload.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Switcher, menus, and alerts now use each database's own container name: Dataset for BigQuery, Keyspace for Cassandra and ScyllaDB. (#509)
+- Refresh (Cmd+R) now acts only on the focused window's connection, instead of also reloading views and clearing autocomplete caches for every other open connection.
 
 ### Fixed
 
 - iCloud Sync between the iPhone and Mac apps: the iOS app now uses the Production CloudKit environment, so a development build no longer syncs into a separate database the Mac never reads.
 - Exports no longer fail mid-table on servers that enforce a statement time limit; the export session disables the limit and restores it afterwards, the same way mysqldump does. (#1633)
 - Refreshing a table now reloads its data even when the previous load is still running; before, the refresh was silently dropped and the grid kept stale rows. (#1637)
+- Cmd+R on a table now reloads its rows instead of failing with a query error; the refresh was sending the database a stray cancel that aborted its own freshly-issued reload.
 - SQL autocomplete now suggests tables after JOIN. It detects the clause at the cursor across multi-join and multi-clause queries, so columns no longer appear where a table is expected, and tables lead the list. (#1646)
 
 ### Security

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -60,6 +60,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         NSWindow.allowsAutomaticWindowTabbing = true
+        KeyRepeatFilter.shared.install()
         let syncSettings = AppSettingsStorage.shared.loadSync()
         let passwordSyncExpected = syncSettings.enabled && syncSettings.syncConnections && syncSettings.syncPasswords
         UserDefaults.standard.set(passwordSyncExpected, forKey: KeychainHelper.passwordSyncEnabledKey)

--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -129,10 +129,11 @@ final class PaginationCoordinator {
     // MARK: - Cancel Current Query
 
     func cancelCurrentQuery() {
+        let hadInFlightTask = parent.currentQueryTask != nil
         parent.currentQueryTask?.cancel()
         parent.currentQueryTask = nil
         parent.queryGeneration += 1
-        if let driver = DatabaseManager.shared.driver(for: parent.connectionId) {
+        if hadInFlightTask, let driver = DatabaseManager.shared.driver(for: parent.connectionId) {
             try? driver.cancelQuery()
         }
         parent.toolbarState.setExecuting(false)

--- a/TablePro/Core/Database/DatabaseManager+Schema.swift
+++ b/TablePro/Core/Database/DatabaseManager+Schema.swift
@@ -112,7 +112,7 @@ extension DatabaseManager {
                 }
 
                 await MainActor.run {
-                    AppCommands.shared.refreshData.send(nil)
+                    AppCommands.shared.refreshData.send(connectionId)
                 }
             } catch {
                 if useTransaction {

--- a/TablePro/Core/Events/AppCommands.swift
+++ b/TablePro/Core/Events/AppCommands.swift
@@ -12,7 +12,7 @@ final class AppCommands {
 
     // MARK: - Refresh
 
-    let refreshData = PassthroughSubject<UUID?, Never>()
+    let refreshData = PassthroughSubject<UUID, Never>()
 
     // MARK: - File / Connection Import-Export
 

--- a/TablePro/Core/KeyboardHandling/KeyRepeatFilter.swift
+++ b/TablePro/Core/KeyboardHandling/KeyRepeatFilter.swift
@@ -1,0 +1,36 @@
+//
+//  KeyRepeatFilter.swift
+//  TablePro
+//
+//  Drops OS key auto-repeat for actions that must fire once per physical press.
+//  SwiftUI `.commands` key-equivalents auto-repeat while held, but menu actions
+//  like Refresh should fire once per press, matching standard macOS behaviour.
+//
+
+import AppKit
+
+@MainActor
+final class KeyRepeatFilter {
+    static let shared = KeyRepeatFilter()
+
+    private static let nonRepeatingActions: [ShortcutAction] = [.refresh]
+
+    private var monitor: Any?
+
+    private init() {}
+
+    func install() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { nsEvent in
+            nonisolated(unsafe) let event = nsEvent
+            return MainActor.assumeIsolated {
+                guard event.isARepeat else { return event }
+                let keyboard = AppSettingsManager.shared.keyboard
+                let suppress = Self.nonRepeatingActions.contains {
+                    keyboard.shortcut(for: $0)?.matches(event) == true
+                }
+                return suppress ? nil : event
+            }
+        }
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Actions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Actions.swift
@@ -16,7 +16,7 @@ extension MainWindowToolbar {
     }
 
     @objc func performRefresh(_ sender: Any?) {
-        AppCommands.shared.refreshData.send(nil)
+        coordinator?.commandActions?.refresh()
     }
 
     @objc func performSaveChanges(_ sender: Any?) {

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
@@ -85,7 +85,7 @@ struct RefreshToolbarButton: View {
     var body: some View {
         let state = coordinator.toolbarState
         Button {
-            AppCommands.shared.refreshData.send(nil)
+            coordinator.commandActions?.refresh()
         } label: {
             Label("Refresh", systemImage: "arrow.clockwise")
         }

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -40,15 +40,9 @@ final class SchemaProviderRegistry {
             .store(in: &cancellables)
     }
 
-    func invalidateColumnCache(for connectionId: UUID?) {
-        if let id = connectionId {
-            guard let provider = providers[id] else { return }
-            Task { await provider.clearColumnCache() }
-            return
-        }
-        for provider in providers.values {
-            Task { await provider.clearColumnCache() }
-        }
+    func invalidateColumnCache(for connectionId: UUID) {
+        guard let provider = providers[connectionId] else { return }
+        Task { await provider.clearColumnCache() }
     }
 
     func provider(for connectionId: UUID) -> SQLSchemaProvider? {

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -237,7 +237,7 @@ struct AppMenuCommands: Commands {
         //    - Clean method calls, no global event bus
         //
         // 3. **NotificationCenter** (Multi-listener broadcasts only):
-        //    - refreshData (Sidebar + Coordinator + StructureView)
+        //    - refreshData: targeted per-connection data-changed signal
         //    - Legitimate broadcasts where multiple views respond
 
         // File menu
@@ -423,7 +423,7 @@ struct AppMenuCommands: Commands {
             .disabled(!(actions?.isQueryExecuting ?? false))
 
             Button("Refresh") {
-                AppCommands.shared.refreshData.send(nil)
+                actions?.refresh()
             }
             .optionalKeyboardShortcut(shortcut(for: .refresh))
             .disabled(!(actions?.isConnected ?? false))

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -11,6 +11,31 @@ import Foundation
 extension MainContentCoordinator {
     // MARK: - Refresh Handling
 
+    private static let refreshCoalesceInterval: Duration = .milliseconds(250)
+
+    func requestRefresh(hasPendingTableOps: Bool, onDiscard: @escaping () -> Void) {
+        if refreshCoalesceTask == nil {
+            fireRefresh(hasPendingTableOps: hasPendingTableOps, onDiscard: onDiscard)
+        } else {
+            refreshPendingTrailing = true
+        }
+        refreshCoalesceTask?.cancel()
+        refreshCoalesceTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.refreshCoalesceInterval)
+            guard let self, !Task.isCancelled else { return }
+            self.refreshCoalesceTask = nil
+            if self.refreshPendingTrailing {
+                self.refreshPendingTrailing = false
+                self.fireRefresh(hasPendingTableOps: hasPendingTableOps, onDiscard: onDiscard)
+            }
+        }
+    }
+
+    private func fireRefresh(hasPendingTableOps: Bool, onDiscard: @escaping () -> Void) {
+        handleRefresh(hasPendingTableOps: hasPendingTableOps, onDiscard: onDiscard)
+        Task { await refreshTables() }
+    }
+
     func handleRefresh(
         hasPendingTableOps: Bool,
         onDiscard: @escaping () -> Void

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -15,37 +15,41 @@ extension MainContentCoordinator {
         hasPendingTableOps: Bool,
         onDiscard: @escaping () -> Void
     ) {
-        // If showing structure view, let it handle refresh notifications
-        if let (tab, _) = tabManager.selectedTabAndIndex,
-           tab.display.resultsViewMode == .structure {
+        guard let (tab, _) = tabManager.selectedTabAndIndex else { return }
+        if tab.display.resultsViewMode == .structure {
+            structureActions?.refresh?()
+            return
+        }
+        reloadActiveTableData(hasPendingTableOps: hasPendingTableOps, onDiscard: onDiscard)
+    }
+
+    func reloadActiveTableData(
+        hasPendingTableOps: Bool,
+        onDiscard: @escaping () -> Void
+    ) {
+        guard let (tab, tabIndex) = tabManager.selectedTabAndIndex,
+              tab.tabType == .table,
+              tab.display.resultsViewMode != .structure else { return }
+
+        guard changeManager.hasChanges || hasPendingTableOps else {
+            reloadTableTab(at: tabIndex)
             return
         }
 
-        let hasEditedCells = changeManager.hasChanges
-
-        if hasEditedCells || hasPendingTableOps {
-            Task {
-                let window = NSApp.keyWindow
-                let confirmed = await confirmDiscardChanges(action: .refresh, window: window)
-                if confirmed {
-                    onDiscard()
-                    changeManager.clearChangesAndUndoHistory()
-                    // Query tabs should not auto-execute on refresh (use Cmd+Enter to execute)
-                    if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
-                       tab.tabType == .table {
-                        cancelCurrentQuery()
-                        rebuildTableQuery(at: tabIndex)
-                        runQuery()
-                    }
-                }
-            }
-        } else {
-            if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
-               tab.tabType == .table {
-                cancelCurrentQuery()
-                rebuildTableQuery(at: tabIndex)
-                runQuery()
-            }
+        Task {
+            let confirmed = await confirmDiscardChanges(action: .refresh, window: NSApp.keyWindow)
+            guard confirmed else { return }
+            onDiscard()
+            changeManager.clearChangesAndUndoHistory()
+            guard let (tab, tabIndex) = tabManager.selectedTabAndIndex,
+                  tab.tabType == .table else { return }
+            reloadTableTab(at: tabIndex)
         }
+    }
+
+    private func reloadTableTab(at tabIndex: Int) {
+        cancelCurrentQuery()
+        rebuildTableQuery(at: tabIndex)
+        runQuery()
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SessionContexts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SessionContexts.swift
@@ -28,7 +28,7 @@ extension MainContentCoordinator {
         do {
             try await driver.switchSessionContext(id: id, to: value)
             await loadSessionContexts()
-            AppCommands.shared.refreshData.send(nil)
+            AppCommands.shared.refreshData.send(connectionId)
         } catch {
             AlertHelper.showErrorSheet(
                 title: String(localized: "Switch Failed"),

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -895,11 +895,10 @@ final class MainContentCommandActions {
 
     func refresh() {
         guard let coordinator else { return }
-        coordinator.handleRefresh(
+        coordinator.requestRefresh(
             hasPendingTableOps: hasPendingTableOps,
             onDiscard: { [weak self] in self?.clearPendingTableOps() }
         )
-        Task { await coordinator.refreshTables() }
     }
 
     private var hasPendingTableOps: Bool {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -893,34 +893,37 @@ final class MainContentCommandActions {
 
     // MARK: Data Broadcasts
 
+    func refresh() {
+        guard let coordinator else { return }
+        coordinator.handleRefresh(
+            hasPendingTableOps: hasPendingTableOps,
+            onDiscard: { [weak self] in self?.clearPendingTableOps() }
+        )
+        Task { await coordinator.refreshTables() }
+    }
+
+    private var hasPendingTableOps: Bool {
+        !pendingTruncates.wrappedValue.isEmpty || !pendingDeletes.wrappedValue.isEmpty
+    }
+
+    private func clearPendingTableOps() {
+        pendingTruncates.wrappedValue.removeAll()
+        pendingDeletes.wrappedValue.removeAll()
+    }
+
     private func setupDataBroadcastObservers() {
         AppCommands.shared.refreshData
             .receive(on: RunLoop.main)
-            .sink { [weak self] target in
-                guard let self else { return }
-                if let target, target != self.connection.id {
-                    return
-                }
-                if target == nil && !self.isKeyWindow() {
-                    return
-                }
-                self.handleRefreshData()
+            .sink { [weak self] changedConnectionId in
+                guard let self, changedConnectionId == self.connection.id,
+                      let coordinator = self.coordinator else { return }
+                coordinator.reloadActiveTableData(
+                    hasPendingTableOps: self.hasPendingTableOps,
+                    onDiscard: { [weak self] in self?.clearPendingTableOps() }
+                )
+                Task { await coordinator.refreshTables() }
             }
             .store(in: &eventCancellables)
-    }
-
-    private func handleRefreshData() {
-        let hasPendingTableOps = !pendingTruncates.wrappedValue.isEmpty || !pendingDeletes.wrappedValue.isEmpty
-        coordinator?.handleRefresh(
-            hasPendingTableOps: hasPendingTableOps,
-            onDiscard: { [weak self] in
-                self?.pendingTruncates.wrappedValue.removeAll()
-                self?.pendingDeletes.wrappedValue.removeAll()
-            }
-        )
-        if let coordinator {
-            Task { await coordinator.refreshTables() }
-        }
     }
 
     // MARK: Tab Broadcasts

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -231,6 +231,9 @@ final class MainContentCoordinator {
     /// Eviction task scheduled in `handleWindowDidResignKey` (fires 5s later).
     @ObservationIgnored var evictionTask: Task<Void, Never>?
 
+    @ObservationIgnored var refreshCoalesceTask: Task<Void, Never>?
+    @ObservationIgnored var refreshPendingTrailing = false
+
     /// True once the coordinator's view has appeared (onAppear fired).
     /// Coordinators that SwiftUI creates during body re-evaluation but never
     /// adopts into @State are silently discarded — no teardown warning needed.
@@ -652,6 +655,8 @@ final class MainContentCoordinator {
         fileWatcher = nil
         currentQueryTask?.cancel()
         currentQueryTask = nil
+        refreshCoalesceTask?.cancel()
+        refreshCoalesceTask = nil
         for entry in tableLoadTasks.values { entry.task.cancel() }
         tableLoadTasks.removeAll()
         changeManagerUpdateTask?.cancel()

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -535,7 +535,8 @@ final class MainContentCoordinator {
             return
         }
         let task = Task { [weak self] in
-            await self?.reloadSchema()
+            guard let self else { return }
+            await self.reloadSchema()
         }
         schemaReloadTask = task
         await task.value

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -233,6 +233,7 @@ final class MainContentCoordinator {
 
     @ObservationIgnored var refreshCoalesceTask: Task<Void, Never>?
     @ObservationIgnored var refreshPendingTrailing = false
+    @ObservationIgnored private var schemaReloadTask: Task<Void, Never>?
 
     /// True once the coordinator's view has appeared (onAppear fired).
     /// Coordinators that SwiftUI creates during body re-evaluation but never
@@ -529,6 +530,19 @@ final class MainContentCoordinator {
     }
 
     func refreshTables() async {
+        if let existing = schemaReloadTask {
+            await existing.value
+            return
+        }
+        let task = Task { [weak self] in
+            await self?.reloadSchema()
+        }
+        schemaReloadTask = task
+        await task.value
+        schemaReloadTask = nil
+    }
+
+    private func reloadSchema() async {
         schemaColumns.removeAll()
         let schemaService = services.schemaService
         let connectionId = connectionId
@@ -657,6 +671,8 @@ final class MainContentCoordinator {
         currentQueryTask = nil
         refreshCoalesceTask?.cancel()
         refreshCoalesceTask = nil
+        schemaReloadTask?.cancel()
+        schemaReloadTask = nil
         for entry in tableLoadTasks.values { entry.task.cancel() }
         tableLoadTasks.removeAll()
         changeManagerUpdateTask?.cancel()

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -14,6 +14,7 @@ struct ClickHousePartsView: View {
 
     let tableName: String
     let connectionId: UUID
+    let reloadToken: Int
 
     @State private var parts: [ClickHousePartInfo] = []
     @State private var isLoading = true
@@ -50,10 +51,7 @@ struct ClickHousePartsView: View {
                 partsTable
             }
         }
-        .task { await loadParts() }
-        .onReceive(AppCommands.shared.refreshData) { _ in
-            Task { await loadParts() }
-        }
+        .task(id: reloadToken) { await loadParts() }
     }
 
     private var partsToolbar: some View {

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -389,7 +389,7 @@ struct CreateTableView: View {
                     wasSuccessful: true
                 )
 
-                AppCommands.shared.refreshData.send(nil)
+                AppCommands.shared.refreshData.send(connection.id)
 
                 if let coordinator {
                     coordinator.openTableTab(tableName)

--- a/TablePro/Views/Structure/StructureViewActionHandler.swift
+++ b/TablePro/Views/Structure/StructureViewActionHandler.swift
@@ -15,4 +15,5 @@ final class StructureViewActionHandler {
     var redo: (() -> Void)?
     var addRow: (() -> Void)?
     var removeRow: (() -> Void)?
+    var refresh: (() -> Void)?
 }

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -168,6 +168,7 @@ extension TableStructureView {
 
     private func reloadAllTabs() async {
         loadedTabs.removeAll()
+        partsReloadToken += 1
         await loadColumns()
         await fetchTabData(.indexes)
         if connection.type.supportsForeignKeys {

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -35,6 +35,7 @@ struct TableStructureView: View {
     @State var isInitialLoading = true
     @State var errorMessage: String?
     @State var loadedTabs: Set<StructureTab> = []
+    @State var partsReloadToken = 0
     @State var isReloadingAfterSave = false  // Prevent onChange loops during save reload
     @State var lastSaveTime: Date?  // Track when we last saved
     @AppStorage("skipSchemaPreview") var skipSchemaPreview = false
@@ -126,6 +127,7 @@ struct TableStructureView: View {
             actionHandler.redo = { self.gridDelegate.dataGridRedo() }
             actionHandler.addRow = { self.gridDelegate.dataGridAddRow() }
             actionHandler.removeRow = { self.gridDelegate.dataGridDeleteRows(self.selectedRows) }
+            actionHandler.refresh = { self.onRefreshData() }
             coordinator?.structureActions = actionHandler
             publishFooterState()
         }
@@ -148,7 +150,10 @@ struct TableStructureView: View {
             // manager but the grid never displays it.
             displayVersion += 1
         }
-        .onReceive(AppCommands.shared.refreshData) { _ in onRefreshData() }
+        .onReceive(AppCommands.shared.refreshData) { changedConnectionId in
+            guard changedConnectionId == connection.id else { return }
+            onRefreshData()
+        }
     }
 
     // MARK: - Toolbar
@@ -283,7 +288,11 @@ struct TableStructureView: View {
         case .ddl:
             ddlView
         case .parts:
-            ClickHousePartsView(tableName: tableName, connectionId: connection.id)
+            ClickHousePartsView(
+                tableName: tableName,
+                connectionId: connection.id,
+                reloadToken: partsReloadToken
+            )
         }
     }
 
@@ -358,7 +367,7 @@ struct TableStructureView: View {
                         loadSchemaForEditing()
                         isReloadingAfterSave = false
                         columnLayoutPersister.clear(for: tableName, connectionId: connection.id)
-                        AppCommands.shared.refreshData.send(nil)
+                        AppCommands.shared.refreshData.send(connection.id)
                     } catch {
                         AlertHelper.showErrorSheet(
                             title: String(localized: "Column Reorder Failed"),

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -24,6 +24,7 @@ final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var fetchColumnsCalls: [String] = []
     var fetchSchemaTablesCalls: [String] = []
     var applyQueryTimeoutValues: [Int] = []
+    var cancelQueryCallCount = 0
 
     init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
         self.connection = connection
@@ -94,7 +95,7 @@ final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func createDatabase(name: String, charset: String, collation: String?) async throws {}
-    func cancelQuery() throws {}
+    func cancelQuery() throws { cancelQueryCallCount += 1 }
     func beginTransaction() async throws {}
     func commitTransaction() async throws {}
     func rollbackTransaction() async throws {}

--- a/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
@@ -248,4 +248,51 @@ struct MainContentCoordinatorRefreshTests {
         #expect(coordinator.queryGeneration == initialGeneration)
         #expect(coordinator.currentQueryTask == nil)
     }
+
+    @Test("requestRefresh fires immediately and coalesces a rapid second call")
+    func requestRefreshCoalescesRapidCalls() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].execution.lastExecutedAt = Date()
+        defer {
+            coordinator.refreshCoalesceTask?.cancel()
+            coordinator.currentQueryTask?.cancel()
+        }
+        let initialGeneration = coordinator.queryGeneration
+
+        coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
+        let generationAfterLeading = coordinator.queryGeneration
+        coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
+        let generationAfterSecond = coordinator.queryGeneration
+
+        #expect(generationAfterLeading == initialGeneration + 2)
+        #expect(generationAfterSecond == generationAfterLeading)
+        #expect(coordinator.refreshPendingTrailing == true)
+        #expect(coordinator.refreshCoalesceTask != nil)
+    }
+
+    @Test("A single requestRefresh fires once and schedules no trailing refresh")
+    func singleRequestRefreshHasNoTrailing() async {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].execution.lastExecutedAt = Date()
+        defer { coordinator.currentQueryTask?.cancel() }
+
+        coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
+        let generationAfterLeading = coordinator.queryGeneration
+
+        try? await Task.sleep(for: .milliseconds(400))
+
+        #expect(coordinator.queryGeneration == generationAfterLeading)
+        #expect(coordinator.refreshPendingTrailing == false)
+        #expect(coordinator.refreshCoalesceTask == nil)
+    }
 }

--- a/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
@@ -17,14 +17,33 @@ import Testing
 @MainActor
 struct MainContentCoordinatorRefreshTests {
     private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        makeCoordinator(connection: TestFixtures.makeConnection())
+    }
+
+    private func makeCoordinator(
+        connection: DatabaseConnection
+    ) -> (MainContentCoordinator, QueryTabManager) {
         let tabManager = QueryTabManager()
         let coordinator = MainContentCoordinator(
-            connection: TestFixtures.makeConnection(),
+            connection: connection,
             tabManager: tabManager,
             changeManager: DataChangeManager(),
             toolbarState: ConnectionToolbarState()
         )
         return (coordinator, tabManager)
+    }
+
+    private func withInjectedDriver(
+        _ body: (DatabaseConnection, MockDatabaseDriver) -> Void
+    ) {
+        let connection = TestFixtures.makeConnection()
+        let driver = MockDatabaseDriver(connection: connection)
+        DatabaseManager.shared.injectSession(
+            ConnectionSession(connection: connection, driver: driver),
+            for: connection.id
+        )
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+        body(connection, driver)
     }
 
     private func addTableTab(
@@ -162,5 +181,71 @@ struct MainContentCoordinatorRefreshTests {
         #expect(staleTask.isCancelled == false)
         #expect(coordinator.queryGeneration == initialGeneration)
         #expect(tabManager.tabs[idx].execution.isExecuting == true)
+    }
+
+    @Test("cancelCurrentQuery leaves the driver alone when no query is in flight")
+    func cancelWithoutInFlightDoesNotTouchDriver() {
+        withInjectedDriver { connection, driver in
+            let (coordinator, _) = makeCoordinator(connection: connection)
+
+            coordinator.cancelCurrentQuery()
+
+            #expect(driver.cancelQueryCallCount == 0)
+        }
+    }
+
+    @Test("cancelCurrentQuery cancels the driver when a query is in flight")
+    func cancelWithInFlightCancelsDriver() {
+        withInjectedDriver { connection, driver in
+            let (coordinator, _) = makeCoordinator(connection: connection)
+            let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
+            defer { inFlight.cancel() }
+            coordinator.currentQueryTask = inFlight
+
+            coordinator.cancelCurrentQuery()
+
+            #expect(driver.cancelQueryCallCount == 1)
+        }
+    }
+
+    @Test("Refresh on an idle table tab does not issue a stray driver cancel")
+    func idleRefreshDoesNotCancelDriver() {
+        withInjectedDriver { connection, driver in
+            let (coordinator, tabManager) = makeCoordinator(connection: connection)
+            let tabId = addTableTab(to: tabManager)
+            guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+                Issue.record("expected tab to exist")
+                return
+            }
+            tabManager.tabs[idx].execution.lastExecutedAt = Date()
+
+            coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+            defer { coordinator.currentQueryTask?.cancel() }
+
+            #expect(driver.cancelQueryCallCount == 0)
+        }
+    }
+
+    @Test("Refresh in structure view dispatches to the structure refresh handler")
+    func refreshInStructureViewDispatchesToHandler() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+            Issue.record("expected tab to exist")
+            return
+        }
+        tabManager.tabs[idx].display.resultsViewMode = .structure
+
+        let handler = StructureViewActionHandler()
+        var refreshCalled = false
+        handler.refresh = { refreshCalled = true }
+        coordinator.structureActions = handler
+
+        let initialGeneration = coordinator.queryGeneration
+        coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
+
+        #expect(refreshCalled == true)
+        #expect(coordinator.queryGeneration == initialGeneration)
+        #expect(coordinator.currentQueryTask == nil)
     }
 }


### PR DESCRIPTION
## Summary

Cmd+R refresh behaved incorrectly and laggily. Diagnosed with structured OSLog tracing, then refactored the refresh path onto native, key-window-scoped dispatch.

Two distinct bugs, both confirmed from logs:

1. **Refresh on a table failed silently.** On an idle table tab, `cancelCurrentQuery()` always called `driver.cancelQuery()` even with no query in flight. That stray cancel (e.g. Postgres `PQcancel`) raced and aborted the reload query the same refresh had just issued, so the grid never updated.
2. **Holding Cmd+R piled up work.** SwiftUI `.commands` auto-repeats the shortcut while held, and each fire spawned an un-coalesced full schema reload. A 2s hold queued ~16 refreshes; ~12 bulk schema reloads ran concurrently and kept draining for ~2s after release, saturating the main actor (a query whose data was ready took 1.5s just to post its result).

## Changes

- **Cancel only when needed:** `cancelCurrentQuery()` calls `driver.cancelQuery()` only when a query is actually in flight, so an idle refresh stops poisoning its own reload.
- **Native dispatch:** user Cmd+R / toolbar refresh now calls `MainContentCommandActions.refresh()` on the key window via `@FocusedValue` / `CommandActionsRegistry`, like every other menu command. No more global broadcast or hand-rolled key-window filtering.
- **Targeted data-changed signal:** `AppCommands.refreshData` is now `PassthroughSubject<UUID, Never>` (per-connection). Programmatic senders pass a `connectionId`; subscribers filter by it, so a refresh no longer reloads views or clears autocomplete caches for unrelated connections.
- **Dispatch by active view:** structure mode reloads via `structureActions.refresh()`; table/data (and JSON) reload the grid; query tabs stay a no-op (Cmd+Enter runs them). ClickHouse Parts reloads through the same `reloadAllTabs()` path (it had no other refresh hook after the broadcast change).
- **Coalescing:** rapid refreshes collapse to one leading + one trailing run; a held key never stacks work.
- **Ignore key auto-repeat:** `KeyRepeatFilter` drops only `isARepeat` keydown events matching the Refresh shortcut, so holding Cmd+R fires once per physical press (matching Finder/Safari/Mail).

## Tests

`MainContentCoordinatorRefreshTests`: idle refresh does not cancel the driver, in-flight refresh does, structure-mode refresh dispatches to the structure handler, plus the existing in-flight/idle/query-tab coverage. `MockDatabaseDriver` gained a `cancelQuery` counter.

## Not in this PR

Loading a very large result set (e.g. 40k rows) is slow because the on-screen load uses the bulk `PQexec` path while the driver's streaming path (`streamRows`, single-row mode) is only used by exports. That is a separate data-load effort, tracked independently.

## Verification

`swiftlint lint --strict` clean. Verified via `log stream` (category `Refresh`, since removed): a held Cmd+R now fires one refresh per press with nothing trailing after release, and table refresh reloads rows instead of erroring.