### PR TITLE
Make the inspector actually resize freely

### DIFF
--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -211,6 +211,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         inspectorSplitItem = NSSplitViewItem(inspectorWithViewController: inspectorHosting)
         inspectorSplitItem.canCollapse = true
         inspectorSplitItem.minimumThickness = 270
+        inspectorSplitItem.maximumThickness = NSSplitViewItem.unspecifiedDimension
         addSplitViewItem(inspectorSplitItem)
 
         if currentSession?.driver == nil {


### PR DESCRIPTION
## What

Sets the inspector pane's `maximumThickness` to `NSSplitViewItem.unspecifiedDimension` so it can be dragged to any width.

## Why

#1676 tried to free the inspector by deleting `maximumThickness = 400`, but that made it worse. On macOS 14+, `NSSplitViewItem(inspectorWithViewController:)` defaults both `minimumThickness` and `maximumThickness` to 270 ("aren't resizable by default"). Removing the explicit 400 let the max fall back to that 270 default, so `min == max == 270`: zero divider travel, the inspector was pinned and could not resize at all.

Setting `maximumThickness = unspecifiedDimension` removes the hard drag stop entirely, which is the documented, necessary-and-sufficient change for unbounded drag width. The 270 minimum stays so the panel keeps a usable floor.

## Notes

- `recomputeWindowMinSize()` only reads minimums, so the window min-size logic is unaffected.
- The divider drag and existing `autosaveName` ("com.TablePro.mainSplit") persist the chosen width.
- The CHANGELOG entry for free inspector resize already landed in [Unreleased] via #1676, so it's not repeated here; this PR makes that entry true.

Ref: https://developer.apple.com/documentation/appkit/nssplitviewitem/init(inspectorwithviewcontroller:)