### PR TITLE
build: drop SwiftLint build-tool plugin from vendored CodeEdit packages

### DIFF
--- a/LocalPackages/CodeEditSourceEditor/Package.swift
+++ b/LocalPackages/CodeEditSourceEditor/Package.swift
@@ -23,11 +23,6 @@ let package = Package(
             url: "https://github.com/CodeEditApp/CodeEditSymbols.git",
             exact: "0.2.3"
         ),
-        // SwiftLint
-        .package(
-            url: "https://github.com/lukepistrol/SwiftLintPlugin",
-            from: "0.2.2"
-        ),
         // Rules for indentation, pair completion, whitespace
         .package(
             url: "https://github.com/ChimeHQ/TextFormation",
@@ -44,9 +39,6 @@ let package = Package(
                 "CodeEditLanguages",
                 "TextFormation",
                 "CodeEditSymbols"
-            ],
-            plugins: [
-                .plugin(name: "SwiftLint", package: "SwiftLintPlugin")
             ]
         ),
 
@@ -57,9 +49,6 @@ let package = Package(
                 "CodeEditSourceEditor",
                 "CodeEditLanguages",
                 .product(name: "CustomDump", package: "swift-custom-dump")
-            ],
-            plugins: [
-                .plugin(name: "SwiftLint", package: "SwiftLintPlugin")
             ]
         ),
     ]

--- a/LocalPackages/CodeEditTextView/Package.swift
+++ b/LocalPackages/CodeEditTextView/Package.swift
@@ -23,11 +23,6 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-collections.git",
             .upToNextMajor(from: "1.0.0")
-        ),
-        // SwiftLint
-        .package(
-            url: "https://github.com/lukepistrol/SwiftLintPlugin",
-            from: "0.52.2"
         )
     ],
     targets: [
@@ -38,9 +33,6 @@ let package = Package(
                 "TextStory",
                 .product(name: "Collections", package: "swift-collections"),
                 "CodeEditTextViewObjC"
-            ],
-            plugins: [
-                .plugin(name: "SwiftLint", package: "SwiftLintPlugin")
             ]
         ),
 
@@ -55,9 +47,6 @@ let package = Package(
             name: "CodeEditTextViewTests",
             dependencies: [
                 "CodeEditTextView"
-            ],
-            plugins: [
-                .plugin(name: "SwiftLint", package: "SwiftLintPlugin")
             ]
         ),
     ]

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "475d5c8ee85aa1d1e11facad23a0ba0c8149e7ea855d30de709ab6e3dd78d3be",
+  "originHash" : "e3a3828307ccec4f2ef033715de2df6c1d530d8772905d223ccdb8d7525b77ad",
   "pins" : [
     {
       "identity" : "bigint",
@@ -178,15 +178,6 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swiftlintplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
-      "state" : {
-        "revision" : "a3877065a7d72ee40e1fa64e13b9e33e846c667c",
-        "version" : "0.63.1"
       }
     },
     {


### PR DESCRIPTION
## Problem
Building on Xcode 27 / macOS 27 fails with `Plug-in ended with uncaught signal: 5`. The crash is the SwiftLint build-tool plugin bundled in the vendored CodeEdit packages:

```
swiftlint: .../SwiftLintBinary.artifactbundle/macos/swiftlint
SourceKittenFramework/library_wrapper.swift:58: Fatal error:
  Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed
** BUILD FAILED **
```

The prebuilt swiftlint binary can't load `sourcekitd` under the Xcode 27 toolchain. macOS 27 can't run the pinned Xcode 26.4.1, so there is no supported-toolchain workaround.

## Change
Remove the `SwiftLint` build-tool plugin (and the `SwiftLintPlugin` dependency) from:
- `LocalPackages/CodeEditSourceEditor/Package.swift`
- `LocalPackages/CodeEditTextView/Package.swift`

That plugin lints CodeEdit's own vendored source, not TablePro code. TablePro lints itself with the root `swiftlint` + the CI lint gate, so nothing is lost. The app targets build unchanged; only the per-build lint of vendored third-party code is dropped.

## Verification
`xcodebuild ... build -skipPackagePluginValidation` on Xcode 27 beta: **BUILD SUCCEEDED**.