### PR TITLE
Let the inspector panel resize freely

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -211,7 +211,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         inspectorSplitItem = NSSplitViewItem(inspectorWithViewController: inspectorHosting)
         inspectorSplitItem.canCollapse = true
         inspectorSplitItem.minimumThickness = 270
-        inspectorSplitItem.maximumThickness = 400
         addSplitViewItem(inspectorSplitItem)
 
         if currentSession?.driver == nil {


### PR DESCRIPTION
## What

Removes the fixed 400pt max-width cap on the right inspector panel so it can be resized freely by dragging its divider.

## Why

The inspector was hard-capped between 270 and 400 points. Users with wider content (long values, AI chat) couldn't widen it past 400.

## Changes

- `MainSplitViewController`: dropped `inspectorSplitItem.maximumThickness = 400`. The default is `NSSplitViewItemUnspecifiedDimension`, so there is no upper bound now.
- Kept `minimumThickness = 270` so the panel can't shrink to an unusable width.
- No effect on window min-size logic: `recomputeWindowMinSize()` only reads minimums.
- The divider drag and existing `autosaveName` ("com.TablePro.mainSplit") persist the chosen width across launches.

## Notes

The CHANGELOG entry for this already landed on main via #1674, so it's not repeated here.