### PR TITLE
fix(plugin-oracle): prevent connect crash on malformed handshake packets (#1683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The tree sidebar can show only the databases you pick. Use the filter button to check the ones you want, with a search box for long lists. The choice is saved per connection. (#1667)
 
+### Fixed
+
+- Oracle connections no longer crash the app during connect. A short or unexpected handshake packet from the server (such as session-setup metadata or an error) now surfaces the error or continues instead of trapping. (#1683)
+
 ## [0.51.0] - 2026-06-13
 
 ### Added

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -4776,7 +4776,7 @@
 			repositoryURL = "https://github.com/TableProApp/oracle-nio";
 			requirement = {
 				kind = revision;
-				revision = b2a5e27b32cc0b6e36057ef89fd52fde15e96b25;
+				revision = 8b39c44c22ff23659ec085def01c767f5e141196;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -4776,7 +4776,7 @@
 			repositoryURL = "https://github.com/TableProApp/oracle-nio";
 			requirement = {
 				kind = revision;
-				revision = 18a4872b16f6fb6919833f7897e75b0ea4d19428;
+				revision = b2a5e27b32cc0b6e36057ef89fd52fde15e96b25;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "b2a5e27b32cc0b6e36057ef89fd52fde15e96b25"
+        "revision" : "8b39c44c22ff23659ec085def01c767f5e141196"
       }
     },
     {

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "18a4872b16f6fb6919833f7897e75b0ea4d19428"
+        "revision" : "b2a5e27b32cc0b6e36057ef89fd52fde15e96b25"
       }
     },
     {


### PR DESCRIPTION
Fixes #1683.

## Problem

TablePro crashed (`EXC_BREAKPOINT` / Swift trap) on the NIO channel thread when connecting to some Oracle databases. Proven by symbolicating the shipped `OracleDriver` 1.2.11 crash binary (UUID-matched): the trap was inside `ServerSidePiggyback.decode` in OracleNIO, at a non-throwing `moveReaderIndex(forwardBy:)`. Oracle 12c+ sends a `.sync` server-side piggyback during normal session setup; on some servers the packet is shorter than the decoder's fixed skips, so the move ran past the buffer end and trapped. A trap is not catchable by the connection's error handling, so the whole app died on connect.

## Fix

The fix lives in the OracleNIO fork: **TableProApp/oracle-nio#5**. This PR bumps the app's `oracle-nio` pin to that commit and adds the changelog entry.

The fork change hardens the connection-handshake decode path so a short or unexpected server packet surfaces a decoding error (or is ignored, for informational piggybacks) instead of trapping:
- `ServerSidePiggyback.decode` uses throwing buffer moves.
- The server-side piggyback `fatalError` in the channel handler is replaced with informational handling.
- `Protocol.decode` FDO parsing is bounds-checked and computed in `Int` (no `UInt8` overflow).
- `BackendError.decode` batch indexing is bounds-guarded.
- The `ByteBuffer` UB/SB readers throw or return nil instead of trapping on bad length prefixes.
- Regression tests cover each path.

## Notes

- Merge **oracle-nio#5** first, then the pin here points at it.
- Registry plugin: after merge, `plugin-oracle-v1.2.12` needs to be tagged so the rebuilt `OracleDriver` reaches users via plugin auto-update.
- Local `swift test`/build is blocked by an Xcode 27 beta toolchain issue in a dependency; the fork CI and an Xcode build validate.