### PR TITLE
fix(editor): detect SQL clause from text before the token being typed

### DIFF
--- a/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
+++ b/TablePro/Core/Autocomplete/SQLContextAnalyzer.swift
@@ -337,13 +337,20 @@ final class SQLContextAnalyzer {
         // Check if immediately after comma
         let isAfterComma = checkIfAfterComma(textBeforeCursor)
 
+        // Clause detection runs on the text BEFORE the token being typed: the
+        // prefix is what completion filters on, so it cannot also count as a
+        // committed clause keyword ("SELECT|" must still suggest the SELECT
+        // keyword, not switch to select-list completions).
+        let nsBeforeCursor = textBeforeCursor as NSString
+        let textBeforePrefix = nsBeforeCursor.substring(to: min(prefixStart, nsBeforeCursor.length))
+
         // For subquery context, extract text from the innermost subquery
         // so clause detection works on the subquery's SQL, not the outer query
         let clauseText: String
         if nestingLevel > 0 {
-            clauseText = extractInnermostSubqueryText(from: textBeforeCursor)
+            clauseText = extractInnermostSubqueryText(from: textBeforePrefix)
         } else {
-            clauseText = textBeforeCursor
+            clauseText = textBeforePrefix
         }
 
         // Determine clause type

--- a/TableProTests/Core/Autocomplete/SQLContextAnalyzerTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLContextAnalyzerTests.swift
@@ -766,7 +766,7 @@ struct SQLContextAnalyzerTests {
 
     @Test("Multiple block comments with code between")
     func testMultipleBlockComments() {
-        let context = analyzer.analyze(query: "/* c1 */ SELECT /* c2 */ * FROM ", cursorPosition: 31)
+        let context = analyzer.analyze(query: "/* c1 */ SELECT /* c2 */ * FROM ", cursorPosition: 32)
         #expect(context.isInsideComment == false)
         #expect(context.clauseType == .from)
     }


### PR DESCRIPTION
## What

Fixes the macOS Tests failures on main introduced by #1653 (red since 42ecf68d): "SELECT keyword returns completions" and "Replacement range does not exceed text length".

## Root cause

`SQLContextAnalyzer` ran clause detection on the text including the token under the cursor. With `SELECT|` the word SELECT is both the completion prefix and, to the analyzer, a committed clause keyword. The resolved clause became `.select`, whose candidate set (columns, functions) contains nothing matching the prefix "select", so the engine returned zero items and `getCompletions` returned nil. Same failure for `... WHERE|`.

## Fix

Clause detection now runs on the text before the prefix token (`substring(to: prefixStart)`). The token being typed stays what it is: the filter prefix. Typing `SELE` or a full `SELECT` keeps suggesting the SELECT keyword; positions with a trailing space (`JOIN |`, `FROM users |`) are unchanged, so the table suggestions #1653 added still work.

One test from #1653 placed the cursor touching the end of `FROM|` and asserted `.from`. Its intent (block comments do not break clause detection) is preserved by moving the cursor after the trailing space, where FROM is committed.

## Testing

All five autocomplete suites pass locally (698 cases): CompletionEngineTests, CompletionEngineFilterTests, SQLClauseDetectionTests, SQLContextAnalyzerTests, SQLCompletionProviderTests. The three remaining local failures (testMySQLProviderTypes, testProviderAcceptsDatabaseType, testCommaFromScopesColumnsToAllTables) fail identically on clean main without this change; they need driver plugins present and pass on CI.

No CHANGELOG entry: this fixes behavior that is itself still unreleased (#1653).