### PR TITLE
fix(coordinator): persist sidebar and inspector layout per connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Oracle connections no longer crash the app during connect. A short or unexpected handshake packet from the server (such as session-setup metadata or an error) now surfaces the error or continues instead of trapping. (#1683)
 - MongoDB filters on `_id` and other ObjectId fields now match. A 24-character hex value is matched as an ObjectId as well as a string, so filtering by `_id` returns the row instead of nothing. (#1682)
+- The sidebar and inspector keep their width per connection, the sidebar keeps its collapsed state, and the inspector keeps its selected tab, when you quit and reopen the app.
 
 ## [0.51.0] - 2026-06-13
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -43,12 +43,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private var sidebarContainer: SidebarContainerViewController!
     private var detailHosting: NSHostingController<AnyView>!
     private var inspectorHosting: NSHostingController<AnyView>!
-    private var hasMaterializedInspector = false
 
     // MARK: - Panel Layout State
 
     private var splitAutosaveName: NSSplitView.AutosaveName {
-        if let connectionId = payload?.connectionId {
+        if let connectionId = payload?.connectionId ?? currentSession?.connection.id {
             return "com.TablePro.mainSplit.\(connectionId.uuidString)"
         }
         return "com.TablePro.mainSplit"
@@ -230,12 +229,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         recomputeWindowMinSize()
     }
 
-    private func materializeInspectorIfNeeded() {
-        guard !hasMaterializedInspector, let inspectorHosting else { return }
-        hasMaterializedInspector = true
-        inspectorHosting.rootView = AnyView(buildInspectorView())
-    }
-
     override func viewWillAppear() {
         super.viewWillAppear()
         guard let window = view.window else { return }
@@ -324,6 +317,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                 sessionState = nil
                 currentSession = nil
                 sidebarContainer.updateSidebarState(nil, windowState: nil)
+                sidebarContainer.rootView = AnyView(buildSidebarView())
             }
             return
         }
@@ -514,7 +508,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     }
 
     func showInspector() {
-        materializeInspectorIfNeeded()
+        inspectorHosting.rootView = AnyView(buildInspectorView())
         inspectorSplitItem?.animator().isCollapsed = false
         recomputeWindowMinSize()
     }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -45,6 +45,15 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private var inspectorHosting: NSHostingController<AnyView>!
     private var hasMaterializedInspector = false
 
+    // MARK: - Panel Layout State
+
+    private var splitAutosaveName: NSSplitView.AutosaveName {
+        if let connectionId = payload?.connectionId {
+            return "com.TablePro.mainSplit.\(connectionId.uuidString)"
+        }
+        return "com.TablePro.mainSplit"
+    }
+
     // MARK: - Toolbar
 
     private var toolbarOwner: MainWindowToolbar?
@@ -151,7 +160,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
 
         if let session = resolvedSession {
-            self.rightPanelState = RightPanelState()
+            self.rightPanelState = RightPanelState(connectionId: session.connection.id)
             let state: SessionStateFactory.SessionState
             if let payloadId = payload?.id,
                let pending = SessionStateFactory.consumePending(for: payloadId) {
@@ -184,45 +193,36 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
         splitView.dividerStyle = .thin
         splitView.isVertical = true
-        splitView.autosaveName = "com.TablePro.mainSplit"
 
         sidebarContainer = SidebarContainerViewController(rootView: AnyView(buildSidebarView()))
         sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarContainer)
         sidebarSplitItem.canCollapse = true
-        sidebarSplitItem.minimumThickness = 280
-        sidebarSplitItem.maximumThickness = 600
+        sidebarSplitItem.minimumThickness = Self.sidebarMinThickness
+        sidebarSplitItem.maximumThickness = Self.sidebarMaxThickness
         addSplitViewItem(sidebarSplitItem)
 
         detailHosting = NSHostingController(rootView: AnyView(buildDetailView()))
         detailSplitItem = NSSplitViewItem(viewController: detailHosting)
-        detailSplitItem.minimumThickness = 400
+        detailSplitItem.minimumThickness = Self.detailMinThickness
         detailSplitItem.holdingPriority = .defaultLow
         addSplitViewItem(detailSplitItem)
 
-        let inspectorPresented = UserDefaults.standard.bool(forKey: Self.inspectorPresentedKey)
-        let initialInspectorContent: AnyView
-        if inspectorPresented {
-            initialInspectorContent = AnyView(buildInspectorView())
-            hasMaterializedInspector = true
-        } else {
-            initialInspectorContent = AnyView(Color.clear)
-        }
-        inspectorHosting = NSHostingController(rootView: initialInspectorContent)
+        inspectorHosting = NSHostingController(rootView: AnyView(Color.clear))
         inspectorSplitItem = NSSplitViewItem(inspectorWithViewController: inspectorHosting)
         inspectorSplitItem.canCollapse = true
-        inspectorSplitItem.minimumThickness = 270
+        inspectorSplitItem.minimumThickness = Self.inspectorMinThickness
         inspectorSplitItem.maximumThickness = NSSplitViewItem.unspecifiedDimension
         addSplitViewItem(inspectorSplitItem)
 
-        if currentSession?.driver == nil {
-            sidebarSplitItem.isCollapsed = true
-        } else if let session = currentSession, let coordinator = sessionState?.coordinator {
+        splitView.autosaveName = splitAutosaveName
+        applyDefaultCollapseStateIfNoAutosave()
+
+        if let session = currentSession, session.driver != nil, let coordinator = sessionState?.coordinator {
             sidebarContainer.updateSidebarState(
                 SharedSidebarState.forConnection(session.connection.id),
                 windowState: coordinator.windowSidebarState
             )
         }
-        inspectorSplitItem.isCollapsed = !inspectorPresented
     }
 
     override func splitViewDidResizeSubviews(_ notification: Notification) {
@@ -324,11 +324,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                 sessionState = nil
                 currentSession = nil
                 sidebarContainer.updateSidebarState(nil, windowState: nil)
-                if view.window?.isVisible == true {
-                    sidebarSplitItem.animator().isCollapsed = true
-                } else {
-                    sidebarSplitItem.isCollapsed = true
-                }
             }
             return
         }
@@ -345,7 +340,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
 
         if rightPanelState == nil {
-            rightPanelState = RightPanelState()
+            rightPanelState = RightPanelState(connectionId: newSession.connection.id)
         }
         if sessionState == nil {
             let state = SessionStateFactory.create(connection: newSession.connection, payload: payload)
@@ -355,12 +350,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             installToolbar(coordinator: state.coordinator)
         }
 
-        let collapseSidebar = newSession.driver == nil
-        if view.window?.isVisible == true {
-            sidebarSplitItem.animator().isCollapsed = collapseSidebar
-        } else {
-            sidebarSplitItem.isCollapsed = collapseSidebar
-        }
         rebuildPanes()
     }
 
