### PR TITLE
fix(editor): convert create-table tab in place on commit and wire Cmd+S

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Creating a table now turns the Create Table tab into the new table's tab instead of leaving the creation tab open next to a duplicate, and the sidebar shows the new table without a manual refresh. (#1664)
+- Cmd+S in the Create Table tab now creates the table, matching the Save shortcut everywhere else. (#1664)
 - Format Query can now be undone with Cmd+Z; the formatting is applied as a single editor edit instead of clearing the undo history. (#1645)
 - Format Query now formats only the selected text when a selection is active, and the full query when nothing is selected. (#1656)
 - Sorting a query result no longer overwrites the SQL editor text or the contents of an opened `.sql` file; the sort runs as a separate query and the editor keeps what you wrote. (#1645)

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -196,6 +196,9 @@ final class ConnectionToolbarState {
     /// Whether the structure view has pending schema changes
     var hasStructureChanges: Bool = false
 
+    /// Whether the Create Table tab has a committable definition (name + valid column)
+    var hasCreateTablePending: Bool = false
+
     /// Whether the current editor has non-empty query text
     var hasQueryText: Bool = false
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -304,6 +304,7 @@ extension MainContentCoordinator {
             || tab.hasUserActiveSort {
             return false
         }
+        if tab.tabType == .createTable { return !toolbarState.hasCreateTablePending }
         if tab.isPreview { return true }
         if tab.tabType == .query,
            tab.execution.lastExecutedAt == nil,

--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -137,4 +137,5 @@ struct PendingChangeTrigger: Equatable {
     let pendingDeletes: Set<String>
     let hasStructureChanges: Bool
     let isFileDirty: Bool
+    let hasCreateTablePending: Bool
 }

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -170,6 +170,11 @@ extension MainContentView {
     // MARK: - Command Actions Setup
 
     func updateToolbarPendingState() {
+        if tabManager.selectedTab?.tabType == .createTable {
+            toolbarState.hasDataPendingChanges = false
+            toolbarState.hasPendingChanges = toolbarState.hasCreateTablePending
+            return
+        }
         let hasDataChanges =
             changeManager.hasChanges
             || !pendingTruncates.isEmpty

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -584,6 +584,10 @@ final class MainContentCommandActions {
     // MARK: - Data Operations (Group A — Called Directly)
 
     func saveChanges() {
+        if coordinator?.tabManager.selectedTab?.tabType == .createTable {
+            coordinator?.createTableActions?.createTable?()
+            return
+        }
         // Check if we're in structure view mode
         if coordinator?.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator?.structureActions?.saveChanges?()

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -117,6 +117,10 @@ final class MainContentCoordinator {
     /// Direct reference to structure view actions — eliminates notification broadcasts
     weak var structureActions: StructureViewActionHandler?
 
+    /// Direct reference to create-table view actions so the Save Changes menu
+    /// (Cmd+S) routes to table creation. Set by `CreateTableView` on appear.
+    weak var createTableActions: CreateTableActionHandler?
+
     /// Published capability/labels for the structure-mode footer in the bottom status bar.
     /// `TableStructureView` writes to this; `MainStatusBarView` reads from it.
     let structureFooterState = StructureFooterState()

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -296,7 +296,8 @@ struct MainContentView: View {
             pendingTruncates: pendingTruncates,
             pendingDeletes: pendingDeletes,
             hasStructureChanges: toolbarState.hasStructureChanges,
-            isFileDirty: tabManager.selectedTab?.content.isFileDirty ?? false
+            isFileDirty: tabManager.selectedTab?.content.isFileDirty ?? false,
+            hasCreateTablePending: toolbarState.hasCreateTablePending
         )
     }
 

--- a/TablePro/Views/Structure/CreateTableActionHandler.swift
+++ b/TablePro/Views/Structure/CreateTableActionHandler.swift
@@ -1,0 +1,11 @@
+//
+//  CreateTableActionHandler.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+final class CreateTableActionHandler {
+    var createTable: (() -> Void)?
+}

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -45,6 +45,7 @@ struct CreateTableView: View {
     @State private var showError = false
     @State private var previewSQL = ""
     @State private var gridDelegate: CreateTableGridDelegate
+    @State private var actionHandler = CreateTableActionHandler()
 
     // DataGridView state
     @State private var selectedRows: Set<Int> = []
@@ -85,10 +86,18 @@ struct CreateTableView: View {
             if structureChangeManager.workingColumns.isEmpty {
                 structureChangeManager.addNewColumn()
             }
+            actionHandler.createTable = { createTable() }
+            coordinator?.createTableActions = actionHandler
+            coordinator?.toolbarState.hasCreateTablePending = isReadyToCreate
         }
-        .onDisappear { selectionState.indices = [] }
+        .onDisappear {
+            selectionState.indices = []
+            coordinator?.createTableActions = nil
+            coordinator?.toolbarState.hasCreateTablePending = false
+        }
         .onChange(of: selectedRows) { _, newRows in selectionState.indices = newRows }
         .onChange(of: selectedTab) { updateGridDelegate() }
+        .onChange(of: isReadyToCreate) { updateCreateTablePendingState() }
         .alert(String(localized: "Create Table Failed"), isPresented: $showError) {
             Button("OK") {}
         } message: {
@@ -340,8 +349,18 @@ struct CreateTableView: View {
 
     // MARK: - Create Table
 
+    private var isReadyToCreate: Bool {
+        !isCreating
+            && !tableName.isEmpty
+            && structureChangeManager.workingColumns.contains { !$0.name.isEmpty && !$0.dataType.isEmpty }
+    }
+
+    private func updateCreateTablePendingState() {
+        coordinator?.toolbarState.hasCreateTablePending = isReadyToCreate
+    }
+
     private func createTable() {
-        guard !tableName.isEmpty else { return }
+        guard !isCreating, !tableName.isEmpty else { return }
         guard let sql = buildCreateTableSQL() else {
             errorMessage = String(localized: "Add at least one column with a name and type")
             showError = true
@@ -350,6 +369,7 @@ struct CreateTableView: View {
 
         isCreating = true
         errorMessage = nil
+        updateCreateTablePendingState()
 
         Task {
             defer { isCreating = false }
@@ -389,11 +409,11 @@ struct CreateTableView: View {
                     wasSuccessful: true
                 )
 
-                AppCommands.shared.refreshData.send(connection.id)
-
                 if let coordinator {
                     coordinator.openTableTab(tableName)
                 }
+
+                AppCommands.shared.refreshData.send(connection.id)
             } catch {
                 Self.logger.error("Create table failed: \(error.localizedDescription, privacy: .public)")
                 errorMessage = error.localizedDescription

--- a/TableProTests/Views/Main/CommandActionsDispatchTests.swift
+++ b/TableProTests/Views/Main/CommandActionsDispatchTests.swift
@@ -173,4 +173,42 @@ struct CommandActionsDispatchTests {
 
         #expect(removeRowCalled)
     }
+
+    // MARK: - saveChanges (createTable tab)
+
+    @Test("saveChanges dispatches createTableActions when the selected tab is createTable")
+    func saveChanges_createTableTab_callsCreateTableAction() {
+        let (actions, coordinator) = makeSUT()
+        coordinator.tabManager.addCreateTableTab(databaseName: "testdb")
+
+        let createHandler = CreateTableActionHandler()
+        var createCalled = false
+        createHandler.createTable = { createCalled = true }
+        coordinator.createTableActions = createHandler
+
+        let handler = StructureViewActionHandler()
+        var structureSaveCalled = false
+        handler.saveChanges = { structureSaveCalled = true }
+        coordinator.structureActions = handler
+
+        actions.saveChanges()
+
+        #expect(createCalled)
+        #expect(!structureSaveCalled)
+    }
+
+    @Test("saveChanges without createTableActions is a no-op for a createTable tab")
+    func saveChanges_createTableTab_withoutAction_doesNothing() {
+        let (actions, coordinator) = makeSUT()
+        coordinator.tabManager.addCreateTableTab(databaseName: "testdb")
+
+        let handler = StructureViewActionHandler()
+        var structureSaveCalled = false
+        handler.saveChanges = { structureSaveCalled = true }
+        coordinator.structureActions = handler
+
+        actions.saveChanges()
+
+        #expect(!structureSaveCalled)
+    }
 }

--- a/TableProTests/Views/Main/OpenTableTabTests.swift
+++ b/TableProTests/Views/Main/OpenTableTabTests.swift
@@ -82,6 +82,30 @@ struct OpenTableTabTests {
         #expect(tabManager.selectedTab?.filterState.isVisible == false)
     }
 
+    @Test("openTableTab converts a createTable tab in place after the table is created")
+    @MainActor
+    func convertsCreateTableTabInPlace() {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        tabManager.addCreateTableTab(databaseName: "db_a")
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.selectedTab?.tabType == .createTable)
+
+        coordinator.openTableTab("users")
+
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.selectedTab?.tabType == .table)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+    }
+
     @Test("Clicking the active table again is a no-op")
     @MainActor
     func clickingActiveTableAgainIsNoOp() throws {
@@ -122,6 +146,25 @@ struct OpenTableTabTests {
         let coordinator = Self.makeCoordinator()
         defer { coordinator.teardown() }
         try coordinator.tabManager.addTableTab(tableName: "users", databaseType: .mysql, databaseName: "db")
+        #expect(coordinator.isActiveTabReusable == false)
+    }
+
+    @Test("A createTable tab without a committable design is reusable")
+    @MainActor
+    func createTableTabIsReusable() {
+        let coordinator = Self.makeCoordinator()
+        defer { coordinator.teardown() }
+        coordinator.tabManager.addCreateTableTab(databaseName: "db")
+        #expect(coordinator.isActiveTabReusable == true)
+    }
+
+    @Test("A createTable tab with a committable design is protected and not reusable")
+    @MainActor
+    func createTableTabWithPendingDesignIsNotReusable() {
+        let coordinator = Self.makeCoordinator()
+        defer { coordinator.teardown() }
+        coordinator.tabManager.addCreateTableTab(databaseName: "db")
+        coordinator.toolbarState.hasCreateTablePending = true
         #expect(coordinator.isActiveTabReusable == false)
     }
 

--- a/TableProTests/Views/Main/TriggerStructTests.swift
+++ b/TableProTests/Views/Main/TriggerStructTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import TableProPluginKit
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 // MARK: - InspectorTrigger Tests
@@ -61,45 +61,70 @@ struct InspectorTriggerTests {
 
 @Suite("PendingChangeTrigger")
 struct PendingChangeTriggerTests {
+    private func makeTrigger(
+        hasDataChanges: Bool = false,
+        pendingTruncates: Set<String> = [],
+        pendingDeletes: Set<String> = [],
+        hasStructureChanges: Bool = false,
+        isFileDirty: Bool = false,
+        hasCreateTablePending: Bool = false
+    ) -> PendingChangeTrigger {
+        PendingChangeTrigger(
+            hasDataChanges: hasDataChanges,
+            pendingTruncates: pendingTruncates,
+            pendingDeletes: pendingDeletes,
+            hasStructureChanges: hasStructureChanges,
+            isFileDirty: isFileDirty,
+            hasCreateTablePending: hasCreateTablePending
+        )
+    }
+
     @Test("Same values are equal")
     func sameValuesAreEqual() {
-        let a = PendingChangeTrigger(hasDataChanges: true, pendingTruncates: ["t1"], pendingDeletes: ["t2"], hasStructureChanges: false, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: true, pendingTruncates: ["t1"], pendingDeletes: ["t2"], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger(hasDataChanges: true, pendingTruncates: ["t1"], pendingDeletes: ["t2"])
+        let b = makeTrigger(hasDataChanges: true, pendingTruncates: ["t1"], pendingDeletes: ["t2"])
         #expect(a == b)
     }
 
     @Test("Empty sets are equal")
     func emptySetsAreEqual() {
-        let a = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger()
+        let b = makeTrigger()
         #expect(a == b)
     }
 
     @Test("Different hasDataChanges produces unequal triggers")
     func differentHasDataChanges() {
-        let a = PendingChangeTrigger(hasDataChanges: true, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger(hasDataChanges: true)
+        let b = makeTrigger(hasDataChanges: false)
         #expect(a != b)
     }
 
     @Test("Different pendingTruncates produces unequal triggers")
     func differentPendingTruncates() {
-        let a = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: ["t1"], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: ["t2"], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger(pendingTruncates: ["t1"])
+        let b = makeTrigger(pendingTruncates: ["t2"])
         #expect(a != b)
     }
 
     @Test("Different pendingDeletes produces unequal triggers")
     func differentPendingDeletes() {
-        let a = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: ["d1"], hasStructureChanges: false, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: ["d2"], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger(pendingDeletes: ["d1"])
+        let b = makeTrigger(pendingDeletes: ["d2"])
         #expect(a != b)
     }
 
     @Test("Different hasStructureChanges produces unequal triggers")
     func differentHasStructureChanges() {
-        let a = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: true, isFileDirty: false)
-        let b = PendingChangeTrigger(hasDataChanges: false, pendingTruncates: [], pendingDeletes: [], hasStructureChanges: false, isFileDirty: false)
+        let a = makeTrigger(hasStructureChanges: true)
+        let b = makeTrigger(hasStructureChanges: false)
+        #expect(a != b)
+    }
+
+    @Test("Different hasCreateTablePending produces unequal triggers")
+    func differentHasCreateTablePending() {
+        let a = makeTrigger(hasCreateTablePending: true)
+        let b = makeTrigger(hasCreateTablePending: false)
         #expect(a != b)
     }
 }

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -128,6 +128,7 @@ TablePro is keyboard-driven. Most actions have shortcuts, and most menu shortcut
 | Undo change | `Cmd+Z` |
 | Redo change | `Cmd+Shift+Z` |
 | Commit all changes | `Cmd+S` |
+| Create table from the Create Table tab | `Cmd+S` or `Cmd+Return` |
 | Preview SQL | `Cmd+Shift+P` | Preview pending SQL before commit |
 
 ### Selection

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -167,7 +167,7 @@ Right-click in the sidebar and select **Create New Table...**. A visual editor o
 - **Foreign Keys tab** - define relationships with referenced tables, ON DELETE/ON UPDATE actions
 - **SQL Preview tab** - live-generated CREATE TABLE DDL with syntax highlighting
 
-Click **Create Table** (or `Cmd+Return`) to execute. The new table appears in the sidebar immediately.
+Click **Create Table** (or press `Cmd+S` or `Cmd+Return`) to execute. The tab becomes the new table's data view and the table appears in the sidebar immediately.
 
 <Note>
 Supported databases: MySQL, MariaDB, PostgreSQL, SQLite, SQL Server, ClickHouse, and DuckDB. Each generates database-specific DDL syntax.


### PR DESCRIPTION
## Problem

Two defects in the create-table flow:

1. Clicking Create Table opened a second window tab for the new table, left the creation tab open, and the sidebar did not show the new table until a manual Cmd+R.
2. Cmd+S did nothing in the creation tab; only the Create Table button worked.

## Root causes

1. `isActiveTabReusable` had no case for `.createTable`, so `openTableTab()` skipped the in-place `replaceTabContent` path and spawned a new NSWindow tab. The refresh also fired before the tab transform, so the refresh subscriber bailed on the still-`.createTable` tab.
2. Two gaps: the Save Changes menu item was always disabled for creation tabs (`updateToolbarPendingState` knew nothing about them), and `saveChanges()` had no `.createTable` branch.

## Fix

- `.createTable` tabs are now reusable: on success the creation tab converts in place into the new table's data tab (one tab, same window), matching TablePlus behavior and HIG Save semantics (commit in place, never spawn a second surface).
- `createTable()` now transforms the tab before sending the refresh, so the sidebar and grid pick up the new table immediately.
- Cmd+S routes through the existing Save Changes path: `CreateTableView` registers a `createTableAction` on the coordinator (same pattern as `StructureViewActionHandler`), and a `hasCreateTablePending` flag enables the menu item only when the form has a name, at least one valid column, and no create in flight. The flag observes the readiness condition itself, so edits made in any order (name first or columns first) update the menu state.
- Cmd+Return on the button keeps working; Cmd+S is the standard additional path.
- A creation tab with a committable design (name plus a valid column) is protected: opening another table from the sidebar opens a new tab instead of replacing the in-progress design. Only an empty or in-flight creation tab is reused.
- The Cmd+S action lives on a `CreateTableActionHandler` held weakly by the coordinator (same lifetime semantics as `StructureViewActionHandler`), and `createTable()` guards against reentry while a create is in flight.

## Error handling

A failed CREATE TABLE (SQL error, duplicate name) keeps the creation tab untouched; the error path never reaches the tab conversion.

## Tests

- `OpenTableTabTests`: createTable tab is reusable; `openTableTab` converts it in place.
- `CommandActionsDispatchTests`: `saveChanges()` dispatches `createTableAction` for createTable tabs (and is a no-op without one).
- `PendingChangeTriggerTests`: equality covers the new field (suite rewritten with a factory helper to stay within line limits).

Note: `insertQueryFromAI_appendsToExisting` fails at origin/main too (stale test expecting append behavior the app no longer has); verified pre-existing with a clean stash run, not touched here.

UI automation: the full flow needs a live database connection, so no deterministic UI test was added.

## Docs

CHANGELOG under Unreleased (Fixed), `docs/features/keyboard-shortcuts.mdx`, `docs/features/table-structure.mdx`.

## Out of scope

Cmd+W on a creation tab with unsaved work still closes silently (pre-existing: the unsaved-changes check never flags creation tabs). Doing it properly needs an async create-then-close flow; can follow up separately.