@@ -527,13 +516,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     func showInspector() {
         materializeInspectorIfNeeded()
         inspectorSplitItem?.animator().isCollapsed = false
-        UserDefaults.standard.set(true, forKey: Self.inspectorPresentedKey)
         recomputeWindowMinSize()
     }
 
     func hideInspector() {
         inspectorSplitItem?.animator().isCollapsed = true
-        UserDefaults.standard.set(false, forKey: Self.inspectorPresentedKey)
         recomputeWindowMinSize()
     }
 
@@ -572,15 +559,19 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     private static let baseWindowMinWidth: CGFloat = 720
     private static let baseWindowMinHeight: CGFloat = 480
+    private static let sidebarMinThickness: CGFloat = 280
+    private static let sidebarMaxThickness: CGFloat = 600
+    private static let detailMinThickness: CGFloat = 400
+    private static let inspectorMinThickness: CGFloat = 270
 
     private func recomputeWindowMinSize() {
         guard let window = view.window else { return }
         let sidebarVisible = !(sidebarSplitItem?.isCollapsed ?? true)
         let inspectorVisible = !(inspectorSplitItem?.isCollapsed ?? true)
 
-        let detailMin: CGFloat = detailSplitItem?.minimumThickness ?? 400
-        let sidebarMin: CGFloat = sidebarSplitItem?.minimumThickness ?? 280
-        let inspectorMin: CGFloat = inspectorSplitItem?.minimumThickness ?? 270
+        let detailMin = Self.detailMinThickness
+        let sidebarMin = Self.sidebarMinThickness
+        let inspectorMin = Self.inspectorMinThickness
         let dividerThickness = splitView.dividerThickness
 
         var width: CGFloat = detailMin
@@ -612,7 +603,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
     }
 
-    // MARK: - Constants
+    // MARK: - Panel Layout Persistence
 
-    private static let inspectorPresentedKey = "com.TablePro.rightPanel.isPresented"
+    private func applyDefaultCollapseStateIfNoAutosave() {
+        let key = "NSSplitView Subview Frames \(splitAutosaveName)"
+        guard UserDefaults.standard.object(forKey: key) == nil else { return }
+        inspectorSplitItem.isCollapsed = true
+    }
 }

--- a/TablePro/Models/UI/RightPanelState.swift
+++ b/TablePro/Models/UI/RightPanelState.swift
@@ -10,8 +10,16 @@ import os
 
 @MainActor @Observable final class RightPanelState {
     @ObservationIgnored private let _didTeardown = OSAllocatedUnfairLock(initialState: false)
+    @ObservationIgnored private let connectionId: UUID?
+    @ObservationIgnored private let defaults: UserDefaults
 
-    var activeTab: RightPanelTab = .details
+    var activeTab: RightPanelTab {
+        didSet {
+            guard let connectionId else { return }
+            defaults.set(activeTab.rawValue, forKey: Self.activeTabKey(connectionId))
+        }
+    }
+
     var inspectorContext: InspectorContext = .empty
 
     // Save closure — set by MainContentCommandActions, called by UnifiedRightPanelView
@@ -25,6 +33,22 @@ import os
             _aiViewModel = AIChatViewModel()
         }
         return _aiViewModel! // swiftlint:disable:this force_unwrapping
+    }
+
+    init(connectionId: UUID? = nil, defaults: UserDefaults = .standard) {
+        self.connectionId = connectionId
+        self.defaults = defaults
+        if let connectionId,
+           let raw = defaults.string(forKey: Self.activeTabKey(connectionId)),
+           let tab = RightPanelTab(rawValue: raw) {
+            self.activeTab = tab
+        } else {
+            self.activeTab = .details
+        }
+    }
+
+    private static func activeTabKey(_ connectionId: UUID) -> String {
+        "com.TablePro.rightPanel.activeTab.\(connectionId.uuidString)"
     }
 
     /// Release all heavy data on disconnect so memory drops

--- a/TableProTests/Models/RightPanelStateTests.swift
+++ b/TableProTests/Models/RightPanelStateTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import TableProPluginKit
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 @Suite("RightPanelState", .serialized)
@@ -43,5 +43,51 @@ struct RightPanelStateTests {
         state.teardown()
 
         #expect(state.onSave == nil)
+    }
+
+    private func makeDefaults() throws -> UserDefaults {
+        let suite = "RightPanelStateTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test("active tab defaults to details when nothing stored")
+    @MainActor
+    func activeTabDefaults() throws {
+        let defaults = try makeDefaults()
+        let state = RightPanelState(connectionId: UUID(), defaults: defaults)
+        #expect(state.activeTab == .details)
+    }
+
+    @Test("active tab round-trips per connection")
+    @MainActor
+    func activeTabRoundTrip() throws {
+        let defaults = try makeDefaults()
+        let connectionId = UUID()
+        let state = RightPanelState(connectionId: connectionId, defaults: defaults)
+        state.activeTab = .aiChat
+        let restored = RightPanelState(connectionId: connectionId, defaults: defaults)
+        #expect(restored.activeTab == .aiChat)
+    }
+
+    @Test("active tab is isolated per connection")
+    @MainActor
+    func activeTabPerConnectionIsolation() throws {
+        let defaults = try makeDefaults()
+        let a = UUID()
+        let b = UUID()
+        RightPanelState(connectionId: a, defaults: defaults).activeTab = .aiChat
+        #expect(RightPanelState(connectionId: b, defaults: defaults).activeTab == .details)
+        #expect(RightPanelState(connectionId: a, defaults: defaults).activeTab == .aiChat)
+    }
+
+    @Test("active tab is not persisted without a connection id")
+    @MainActor
+    func activeTabNoConnectionNotPersisted() throws {
+        let defaults = try makeDefaults()
+        let state = RightPanelState(connectionId: nil, defaults: defaults)
+        state.activeTab = .aiChat
+        #expect(defaults.dictionaryRepresentation().keys.allSatisfy { !$0.contains("rightPanel.activeTab") })
     }
 }


### PR DESCRIPTION
## What

The main window's sidebar and inspector now keep their layout across quit/relaunch and close-to-Welcome/reconnect, per connection:

- **Sidebar + inspector width** — persisted and restored per connection.
- **Sidebar collapsed state** — persisted.
- **Inspector selected tab** (Details / AI Chat) — persisted per connection.

## Why it was broken

Panel widths weren't persisting, and earlier attempts flashed the default width during the async-connect phase before snapping to the saved size. Root cause: width was being applied *after* the connection completed, then overwritten by the `adjustSubviews` re-layout triggered by content swaps and the sidebar un-collapse. `setPosition(_:ofDividerAt:)` was the wrong tool — Apple documents it as a drag simulation that the framework doesn't invoke, so it's one-shot and gets clobbered by the next layout pass.

## Approach (native)

- Use **`NSSplitView.autosaveName`** (per connection: `com.TablePro.mainSplit.<connectionId>`), set after the split items are added. AppKit persists/restores divider geometry and re-applies it on every layout, so it survives the content-load re-layout. Geometry is decoupled from the connection lifecycle (`handleConnectionStatusChange` no longer touches collapse or width).
- The inspector tab is a simple enum selection, not split geometry, so it persists via per-connection `UserDefaults` in `RightPanelState` — the same pattern `SharedSidebarState.selectedSidebarTab` already uses.

This removes the custom width-persistence machinery (manual `setPosition`/pin code, a bespoke store, suppression flags) in favor of the documented framework mechanism.

## Behavior notes

- Saved widths reset to defaults once (the storage key changed), then persist.
- During the ~1s async connect the sidebar shows its remembered state rather than being force-collapsed; this decoupling is what removes the re-layout race.

## Tests

- `RightPanelStateTests`: inspector-tab default, per-connection round-trip, per-connection isolation, and no-persistence-without-connection-id (injected `UserDefaults`).
- Split-view geometry is now framework-managed (autosave), so it isn't unit-testable; verified manually (relaunch, close/reconnect, two connections).